### PR TITLE
TCTI refactor part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ test-suite.log
 test/ibmtpm*
 # ignore all files in test/unit without a file extension
 test/unit/*
-test/unit/!*.*
+!test/unit/*.[ch]
 doc/Doxyfile
 doc/doxy/
 doc/html/

--- a/Makefile.am
+++ b/Makefile.am
@@ -233,7 +233,8 @@ libutil_la_SOURCES = log/log.c log/log.h tcti/tcti.c tcti/tcti.h
 if HAVE_LD_VERSION_SCRIPT
 marshal_libmarshal_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/libmarshal.map
 endif # HAVE_LD_VERSION_SCRIPT
-marshal_libmarshal_la_SOURCES = $(MARSHAL_SRC) log/log.c log/log.h
+marshal_libmarshal_la_LIBADD = $(libutil)
+marshal_libmarshal_la_SOURCES = $(MARSHAL_SRC)
 
 sysapi_libsapi_la_LIBADD  = $(libmarshal)
 sysapi_libsapi_la_SOURCES = $(SYSAPI_C) $(SYSAPI_H) $(SYSAPIUTIL_C) \
@@ -245,9 +246,9 @@ esapi_libesapi_la_CFLAGS  = $(AM_CFLAGS) -Wno-unused-variable -Wno-unused-label 
                             -I$(srcdir)/esapi/esapi_util \
                             -DESYS_TCTI_DEFAULT_MODULE=$(TCTI_DEFAULT_MODULE) \
                             -DESYS_TCTI_DEFAULT_CONFIG=$(TCTI_DEFAULT_CONFIG)
-esapi_libesapi_la_LIBADD  = $(libsapi) $(libmarshal) $(libtcti_device) $(libtcti_socket)
+esapi_libesapi_la_LIBADD  = $(libsapi) $(libmarshal) $(libtcti_device) $(libtcti_socket) $(libutil)
 esapi_libesapi_la_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
-esapi_libesapi_la_SOURCES = $(ESAPI_SRC) log/log.h log/log.c
+esapi_libesapi_la_SOURCES = $(ESAPI_SRC)
 endif
 
 tcti_libtcti_device_la_CFLAGS   = $(AM_CFLAGS)
@@ -255,15 +256,15 @@ if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_device.map
 endif # HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_device_la_LIBADD   = $(libmarshal) $(libutil)
-tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c log/log.h
+tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c
 
 tcti_libtcti_socket_la_CFLAGS   = $(AM_CFLAGS) $(URIPARSER_CFLAGS)
 if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_socket_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
 endif # HAVE_LD_VERSION_SCRIPT
-tcti_libtcti_socket_la_LIBADD   = $(libmarshal) $(URIPARSER_LIBS)
+tcti_libtcti_socket_la_LIBADD   = $(libmarshal) $(URIPARSER_LIBS) $(libutil)
 tcti_libtcti_socket_la_SOURCES  = tcti/platformcommand.c tcti/tcti_socket.c \
-    tcti/tcti.c tcti/tcti.h tcti/sockets.c tcti/sockets.h log/log.h log/log.c
+    tcti/sockets.c tcti/sockets.h
 
 test_tpmclient_tpmclient_int_CFLAGS   = $(AM_CFLAGS) -U_FORTIFY_SOURCE  $(TESTS_CFLAGS)
 test_tpmclient_tpmclient_int_LDADD    = $(TESTS_LDADD)
@@ -277,8 +278,7 @@ test_tpmclient_tpmclient_int_SOURCES  = \
     test/tpmclient/StartAuthSession.c test/tpmclient/syscontext.c \
     test/tpmclient/syscontext.h test/tpmclient/TpmCalcPHash.c \
     test/tpmclient/tpmclient.int.c test/tpmclient/tpmclient.h \
-    test/tpmclient/TpmHandleToName.c test/tpmclient/TpmHash.c \
-    log/log.h log/log.c
+    test/tpmclient/TpmHandleToName.c test/tpmclient/TpmHash.c
 
 test_integration_libtest_utils_la_SOURCES = \
     test/integration/context-util.c test/integration/context-util.h \
@@ -289,83 +289,77 @@ test_integration_libtest_utils_la_SOURCES = \
 test_integration_asymmetric_encrypt_decrypt_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_asymmetric_encrypt_decrypt_int_LDADD   = $(TESTS_LDADD)
 test_integration_asymmetric_encrypt_decrypt_int_SOURCES = \
-    test/integration/asymmetric-encrypt-decrypt.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/asymmetric-encrypt-decrypt.int.c test/integration/main.c
 
 test_integration_create_primary_rsa_2048_aes_128_cfb_int_CFLAGS = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_create_primary_rsa_2048_aes_128_cfb_int_LDADD  = $(TESTS_LDADD)
 test_integration_create_primary_rsa_2048_aes_128_cfb_int_SOURCES = \
     test/integration/create-primary-rsa-2048-aes-128-cfb.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_create_keyedhash_sha1_hmac_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_create_keyedhash_sha1_hmac_int_LDADD   = $(TESTS_LDADD)
 test_integration_create_keyedhash_sha1_hmac_int_SOURCES = \
-    test/integration/create-keyedhash-sha1-hmac.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/create-keyedhash-sha1-hmac.int.c test/integration/main.c
 
 test_integration_encrypt_decrypt_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_encrypt_decrypt_int_LDADD   = $(TESTS_LDADD)
 test_integration_encrypt_decrypt_int_SOURCES = \
-    test/integration/encrypt-decrypt.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/encrypt-decrypt.int.c test/integration/main.c
 
 test_integration_encrypt_decrypt_2_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_encrypt_decrypt_2_int_LDADD   = $(TESTS_LDADD)
 test_integration_encrypt_decrypt_2_int_SOURCES = \
-    test/integration/encrypt-decrypt-2.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/encrypt-decrypt-2.int.c test/integration/main.c
 
 test_integration_evict_ctrl_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_evict_ctrl_int_LDADD   = $(TESTS_LDADD)
 test_integration_evict_ctrl_int_SOURCES = \
-    test/integration/evict-ctrl.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/evict-ctrl.int.c test/integration/main.c
 
 test_integration_sys_initialize_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_sys_initialize_int_LDADD   = $(TESTS_LDADD)
 test_integration_sys_initialize_int_SOURCES = test/integration/sys-initialize.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_get_random_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_get_random_int_LDADD   = $(TESTS_LDADD)
 test_integration_get_random_int_SOURCES = test/integration/get-random.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_abi_version_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_abi_version_int_LDADD   = $(TESTS_LDADD)
 test_integration_abi_version_int_SOURCES = test/integration/abi-version.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_pcr_extension_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pcr_extension_int_LDADD   = $(TESTS_LDADD)
 test_integration_pcr_extension_int_SOURCES = test/integration/pcr-extension.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_self_test_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_self_test_int_LDADD   = $(TESTS_LDADD)
 test_integration_self_test_int_SOURCES = test/integration/self-test.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/main.c
 
 test_integration_hierarchy_change_auth_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_hierarchy_change_auth_int_LDADD   = $(TESTS_LDADD)
 test_integration_hierarchy_change_auth_int_SOURCES = \
-    test/integration/hierarchy-change-auth.int.c \
-    test/integration/main.c log/log.h log/log.c
+    test/integration/hierarchy-change-auth.int.c test/integration/main.c
 
 test_integration_start_auth_session_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_start_auth_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_start_auth_session_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+test_integration_start_auth_session_int_SOURCES = test/integration/main.c \
     test/integration/start-auth-session.int.c
 
 test_integration_tpm_properties_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_tpm_properties_int_LDADD   = $(TESTS_LDADD)
-test_integration_tpm_properties_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+test_integration_tpm_properties_int_SOURCES = test/integration/main.c \
     test/integration/tpm-properties.int.c
 
 test_integration_system_api_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_system_api_int_LDADD   = $(TESTS_LDADD)
-test_integration_system_api_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+test_integration_system_api_int_SOURCES = test/integration/main.c \
     test/integration/system-api.int.c
 
 if ESAPI
@@ -375,7 +369,7 @@ test_integration_esys_get_random_int_CFLAGS  = $(AM_CFLAGS) \
 test_integration_esys_get_random_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_get_random_int_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
 test_integration_esys_get_random_int_SOURCES = test/integration/esys-get-random.int.c \
-	test/integration/main-esapi.c log/log.h log/log.c test/integration/test-esapi.h
+	test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_session_auth_int_CFLAGS  = $(AM_CFLAGS) \
     -I. -I$(srcdir)/esapi/esapi -I$(srcdir)/include/esapi \
@@ -383,7 +377,7 @@ test_integration_esys_create_session_auth_int_CFLAGS  = $(AM_CFLAGS) \
 test_integration_esys_create_session_auth_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_create_session_auth_int_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
 test_integration_esys_create_session_auth_int_SOURCES = test/integration/esys-create-session-auth.int.c \
-	test/integration/main-esapi.c log/log.h log/log.c test/integration/test-esapi.h
+	test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_primary_hmac_int_CFLAGS  = $(AM_CFLAGS) \
     -I. -I$(srcdir)/esapi/esapi -I$(srcdir)/include/esapi \
@@ -392,7 +386,7 @@ test_integration_esys_create_primary_hmac_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_create_primary_hmac_int_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
 test_integration_esys_create_primary_hmac_int_SOURCES = \
     test/integration/esys-create-primary-hmac.int.c test/integration/main-esapi.c \
-    log/log.h log/log.c test/integration/test-esapi.h
+    test/integration/test-esapi.h
 
 test_integration_esys_create_primary_ecc_hmac_int_CFLAGS  = $(AM_CFLAGS) -DTEST_ECC \
     -I. -I$(srcdir)/esapi/esapi -I$(srcdir)/include/esapi \
@@ -401,21 +395,21 @@ test_integration_esys_create_primary_ecc_hmac_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_create_primary_ecc_hmac_int_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
 test_integration_esys_create_primary_ecc_hmac_int_SOURCES = \
     test/integration/esys-create-primary-hmac.int.c test/integration/main-esapi.c \
-    log/log.h log/log.c test/integration/test-esapi.h
+    test/integration/test-esapi.h
 endif
 
 test_integration_policy_template_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_policy_template_int_LDADD   = $(TESTS_LDADD)
-test_integration_policy_template_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+test_integration_policy_template_int_SOURCES = test/integration/main.c \
     test/integration/policy-template.int.c
 
 test_integration_create_loaded_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_create_loaded_int_LDADD   = $(TESTS_LDADD)
-test_integration_create_loaded_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+test_integration_create_loaded_int_SOURCES = test/integration/main.c \
     test/integration/create-loaded.int.c
 
 TESTS_CFLAGS = $(LIBCRYPTO_CFLAGS)
-TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS)
+TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS) $(libutil)
 
 AUTHORS :
 	$(AM_V_GEN)git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \

--- a/Makefile.am
+++ b/Makefile.am
@@ -167,11 +167,10 @@ test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,-wrap=write
 test_unit_tcti_device_SOURCES = test/unit/tcti-device.c tcti/tcti_device.c log/log.h
 
 test_unit_tcti_socket_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS) $(URIPARSER_CFLAGS)
-test_unit_tcti_socket_LDADD   = $(CMOCKA_LIBS) $(libmarshal) $(URIPARSER_LIBS)
-test_unit_tcti_socket_LDFLAGS = -Wl,--wrap=connect,--wrap=recv,--wrap=select,--wrap=send
+test_unit_tcti_socket_LDADD   = $(CMOCKA_LIBS) $(libmarshal) $(URIPARSER_LIBS) $(libutil)
+test_unit_tcti_socket_LDFLAGS = -Wl,--wrap=connect,--wrap=recv,--wrap=select,--wrap=write
 test_unit_tcti_socket_SOURCES = tcti/platformcommand.c tcti/tcti_socket.c \
-    tcti/tcti.c tcti/tcti.h tcti/sockets.c tcti/sockets.h \
-     test/unit/tcti-socket.c log/log.h log/log.c
+    tcti/sockets.c tcti/sockets.h test/unit/tcti-socket.c
 
 test_unit_CommonPreparePrologue_CFLAGS = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
 test_unit_CommonPreparePrologue_LDFLAGS = -Wl,--unresolved-symbols=ignore-all

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 # stuff to build, what that stuff is, and where/if to install said stuff
 lib_LTLIBRARIES = $(libmarshal) $(libsapi) $(libtcti_device) $(libtcti_socket)
+noinst_LTLIBRARIES = $(libutil)
 
 if ESAPI
 lib_LTLIBRARIES += $(libesapi)
@@ -59,6 +60,7 @@ TESTS_UNIT  = \
     test/unit/GetNumHandles \
     test/unit/tcti-device \
     test/unit/tcti-socket \
+    test/unit/util \
     test/unit/UINT8-marshal \
     test/unit/UINT16-marshal \
     test/unit/UINT32-marshal \
@@ -71,7 +73,7 @@ TESTS_UNIT  = \
     test/unit/TPMU-marshal
 endif #UNIT
 if SIMULATOR_BIN
-noinst_LTLIBRARIES = test/integration/libtest_utils.la
+noinst_LTLIBRARIES += test/integration/libtest_utils.la
 TESTS_INTEGRATION = \
     test/integration/asymmetric-encrypt-decrypt.int \
     test/integration/create-primary-rsa-2048-aes-128-cfb.int \
@@ -154,11 +156,15 @@ EXTRA_DIST = \
     tcti/tcti_socket.map
 
 if UNIT
+test_unit_util_CFLAGS = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
+test_unit_util_LDADD = $(CMOCKA_LIBS) $(libutil)
+test_unit_util_LDFLAGS = -Wl,--wrap=write
+test_unit_util_SOURCES = test/unit/util.c
+
 test_unit_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
-test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libmarshal)
+test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libmarshal) $(libutil)
 test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,-wrap=write
-test_unit_tcti_device_SOURCES = tcti/tcti.c tcti/tcti.h tcti/tcti_device.c \
-    test/unit/tcti-device.c log/log.h log/log.c
+test_unit_tcti_device_SOURCES = test/unit/tcti-device.c tcti/tcti_device.c log/log.h
 
 test_unit_tcti_socket_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS) $(URIPARSER_CFLAGS)
 test_unit_tcti_socket_LDADD   = $(CMOCKA_LIBS) $(libmarshal) $(URIPARSER_LIBS)
@@ -222,6 +228,9 @@ test_unit_TPMU_marshal_LDADD   = $(CMOCKA_LIBS) $(libmarshal)
 test_unit_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c
 endif # UNIT
 
+libutil_la_CFLAGS = $(AM_CFLAGS)
+libutil_la_SOURCES = log/log.c log/log.h tcti/tcti.c tcti/tcti.h
+
 if HAVE_LD_VERSION_SCRIPT
 marshal_libmarshal_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/libmarshal.map
 endif # HAVE_LD_VERSION_SCRIPT
@@ -246,9 +255,8 @@ tcti_libtcti_device_la_CFLAGS   = $(AM_CFLAGS)
 if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_device.map
 endif # HAVE_LD_VERSION_SCRIPT
-tcti_libtcti_device_la_LIBADD   = $(libmarshal)
-tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c tcti/tcti.c \
-    tcti/tcti.h log/log.h log/log.c
+tcti_libtcti_device_la_LIBADD   = $(libmarshal) $(libutil)
+tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c log/log.h
 
 tcti_libtcti_socket_la_CFLAGS   = $(AM_CFLAGS) $(URIPARSER_CFLAGS)
 if HAVE_LD_VERSION_SCRIPT
@@ -433,6 +441,7 @@ libesapi = esapi/libesapi.la
 endif
 libtcti_device = tcti/libtcti-device.la
 libtcti_socket = tcti/libtcti-socket.la
+libutil = libutil.la
 libmarshal = marshal/libmarshal.la
 
 define make_parent_dir

--- a/include/tcti/common.h
+++ b/include/tcti/common.h
@@ -28,16 +28,10 @@
 #ifndef TCTI_COMMON_H
 #define TCTI_COMMON_H
 
-#include "sapi/tpm20.h"
-
 #if defined (__GNUC__)
 #define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
 #else
 #define COMPILER_ATTR(...)
 #endif
-
-typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
-typedef int (*TCTI_LOG_CALLBACK)( void *data, printf_type type, const char *format, ...);
-typedef int (*TCTI_LOG_BUFFER_CALLBACK)( void *useriData, printf_type type, UINT8 *buffer, UINT32 length);
 
 #endif /* TCTI_COMMON_H */

--- a/include/tcti/common.h
+++ b/include/tcti/common.h
@@ -1,30 +1,29 @@
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
-
+/*
+ * Copyright (c) 2016 - 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef TCTI_COMMON_H
 #define TCTI_COMMON_H
 

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -1,30 +1,29 @@
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
-
+/*
+ * Copyright (c) 2015 - 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef TCTI_DEVICE_H
 #define TCTI_DEVICE_H
 

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -43,9 +43,6 @@ extern "C" {
 
 #define TCTI_SOCKET_DEFAULT "tcp://127.0.0.1:2321"
 
-/* global data defined in the socket TCTI */
-extern int (*printfFunction)( printf_type type, const char *format, ...);
-
 TSS2_RC PlatformCommand(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     char cmd );

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -1,30 +1,29 @@
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
-
+/*
+ * Copyright (c) 2015 - 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef TCTI_SOCKET_H
 #define TCTI_SOCKET_H
 

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -43,16 +43,17 @@ TSS2_RC PlatformCommand(
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     int iResult = 0;            // used to return function results
-    char sendbuf[] = { 0x0,0x0,0x0,0x0 };
+    uint8_t sendbuf[] = { 0x0, 0x0, 0x0, 0x0 };
     char recvbuf[] = { 0x0, 0x0, 0x0, 0x0 };
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
     sendbuf[3] = cmd;
 
     // Send the command
-    iResult = send (tcti_intel->otherSock, sendbuf, 4, MSG_NOSIGNAL);
-    if (iResult == SOCKET_ERROR) {
-        LOG_ERROR("send failed with error: %d", WSAGetLastError() );
+    iResult = write_all (tcti_intel->otherSock, sendbuf, sizeof (sendbuf));
+    if (iResult < sizeof (sendbuf)) {
+        LOG_ERROR("Failed to send platform command %d with error: %d",
+                  cmd, iResult);
         rval = TSS2_TCTI_RC_IO_ERROR;
     }
     else

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -1,39 +1,32 @@
-//**********************************************************************;
-// Copyright (c) 2015, 2017 Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
-
-//
-// NOTE:  this file is only used when the TPM simulator is being used
-// as the TPM device.  It is used in two places:  application SAPI (to
-// communicate platform commands to the RM) and when RM needs
-// to send platform commands to the simulator.
-//
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <stdio.h>
-#include <stdlib.h>   // Needed for _wtoi
+#include <stdlib.h>
 
 #include "sapi/tpm20.h"
 #include "tcti/tcti_socket.h"

--- a/tcti/sockets.c
+++ b/tcti/sockets.c
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #include <unistd.h>
 #include <netinet/in.h>
 

--- a/tcti/sockets.c
+++ b/tcti/sockets.c
@@ -67,29 +67,6 @@ TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len )
     return TSS2_RC_SUCCESS;
 }
 
-TSS2_RC sendBytes( SOCKET tpmSock, const unsigned char *data, int len )
-{
-    int iResult = 0;
-    int sentLength = 0;
-
-    for( sentLength = 0; sentLength < len; )
-    {
-        iResult = send( tpmSock, (char *)data, len, MSG_NOSIGNAL );
-        if (iResult == SOCKET_ERROR)
-        {
-            if (wasInterrupted())
-                continue;
-            else
-                return TSS2_TCTI_RC_IO_ERROR;
-        }
-
-        len -= iResult;
-        sentLength += iResult;
-    }
-
-    return TSS2_RC_SUCCESS;
-}
-
 int
 InitSockets( const char *hostName,
              UINT16 port,

--- a/tcti/sockets.h
+++ b/tcti/sockets.h
@@ -34,7 +34,6 @@ InitSockets( const char *hostName,
              SOCKET *tpmSock);
 void CloseSockets( SOCKET serverSock, SOCKET tpmSock );
 TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len );
-TSS2_RC sendBytes( SOCKET tpmSock, const unsigned char *data, int len );
 
 #ifdef __cplusplus
 }

--- a/tcti/tcti.c
+++ b/tcti/tcti.c
@@ -1,5 +1,5 @@
-/***********************************************************************
- * Copyright (c) 2015 - 2017 Intel Corporation
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- ***********************************************************************/
+ */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -40,6 +40,8 @@
 #ifndef TSS2_TCTI_UTIL_H
 #define TSS2_TCTI_UTIL_H
 
+#include <errno.h>
+
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <sys/socket.h>
 #define SOCKET int
@@ -51,6 +53,13 @@
 #define TCTI_VERSION 0x1
 
 #define TCTI_CONTEXT ((TSS2_TCTI_CONTEXT_COMMON_CURRENT *)(SYS_CONTEXT->tctiContext))
+
+#define TEMP_RETRY(exp) \
+({  int __ret; \
+    do { \
+        __ret = exp; \
+    } while (__ret == -1 && errno == EINTR); \
+    __ret; })
 
 typedef TSS2_RC (*TCTI_TRANSMIT_PTR)( TSS2_TCTI_CONTEXT *tctiContext, size_t size, uint8_t *command);
 typedef TSS2_RC (*TCTI_RECEIVE_PTR) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size, uint8_t *response, int32_t timeout);

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -41,6 +41,7 @@
 #define TSS2_TCTI_UTIL_H
 
 #include <errno.h>
+#include <sapi/tpm20.h>
 
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <sys/socket.h>
@@ -138,5 +139,15 @@ TSS2_RC tcti_receive_checks (
     size_t            *response_size,
     unsigned char     *response_buffer
     );
+/*
+ * Write 'size' bytes from 'buf' to file descriptor 'fd'. Additionally this
+ * function will retry calls to the 'write' function when recoverable errors
+ * are detected. This is currently limited to interrupted system calls and
+ * short writes.
+ */
+ssize_t write_all (
+    int fd,
+    const uint8_t *buf,
+    size_t size);
 
 #endif

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -57,13 +57,16 @@ TSS2_RC LocalTpmSendTpmCommand(
     }
     LOGBLOB_DEBUG (command_buffer,
                    command_size,
-                   "sending " PRIx16 " byte command buffer:",
+                   "sending %zu byte command buffer:",
                    command_size);
     size = write (tcti_intel->devFile, command_buffer, command_size);
     if (size < 0) {
         LOG_ERROR("send failed with error: %d", errno);
         return TSS2_TCTI_RC_IO_ERROR;
     } else if ((size_t)size != command_size) {
+        LOG_ERROR ("wrong number of bytes written. Expected %zu, wrote %zd.",
+                   command_size,
+                   size);
         return TSS2_TCTI_RC_IO_ERROR;
     }
 

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -55,26 +55,10 @@ TSS2_RC LocalTpmSendTpmCommand(
     if (rval != TSS2_RC_SUCCESS) {
         return rval;
     }
-
-#if LOGLEVEL == LOGLEVEL_DEBUG || \
-    LOGLEVEL == LOGLEVEL_TRACE
-    TPM2_ST commandCode = 0xffff;
-    UINT32 cnt = 0xffffffff;
-    TSS2_RC rc;
-    size_t offset = sizeof (TPM2_ST);
-    rc = Tss2_MU_TPM2_ST_Unmarshal (command_buffer,
-                                   command_size,
-                                   &offset,
-                                   &commandCode);
-    if (rc) return rc;
-    rc = Tss2_MU_UINT32_Unmarshal (command_buffer,
-                                   command_size,
-                                   &offset,
-                                   &cnt);
-    if (rc) return rc;
-    LOGBLOB_DEBUG(command_buffer, cnt, "Cmd sent: %" PRIx16 "; Buffer:",
-        commandCode);
-#endif
+    LOGBLOB_DEBUG (command_buffer,
+                   command_size,
+                   "sending " PRIx16 " byte command buffer:",
+                   command_size);
     size = write (tcti_intel->devFile, command_buffer, command_size);
     if (size < 0) {
         LOG_ERROR("send failed with error: %d", errno);

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -59,9 +59,9 @@ TSS2_RC LocalTpmSendTpmCommand(
                    command_size,
                    "sending %zu byte command buffer:",
                    command_size);
-    size = TEMP_RETRY (write (tcti_intel->devFile,
-                              command_buffer,
-                              command_size));
+    size = write_all (tcti_intel->devFile,
+                      command_buffer,
+                      command_size);
     if (size < 0) {
         LOG_ERROR("send failed with error: %d", errno);
         return TSS2_TCTI_RC_IO_ERROR;

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -1,5 +1,5 @@
-/***********************************************************************
- * Copyright (c) 2015 - 2017 Intel Corporation
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- ***********************************************************************/
+ */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -59,7 +59,9 @@ TSS2_RC LocalTpmSendTpmCommand(
                    command_size,
                    "sending %zu byte command buffer:",
                    command_size);
-    size = write (tcti_intel->devFile, command_buffer, command_size);
+    size = TEMP_RETRY (write (tcti_intel->devFile,
+                              command_buffer,
+                              command_size));
     if (size < 0) {
         LOG_ERROR("send failed with error: %d", errno);
         return TSS2_TCTI_RC_IO_ERROR;
@@ -96,7 +98,9 @@ TSS2_RC LocalTpmReceiveTpmResponse(
     }
 
     if (tcti_intel->status.tagReceived == 0) {
-        size = read (tcti_intel->devFile, tcti_intel->responseBuffer, 4096);
+        size = TEMP_RETRY (read (tcti_intel->devFile,
+                                 tcti_intel->responseBuffer,
+                                 4096));
         if (size < 0) {
             LOG_ERROR("send failed with error: %d", errno);
             rval = TSS2_TCTI_RC_IO_ERROR;

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -1,5 +1,5 @@
-/***********************************************************************
- * Copyright (c) 2015 - 2017 Intel Corporation
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- **********************************************************************/
+ */
 
 #include <inttypes.h>
 #include <limits.h>

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -70,16 +70,15 @@ static TSS2_RC tctiSendBytes (
     int len
     )
 {
-    TSS2_RC ret = TSS2_RC_SUCCESS;
-
+    int ret;
     LOGBLOB_DEBUG(data, len, "Send Bytes to socket #0x%x:", sock);
 
-    ret = sendBytes (sock, data, len);
-    if (ret != TSS2_RC_SUCCESS) {
-        LOG_ERROR("In recvBytes, recv failed (socket: 0x%x) with error: %d",
-                  sock, WSAGetLastError ());
+    ret = write_all (sock, data, len);
+    if (ret < len) {
+        LOG_ERROR("Failed to write to fd %d: %d", sock, WSAGetLastError ());
+        return TSS2_TCTI_RC_IO_ERROR;
     }
-    return ret;
+    return TSS2_RC_SUCCESS;
 }
 
 TSS2_RC SendSessionEndSocketTcti (

--- a/test/unit/tcti-socket.c
+++ b/test/unit/tcti-socket.c
@@ -107,10 +107,9 @@ __wrap_select (int             nfds,
  * integer to return as a response.
  */
 ssize_t
-__wrap_send (int         sockfd,
-             const void *buf,
-             size_t      len,
-             int         flags)
+__wrap_write (int sockfd,
+              const void *buf,
+              size_t len)
 
 {
     return mock_type (TSS2_RC);
@@ -142,10 +141,10 @@ tcti_socket_init_from_conf (const char *conf)
      * two 'PlatformCommands are sent on initialization, 4 bytes sent for
      * each, 4 byte response received (all 0's) for each.
      */
-    will_return (__wrap_send, 4);
+    will_return (__wrap_write, 4);
     will_return (__wrap_recv, 4);
     will_return (__wrap_recv, recv_buf);
-    will_return (__wrap_send, 4);
+    will_return (__wrap_write, 4);
     will_return (__wrap_recv, 4);
     will_return (__wrap_recv, recv_buf);
     ret = Tss2_Tcti_Socket_Init (ctx, &tcti_size, conf);
@@ -212,7 +211,7 @@ tcti_socket_receive_success_test (void **state)
     will_return (__wrap_recv, 4);
     will_return (__wrap_recv, &response_in [12]);
     /* platform command sends 4 bytes and receives the same */
-    will_return (__wrap_send, 4);
+    will_return (__wrap_write, 4);
     will_return (__wrap_recv, 4);
     will_return (__wrap_recv, platform_command_recv);
 
@@ -235,13 +234,13 @@ tcti_socket_transmit_success_test (void **state)
     size_t  command_size = sizeof (command);
 
     /* send the TPM2_SEND_COMMAND code */
-    will_return (__wrap_send, 4);
+    will_return (__wrap_write, 4);
     /* send the locality for the command */
-    will_return (__wrap_send, 1);
+    will_return (__wrap_write, 1);
     /* send the number of bytes in command */
-    will_return (__wrap_send, 4);
+    will_return (__wrap_write, 4);
     /* send the command buffer */
-    will_return (__wrap_send, 0xc);
+    will_return (__wrap_write, 0xc);
     rc = Tss2_Tcti_Transmit (ctx, command_size, command);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }

--- a/test/unit/util.c
+++ b/test/unit/util.c
@@ -1,0 +1,44 @@
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tcti/tcti.h"
+#define LOGMODULE unit_util
+#include "log/log.h"
+
+ssize_t
+__wrap_write (int fd, const void *buffer, size_t buffer_size)
+{
+    LOG_DEBUG ("writing %zd bytes from 0x%" PRIxPTR " to fd: %d",
+               buffer_size, (uintptr_t)buffer, fd);
+    return mock_type (ssize_t);
+}
+
+/*
+ * A test case for a successful call to the receive function. This requires
+ * that the context and the command buffer be valid (including the size
+ * field being set appropriately). The result should be an RC indicating
+ * success and the size parameter be updated to reflect the size of the
+ * data received.
+ */
+static void
+util_write_all_simple_success_test (void **state)
+{
+    ssize_t ret;
+    uint8_t buf [10];
+
+    will_return (__wrap_write, sizeof (buf));
+    ret = write_all (99, buf, sizeof (buf));
+    assert_int_equal(ret, sizeof (buf));
+}
+int
+main(int argc, char* argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (util_write_all_simple_success_test),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
This is the "low hanging fruit" in the TCTI modules. Most of this is re-organizing some of the build bits. The rest implements a common write function shared between the device and socket TCTIs. This is easier than messing with the read path since it's not an async call. The build structure introduced here will make writing and testing the async read stuff easier though.