### PR TITLE
sapi: change version to the latest defined by spec

### DIFF
--- a/esapi/esapi/Esys_ActivateCredential.c
+++ b/esapi/esapi/Esys_ActivateCredential.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Certify.c
+++ b/esapi/esapi/Esys_Certify.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_CertifyCreation.c
+++ b/esapi/esapi/Esys_CertifyCreation.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ChangeEPS.c
+++ b/esapi/esapi/Esys_ChangeEPS.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ChangePPS.c
+++ b/esapi/esapi/Esys_ChangePPS.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Clear.c
+++ b/esapi/esapi/Esys_Clear.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ClearControl.c
+++ b/esapi/esapi/Esys_ClearControl.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ClockRateAdjust.c
+++ b/esapi/esapi/Esys_ClockRateAdjust.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ClockSet.c
+++ b/esapi/esapi/Esys_ClockSet.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Commit.c
+++ b/esapi/esapi/Esys_Commit.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ContextLoad.c
+++ b/esapi/esapi/Esys_ContextLoad.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ContextSave.c
+++ b/esapi/esapi/Esys_ContextSave.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Create.c
+++ b/esapi/esapi/Esys_Create.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_CreatePrimary.c
+++ b/esapi/esapi/Esys_CreatePrimary.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_DictionaryAttackLockReset.c
+++ b/esapi/esapi/Esys_DictionaryAttackLockReset.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_DictionaryAttackParameters.c
+++ b/esapi/esapi/Esys_DictionaryAttackParameters.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Duplicate.c
+++ b/esapi/esapi/Esys_Duplicate.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ECC_Parameters.c
+++ b/esapi/esapi/Esys_ECC_Parameters.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ECDH_KeyGen.c
+++ b/esapi/esapi/Esys_ECDH_KeyGen.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ECDH_ZGen.c
+++ b/esapi/esapi/Esys_ECDH_ZGen.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_EC_Ephemeral.c
+++ b/esapi/esapi/Esys_EC_Ephemeral.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_EncryptDecrypt.c
+++ b/esapi/esapi/Esys_EncryptDecrypt.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_EventSequenceComplete.c
+++ b/esapi/esapi/Esys_EventSequenceComplete.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_EvictControl.c
+++ b/esapi/esapi/Esys_EvictControl.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_FlushContext.c
+++ b/esapi/esapi/Esys_FlushContext.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetCapability.c
+++ b/esapi/esapi/Esys_GetCapability.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetCommandAuditDigest.c
+++ b/esapi/esapi/Esys_GetCommandAuditDigest.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetRandom.c
+++ b/esapi/esapi/Esys_GetRandom.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetSessionAuditDigest.c
+++ b/esapi/esapi/Esys_GetSessionAuditDigest.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetTestResult.c
+++ b/esapi/esapi/Esys_GetTestResult.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_GetTime.c
+++ b/esapi/esapi/Esys_GetTime.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_HMAC.c
+++ b/esapi/esapi/Esys_HMAC.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_HMAC_Start.c
+++ b/esapi/esapi/Esys_HMAC_Start.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Hash.c
+++ b/esapi/esapi/Esys_Hash.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_HashSequenceStart.c
+++ b/esapi/esapi/Esys_HashSequenceStart.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_HierarchyChangeAuth.c
+++ b/esapi/esapi/Esys_HierarchyChangeAuth.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_HierarchyControl.c
+++ b/esapi/esapi/Esys_HierarchyControl.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Import.c
+++ b/esapi/esapi/Esys_Import.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_IncrementalSelfTest.c
+++ b/esapi/esapi/Esys_IncrementalSelfTest.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Load.c
+++ b/esapi/esapi/Esys_Load.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_LoadExternal.c
+++ b/esapi/esapi/Esys_LoadExternal.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_MakeCredential.c
+++ b/esapi/esapi/Esys_MakeCredential.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_Certify.c
+++ b/esapi/esapi/Esys_NV_Certify.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_ChangeAuth.c
+++ b/esapi/esapi/Esys_NV_ChangeAuth.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_DefineSpace.c
+++ b/esapi/esapi/Esys_NV_DefineSpace.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_Extend.c
+++ b/esapi/esapi/Esys_NV_Extend.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_GlobalWriteLock.c
+++ b/esapi/esapi/Esys_NV_GlobalWriteLock.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_Increment.c
+++ b/esapi/esapi/Esys_NV_Increment.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_Read.c
+++ b/esapi/esapi/Esys_NV_Read.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_ReadLock.c
+++ b/esapi/esapi/Esys_NV_ReadLock.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_ReadPublic.c
+++ b/esapi/esapi/Esys_NV_ReadPublic.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_SetBits.c
+++ b/esapi/esapi/Esys_NV_SetBits.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_UndefineSpace.c
+++ b/esapi/esapi/Esys_NV_UndefineSpace.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_UndefineSpaceSpecial.c
+++ b/esapi/esapi/Esys_NV_UndefineSpaceSpecial.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_Write.c
+++ b/esapi/esapi/Esys_NV_Write.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_NV_WriteLock.c
+++ b/esapi/esapi/Esys_NV_WriteLock.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ObjectChangeAuth.c
+++ b/esapi/esapi/Esys_ObjectChangeAuth.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_Allocate.c
+++ b/esapi/esapi/Esys_PCR_Allocate.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_Event.c
+++ b/esapi/esapi/Esys_PCR_Event.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_Extend.c
+++ b/esapi/esapi/Esys_PCR_Extend.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_Read.c
+++ b/esapi/esapi/Esys_PCR_Read.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_Reset.c
+++ b/esapi/esapi/Esys_PCR_Reset.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_SetAuthPolicy.c
+++ b/esapi/esapi/Esys_PCR_SetAuthPolicy.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PCR_SetAuthValue.c
+++ b/esapi/esapi/Esys_PCR_SetAuthValue.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PP_Commands.c
+++ b/esapi/esapi/Esys_PP_Commands.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyAuthValue.c
+++ b/esapi/esapi/Esys_PolicyAuthValue.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyAuthorize.c
+++ b/esapi/esapi/Esys_PolicyAuthorize.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyCommandCode.c
+++ b/esapi/esapi/Esys_PolicyCommandCode.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyCounterTimer.c
+++ b/esapi/esapi/Esys_PolicyCounterTimer.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyCpHash.c
+++ b/esapi/esapi/Esys_PolicyCpHash.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyDuplicationSelect.c
+++ b/esapi/esapi/Esys_PolicyDuplicationSelect.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyGetDigest.c
+++ b/esapi/esapi/Esys_PolicyGetDigest.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyLocality.c
+++ b/esapi/esapi/Esys_PolicyLocality.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyNV.c
+++ b/esapi/esapi/Esys_PolicyNV.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyNameHash.c
+++ b/esapi/esapi/Esys_PolicyNameHash.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyNvWritten.c
+++ b/esapi/esapi/Esys_PolicyNvWritten.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyOR.c
+++ b/esapi/esapi/Esys_PolicyOR.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyPCR.c
+++ b/esapi/esapi/Esys_PolicyPCR.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyPassword.c
+++ b/esapi/esapi/Esys_PolicyPassword.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyPhysicalPresence.c
+++ b/esapi/esapi/Esys_PolicyPhysicalPresence.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyRestart.c
+++ b/esapi/esapi/Esys_PolicyRestart.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicySecret.c
+++ b/esapi/esapi/Esys_PolicySecret.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicySigned.c
+++ b/esapi/esapi/Esys_PolicySigned.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_PolicyTicket.c
+++ b/esapi/esapi/Esys_PolicyTicket.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Quote.c
+++ b/esapi/esapi/Esys_Quote.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_RSA_Decrypt.c
+++ b/esapi/esapi/Esys_RSA_Decrypt.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_RSA_Encrypt.c
+++ b/esapi/esapi/Esys_RSA_Encrypt.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ReadClock.c
+++ b/esapi/esapi/Esys_ReadClock.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ReadPublic.c
+++ b/esapi/esapi/Esys_ReadPublic.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Rewrap.c
+++ b/esapi/esapi/Esys_Rewrap.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SelfTest.c
+++ b/esapi/esapi/Esys_SelfTest.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SequenceComplete.c
+++ b/esapi/esapi/Esys_SequenceComplete.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SequenceUpdate.c
+++ b/esapi/esapi/Esys_SequenceUpdate.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SetAlgorithmSet.c
+++ b/esapi/esapi/Esys_SetAlgorithmSet.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SetCommandCodeAuditStatus.c
+++ b/esapi/esapi/Esys_SetCommandCodeAuditStatus.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_SetPrimaryPolicy.c
+++ b/esapi/esapi/Esys_SetPrimaryPolicy.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Shutdown.c
+++ b/esapi/esapi/Esys_Shutdown.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Sign.c
+++ b/esapi/esapi/Esys_Sign.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_StartAuthSession.c
+++ b/esapi/esapi/Esys_StartAuthSession.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Startup.c
+++ b/esapi/esapi/Esys_Startup.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_StirRandom.c
+++ b/esapi/esapi/Esys_StirRandom.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_TestParms.c
+++ b/esapi/esapi/Esys_TestParms.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Unseal.c
+++ b/esapi/esapi/Esys_Unseal.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_Vendor_TCG_Test.c
+++ b/esapi/esapi/Esys_Vendor_TCG_Test.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_VerifySignature.c
+++ b/esapi/esapi/Esys_VerifySignature.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/Esys_ZGen_2Phase.c
+++ b/esapi/esapi/Esys_ZGen_2Phase.c
@@ -26,9 +26,9 @@
  ******************************************************************************/
 
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 #include "esys_types.h"
 #include <esapi/tss2_esys.h>
 #include "esys_iutil.h"

--- a/esapi/esapi/esys_context.c
+++ b/esapi/esapi/esys_context.c
@@ -25,9 +25,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif                          /* TSS2_API_VERSION_1_1_1_1 */
+#endif                          /* TSS2_API_VERSION_1_2_1_108 */
 #include <sapi/tss2_sys.h>
 #include <sysapi_util.h>
 #include <tss2_esys.h>

--- a/esapi/esapi/esys_tr.c
+++ b/esapi/esapi/esys_tr.c
@@ -25,9 +25,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif                          /* TSS2_API_VERSION_1_1_1_1 */
+#endif                          /* TSS2_API_VERSION_1_2_1_108 */
 #include <sapi/tss2_sys.h>
 #include <sapi/tss2_sys.h>
 #include <sysapi_util.h>

--- a/esapi/esapi_util/esys_crypto.c
+++ b/esapi/esapi_util/esys_crypto.c
@@ -25,9 +25,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 #include <sapi/tpm20.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif                          /* TSS2_API_VERSION_1_1_1_1 */
+#endif                          /* TSS2_API_VERSION_1_2_1_108 */
 
 #include <sapi/tss2_sys.h>
 #include <sysapi_util.h>

--- a/esapi/esapi_util/esys_crypto.h
+++ b/esapi/esapi_util/esys_crypto.h
@@ -28,9 +28,9 @@
 #define ESYS_CRYPTO_H
 
 #include <sapi/tss2_common.h>
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
+#endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 #include <stdint.h>
 #include <stddef.h>

--- a/esapi/esapi_util/esys_mu.c
+++ b/esapi/esapi_util/esys_mu.c
@@ -32,9 +32,9 @@
 #endif
 
 #include "sapi/tpm20.h"
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version missmatch among TSS2 header files !
-#endif /* TSS2_API_VERSION_1_1_1_1 */
+#endif /* TSS2_API_VERSION_1_2_1_108 */
 
 #include <sysapi_util.h>
 #include <sapi/tss2_mu.h>

--- a/include/sapi/sys_api_part3.h
+++ b/include/sapi/sys_api_part3.h
@@ -28,10 +28,10 @@
 #ifndef TSS2_SYS_API_PART3_H
 #define TSS2_SYS_API_PART3_H
 
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version mismatch among TSS2 header files. \
        Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
+#endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 typedef struct {
 	TPM2_ST tag;

--- a/include/sapi/tpm20.h
+++ b/include/sapi/tpm20.h
@@ -1,36 +1,35 @@
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
+/***********************************************************************;
+ * Copyright (c) 2015-2018, Intel Corporation
+ *
+ * Copyright 2015, Andreas Fuchs @ Fraunhofer SIT
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ ***********************************************************************/
 
 #ifndef     TPM20_H
 #define     TPM20_H
-
-/* TSS2_VERSION_<CREATOR>_<FAMILY>_<LEVEL>_<REVISION> */
-#define TSS2_API_VERSION_1_1_1_1
-
 #include    <stddef.h>
 #include    <stdint.h>
 #include    <stdlib.h>
@@ -39,9 +38,7 @@
 #include    "sapi/tss2_common.h"
 #include    "sapi/tpmb.h"
 #include    "sapi/tss2_tpm2_types.h"
-
 #include    "sapi/tss2_tcti.h"
 #include    "sapi/tss2_sys.h"
 #include    "sapi/tss2_mu.h"
-
 #endif

--- a/include/sapi/tpmb.h
+++ b/include/sapi/tpmb.h
@@ -28,10 +28,10 @@
 #ifndef _TPMB_H
 #define _TPMB_H
 
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version mismatch among TSS2 header files. \
        Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
+#endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 typedef struct {
     UINT16  size;

--- a/include/sapi/tss2_common.h
+++ b/include/sapi/tss2_common.h
@@ -1,5 +1,5 @@
 /***********************************************************************;
- * Copyright (c) 2015, Intel Corporation
+ * Copyright (c) 2015-2018, Intel Corporation
  *
  * Copyright 2015, Andreas Fuchs @ Fraunhofer SIT
  *
@@ -30,132 +30,104 @@
 
 #ifndef TSS2_COMMON_H
 #define TSS2_COMMON_H
+#define TSS2_API_VERSION_1_2_1_108
 
-#ifndef TSS2_API_VERSION_1_1_1_1
-#error Version mismatch among TSS2 header files. \
-       Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
-
-/**
+#include <stdint.h>
+/*
  * Type definitions
  */
-#include <stdint.h>
+typedef uint8_t     UINT8;
+typedef uint8_t     BYTE;
+typedef int8_t      INT8;
+typedef int         BOOL;
+typedef uint16_t    UINT16;
+typedef int16_t     INT16;
+typedef uint32_t    UINT32;
+typedef int32_t     INT32;
+typedef uint64_t    UINT64;
+typedef int64_t     INT64;
 
-typedef uint8_t     UINT8;      /* unsigned, 8-bit integer */
-typedef uint8_t     BYTE;       /* unsigned 8-bit integer */
-typedef int8_t      INT8;       /* signed, 8-bit integer */
-typedef int         BOOL;       /* a bit in an int  */
-typedef uint16_t    UINT16;     /* unsigned, 16-bit integer */
-typedef int16_t     INT16;      /* signed, 16-bit integer */
-typedef uint32_t    UINT32;     /* unsigned, 32-bit integer */
-typedef int32_t     INT32;      /* signed, 32-bit integer */
-typedef uint64_t    UINT64;     /* unsigned, 64-bit integer */
-typedef int64_t     INT64;      /* signed, 64-bit integer */
-
-typedef UINT32 TSS2_RC;
-
-
-/**
- * ABI runetime negotiation structure.
+/*
+ * ABI runtime negotiation definitions
  */
 typedef struct {
-    UINT32 tssCreator;  /* If == 1, this equals TSSWG-Interop
-                   If == 2..9, this is reserved
-                   If > TCG_VENDOR_ID_FIRST, this equals Vendor-ID */
-    UINT32 tssFamily;   /* Free-to-use for creator > TCG_VENDOR_FIRST */
-    UINT32 tssLevel;    /* Free-to-use for creator > TCG_VENDOR_FIRST */
-    UINT32 tssVersion;      /* Free-to-use for creator > TCG_VENDOR_FIRST */
+    uint32_t tssCreator;
+    uint32_t tssFamily;
+    uint32_t tssLevel;
+    uint32_t tssVersion;
 } TSS2_ABI_VERSION;
 
+#define TSS2_ABI_VERSION_CURRENT {1, 2, 1, 108}
 
-/**
- * Error Levels
- *
- *
+/*
+ * Return Codes
  */
+/* The return type for all TSS2 functions */
+typedef uint32_t TSS2_RC;
 
-// This macro is used to indicate the level of the error:  use 5 and 6th
-// nibble for error level.
+/* For return values other than SUCCESS, the second most significant
+ * byte of the return value is a layer code indicating the software
+ * layer that generated the error.
+ */
+#define TSS2_RC_LAYER_SHIFT      (16)
+#define TSS2_RC_LAYER(level)     ((TSS2_RC)level << TSS2_RC_LAYER_SHIFT)
+#define TSS2_RC_LAYER_MASK       TSS2_RC_LAYER(0xff)
 
-#define TSS2_RC_LAYER_SHIFT   16
-
-#define TSS2_RC_LAYER( level )     ( level << TSS2_RC_LAYER_SHIFT )
-
-
-//
-// Error code levels.   These indicate what level in the software stack
-// the error codes are coming from.
-//
+/* These layer codes are reserved for software layers defined in the TCG
+ * specifications.
+ */
 #define TSS2_TPM_RC_LAYER             TSS2_RC_LAYER(0)
 #define TSS2_FEATURE_RC_LAYER         TSS2_RC_LAYER(6)
 #define TSS2_ESAPI_RC_LAYER           TSS2_RC_LAYER(7)
 #define TSS2_SYS_RC_LAYER             TSS2_RC_LAYER(8)
 #define TSS2_MU_RC_LAYER              TSS2_RC_LAYER(9)
 #define TSS2_TCTI_RC_LAYER            TSS2_RC_LAYER(10)
-#define TSS2_RESMGRTPM_RC_LAYER       TSS2_RC_LAYER(11)
-#define TSS2_RESMGR_RC_LAYER          TSS2_RC_LAYER(12)
+#define TSS2_RESMGR_RC_LAYER          TSS2_RC_LAYER(11)
+#define TSS2_RESMGR_TPM_RC_LAYER      TSS2_RC_LAYER(12)
 #define TSS2_DRIVER_RC_LAYER          TSS2_RC_LAYER(13)
 
-#define TSS2_RC_LAYER_MASK            TSS2_RC_LAYER(0xff)
-
-/**
- * Error Codes
+/* Base return codes.
+ * These base codes indicate the error that occurred. They are
+ * logical-ORed with a layer code to produce the TSS2 return value.
  */
-
-//
-// Base error codes
-// These are not returned directly, but are combined with an RC_LAYER to
-// produce the error codes for each layer.
-//
-#define TSS2_BASE_RC_GENERAL_FAILURE        1 /* Catch all for all errors
-                                                 not otherwise specifed */
-#define TSS2_BASE_RC_NOT_IMPLEMENTED        2 /* If called functionality isn't implemented */
-#define TSS2_BASE_RC_BAD_CONTEXT            3 /* A context structure is bad */
-#define TSS2_BASE_RC_ABI_MISMATCH           4 /* Passed in ABI version doesn't match
-                                                 called module's ABI version */
-#define TSS2_BASE_RC_BAD_REFERENCE          5 /* A pointer is NULL that isn't allowed to
-                                                 be NULL. */
-#define TSS2_BASE_RC_INSUFFICIENT_BUFFER    6 /* A buffer isn't large enough */
-#define TSS2_BASE_RC_BAD_SEQUENCE           7 /* Function called in the wrong order */
-#define TSS2_BASE_RC_NO_CONNECTION          8 /* Fails to connect to next lower layer */
-#define TSS2_BASE_RC_TRY_AGAIN              9 /* Operation timed out; function must be
-                                                 called again to be completed */
-#define TSS2_BASE_RC_IO_ERROR              10 /* IO failure */
-#define TSS2_BASE_RC_BAD_VALUE             11 /* A parameter has a bad value */
-#define TSS2_BASE_RC_NOT_PERMITTED         12 /* Operation not permitted. */
-#define TSS2_BASE_RC_INVALID_SESSIONS      13 /* Session structures were sent, but */
-                                              /* command doesn't use them or doesn't use
-                                                 the specifed number of them */
-#define TSS2_BASE_RC_NO_DECRYPT_PARAM      14 /* If function called that uses decrypt
-                                                 parameter, but command doesn't support
-                                                 crypt parameter. */
-#define TSS2_BASE_RC_NO_ENCRYPT_PARAM      15 /* If function called that uses encrypt
-                                                 parameter, but command doesn't support
-                                                 encrypt parameter. */
-#define TSS2_BASE_RC_BAD_SIZE              16 /* If size of a parameter is incorrect */
-#define TSS2_BASE_RC_MALFORMED_RESPONSE    17 /* Response is malformed */
-#define TSS2_BASE_RC_INSUFFICIENT_CONTEXT  18 /* Context not large enough */
-#define TSS2_BASE_RC_INSUFFICIENT_RESPONSE 19 /* Response is not long enough */
-#define TSS2_BASE_RC_INCOMPATIBLE_TCTI     20 /* Unknown or unusable TCTI version */
-#define TSS2_BASE_RC_NOT_SUPPORTED         21 /* Functionality not supported. */
-#define TSS2_BASE_RC_BAD_TCTI_STRUCTURE    22 /* TCTI context is bad. */
-#define TSS2_BASE_RC_MEMORY                23U /* memory allocation failed */
-#define TSS2_BASE_RC_BAD_TR                24U /* invalid ESYS_TR handle */
+#define TSS2_BASE_RC_GENERAL_FAILURE            1U /* Catch all for all errors not otherwise specifed */
+#define TSS2_BASE_RC_NOT_IMPLEMENTED            2U /* If called functionality isn't implemented */
+#define TSS2_BASE_RC_BAD_CONTEXT                3U /* A context structure is bad */
+#define TSS2_BASE_RC_ABI_MISMATCH               4U /* Passed in ABI version doesn't match called module's ABI version */
+#define TSS2_BASE_RC_BAD_REFERENCE              5U /* A pointer is NULL that isn't allowed to be NULL. */
+#define TSS2_BASE_RC_INSUFFICIENT_BUFFER        6U /* A buffer isn't large enough */
+#define TSS2_BASE_RC_BAD_SEQUENCE               7U /* Function called in the wrong order */
+#define TSS2_BASE_RC_NO_CONNECTION              8U /* Fails to connect to next lower layer */
+#define TSS2_BASE_RC_TRY_AGAIN                  9U /* Operation timed out; function must be called again to be completed */
+#define TSS2_BASE_RC_IO_ERROR                  10U /* IO failure */
+#define TSS2_BASE_RC_BAD_VALUE                 11U /* A parameter has a bad value */
+#define TSS2_BASE_RC_NOT_PERMITTED             12U /* Operation not permitted. */
+#define TSS2_BASE_RC_INVALID_SESSIONS          13U /* Session structures were sent, but command doesn't use them or doesn't use the specifed number of them */
+#define TSS2_BASE_RC_NO_DECRYPT_PARAM          14U /* If function called that uses decrypt parameter, but command doesn't support crypt parameter. */
+#define TSS2_BASE_RC_NO_ENCRYPT_PARAM          15U /* If function called that uses encrypt parameter, but command doesn't support encrypt parameter. */
+#define TSS2_BASE_RC_BAD_SIZE                  16U /* If size of a parameter is incorrect */
+#define TSS2_BASE_RC_MALFORMED_RESPONSE        17U /* Response is malformed */
+#define TSS2_BASE_RC_INSUFFICIENT_CONTEXT      18U /* Context not large enough */
+#define TSS2_BASE_RC_INSUFFICIENT_RESPONSE     19U /* Response is not long enough */
+#define TSS2_BASE_RC_INCOMPATIBLE_TCTI         20U /* Unknown or unusable TCTI version */
+#define TSS2_BASE_RC_NOT_SUPPORTED             21U /* Functionality not supported. */
+#define TSS2_BASE_RC_BAD_TCTI_STRUCTURE        22U /* TCTI context is bad. */
+#define TSS2_BASE_RC_MEMORY                    23U /* memory allocation failed */
+#define TSS2_BASE_RC_BAD_TR                    24U /* invalid ESYS_TR handle */
 #define TSS2_BASE_RC_MULTIPLE_DECRYPT_SESSIONS 25U /* More than one session with TPMA_SESSION_DECRYPT bit set */
-#define TSS2_BASE_RC_MULTIPLE_ENCRYPT_SESSIONS 26U /* More than one session with TPMA_SE
-SSION_ENCRYPT bit set */
+#define TSS2_BASE_RC_MULTIPLE_ENCRYPT_SESSIONS 26U /* More than one session with TPMA_SESSION_ENCRYPT bit set */
+#define TSS2_BASE_RC_RSP_AUTH_FAILED           27U /* Response HMAC from TPM did not verify */
 
-// Base error codes from 0xf800 - 0xffff are reserved for level- and implementation-specific
-// errors.
+/* Base return codes in the range 0xf800 - 0xffff are reserved for
+ * implementation-specific purposes.
+ */
+#define TSS2_LAYER_IMPLEMENTATION_SPECIFIC_OFFSET 0xf800
 #define TSS2_LEVEL_IMPLEMENTATION_SPECIFIC_SHIFT 11
-#define TSS2_LEVEL_IMPLEMENTATION_SPECIFIC_OFFSET 0xf800
 
-#define TSS2_RC_SUCCESS                         ((TSS2_RC)0)
+/* Success is the same for all software layers */
+#define TSS2_RC_SUCCESS ((TSS2_RC) 0)
 
-//
-// TCTI error codes
-//
-
+/* TCTI error codes */
 #define TSS2_TCTI_RC_GENERAL_FAILURE            ((TSS2_RC)(TSS2_TCTI_RC_LAYER | \
                                                     TSS2_BASE_RC_GENERAL_FAILURE))
 #define TSS2_TCTI_RC_NOT_IMPLEMENTED            ((TSS2_RC)(TSS2_TCTI_RC_LAYER | \
@@ -184,9 +156,7 @@ SSION_ENCRYPT bit set */
                                                      TSS2_BASE_RC_MALFORMED_RESPONSE))
 #define TSS2_TCTI_RC_NOT_SUPPORTED              ((TSS2_RC)(TSS2_TCTI_RC_LAYER | \
                                                      TSS2_BASE_RC_NOT_SUPPORTED))
-//
-// SAPI error codes
-//
+/* SAPI error codes */
 #define TSS2_SYS_RC_GENERAL_FAILURE            ((TSS2_RC)(TSS2_SYS_RC_LAYER | \
                                                     TSS2_BASE_RC_GENERAL_FAILURE))
 #define TSS2_SYS_RC_ABI_MISMATCH                ((TSS2_RC)(TSS2_SYS_RC_LAYER | \
@@ -218,9 +188,7 @@ SSION_ENCRYPT bit set */
 #define TSS2_SYS_RC_BAD_TCTI_STRUCTURE          ((TSS2_RC)(TSS2_SYS_RC_LAYER | \
                                                      TSS2_BASE_RC_BAD_TCTI_STRUCTURE))
 
-//
-// NUAPI error codes
-//
+/* MUAPI error codes */
 #define TSS2_MU_RC_GENERAL_FAILURE              ((TSS2_RC)(TSS2_MU_RC_LAYER | \
                                                      TSS2_BASE_RC_GENERAL_FAILURE))
 #define TSS2_MU_RC_BAD_REFERENCE                ((TSS2_RC)(TSS2_MU_RC_LAYER | \
@@ -232,9 +200,7 @@ SSION_ENCRYPT bit set */
 #define TSS2_MU_RC_INSUFFICIENT_BUFFER          ((TSS2_RC)(TSS2_MU_RC_LAYER | \
                                                      TSS2_BASE_RC_INSUFFICIENT_BUFFER))
 
-/*
- * ESAPI Error Codes
- */
+/* ESAPI Error Codes */
 #define TSS2_ESYS_RC_GENERAL_FAILURE             ((TSS2_RC)(TSS2_ESAPI_RC_LAYER | \
                                                       TSS2_BASE_RC_GENERAL_FAILURE))
 #define TSS2_ESYS_RC_ABI_MISMATCH                ((TSS2_RC)(TSS2_ESAPI_RC_LAYER | \
@@ -285,5 +251,4 @@ SSION_ENCRYPT bit set */
                                                         TSS2_BASE_RC_BAD_CONTEXT))
 #define TSS2_ESYS_RC_FILE_ERROR                  ((TSS2_RC)(TSS2_ESAPI_RC_LAYER | \
                                                       STSS2_BASE_RC_FILE_ERROR))
-
 #endif /* TSS2_COMMON_H */

--- a/include/sapi/tss2_sys.h
+++ b/include/sapi/tss2_sys.h
@@ -28,10 +28,10 @@
 #ifndef TSS2_SYS_H
 #define TSS2_SYS_H
 
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version mismatch among TSS2 header files. \
        Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
+#endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -28,10 +28,10 @@
 #ifndef TSS2_TPMS_TYPES_H
 #define TSS2_TPMS_TYPES_H
 
-#ifndef TSS2_API_VERSION_1_1_1_1
+#ifndef TSS2_API_VERSION_1_2_1_108
 #error Version mismatch among TSS2 header files. \
        Do not include this file, #include <sapi/tpm20.h> instead.
-#endif  /* TSS2_API_VERSION_1_1_1_1 */
+#endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 #include <stdint.h>
 

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -144,7 +144,7 @@ void ErrorHandler( UINT32 rval )
         case TSS2_TCTI_RC_LAYER:
             strncpy( levelString, "TCTI", LEVEL_STRING_SIZE );
             break;
-        case TSS2_RESMGRTPM_RC_LAYER:
+        case TSS2_RESMGR_TPM_RC_LAYER:
             strncpy( levelString, "Resource Mgr TPM encoded", LEVEL_STRING_SIZE );
             break;
         case TSS2_RESMGR_RC_LAYER:


### PR DESCRIPTION
Currently the spec defines ABI version to TSS2_API_VERSION_1_2_1_108.
Update rest of the headers respectively.
