### PR TITLE
headers: Move TPM2B type from tss2_common.h to $(srcdir)/src/util.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,8 +93,7 @@ tss2_HEADERS = \
 libutil = libutil.la
 noinst_LTLIBRARIES += $(libutil)
 libutil_la_CFLAGS = $(AM_CFLAGS)
-libutil_la_SOURCES = src/util/log.c src/util/log.h src/util/tss2_endian.h \
-    src/util/io.c src/util/io.h
+libutil_la_SOURCES = $(UTIL_SRC)
 
 ### TCG TSS Marshaling/Unmarshalling spec library ###
 libtss2_mu = src/tss2-mu/libtss2-mu.la

--- a/bootstrap
+++ b/bootstrap
@@ -17,6 +17,10 @@ AUTORECONF=${AUTORECONF:-autoreconf}
 
 echo "Generating file lists: ${VARS_FILE}"
 (
+  src_listvar "src/util" "*.c" "UTIL_C"
+  src_listvar "src/util" "*.h" "UTIL_H"
+  printf "UTIL_SRC = \$(UTIL_C) \$(UTIL_H)\n"
+
   src_listvar "src/tss2-sys/" "*.c" "TSS2_SYS_C"
   src_listvar "src/tss2-sys/" "*.h" "TSS2_SYS_H"
   printf "TSS2_SYS_SRC = \$(TSS2_SYS_H) \$(TSS2_SYS_C)\n"

--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -47,11 +47,6 @@ typedef int32_t     INT32;
 typedef uint64_t    UINT64;
 typedef int64_t     INT64;
 
-typedef struct {
-    UINT16 size;
-    BYTE buffer[1];
-} TPM2B;
-
 /*
  * ABI runtime negotiation definitions
  */

--- a/src/tss2-esys/esys_crypto.h
+++ b/src/tss2-esys/esys_crypto.h
@@ -38,6 +38,8 @@
 
 #include <stdarg.h>
 
+#include "util/tpm2b.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -31,6 +31,7 @@
 
 #include "tss2_mu.h"
 
+#include "util/tpm2b.h"
 #include "util/tss2_endian.h"
 #define LOGMODULE marshal
 #include "util/log.h"

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -31,6 +31,7 @@
 #include "tss2_tpm2_types.h"
 #include "tss2_tcti.h"
 #include "tss2_sys.h"
+#include "util/tpm2b.h"
 
 enum cmdStates {CMD_STAGE_INITIALIZE,
                 CMD_STAGE_PREPARE,

--- a/src/util/tpm2b.h
+++ b/src/util/tpm2b.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TPM2B_H
+#define TPM2B_H
+
+#include "tss2_tpm2_types.h"
+
+typedef struct {
+    UINT16 size;
+    BYTE buffer[1];
+} TPM2B;
+
+#endif /* TPM2B_H */

--- a/test/tpmclient/CatSizedByteBuffer.c
+++ b/test/tpmclient/CatSizedByteBuffer.c
@@ -27,6 +27,8 @@
 
 #include "tss2_tpm2_types.h"
 
+#include "util/tpm2b.h"
+
 void CatSizedByteBuffer( TPM2B *dest, TPM2B *src )
 {
     int i;

--- a/test/tpmclient/CopySizedBuffer.c
+++ b/test/tpmclient/CopySizedBuffer.c
@@ -29,6 +29,8 @@
 
 #include "tss2_tpm2_types.h"
 
+#include "util/tpm2b.h"
+
 UINT16 CopySizedByteBuffer( TPM2B *dest, TPM2B *src )
 {
     int i;

--- a/test/tpmclient/tpmclient.h
+++ b/test/tpmclient/tpmclient.h
@@ -30,6 +30,7 @@
 
 #include "tss2_mu.h"
 #include "tss2_sys.h"
+#include "util/tpm2b.h"
 
 #define TPMBUF_LEN 0x8000
 #define GLOBAL_SYS_CONTEXT_SIZE 4096


### PR DESCRIPTION
This type isn't in the common header spec, or any TSS2 spec so it
definitely doesn't belong in any of the headers that get installed.
Since this is a type used by tss2-mu, sys and esys it now lives in
$(srcdir)/src/util/tpm2b.h.

To distribute this header in source tarballs via `make dist` it must be
added to the util library's SOURCE variable. To make this easier in the
future this commit adds code to the `bootstrap` script that populates
the UTIL_SRC variable with all source files under `$(srcdir)/src/util.`

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>