### PR TITLE
Tcti v2 and cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,7 +177,7 @@ esapi_libesapi_la_SOURCES = $(ESAPI_SRC)
 endif #ESAPI
 
 ### Man Pages
-man3_MANS = man/man3/InitDeviceTcti.3 man/man3/InitSocketTcti.3
+man3_MANS = man/man3/Tss2_Tcti_Device_Init.3 man/man3/InitSocketTcti.3
 man7_MANS = man/man7/tcti-device.7 man/man7/tcti-socket.7
 
 man/man3/%.3 : man/%.3.in $(srcdir)/man/man-postlude.troff
@@ -188,7 +188,7 @@ man/man7/%.7 : man/%.7.in $(srcdir)/man/man-postlude.troff
 
 EXTRA_DIST += \
     man/man-postlude.troff \
-    man/InitDeviceTcti.3.in \
+    man/Tss2_Tcti_Device_Init.3.in \
     man/InitSocketTcti.3.in \
     man/tcti-device.7.in \
     man/tcti-socket.7.in

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -155,6 +155,10 @@ typedef TSS2_RC (*TSS2_TCTI_MAKE_STICKY_FCN) (
     TSS2_TCTI_CONTEXT *tctiContext,
     TPM2_HANDLE *handle,
     uint8_t sticky);
+typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *config);
 
 /* superclass to get the version */
 typedef struct {
@@ -184,12 +188,6 @@ typedef struct {
 typedef TSS2_TCTI_CONTEXT_COMMON_V2 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 
 #define TSS2_TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
-
-typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
-    TSS2_TCTI_CONTEXT *tctiContext,
-    size_t *size,
-    const char *config
-    );
 
 typedef struct {
     TSS2_TCTI_VERSION version;

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -30,10 +30,6 @@
 #ifndef TSS2_TCTI_H
 #define TSS2_TCTI_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stddef.h>
 #include "tss2_common.h"
@@ -204,9 +200,5 @@ typedef struct {
 } TSS2_TCTI_INFO;
 
 typedef const TSS2_TCTI_INFO* (*TSS2_TCTI_INFO_FUNC) (void);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -73,6 +73,8 @@ typedef void TSS2_TCTI_POLL_HANDLE;
     ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->getPollHandles
 #define TSS2_TCTI_SET_LOCALITY(tctiContext) \
     ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->setLocality
+#define TSS2_TCTI_MAKE_STICKY(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V2*)tctiContext)->makeSticky
 
 /* Macros to simplify invocation of functions from the common TCTI structure */
 #define Tss2_Tcti_Transmit(tctiContext, size, command) \
@@ -119,6 +121,13 @@ typedef void TSS2_TCTI_POLL_HANDLE;
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, locality))
+#define Tss2_Tcti_MakeSticky(tctiContext, handle, sticky) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 2) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_MAKE_STICKY(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_MAKE_STICKY(tctiContext)(tctiContext, handle, sticky))
 
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 
@@ -146,6 +155,10 @@ typedef TSS2_RC (*TSS2_TCTI_GET_POLL_HANDLES_FCN) (
 typedef TSS2_RC (*TSS2_TCTI_SET_LOCALITY_FCN) (
     TSS2_TCTI_CONTEXT *tctiContext,
     uint8_t locality);
+typedef TSS2_RC (*TSS2_TCTI_MAKE_STICKY_FCN) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TPM2_HANDLE *handle,
+    uint8_t sticky);
 
 /* superclass to get the version */
 typedef struct {
@@ -167,7 +180,12 @@ typedef struct {
     TSS2_TCTI_SET_LOCALITY_FCN setLocality;
 } TSS2_TCTI_CONTEXT_COMMON_V1;
 
-typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
+typedef struct {
+    TSS2_TCTI_CONTEXT_COMMON_V1 v1;
+    TSS2_TCTI_MAKE_STICKY_FCN makeSticky;
+} TSS2_TCTI_CONTEXT_COMMON_V2;
+
+typedef TSS2_TCTI_CONTEXT_COMMON_V2 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 
 #define TSS2_TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
 

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -34,6 +34,7 @@
 #endif  /* TSS2_API_VERSION_1_2_1_108 */
 
 #include <stdint.h>
+#include "tpmb.h"
 
 #define TPM2_MAX_COMMAND_SIZE  4096 /* maximum size of a command */
 #define TPM2_MAX_RESPONSE_SIZE 4096 /* maximum size of a response */

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -27,31 +27,17 @@
 #ifndef TCTI_DEVICE_H
 #define TCTI_DEVICE_H
 
+#include <sapi/tss2_tcti.h>
+#include "common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "common.h"
-
-#include "sapi/tpm20.h"
-
-#define TCTI_DEVICE_DEFAULT "/dev/tpm0"
-
-typedef struct {
-    const char *device_path;
-} TCTI_DEVICE_CONF;
-
-TSS2_RC InitDeviceTcti (
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    size_t *contextSize,            // IN/OUT
-    const TCTI_DEVICE_CONF *config  // IN
-    ) COMPILER_ATTR (deprecated);
-
 TSS2_RC Tss2_Tcti_Device_Init (
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t *size,
-    const char *conf
-    );
+    const char *conf);
 
 #ifdef __cplusplus
 }

--- a/man/Tss2_Tcti_Device_Init.3.in
+++ b/man/Tss2_Tcti_Device_Init.3.in
@@ -1,66 +1,60 @@
 .\" Process this file with
 .\" groff -man -Tascii foo.1
 .\"
-.TH InitDeviceTcti 3 "JUNE 2017" Intel "TPM2 Software Stack"
+.TH Tss2_Tcti_Device_Init 3 "MARCH 2018" Intel "TPM2 Software Stack"
 .SH NAME
-InitDeviceTcti \- Initialization function for the device TCTI library.
+Tss2_Tcti_Device_init \- Initialization function for the device TCTI library.
 .SH SYNOPSIS
 .B #include <tcti/tcti_device.h>
 .sp
-.nf
-typedef struct {
-    const char *device_path;
-} TCTI_DEVICE_CONF;
-.fi
 .sp
-.BI "TSS2_RC InitDeviceTcti (TSS2_TCTI_CONTEXT " "*tctiContext" ", size_t " "*contextSize" ", const TCTI_DEVICE_CONF " "*config" ");"
+.BI "TSS2_RC Tss2_Tcti_Device_Init (TSS2_TCTI_CONTEXT " "*tctiContext" ", size_t " "*size" ", const char " "*conf" ");"
 .sp
 The
-.BR  InitDeviceTcti ()
+.BR  Tss2_Tcti_Device_Init ()
 function initializes a TCTI context used to communicate with the TPM device
 driver.
 .SH DESCRIPTION
-.BR InitDeviceTcti ()
+.BR Tss2_Tcti_Device_Init ()
 attempts to initialize a caller allocated
-.I tcti_context
+.I tctiContext
 of size
 .I size
 \&. Since the
-.I tcti_context
+.I tctiContext
 must be a caller allocated buffer, the caller needs to know the size required
 by the TCTI library. The minimum size of this context can be discovered by
 providing
 .BR NULL
 for the
-.I tcti_context
+.I tctiContext
 and a non-
 .BR NULL
 .I size
 parameter. The initialization function will then populate the
 .I size
 parameter with the minimum size of the
-.I tcti_context
+.I tctiContext
 buffer. The caller must then allocate a buffer of this size (or larger) and
 call
-.B InitDeviceTcti ()
+.B Tss2_Tcti_Device_Init ()
 again providing the newly allocated
-.I tcti_context
+.I tctiContext
 and the size of this context in the
 .I size
 parameter. This patterm is common to all TCTI initialization functions. We
 provide an example of this pattern using the
-.BR InitDeviceTcti ()
+.BR Tss2_Tcti_Device_Init ()
 function in the section titled
 .B EXAMPLE.
 .sp
 The
-.I config
-parameter is a reference to an instance of the
-.B TCTI_DEVICE_CONF
-structure. The
-.I device_path
-member of this structure is a C string that contains the path to the device
-node exposed by the TPM device driver.
+.I conf
+parameter is a C string. If this string is
+.BR NULL
+then the library will use a default configuration string for the caller.
+Alternatively, the caller may provide a configuration string that must
+contain the path to the device node exposed by the TPM device driver.
 .sp
 Once initialized, the TCTI context returned exposes the Trusted Computing
 Group (TCG) defined API for the lowest level communication with the TPM.
@@ -70,26 +64,30 @@ caller will initialize a context using this funnction before passing the
 context to a higher level API like the System API (SAPI), and then never touch
 it again.
 .sp
-For a more thorough discussion of the TCTI API see the \*(lqTSS System Level
-API and TPM Command Transmission Interface Specification\*(rq as published by
+TCG TSS 2.0 TPM Command
+Transmission Interface (TCTI) API
+Specification
+
+For a more thorough discussion of the TCTI API see the \*(lqTCG TSS 2.0 TPM Command
+Transmission Interface (TCTI) API Specification\*(rq as published by
 the TCG:
-\%https://trustedcomputinggroup.org/tss-system-level-api-tpm-command-transmission-interface-specification/
+\%https://trustedcomputinggroup.org/wp-content/uploads/TSS_TCTI_Version-1.0_Revision-05_Review_END030918.pdf
 .SH RETURN VALUE
 A successful call to
-.BR InitDeviceTcti ()
+.BR Tss2_Tcti_Device_Init ()
 will return
 .B TSS2_RC_SUCCESS.
 An unsuccessful call will produce a response code described in section
 .B ERRORS.
 .SH ERRORS
 .B TSS2_TCTI_RC_BAD_VALUE
-is returned if both the
-.I tcti_context
-and the
-.I size
-parameters are NULL, or if the
-.I config
-parameter is NULL.
+is returned if any parameters contain unexpected values.
+.B TSS2_TCTI_RC_BAD_REFERENCE
+is returned if any parameters are NULL when they should not be.
+.B TSS2_TCTI_RC_BAD_CONTEXT
+is returned if the size of the provided
+.i tctiContext
+is insufficient.
 .SH EXAMPLE
 TCTI initialization fragment:
 .sp
@@ -102,11 +100,9 @@ TCTI initialization fragment:
 TSS2_RC rc;
 TSS2_TCTI_CONTEXT *tcti_context;
 size_t size;
-TCTI_DEVICE_CONF conf = {
-    .device_path = "/dev/tpm0",
-};
+char *conf = "/dev/tpm0",
 
-rc = InitDeviceTcti (NULL, &size, NULL);
+rc = Tss2_Tcti_Device_Init (NULL, &size, NULL);
 if (rc != TSS2_RC_SUCCESS) {
     fprintf (stderr, "Failed to get allocation size for device TCTI "
              " context: 0x%" PRIx32 "\n", rc);
@@ -118,7 +114,7 @@ if (tcti_context == NULL) {
              strerror (errno));
     exit (EXIT_FAILURE);
 }
-rc = InitDeviceTcti (&tcti_context, &size, &conf);
+rc = Tss2_Tcti_Device_Init (&tcti_context, &size, &conf);
 if (rc != TSS2_RC_SUCCESS) {
     fprintf (stderr, "Failed to initialize device TCTI context: "
              "0x%" PRIx32 "\n", rc);

--- a/man/man-postlude.troff
+++ b/man/man-postlude.troff
@@ -1,7 +1,7 @@
 .SH AUTHOR
 Philip Tricca <philip.b.tricca@intel.com>
 .SH "SEE ALSO"
-.BR InitDeviceTcti (3),
+.BR Tss2_Tcti_Device_Init (3),
 .BR InitSocketTcti (3),
 .BR tcti-device (7),
 .BR tcti-socket (7),

--- a/tcti/tcti.c
+++ b/tcti/tcti.c
@@ -128,3 +128,11 @@ ssize_t write_all (
 
     return (ssize_t)written_total;
 }
+
+TSS2_RC tcti_make_sticky_not_implemented (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TPM2_HANDLE *handle,
+    uint8_t sticky)
+{
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -25,17 +25,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-
-#include "sapi/tpm20.h"
-#include "sapi/tss2_mu.h"
 #include <errno.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "tcti.h"
 #include "tcti/tcti_device.h"
 #define LOGMODULE tcti

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -214,6 +214,7 @@ _InitDeviceTcti (
     TSS2_TCTI_CANCEL (tctiContext) = LocalTpmCancel;
     TSS2_TCTI_GET_POLL_HANDLES (tctiContext) = LocalTpmGetPollHandles;
     TSS2_TCTI_SET_LOCALITY (tctiContext) = LocalTpmSetLocality;
+    TSS2_TCTI_MAKE_STICKY (tctiContext) = tcti_make_sticky_not_implemented;
     tcti_intel->status.locality = 3;
     tcti_intel->status.commandSent = 0;
     tcti_intel->currentTctiContext = 0;

--- a/tcti/tcti_device.map
+++ b/tcti/tcti_device.map
@@ -1,6 +1,5 @@
 {
     global:
-        InitDeviceTcti;
         Tss2_Tcti_Device_Init;
         Tss2_Tcti_Info;
     local:

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -509,6 +509,7 @@ _InitSocketTcti (
     TSS2_TCTI_CANCEL (tctiContext) = SocketCancel;
     TSS2_TCTI_GET_POLL_HANDLES (tctiContext) = SocketGetPollHandles;
     TSS2_TCTI_SET_LOCALITY (tctiContext) = SocketSetLocality;
+    TSS2_TCTI_MAKE_STICKY (tctiContext) = tcti_make_sticky_not_implemented;
     tcti_intel->status.locality = 3;
     tcti_intel->status.commandSent = 0;
     tcti_intel->status.tagReceived = 0;

--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -22,8 +22,8 @@
 typedef struct {
     uint64_t magic;
     uint32_t version;
-    TCTI_TRANSMIT_PTR transmit;
-    TCTI_RECEIVE_PTR receive;
+    TSS2_TCTI_TRANSMIT_FCN transmit;
+    TSS2_TCTI_RECEIVE_FCN receive;
     TSS2_RC (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
     TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
     TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,

--- a/test/integration/sys-initialize.int.c
+++ b/test/integration/sys-initialize.int.c
@@ -44,8 +44,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     // NOTE: don't do this in real applications.
-    tctiContextIntel.transmit = (TCTI_TRANSMIT_PTR)0;
-    tctiContextIntel.receive = (TCTI_RECEIVE_PTR)1;
+    tctiContextIntel.transmit = (TSS2_TCTI_TRANSMIT_FCN)0;
+    tctiContextIntel.receive = (TSS2_TCTI_RECEIVE_FCN)1;
 
     rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
@@ -54,8 +54,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     // NOTE: don't do this in real applications.
-    tctiContextIntel.transmit = (TCTI_TRANSMIT_PTR)1;
-    tctiContextIntel.receive = (TCTI_RECEIVE_PTR)0;
+    tctiContextIntel.transmit = (TSS2_TCTI_TRANSMIT_FCN)1;
+    tctiContextIntel.receive = (TSS2_TCTI_RECEIVE_FCN)0;
 
     rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {


### PR DESCRIPTION
Add the TCTI v2 stuff to the TCTI header, remove the deprecated init functions from the device TCTI and do a bit of cleanup.