### PR TITLE
libtcti-mssim: Fix regression in default conf string selection.

### DIFF
--- a/tcti/tcti-mssim.c
+++ b/tcti/tcti-mssim.c
@@ -508,13 +508,13 @@ Tss2_Tcti_Mssim_Init (
     char hostname[HOST_NAME_MAX + 1] = { 0 };
     uint16_t port = TCTI_SOCKET_DEFAULT_PORT;
 
+    LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
+               (uintptr_t)tctiContext, (uintptr_t)size, uri_str);
     if (tctiContext == NULL && size == NULL) {
         return TSS2_TCTI_RC_BAD_VALUE;
-    } else if( tctiContext == NULL ) {
+    } else if (tctiContext == NULL) {
         *size = sizeof (TSS2_TCTI_CONTEXT_INTEL);
         return TSS2_RC_SUCCESS;
-    } else if( conf == NULL ) {
-        return TSS2_TCTI_RC_BAD_VALUE;
     }
 
     rc = conf_str_to_host_port (uri_str, hostname, &port);

--- a/test/unit/tcti-mssim.c
+++ b/test/unit/tcti-mssim.c
@@ -218,6 +218,13 @@ tcti_socket_setup (void **state)
 
     return 0;
 }
+static void
+tcti_socket_init_null_conf_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = tcti_socket_init_from_conf (NULL);
+    assert_non_null (ctx);
+    free (ctx);
+}
 /*
  * This is a utility function to teardown a TCTI context allocated by the
  * tcti_socket_setup function.
@@ -373,6 +380,7 @@ main (int   argc,
         cmocka_unit_test (conf_str_to_host_port_invalid_port_0_test),
         cmocka_unit_test (tcti_socket_init_all_null_test),
         cmocka_unit_test (tcti_socket_init_size_test),
+        cmocka_unit_test (tcti_socket_init_null_conf_test),
         cmocka_unit_test_setup_teardown (tcti_socket_receive_null_size_test,
                                          tcti_socket_setup,
                                          tcti_socket_teardown),


### PR DESCRIPTION
When a `NULL` conf string is provided we're supposed to select a "sane"
default for the caller. Instead we're returning an error. This was
caused by a silly mistake made in checking the 'conf' parameter for
`NULL` in the wrong place.

This patch removes that check. We also add a TRACE level logging
statement to make future debugging a bit easier and a test case to
ensure a NULL conf string doesn't cause this regression again.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>