### PR TITLE
build: Fail configure script if unit tests enabled, but cmocka dep. c…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --with-simulatorbin):
 ** OpenSSL
 * Unit test suite (see ./configure option --enable-unit):
-** cmocka unit test framework
+* cmocka unit test framework, version >= 1.0
 Most users will not need to install these dependencies.
 
 ### Ubuntu

--- a/configure.ac
+++ b/configure.ac
@@ -20,11 +20,14 @@ AC_ARG_ENABLE([unit],
                             [build cmocka unit tests (default is no)])],
             [enable_unit=$enableval],
             [enable_unit=no])
+m4_define([cmocka_min_version], [1.0])
+m4_define([cmocka_err], [Unit test enabled, but cmocka missing or version requirements not met. cmocka version must be >= cmocka_min_version])
 AS_IF([test "x$enable_unit" != xno],
       [PKG_CHECK_MODULES([CMOCKA],
-                         [cmocka >= 1.0],
+                         [cmocka >= cmocka_min_version],
                          [AC_DEFINE([HAVE_CMOCKA],
-                                    [1])])])
+                                    [1])],
+                         [AC_MSG_ERROR([cmocka_err])])])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 
 # Uriparser library required by simulator TCTI library.


### PR DESCRIPTION
…heck fails.

This also puts the dependency information into the INSTALL.md file to
give users a chance to get things right before the configure script
fails on them.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>