### PR TITLE
Spec cleanup

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -76,14 +76,14 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 
 /* Macros to simplify invocation of functions from the common TCTI structure */
 #define Tss2_Tcti_Transmit(tctiContext, size, command) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
 #define Tss2_Tcti_Receive(tctiContext, size, response, timeout) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
@@ -99,21 +99,21 @@ typedef void TSS2_TCTI_POLL_HANDLE;
         } \
     } while (0)
 #define Tss2_Tcti_Cancel(tctiContext) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_CANCEL(tctiContext)(tctiContext))
 #define Tss2_Tcti_GetPollHandles(tctiContext, handles, num_handles) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, handles, num_handles))
 #define Tss2_Tcti_SetLocality(tctiContext, locality) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -120,16 +120,6 @@ typedef void TSS2_TCTI_POLL_HANDLE;
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, locality))
 
-/* The following defines are kept for compatibility reasons.
- * They are however deprecated.
- * TODO: Must be removed before release */
-#define tss2_tcti_transmit Tss2_Tcti_Transmit
-#define tss2_tcti_receive Tss2_Tcti_Receive
-#define tss2_tcti_finalize Tss2_Tcti_Finalize
-#define tss2_tcti_cancel Tss2_Tcti_Cancel
-#define tss2_tcti_get_poll_handles Tss2_Tcti_GetPollHandles
-#define tss2_tcti_set_locality Tss2_Tcti_SetLocality
-
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 
 /* superclass to get the version */

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -1,46 +1,34 @@
-//**********************************************************************;
-// Copyright (c) 2015 - 2017, Intel Corporation
-//
-// Copyright 2015, Andreas Fuchs @ Fraunhofer SIT
-//
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
-
-//
-// The context for TCTI implementations is on opaque
-// structure. There shall never be a definition of its content.
-// Implementation provide the size information to
-// applications via the initialize call.
-// This makes use of a compiler trick that allows type
-// checking of the pointer even though the type isn't
-// defined.
-//
-// The first field of a Context must be the common part
-// (see below).
-#ifndef TSS2_TCTI
-#define TSS2_TCTI
+/*
+ * Copyright (c) 2015 - 2018, Intel Corporation
+ *
+ * Copyright 2015, Andreas Fuchs @ Fraunhofer SIT
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TSS2_TCTI_H
+#define TSS2_TCTI_H
 
 #ifndef TSS2_API_VERSION_1_1_1_1
 #error Version mismatch among TSS2 header files. \
@@ -62,14 +50,16 @@ typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 typedef HANDLE TSS2_TCTI_POLL_HANDLE;
 #else
 typedef void TSS2_TCTI_POLL_HANDLE;
-#error Info: Platform not supported for TCTI_POLL_HANDLES
+#ifndef TSS2_TCTI_SUPPRESS_POLL_WARNINGS
+#pragma message "Info: Platform not supported for TCTI_POLL_HANDLES"
+#endif
 #endif
 
-// The following are used to configure timeout characteristics.
+/* The following are used to configure timeout characteristics. */
 #define  TSS2_TCTI_TIMEOUT_BLOCK    -1
 #define  TSS2_TCTI_TIMEOUT_NONE     0
 
-// Macros to simplify access to values in common TCTI structure
+/* Macros to simplify access to values in common TCTI structure */
 #define TSS2_TCTI_MAGIC(tctiContext) \
     ((TSS2_TCTI_CONTEXT_VERSION*)tctiContext)->magic
 #define TSS2_TCTI_VERSION(tctiContext) \
@@ -87,7 +77,7 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 #define TSS2_TCTI_SET_LOCALITY(tctiContext) \
     ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->setLocality
 
-// Macros to simplify invocation of functions from the common TCTI structure
+/* Macros to simplify invocation of functions from the common TCTI structure */
 #define Tss2_Tcti_Transmit(tctiContext, size, command) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -30,17 +30,14 @@
 #ifndef TSS2_TCTI_H
 #define TSS2_TCTI_H
 
-#ifndef TSS2_API_VERSION_1_1_1_1
-#error Version mismatch among TSS2 header files. \
-       Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "tss2_common.h"
+#include <stdint.h>
 #include <stddef.h>
+#include "tss2_common.h"
+#include "tss2_tpm2_types.h"
 
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <poll.h>

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -122,6 +122,31 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 
+/*
+ * Types for TCTI functions. These are used for pointers to functions in the
+ * TCTI context structure.
+ */
+typedef TSS2_RC (*TSS2_TCTI_TRANSMIT_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t size,
+    uint8_t const *command);
+typedef TSS2_RC (*TSS2_TCTI_RECEIVE_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    uint8_t *response,
+    int32_t timeout);
+typedef void (*TSS2_TCTI_FINALIZE_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext);
+typedef TSS2_RC (*TSS2_TCTI_CANCEL_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext);
+typedef TSS2_RC (*TSS2_TCTI_GET_POLL_HANDLES_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles);
+typedef TSS2_RC (*TSS2_TCTI_SET_LOCALITY_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality);
+
 /* superclass to get the version */
 typedef struct {
     uint64_t magic;
@@ -132,16 +157,12 @@ typedef struct {
 typedef struct {
     uint64_t magic;
     uint32_t version;
-    TSS2_RC (*transmit) (TSS2_TCTI_CONTEXT *tctiContext,
-                         size_t size,
-                         const uint8_t *command);
-    TSS2_RC (*receive) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
-uint8_t *response, int32_t timeout);
-    void (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
-    TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
-    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,
-TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
-    TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
+    TSS2_TCTI_TRANSMIT_FCN transmit;
+    TSS2_TCTI_RECEIVE_FCN receive;
+    TSS2_TCTI_FINALIZE_FCN finalize;
+    TSS2_TCTI_CANCEL_FCN cancel;
+    TSS2_TCTI_GET_POLL_HANDLES_FCN getPollHandles;
+    TSS2_TCTI_SET_LOCALITY_FCN setLocality;
 } TSS2_TCTI_CONTEXT_COMMON_V1;
 
 typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -83,7 +83,7 @@ TSS2_RC LocalTpmSendTpmCommand(
 TSS2_RC LocalTpmReceiveTpmResponse(
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t *response_size,
-    unsigned char *response_buffer,
+    uint8_t *response_buffer,
     int32_t timeout
     )
 {


### PR DESCRIPTION
This brings our implementation of the 'v1' TCTI context structure up to speed with the current spec. We also add some of the new convenience macros / types from the new draft spec. Next will be an update to the v2 structure in the current draft.