### PR TITLE
build: Link against libcrypt, not libssl.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -336,8 +336,8 @@ test_integration_policy_template_int_LDADD   = $(TESTS_LDADD)
 test_integration_policy_template_int_SOURCES = test/integration/main.c log/log.h log/log.c \
     test/integration/policy-template.int.c
 
-TESTS_CFLAGS = $(LIBSSL_CFLAGS)
-TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBSSL_LIBS)
+TESTS_CFLAGS = $(LIBCRYPTO_CFLAGS)
+TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS)
 
 AUTHORS :
 	$(AM_V_GEN)git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_ARG_WITH([simulatorbin],
 AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
 
 AS_IF([test "x$with_simulatorbin_set" == xyes],
-      [PKG_CHECK_MODULES([LIBSSL],[libssl])])
+      [PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])])
 
 gl_LD_VERSION_SCRIPT
 


### PR DESCRIPTION
The crypto operations are lin libcrypto, not libssl.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>