### PR TITLE
Tcti cleanup and state machine docs

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -114,7 +114,7 @@ CLEANFILES += \
 
 if UNIT
 test_unit_util_CFLAGS = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
-test_unit_util_LDADD = $(CMOCKA_LIBS) $(libutil)
+test_unit_util_LDADD = $(CMOCKA_LIBS) $(libutil) $(libmarshal)
 test_unit_util_LDFLAGS = -Wl,--wrap=write
 test_unit_util_SOURCES = test/unit/util.c
 
@@ -130,7 +130,7 @@ test_unit_tcti_socket_SOURCES = tcti/platformcommand.c tcti/tcti_socket.c \
     tcti/sockets.c tcti/sockets.h test/unit/tcti-socket.c
 
 test_unit_socket_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
-test_unit_socket_LDADD   = $(CMOCKA_LIBS) $(libutil)
+test_unit_socket_LDADD   = $(CMOCKA_LIBS) $(libutil) $(libmarshal)
 test_unit_socket_LDFLAGS = -Wl,--wrap=connect,--wrap=socket
 test_unit_socket_SOURCES = test/unit/socket.c tcti/sockets.c tcti/sockets.h
 

--- a/tcti/tcti.c
+++ b/tcti/tcti.c
@@ -52,7 +52,7 @@ tcti_common_checks (
 }
 
 TSS2_RC
-tcti_send_checks (
+tcti_transmit_checks (
     TSS2_TCTI_CONTEXT *tctiContext,
     const uint8_t *command_buffer)
 {
@@ -64,11 +64,11 @@ tcti_send_checks (
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
+    if (tcti_intel->state != TCTI_STATE_TRANSMIT) {
+        return TSS2_TCTI_RC_BAD_SEQUENCE;
+    }
     if (command_buffer == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
-    }
-    if (tcti_intel->previousStage == TCTI_STAGE_SEND_COMMAND) {
-        return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
 
     return TSS2_RC_SUCCESS;
@@ -88,11 +88,11 @@ tcti_receive_checks (
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
+    if (tcti_intel->state != TCTI_STATE_RECEIVE) {
+        return TSS2_TCTI_RC_BAD_SEQUENCE;
+    }
     if (response_buffer == NULL || response_size == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
-    }
-    if (tcti_intel->previousStage == TCTI_STAGE_RECEIVE_RESPONSE) {
-        return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
 
     return TSS2_RC_SUCCESS;

--- a/tcti/tcti.c
+++ b/tcti/tcti.c
@@ -40,14 +40,11 @@ TSS2_RC
 tcti_common_checks (
     TSS2_TCTI_CONTEXT *tcti_context)
 {
-    TSS2_TCTI_CONTEXT_INTEL *tcti_intel;
-
-    tcti_intel = tcti_context_intel_cast (tcti_context);
     if (tcti_context == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
-    if (tcti_intel->magic != TCTI_MAGIC ||
-        tcti_intel->version != TCTI_VERSION) {
+    if (TSS2_TCTI_MAGIC (tcti_context) != TCTI_MAGIC ||
+        TSS2_TCTI_VERSION (tcti_context) != TCTI_VERSION) {
         return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 

--- a/tcti/tcti.c
+++ b/tcti/tcti.c
@@ -36,9 +36,9 @@
 #define LOGMODULE tcti
 #include "log/log.h"
 
-TSS2_RC tcti_common_checks (
-    TSS2_TCTI_CONTEXT *tcti_context
-    )
+TSS2_RC
+tcti_common_checks (
+    TSS2_TCTI_CONTEXT *tcti_context)
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel;
 
@@ -54,10 +54,10 @@ TSS2_RC tcti_common_checks (
     return TSS2_RC_SUCCESS;
 }
 
-TSS2_RC tcti_send_checks (
+TSS2_RC
+tcti_send_checks (
     TSS2_TCTI_CONTEXT *tctiContext,
-    const uint8_t *command_buffer
-    )
+    const uint8_t *command_buffer)
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel;
     TSS2_RC rc;
@@ -77,11 +77,11 @@ TSS2_RC tcti_send_checks (
     return TSS2_RC_SUCCESS;
 }
 
-TSS2_RC tcti_receive_checks (
+TSS2_RC
+tcti_receive_checks (
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t *response_size,
-    unsigned char *response_buffer
-    )
+    unsigned char *response_buffer)
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel;
     TSS2_RC rc;
@@ -101,7 +101,8 @@ TSS2_RC tcti_receive_checks (
     return TSS2_RC_SUCCESS;
 }
 
-ssize_t write_all (
+ssize_t
+write_all (
     int fd,
     const uint8_t *buf,
     size_t size)
@@ -129,7 +130,8 @@ ssize_t write_all (
     return (ssize_t)written_total;
 }
 
-TSS2_RC tcti_make_sticky_not_implemented (
+TSS2_RC
+tcti_make_sticky_not_implemented (
     TSS2_TCTI_CONTEXT *tctiContext,
     TPM2_HANDLE *handle,
     uint8_t sticky)

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -97,12 +97,9 @@ typedef struct {
     TPM2_ST tag;
     TPM2_RC responseSize;
 
-    TSS2_TCTI_CONTEXT *currentTctiContext;
-
     /* Sockets if socket interface is being used. */
     SOCKET otherSock;
     SOCKET tpmSock;
-    SOCKET currentConnectSock;
 
     /* File descriptor for device file if real TPM is being used. */
     int devFile;

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -42,6 +42,7 @@
 
 #include <errno.h>
 #include <sapi/tpm20.h>
+#include <stdbool.h>
 
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <sys/socket.h>
@@ -105,6 +106,7 @@ typedef enum {
 typedef struct {
     TSS2_TCTI_CONTEXT_COMMON_V2 v2;
     tcti_state_t state;
+    tpm_header_t header;
 
     struct {
         UINT32 reserved: 1; /* Used to be debugMsgEnabled which is deprecated */
@@ -125,7 +127,6 @@ typedef struct {
 
     /* File descriptor for device file if real TPM is being used. */
     int devFile;
-    unsigned char responseBuffer[4096];
 } TSS2_TCTI_CONTEXT_INTEL;
 
 /*
@@ -182,5 +183,14 @@ ssize_t write_all (
     int fd,
     const uint8_t *buf,
     size_t size);
+/*
+ * Utility to function to parse the first 10 bytes of a buffer and populate
+ * the 'header' structure with the results. The provided buffer is assumed to
+ * be at least 10 bytes long.
+ */
+TSS2_RC
+parse_header (
+    const uint8_t *buf,
+    tpm_header_t *header);
 
 #endif

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -125,31 +125,32 @@ tcti_context_intel_cast (TSS2_TCTI_CONTEXT *ctx)
  * be used by all externally facing TCTI functions before the context is used
  * as any of the private types.
  */
-TSS2_RC tcti_common_checks (
-    TSS2_TCTI_CONTEXT *tcti_context
-    );
+TSS2_RC
+tcti_common_checks (
+    TSS2_TCTI_CONTEXT *tcti_context);
 /*
  * This function performs common checks on the context structure and the
  * buffer passed into TCTI 'transmit' functions.
  */
-TSS2_RC tcti_send_checks (
+TSS2_RC
+tcti_send_checks (
     TSS2_TCTI_CONTEXT *tctiContext,
-    const uint8_t *command_buffer
-    );
+    const uint8_t *command_buffer);
 /*
  * This function performs common checks on the context structure, buffer and
  * size parameter passed to the TCTI 'receive' functions.
  */
-TSS2_RC tcti_receive_checks (
+TSS2_RC
+tcti_receive_checks (
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t            *response_size,
-    unsigned char     *response_buffer
-    );
+    unsigned char     *response_buffer);
 /*
  * Just a function with the right prototype that returns the not implemented
  * RC for the TCTI layer.
  */
-TSS2_RC tcti_make_sticky_not_implemented (
+TSS2_RC
+tcti_make_sticky_not_implemented (
     TSS2_TCTI_CONTEXT *tctiContext,
     TPM2_HANDLE *handle,
     uint8_t sticky);

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -74,15 +74,7 @@ enum tctiStates { TCTI_STAGE_INITIALIZE, TCTI_STAGE_SEND_COMMAND, TCTI_STAGE_REC
 
 /* current Intel version */
 typedef struct {
-    uint64_t magic;
-    uint32_t version;
-    TSS2_TCTI_TRANSMIT_FCN transmit;
-    TSS2_TCTI_RECEIVE_FCN receive;
-    TSS2_TCTI_FINALIZE_FCN finalize;
-    TSS2_TCTI_CANCEL_FCN cancel;
-    TSS2_TCTI_GET_POLL_HANDLES_FCN getPollHandles;
-    TSS2_TCTI_SET_LOCALITY_FCN setLocality;
-    TSS2_TCTI_MAKE_STICKY_FCN makeSticky;
+    TSS2_TCTI_CONTEXT_COMMON_V2 v2;
 
     struct {
         UINT32 reserved: 1; /* Used to be debugMsgEnabled which is deprecated */

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -221,7 +221,6 @@ Tss2_Tcti_Device_Init (
 
     tcti_intel->status.locality = 3;
     tcti_intel->status.commandSent = 0;
-    tcti_intel->currentTctiContext = 0;
     tcti_intel->previousStage = TCTI_STAGE_INITIALIZE;
 
     tcti_intel->devFile = open (dev_path, O_RDWR);

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -49,12 +49,12 @@ tcti_device_transmit (
     const uint8_t *command_buffer)
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
-    TSS2_RC rval = TSS2_RC_SUCCESS;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
     ssize_t size;
 
-    rval = tcti_send_checks (tctiContext, command_buffer);
-    if (rval != TSS2_RC_SUCCESS) {
-        return rval;
+    rc = tcti_send_checks (tctiContext, command_buffer);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
     }
     LOGBLOB_DEBUG (command_buffer,
                    command_size,
@@ -88,12 +88,12 @@ tcti_device_receive (
     int32_t timeout)
 {
     TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
-    TSS2_RC rval = TSS2_RC_SUCCESS;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
     ssize_t  size;
     unsigned int i;
 
-    rval = tcti_receive_checks (tctiContext, response_size, response_buffer);
-    if (rval != TSS2_RC_SUCCESS) {
+    rc = tcti_receive_checks (tctiContext, response_size, response_buffer);
+    if (rc != TSS2_RC_SUCCESS) {
         goto retLocalTpmReceive;
     }
     if (timeout != TSS2_TCTI_TIMEOUT_BLOCK) {
@@ -109,7 +109,7 @@ tcti_device_receive (
                                  4096));
         if (size < 0) {
             LOG_ERROR("send failed with error: %d", errno);
-            rval = TSS2_TCTI_RC_IO_ERROR;
+            rc = TSS2_TCTI_RC_IO_ERROR;
             goto retLocalTpmReceive;
         } else {
             tcti_intel->status.tagReceived = 1;
@@ -125,7 +125,7 @@ tcti_device_receive (
     }
 
     if (*response_size < tcti_intel->responseSize) {
-        rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+        rc = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
         *response_size = tcti_intel->responseSize;
         goto retLocalTpmReceive;
     }
@@ -141,11 +141,11 @@ tcti_device_receive (
     tcti_intel->status.commandSent = 0;
 
 retLocalTpmReceive:
-    if (rval == TSS2_RC_SUCCESS && response_buffer != NULL ) {
+    if (rc == TSS2_RC_SUCCESS && response_buffer != NULL ) {
         tcti_intel->previousStage = TCTI_STAGE_RECEIVE_RESPONSE;
     }
 
-    return rval;
+    return rc;
 }
 
 void

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -59,46 +59,6 @@ send_sim_session_end (
 }
 
 /*
- * Utility to function to parse the first 10 bytes of a buffer and populate
- * the 'header' structure with the results. The provided buffer is assumed to
- * be at least 10 bytes long.
- */
-TSS2_RC
-parse_header (
-    const uint8_t *buf,
-    tpm_header_t *header)
-{
-    TSS2_RC rc;
-    size_t offset = 0;
-
-    LOG_TRACE ("Parsing header from buffer: 0x%" PRIxPTR, (uintptr_t)buf);
-    rc = Tss2_MU_TPM2_ST_Unmarshal (buf,
-                                    TPM_HEADER_SIZE,
-                                    &offset,
-                                    &header->tag);
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR ("Failed to unmarshal tag.");
-        return rc;
-    }
-    rc = Tss2_MU_UINT32_Unmarshal (buf,
-                                   TPM_HEADER_SIZE,
-                                   &offset,
-                                   &header->size);
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR ("Failed to unmarshal command size.");
-        return rc;
-    }
-    rc = Tss2_MU_UINT32_Unmarshal (buf,
-                                   TPM_HEADER_SIZE,
-                                   &offset,
-                                   &header->code);
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR ("Failed to unmarshal command code.");
-    }
-    return rc;
-}
-
-/*
  * This fucntion is used to send the simulator a sort of command message
  * that tells it we're about to send it a TPM command. This requires that
  * we first send it a 4 byte code that's defined by the simulator. Then

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -474,7 +474,6 @@ tcti_socket_init_context_data (
     tcti_intel->status.tagReceived = 0;
     tcti_intel->status.responseSizeReceived = 0;
     tcti_intel->status.protocolResponseSizeReceived = 0;
-    tcti_intel->currentTctiContext = 0;
     tcti_intel->previousStage = TCTI_STAGE_INITIALIZE;
 }
 /*

--- a/test/integration/sys-initialize.int.c
+++ b/test/integration/sys-initialize.int.c
@@ -44,8 +44,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     // NOTE: don't do this in real applications.
-    tctiContextIntel.transmit = (TSS2_TCTI_TRANSMIT_FCN)0;
-    tctiContextIntel.receive = (TSS2_TCTI_RECEIVE_FCN)1;
+    TSS2_TCTI_RECEIVE (&tctiContextIntel) = (TSS2_TCTI_RECEIVE_FCN)1;
+    TSS2_TCTI_TRANSMIT (&tctiContextIntel) = (TSS2_TCTI_TRANSMIT_FCN)0;
 
     rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
@@ -54,8 +54,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     // NOTE: don't do this in real applications.
-    tctiContextIntel.transmit = (TSS2_TCTI_TRANSMIT_FCN)1;
-    tctiContextIntel.receive = (TSS2_TCTI_RECEIVE_FCN)0;
+    TSS2_TCTI_RECEIVE (&tctiContextIntel) = (TSS2_TCTI_RECEIVE_FCN)0;
+    TSS2_TCTI_TRANSMIT (&tctiContextIntel) = (TSS2_TCTI_TRANSMIT_FCN)1;
 
     rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -115,7 +115,10 @@ tcti_device_receive_success (void **state)
 {
     data_t *data = *state;
     TSS2_RC rc;
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (data->ctx);
 
+    /* Keep state machine check in `receive` from returning error. */
+    tcti_intel->state = TCTI_STATE_RECEIVE;
     will_return (__wrap_read, data->data_size);
     rc = Tss2_Tcti_Receive (data->ctx,
                             &data->buffer_size,

--- a/test/unit/tcti-socket.c
+++ b/test/unit/tcti-socket.c
@@ -237,6 +237,7 @@ static void
 tcti_socket_receive_success_test (void **state)
 {
     TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (ctx);
     TSS2_RC rc = TSS2_RC_SUCCESS;
     size_t response_size = 0xc;
     uint8_t response_in [] = { 0x80, 0x02,
@@ -248,6 +249,8 @@ tcti_socket_receive_success_test (void **state)
     uint8_t response_out [12] = { 0 };
     uint8_t platform_command_recv [4] = { 0 };
 
+    /* Keep state machine check in `receive` from returning error. */
+    tcti_intel->state = TCTI_STATE_RECEIVE;
     /* receive response size */
     will_return (__wrap_read, 4);
     will_return (__wrap_read, &response_in [2]);


### PR DESCRIPTION
This should be the last round of cleanup commits to bring the TCTI stuff in-line with our coding standard & conventions. The second half of this PR starts meddling around with the internals of the TCTI context structure and the state machine that tracks the transmit / receive stuff.