### PR TITLE
INSTALL.md: add missing dependencies and fix formatting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,16 +11,17 @@ following sections describe them for the supported platforms.
 * GNU Automake
 * GNU Libtool
 * C compiler
-* C Library Development Libraries and Header Files
+* C library development libraries and header files
 * pkg-config
-* uriparser
-* libgcrypt
+* uriparser development libraries and header files
+* libgcrypt development libraries and header files
 
 The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --with-simulatorbin):
-* OpenSSL
+* OpenSSL development libraries and header files
 * Unit test suite (see ./configure option --enable-unit):
 * cmocka unit test framework, version >= 1.0
+
 Most users will not need to install these dependencies.
 
 ### Ubuntu


### PR DESCRIPTION
Clarify that uriparser and libgcrypt dependencies require libraries and
header files.
Fix typos in INSTALL.md such as missing blank lines and markup.

Fixes #810.