### PR TITLE
doc: Update link to travis-ci with new Github org name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/intel/tpm2-tss.svg?branch=master)](https://travis-ci.org/intel/tpm2-tss)
+[![Build Status](https://travis-ci.org/tpm2-software/tpm2-tss.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-tss)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/tpm2-tss)
 [![Coverage Status](https://coveralls.io/repos/github/01org/tpm2-tss/badge.svg?branch=master)](https://coveralls.io/github/01org/tpm2-tss?branch=master)
 


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>