### PR TITLE
1.x README.md: Update badge for org move intel -> tpm2-software.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/intel/tpm2-tss.svg?branch=master)](https://travis-ci.org/intel/tpm2-tss)
+[![Build Status](https://travis-ci.org/tpm2-software/tpm2-tss.svg?branch=1.x)](https://travis-ci.org/tpm2-software/tpm2-tss)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/tpm2-tss)
 
 ## TPM (Trusted Platform Module) 2.0 Software Stack (TSS):


### PR DESCRIPTION
This also updates the branch. It was 'master' for some reason. Should
have always been '1.x'.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>