### PR TITLE
configure.ac cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,7 +182,7 @@ AC_MSG_RESULT([
     unit:               $enable_unit
     debug:              $enable_debug
     simulatorbin:       $with_simulatorbin
-    loglevel:           $with_loglevel
+    maxloglevel:        $with_maxloglevel
     doxygen:            $DX_FLAG_doc $enable_doxygen_doc
 ])
     

--- a/configure.ac
+++ b/configure.ac
@@ -27,9 +27,9 @@
 #;**********************************************************************;
 AC_INIT([tpm2-tss],
         [2.0.0-dev],
-        [https://github.com/01org/tpm2-tss/issues],
+        [https://github.com/tpm2-software/tpm2-tss/issues],
         [],
-        [https://github.com/01org/tpm2-tss])
+        [https://github.com/tpm2-software/tpm2-tss])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 LT_INIT()

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,30 @@
+#;**********************************************************************;
+# Copyright (c) 2015 - 2018 Intel Corporation
+# Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
 AC_INIT([tpm2-tss],
         [2.0.0-dev],
         [https://github.com/01org/tpm2-tss/issues],


### PR DESCRIPTION
In this PR:
* Add license header to configure.ac
* Update URLs in AC_INIT to use new tpm2-software URLs
* Use `with_maxloglevel` variable in configure summary output, not `with_loglevel`