### PR TITLE
ESAPI: Fixed PolicyCommandCode

### DIFF
--- a/esapi/esapi_util/esys_int.h
+++ b/esapi/esapi_util/esys_int.h
@@ -590,7 +590,7 @@ typedef struct {
 
 
 typedef struct {
-    TPMI_SH_POLICY policySession;
+    ESYS_TR policySession;
     TPM2_CC code;
 } PolicyCommandCode_IN;
 

--- a/include/esapi/tss2_esys.h
+++ b/include/esapi/tss2_esys.h
@@ -1983,19 +1983,19 @@ Esys_PolicyCounterTimer_finish(
 TSS2_RC
 Esys_PolicyCommandCode(
     ESYS_CONTEXT *esysContext,
+    ESYS_TR policySession,
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_SH_POLICY policySession,
     TPM2_CC code);
 
 TSS2_RC
 Esys_PolicyCommandCode_async(
     ESYS_CONTEXT *esysContext,
+    ESYS_TR policySession,
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_SH_POLICY policySession,
     TPM2_CC code);
 
 TSS2_RC


### PR DESCRIPTION
The session parameter of PolicyCommandCode was
falsely handled as command parameter instead of
an object handle. Thus it appeard at the wrong
place in the parameter list and also was of the
wrong type.

Fixed to work the same as all the other policy
commands.