### PR TITLE
build: write version string to file, not by invoking git @ configure …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ test/ibmtpm*
 # ignore all files in test/unit without a file extension
 test/unit/*
 test/unit/!*.*
+VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST = \
     LICENSE \
     README.md \
     RELEASE.md \
+    VERSION \
     lib/debug_config.site \
     lib/tcti-device.pc.in \
     lib/tcti-socket.pc.in \

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# put version string into file used @ configure time, see AC_INIT
+git describe --tags --always --dirty > VERSION
+
 # generate list of source files for use in Makefile.am
 # if you add new source files, you must run ./bootstrap again
 src_listvar () {

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([tpm2-tss],
-        [m4_esyscmd_s([git describe --tags --always --dirty])])
+        [m4_esyscmd_s([cat VERSION])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX


### PR DESCRIPTION
…time.

Bitbake / Yocto, when building from source, runs autoconf instead of
invoking the `configure` script provided in the tarball. I'm sure they
have their reasons but it's kinda annoying. I'm sure there's a way to
work around this in the bitbake metadata but it's probably easier to
make this small change to the build.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>