### PR TITLE
Add sanity checks to int-log-compiler.sh. Fixes #764

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,16 +11,20 @@ following sections describe them for the supported platforms.
 * GNU Automake
 * GNU Libtool
 * C compiler
-* C Library Development Libraries and Header Files
+* C Library development libraries and header files
 * pkg-config
-* uriparser
-* libgcrypt
+* uriparser development libraries and header files
+* libgcrypt development libraries and header files
 
 The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --with-simulatorbin):
-** OpenSSL
+
+   OpenSSL libraries and header files
+
 * Unit test suite (see ./configure option --enable-unit):
-** cmocka unit test framework
+
+   cmocka unit test framework
+
 Most users will not need to install these dependencies.
 
 ### Ubuntu


### PR DESCRIPTION
This addresses comments and issues from a previous pull request, #775 
https://github.com/tpm2-software/tpm2-tss/pull/775/

Tested with "make check-TESTS".
Negative tested by removing PID file and also killing TPM simulator process.
Minor corrections in INSTALL.md file.
Fixes #764.