### PR TITLE
CI: Add 64bit build to AppVeyor yml.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ configuration:
   - Debug
 platform:
   - x86
+  - x64
 build:
   project: tpm2-tss.sln
   parallel: true


### PR DESCRIPTION
Pretty straight forward. We need to start looking at Debug / Release builds too. Should just be a matter of adding an equivalent to our `--debug` option to the configure script.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>