### PR TITLE
Logging: Fix --with-maxloglevel

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,12 +95,24 @@ AX_ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
 AX_ADD_PREPROC_FLAG([-D_BSD_SOURCE])
 AX_ADD_PREPROC_FLAG([-D_POSIX_SOURCE])
 
-AC_ARG_WITH([loglevel],
-            [AS_HELP_STRING([--with-loglevel={none,error,warning,info,debug,trace}],
+AC_ARG_WITH([maxloglevel],
+            [AS_HELP_STRING([--with-maxloglevel={none,error,warning,info,debug,trace}],
                             [sets the maximum log level (default is trace)])],
             [],
-            [with_loglevel=trace])
-AC_DEFINE_UNQUOTED([LOGLEVEL], [$with_loglevel])
+            [with_maxloglevel=trace])
+AS_IF([test "x$with_maxloglevel" = "xnone"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['N']),
+AS_IF([test "x$with_maxloglevel" = "xerror"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['E']),
+AS_IF([test "x$with_maxloglevel" = "xwarning"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['W']),
+AS_IF([test "x$with_maxloglevel" = "xinfo"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['I']),
+AS_IF([test "x$with_maxloglevel" = "xdebug"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['D']),
+AS_IF([test "x$with_maxloglevel" = "xtrace"],
+      AC_DEFINE_UNQUOTED([MAXLOGLEVEL], ['T']),
+AC_MSG_ERROR([Bad value for --with-maxloglevel])))))))
 
 AC_ARG_ENABLE([debug],
             [AS_HELP_STRING([--enable-debug],

--- a/log/log.h
+++ b/log/log.h
@@ -42,11 +42,24 @@ static const char *log_strings[] COMPILER_ATTR(unused) = {
 
 static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
 
-#if LOGLEVEL == LOGLEVEL_ERROR || \
-    LOGLEVEL == LOGLEVEL_WARNING || \
-    LOGLEVEL == LOGLEVEL_INFO || \
-    LOGLEVEL == LOGLEVEL_DEBUG || \
-    LOGLEVEL == LOGLEVEL_TRACE
+#ifndef MAXLOGLEVEL
+#error "MAXLOGLEVEL undefined"
+#endif
+#if MAXLOGLEVEL != 'E' && \
+    MAXLOGLEVEL != 'W' && \
+    MAXLOGLEVEL != 'I' && \
+    MAXLOGLEVEL != 'D' && \
+    MAXLOGLEVEL != 'T' && \
+    MAXLOGLEVEL != 'N'
+#error "Unknown MAXLOGLEVEL"
+#endif
+
+/* MAXLOGLEVEL is Error or "higher" */
+#if MAXLOGLEVEL == 'E' || \
+    MAXLOGLEVEL == 'W' || \
+    MAXLOGLEVEL == 'I' || \
+    MAXLOGLEVEL == 'D' || \
+    MAXLOGLEVEL == 'T'
 #define LOG_ERROR(FORMAT, ...) doLog(LOGLEVEL_ERROR, \
                                      xstr(LOGMODULE), LOGDEFAULT, \
                                      &LOGMODULE_status, \
@@ -58,15 +71,16 @@ static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
                                              __FILE__, __func__, __LINE__, \
                                              BUFFER, SIZE, \
                                              FORMAT, ## __VA_ARGS__)
-#else /* LOGLEVEL >= LOGLEVEL_ERROR */
+#else /* MAXLOGLEVEL is not Error or "higher" */
 #define LOG_ERROR(FORMAT, ...) {}
 #define LOGBLOB_ERROR(FORMAT, ...) {}
-#endif /* LOGLEVEL >= LOGLEVEL_ERROR */
+#endif
 
-#if LOGLEVEL == LOGLEVEL_WARNING || \
-    LOGLEVEL == LOGLEVEL_INFO || \
-    LOGLEVEL == LOGLEVEL_DEBUG || \
-    LOGLEVEL == LOGLEVEL_TRACE
+/* MAXLOGLEVEL is Warning or "higher" */
+#if MAXLOGLEVEL == 'W' || \
+    MAXLOGLEVEL == 'I' || \
+    MAXLOGLEVEL == 'D' || \
+    MAXLOGLEVEL == 'T'
 #define LOG_WARNING(FORMAT, ...) doLog(LOGLEVEL_WARNING, \
                                      xstr(LOGMODULE), LOGDEFAULT, \
                                      &LOGMODULE_status, \
@@ -78,14 +92,15 @@ static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
                                                  __FILE__, __func__, __LINE__, \
                                                  BUFFER, SIZE, \
                                                  FORMAT, ## __VA_ARGS__)
-#else /* LOGLEVEL >= LOGLEVEL_WARNING */
+#else /* MAXLOGLEVEL is not Warning or "higher" */
 #define LOG_WARNING(FORMAT, ...) {}
 #define LOGBLOB_WARNING(FORMAT, ...) {}
-#endif /* LOGLEVEL >= LOGLEVEL_WARNING */
+#endif
 
-#if LOGLEVEL == LOGLEVEL_INFO || \
-    LOGLEVEL == LOGLEVEL_DEBUG || \
-    LOGLEVEL == LOGLEVEL_TRACE
+/* MAXLOGLEVEL is Info or "higher" */
+#if MAXLOGLEVEL == 'I' || \
+    MAXLOGLEVEL == 'D' || \
+    MAXLOGLEVEL == 'T'
 #define LOG_INFO(FORMAT, ...) doLog(LOGLEVEL_INFO, \
                                      xstr(LOGMODULE), LOGDEFAULT, \
                                      &LOGMODULE_status, \
@@ -97,13 +112,14 @@ static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
                                      __FILE__, __func__, __LINE__, \
                                      BUFFER, SIZE, \
                                      FORMAT, ## __VA_ARGS__)
-#else /* LOGLEVEL >= LOGLEVEL_INFO */
+#else /* MAXLOGLEVEL is not Info or "higher" */
 #define LOG_INFO(FORMAT, ...) {}
 #define LOGBLOB_INFO(FORMAT, ...) {}
-#endif /* LOGLEVEL >= LOGLEVEL_INFO */
+#endif
 
-#if LOGLEVEL == LOGLEVEL_DEBUG || \
-    LOGLEVEL == LOGLEVEL_TRACE
+/* MAXLOGLEVEL is Debug or "higher" */
+#if MAXLOGLEVEL == 'D' || \
+    MAXLOGLEVEL == 'T'
 #define LOG_DEBUG(FORMAT, ...) doLog(LOGLEVEL_DEBUG, \
                                      xstr(LOGMODULE), LOGDEFAULT, \
                                      &LOGMODULE_status, \
@@ -115,12 +131,13 @@ static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
                                              __FILE__, __func__, __LINE__, \
                                              BUFFER, SIZE, \
                                              FORMAT, ## __VA_ARGS__)
-#else /* LOGLEVEL >= LOGLEVEL_DEBUG */
+#else /* MAXLOGLEVEL is not Debug or "higher" */
 #define LOG_DEBUG(FORMAT, ...) {}
 #define LOGBLOB_DEBUG(FORMAT, ...) {}
-#endif /* LOGLEVEL >= LOGLEVEL_DEBUG */
+#endif
 
-#if LOGLEVEL == LOGLEVEL_TRACE
+/* MAXLOGLEVEL is Trace */
+#if MAXLOGLEVEL == 'T'
 #define LOG_TRACE(FORMAT, ...) doLog(LOGLEVEL_TRACE, \
                                      xstr(LOGMODULE), LOGDEFAULT, \
                                      &LOGMODULE_status, \
@@ -132,10 +149,10 @@ static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
                                              __FILE__, __func__, __LINE__, \
                                              BUFFER, SIZE, \
                                              FORMAT, ## __VA_ARGS__)
-#else /* LOGLEVEL >= LOGLEVEL_TRACE */
+#else /* MAXLOGLEVEL is not Trace */
 #define LOG_TRACE(FORMAT, ...) {}
 #define LOGBLOB_TRACE(FORMAT, ...) {}
-#endif /* LOGLEVEL >= LOGLEVEL_TRACE */
+#endif
 
 void
 doLog(log_level loglevel, const char *module, log_level logdefault,

--- a/marshal/tss2-mu.vcxproj
+++ b/marshal/tss2-mu.vcxproj
@@ -71,10 +71,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;MAXLOGLEVEL='T';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;MAXLOGLEVEL='W';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;MAXLOGLEVEL='T';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;_WINDOWS;_USRDLL;libtss2_mu_EXPORTS;MAXLOGLEVEL='W';%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\include;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\include;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/sysapi/tss2-sapi.vcxproj
+++ b/sysapi/tss2-sapi.vcxproj
@@ -199,10 +199,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;MAXLOGLEVEL='T';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;MAXLOGLEVEL='W';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;MAXLOGLEVEL='T';%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;_WINDOWS;_USRDLL;tss2_sapi_EXPORTS;MAXLOGLEVEL='W';%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">include;..\include;..\marshal;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">include;..\include;..\marshal;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -2896,6 +2896,8 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
         testString = testStringPolicy;
 
     LOG_INFO("SIMPLE %s SESSION TEST:", testString );
+    /* If LOG_INFO is not compiled in, this variable is unused */
+    (void)(testString);
 
     // Create sysContext structure.
     simpleTestContext = InitSysContext( 1000, resMgrTctiContext, &abiVersion );


### PR DESCRIPTION
The --with-loglevel configure switch was
not working. Renamed it and made it working
as --with-maxloglevel.
Also fixed an unused variable in tests for
maxloglevel==none.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>