### PR TITLE
Esapi testyielded

### DIFF
--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -205,10 +205,10 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = esys_GetResourceObject(esys_context, objectHandle_handle,
                                &objectHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
-    LOG_INFO("Created Primary with handle 0x%08x...",
+    LOG_INFO("Created Primary with TPM handle 0x%08x...",
              objectHandle_node->rsrc.handle);
-    r = Tss2_Sys_FlushContext(esys_context->sys,
-                              objectHandle_node->rsrc.handle);
+
+    r = Esys_FlushContext(esys_context, objectHandle_handle);
     goto_if_error(r, "Error during FlushContext", error);
 
     LOG_INFO("Done with handle 0x%08x...", objectHandle_node->rsrc.handle);

--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -8,10 +8,145 @@
 #include <esapi/tss2_esys.h>
 #include <esys_types.h>
 #include "esys_iutil.h"
+#include "tcti/tcti.h"
+#include "sapi/tss2_tcti.h"
 
+/** Define a proxy tcti that returns yielded on every second invocation
+ * thus the corresponding handling code in ESAPI can be tested.
+ * The first invocation will be Tss2_Sys_StartUp.
+ */
+
+#define TCTI_PROXY_MAGIC 0x5250584f0a000000ULL /* 'PROXY\0\0\0' */
+#define TCTI_PROXY_VERSION 0x1
+
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    TCTI_TRANSMIT_PTR transmit;
+    TCTI_RECEIVE_PTR receive;
+    TSS2_RC (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
+    TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
+    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,
+              TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
+    TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
+    TSS2_TCTI_CONTEXT *tctiInner;
+    uint8_t count;
+} TSS2_TCTI_CONTEXT_PROXY;
+
+static TSS2_TCTI_CONTEXT_PROXY*
+tcti_proxy_cast (TSS2_TCTI_CONTEXT *ctx)
+{
+    TSS2_TCTI_CONTEXT_PROXY *ctxi = (TSS2_TCTI_CONTEXT_PROXY*)ctx;
+    if (ctxi == NULL || ctxi->magic != TCTI_PROXY_MAGIC) {
+        LOG_ERROR("Bad tcti passed.");
+        return NULL;
+    }
+    return ctxi;
+}
+
+static TSS2_RC
+tcti_proxy_transmit(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t command_size,
+    const uint8_t *command_buffer
+    )
+{
+    TSS2_RC rval;
+    TSS2_TCTI_CONTEXT_PROXY *tcti_proxy = tcti_proxy_cast(tctiContext);
+    if (tcti_proxy->count == 2) {
+        tcti_proxy->count = 1;
+        return TSS2_RC_SUCCESS;
+    }
+    tcti_proxy->count++;
+
+    rval = Tss2_Tcti_Transmit(tcti_proxy->tctiInner, command_size,
+        command_buffer);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Calling TCTI Transmit");
+        return rval;
+    }
+
+    return rval;
+}
+
+uint8_t yielded_response[] = {
+    0x00, 0x00,             /* TPM_ST_NO_SESSION */
+    0x00, 0x00, 0x00, 0x0A, /* Response Size 10 */
+    0x00, 0x00, 0x09, 0x08  /* TPM_RC_YIELDED */
+};
+
+static TSS2_RC
+tcti_proxy_receive(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    uint8_t *response_buffer,
+    int32_t timeout
+    )
+{
+    TSS2_RC rval;
+    TSS2_TCTI_CONTEXT_PROXY *tcti_proxy = tcti_proxy_cast(tctiContext);
+    if (tcti_proxy->count == 2) {
+        if (response_buffer == NULL) {
+            *response_size = sizeof(yielded_response);
+            return TSS2_RC_SUCCESS;
+        }
+        memcpy(response_buffer, &yielded_response[0], sizeof(yielded_response));
+        *response_size = sizeof(yielded_response);
+        return TSS2_RC_SUCCESS;
+    }
+
+    rval = Tss2_Tcti_Receive(tcti_proxy->tctiInner, response_size,
+        response_buffer, timeout);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Calling TCTI Transmit");
+        return rval;
+    }
+
+    return rval;
+}
+
+static void
+tcti_proxy_finalize(
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    memset(tctiContext, 0, sizeof(TSS2_TCTI_CONTEXT_PROXY));
+}
+
+static TSS2_RC
+tcti_proxy_initialize(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *contextSize,
+    TSS2_TCTI_CONTEXT *tctiInner)
+{
+    TSS2_TCTI_CONTEXT_PROXY *tcti_proxy =
+        (TSS2_TCTI_CONTEXT_PROXY*) tctiContext;
+
+    if (tctiContext == NULL && contextSize == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    } else if (tctiContext == NULL) {
+        *contextSize = sizeof(*tcti_proxy);
+        return TSS2_RC_SUCCESS;
+    }
+
+    /* Init TCTI context */
+    memset(tcti_proxy, 0, sizeof(*tcti_proxy));
+    TSS2_TCTI_MAGIC (tctiContext) = TCTI_PROXY_MAGIC;
+    TSS2_TCTI_VERSION (tctiContext) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tctiContext) = tcti_proxy_transmit;
+    TSS2_TCTI_RECEIVE (tctiContext) = tcti_proxy_receive;
+    TSS2_TCTI_FINALIZE (tctiContext) = tcti_proxy_finalize;
+    TSS2_TCTI_CANCEL (tctiContext) = NULL;
+    TSS2_TCTI_GET_POLL_HANDLES (tctiContext) = NULL;
+    TSS2_TCTI_SET_LOCALITY (tctiContext) = NULL;
+    tcti_proxy->tctiInner = tctiInner;
+    tcti_proxy->count = 0;
+
+    return TSS2_RC_SUCCESS;
+}
 
 /** Override the gcrypt random functions in order to not screw over valgrind. */
-TSS2_RC iesys_cryptogcry_random2b(TPM2B_NONCE *nonce, size_t num_bytes) {
+TSS2_RC iesys_cryptogcry_random2b(TPM2B_NONCE *nonce, size_t num_bytes)
+{
     nonce->size = num_bytes;
     for (int i = 0; i < num_bytes; i++)
         nonce->buffer[i] = i % 256;
@@ -28,7 +163,9 @@ int
 main(int argc, char *argv[])
 {
     TSS2_RC rc;
-    TSS2_TCTI_CONTEXT *tcti_context;
+    TSS2_TCTI_CONTEXT *tcti_context = calloc(1,
+        sizeof(TSS2_TCTI_CONTEXT_PROXY));
+    TSS2_TCTI_CONTEXT *tcti_inner;
     ESYS_CONTEXT *esys_context;
     TSS2_ABI_VERSION abiVersion =
         { TSSWG_INTEROP, TSS_SAPI_FIRST_FAMILY, TSS_SAPI_FIRST_LEVEL,
@@ -47,10 +184,16 @@ TSS_SAPI_FIRST_VERSION };
         LOG_ERROR("TPM Startup FAILED! Error in sanity check");
         exit(1);
     }
-    tcti_context = tcti_init_from_opts(&opts);
-    if (tcti_context == NULL) {
+    tcti_inner = tcti_init_from_opts(&opts);
+    if (tcti_inner == NULL) {
         LOG_ERROR("TPM Startup FAILED! Error tcti init");
         exit(1);
+    }
+    size_t tcti_size = sizeof(TSS2_TCTI_CONTEXT_PROXY);
+    rc = tcti_proxy_initialize(tcti_context, &tcti_size, tcti_inner);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("tcti initialization FAILED! Response Code : 0x%x", rc);
+        return 1;
     }
     rc = Esys_Initialize(&esys_context, tcti_context, &abiVersion);
     if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {


### PR DESCRIPTION
Esapi has handling for TPM_RC_YIELDED included in their finish functions.

This patch adds functionality to the tests to return RC_YIELDED every second invocation of the TPM.