### PR TITLE
tcti: Generalize version struct and add to INFO struct as first member.

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -151,7 +151,9 @@ typedef TSS2_RC (*TSS2_TCTI_SET_LOCALITY_FCN) (
 typedef struct {
     uint64_t magic;
     uint32_t version;
-} TSS2_TCTI_CONTEXT_VERSION ;
+} TSS2_TCTI_VERSION ;
+
+typedef TSS2_TCTI_VERSION TSS2_TCTI_CONTEXT_VERSION;
 
 /* current version #1 known to this implementation */
 typedef struct {
@@ -176,6 +178,7 @@ typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
     );
 
 typedef struct {
+    TSS2_TCTI_VERSION version;
     const char *name;
     const char *description;
     const char *config_help;

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -252,6 +252,10 @@ TSS2_RC Tss2_Tcti_Device_Init (
 }
 
 const static TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = {
+        .magic = TCTI_MAGIC,
+        .version = TCTI_VERSION,
+    },
     .name = "tcti-device",
     .description = "TCTI module for communication with Linux kernel interface.",
     .config_help = "Path to TPM character device. Default value is: "

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -611,6 +611,10 @@ out:
 
 /* public info structure */
 const static TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = {
+        .magic = TCTI_MAGIC,
+        .version = TCTI_VERSION,
+    },
     .name = "tcti-socket",
     .description = "TCTI module for communication with the Microsoft TPM2 Simulator.",
     .config_help = "Connection URI in the form tcp://ip_address[:port]. " \


### PR DESCRIPTION
This addresses feedback from TSS2 WG: The INFO structure should be
versioned just like we do the context structure. The two version
structures must be identical for both structures.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>