### PR TITLE
Use __attribute__((packed)) instead of #pragma pack

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -34,25 +34,23 @@ enum cmdStates {CMD_STAGE_INITIALIZE,
                 CMD_STAGE_RECEIVE_RESPONSE,
                 CMD_STAGE_ALL = 0xff };
 
-#pragma pack(push, 1)
-typedef struct _TPM20_Header_In {
+typedef struct __attribute__((packed)) _TPM20_Header_In {
   TPM2_ST tag;
   UINT32 commandSize;
   UINT32 commandCode;
 } TPM20_Header_In;
 
-typedef struct _TPM20_Header_Out {
+typedef struct __attribute__((packed)) _TPM20_Header_Out {
   TPM2_ST tag;
   UINT32 responseSize;
   UINT32 responseCode;
 } TPM20_Header_Out;
 
-typedef struct _TPM20_ErrorResponse {
+typedef struct __attribute__((packed)) _TPM20_ErrorResponse {
   TPM2_ST tag;
   UINT32 responseSize;
   UINT32 responseCode;
 } TPM20_ErrorResponse;
-#pragma pack(pop)
 
 typedef struct {
     TSS2_TCTI_CONTEXT *tctiContext;


### PR DESCRIPTION
Some of our embedded compiler-derivates seem to have a problem with #pragma pack and ignore it,
yielding to wrong sizes and total failure of the tss `__attribute__((packed))` works though.

Imho this is also much cleaner, since it puts the packing to the affected datastructures.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>