### PR TITLE
tcti: don't send MS_SIM_CANCEL_OFF on every receive

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -82,6 +82,7 @@ TESTS_INTEGRATION = \
     test/integration/policy-template.int \
     test/integration/create-loaded.int \
     test/integration/policy-authorizeNV.int \
+    test/integration/command-cancel.int \
     test/tpmclient/tpmclient.int
 if ESAPI
 TESTS_INTEGRATION += \
@@ -473,4 +474,9 @@ test_integration_policy_authorizeNV_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_policy_authorizeNV_int_LDADD   = $(TESTS_LDADD)
 test_integration_policy_authorizeNV_int_SOURCES = test/integration/main.c log/log.h log/log.c \
     test/integration/policy-authorizeNV.int.c
+
+test_integration_command_cancel_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_command_cancel_int_LDADD   = $(TESTS_LDADD)
+test_integration_command_cancel_int_SOURCES = test/integration/main.c log/log.h log/log.c \
+    test/integration/command-cancel.int.c
 endif #SIMULATOR_BIN

--- a/sysapi/sysapi/execute.c
+++ b/sysapi/sysapi/execute.c
@@ -124,7 +124,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
     }
     if (rval == TPM2_RC_CANCELED) {
         ctx->previousStage = CMD_STAGE_PREPARE;
-        return TSS2_SYS_RC_INSUFFICIENT_RESPONSE;
+        return rval;
     }
 
     ctx->previousStage = CMD_STAGE_RECEIVE_RESPONSE;

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -109,6 +109,11 @@ typedef struct {
     tpm_header_t header;
     uint8_t locality;
 
+    /* Flag indicating if a command has been cancelled.
+     * This is a temporary flag, which will be changed into
+     * a tcti state when support for asynch operation will be added */
+    bool cancel;
+
     /* Sockets if socket interface is being used. */
     SOCKET otherSock;
     SOCKET tpmSock;

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -162,6 +162,8 @@ tcti_socket_cancel (
     }
 
     tcti_intel->state = TCTI_STATE_TRANSMIT;
+    tcti_intel->cancel = 1;
+
     return rc;
 }
 
@@ -289,7 +291,10 @@ tcti_socket_receive (
         goto trans_state_out;
     }
 
-    rc = PlatformCommand (tctiContext, MS_SIM_CANCEL_OFF);
+    if (tcti_intel->cancel) {
+        rc = PlatformCommand (tctiContext, MS_SIM_CANCEL_OFF);
+        tcti_intel->cancel = 0;
+    }
     /*
      * Executing code beyond this point transitions the state machine to
      * TRANSMIT. Another call to this function will not be possible until

--- a/test/integration/command-cancel.int.c
+++ b/test/integration/command-cancel.int.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "tcti/tcti_socket.h"
+#define LOGMODULE test
+#include "log/log.h"
+#include "sapi-util.h"
+#include "test.h"
+
+
+/* Test copmmand cancel functionality.
+ * Create a primary object, which should pass. Then send a cancel on platform
+ * command and try to create a primary object again - this should fial with
+ * TPM_CANCEL rc. Then send a Cancel off command and try to create the object
+ * for the third time. This time it should pass again. */
+
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context)
+{
+    TPM2_HANDLE handle = 0;
+    TSS2_TCTI_CONTEXT *tcti_context;
+    TSS2_RC rc;
+    TPM2B_SENSITIVE_CREATE  in_sensitive    = { 0 };
+    TPM2B_PUBLIC            in_public       = { 0 };
+    TPM2B_DATA              outside_info    = { 0 };
+    TPML_PCR_SELECTION      creation_pcr    = { 0 };
+    TPM2B_PUBLIC            out_public      = { 0 };
+    TPM2B_CREATION_DATA     creation_data   = { 0 };
+    TPM2B_DIGEST            creation_hash   = TPM2B_DIGEST_INIT;
+    TPMT_TK_CREATION        creation_ticket = { 0 };
+    TPM2B_NAME              name            = TPM2B_NAME_INIT;
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
+    };
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp     = { 0 };
+
+    in_public.publicArea.type = TPM2_ALG_RSA;
+    in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
+    in_public.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM2_ALG_AES;
+    in_public.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
+    in_public.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM2_ALG_CFB;
+    in_public.publicArea.parameters.rsaDetail.scheme.scheme = TPM2_ALG_NULL;
+    in_public.publicArea.parameters.rsaDetail.keyBits = 2048;
+
+    rc = Tss2_Sys_GetTctiContext(sapi_context, &tcti_context);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetTctiContext FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("GetTctiContext SUCCESS!");
+
+    rc = create_primary_rsa_2048_aes_128_cfb (sapi_context, &handle);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("CreatePrimary FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("create_primary SUCCESS!");
+
+    rc = Tss2_Sys_FlushContext(sapi_context, handle);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("FlushContext SUCCESS!");
+
+    rc = PlatformCommand(tcti_context, MS_SIM_CANCEL_ON);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("PlatformCommand FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("PlatformCommand CANCEL_ON SUCCESS!");
+
+    rc = Tss2_Sys_CreatePrimary (sapi_context,
+                                 TPM2_RH_OWNER,
+                                 &sessions_cmd,
+                                 &in_sensitive,
+                                 &in_public,
+                                 &outside_info,
+                                 &creation_pcr,
+                                 &handle,
+                                 &out_public,
+                                 &creation_data,
+                                 &creation_hash,
+                                 &creation_ticket,
+                                 &name,
+                                 &sessions_rsp);
+    if (rc != TPM2_RC_CANCELED) {
+        LOG_DEBUG("CreatePrimary returned unexpected rc 0x%x, expected 0x%x", rc,
+                 TPM2_RC_CANCELED);
+        exit(1);
+    }
+    LOG_DEBUG("create_primary returned rc cancelled!");
+
+    rc = PlatformCommand(tcti_context, MS_SIM_CANCEL_OFF);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("PlatformCommand CANCEL_OFF SUCCESS!");
+
+    rc = create_primary_rsa_2048_aes_128_cfb(sapi_context, &handle);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("create_primary FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("create_primary SUCCESS!");
+
+    rc = Tss2_Sys_FlushContext(sapi_context, handle);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+    LOG_DEBUG("FlushContext SUCCESS!");
+    return 0;
+}

--- a/test/unit/tcti-socket.c
+++ b/test/unit/tcti-socket.c
@@ -269,7 +269,6 @@ tcti_socket_receive_success_test (void **state)
     /* simulator appends 4 bytes of 0's to every response */
                                0x00, 0x00, 0x00, 0x00 };
     uint8_t response_out [12] = { 0 };
-    uint8_t platform_command_recv [4] = { 0 };
 
     /* Keep state machine check in `receive` from returning error. */
     tcti_intel->state = TCTI_STATE_RECEIVE;
@@ -288,10 +287,6 @@ tcti_socket_receive_success_test (void **state)
     /* receive the 4 bytes of 0's appended by the simulator */
     will_return (__wrap_read, 4);
     will_return (__wrap_read, &response_in [12]);
-    /* platform command sends 4 bytes and receives the same */
-    will_return (__wrap_write, 4);
-    will_return (__wrap_read, 4);
-    will_return (__wrap_read, platform_command_recv);
 
     rc = Tss2_Tcti_Receive (ctx, &response_size, response_out, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -313,7 +308,6 @@ tcti_socket_receive_size_success_test (void **state)
     /* simulator appends 4 bytes of 0's to every response */
                                0x00, 0x00, 0x00, 0x00 };
     uint8_t response_out [12] = { 0 };
-    uint8_t platform_command_recv [4] = { 0 };
 
     /* Keep state machine check in `receive` from returning error. */
     tcti_intel->state = TCTI_STATE_RECEIVE;
@@ -336,10 +330,6 @@ tcti_socket_receive_size_success_test (void **state)
     /* receive the 4 bytes of 0's appended by the simulator */
     will_return (__wrap_read, 4);
     will_return (__wrap_read, &response_in [12]);
-    /* platform command sends 4 bytes and receives the same */
-    will_return (__wrap_write, 4);
-    will_return (__wrap_read, 4);
-    will_return (__wrap_read, platform_command_recv);
 
     rc = Tss2_Tcti_Receive (ctx, &response_size, response_out, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);


### PR DESCRIPTION
TCTI receive sends a platform CANCEL_OFF command on every response
read, which isn't necessary. This changes it to only send CANCEL_OFF
if a CANCEL_ON command has been sent beforehand.