### PR TITLE
build: Distribute the source for the InitSocketTcti man page.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,7 @@ EXTRA_DIST = \
     lib/sapi.pc.in \
     man/man-postlude.troff \
     man/InitDeviceTcti.3.in \
-    man/man3/InitSocketTcti.3 \
+    man/InitSocketTcti.3.in \
     man/tcti-device.7.in \
     man/tcti-socket.7.in \
     $(INT_LOG_COMPILER) \


### PR DESCRIPTION
Before this patch we were shipping the man page after our build
transforms. This means running one of the clean targets will put the
source tree in a state where the build will fail since the source files
for the man page get 'cleaned'.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>