### PR TITLE
ESAPI Change the default TCTI initialization

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -62,6 +62,7 @@ TESTS_UNIT  = \
 if ESAPI
 TESTS_UNIT += \
     test/unit/esys-context-null \
+    test/unit/esys-default-tcti \
     test/unit/esys-resubmissions \
     test/unit/esys-sequence-finish
 endif ESAPI
@@ -210,6 +211,15 @@ test_unit_esys_context_null_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_context_null_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) -lgcrypt
 test_unit_esys_context_null_SOURCES = test/unit/esys-context-null.c
+
+test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_esys_default_tcti_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_esys_default_tcti_LDFLAGS = \
+        -Wl,--wrap=dlopen -Wl,-wrap=dlclose -Wl,-wrap=dlsym \
+        -Wl,--wrap=Tss2_Tcti_Device_Init \
+        -Wl,--wrap=Tss2_Tcti_Mssim_Init
+test_unit_esys_default_tcti_SOURCES = test/unit/esys-default-tcti.c \
+        src/tss2-esys/esys_tcti_default.c src/tss2-esys/esys_tcti_default.h
 
 test_unit_esys_resubmissions_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_resubmissions_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)

--- a/Makefile.am
+++ b/Makefile.am
@@ -158,12 +158,10 @@ lib_LTLIBRARIES += $(libtss2_esys)
 nodist_pkgconfig_DATA += lib/tss2-esys.pc
 EXTRA_DIST += lib/tss2-esys.pc.in
 
-src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys \
-    -DESYS_TCTI_DEFAULT_MODULE=$(TCTI_DEFAULT_MODULE) \
-    -DESYS_TCTI_DEFAULT_CONFIG=$(TCTI_DEFAULT_CONFIG)
+src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys
 src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \
     $(libtss2_tcti_device) $(libtss2_tcti_mssim) $(libutil)
-src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS)  -lgcrypt
+src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) -ldl -lgcrypt
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC)
 
 endif #ESAPI

--- a/Makefile.am
+++ b/Makefile.am
@@ -158,9 +158,7 @@ lib_LTLIBRARIES += $(libtss2_esys)
 nodist_pkgconfig_DATA += lib/tss2-esys.pc
 EXTRA_DIST += lib/tss2-esys.pc.in
 
-src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) \
-    -Wno-unused-variable -Wno-unused-label \
-    -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys \
+src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys \
     -DESYS_TCTI_DEFAULT_MODULE=$(TCTI_DEFAULT_MODULE) \
     -DESYS_TCTI_DEFAULT_CONFIG=$(TCTI_DEFAULT_CONFIG)
 src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \

--- a/configure.ac
+++ b/configure.ac
@@ -78,17 +78,20 @@ AM_CONDITIONAL([ESAPI], [test "x$enable_esapi" != xno])
 
 AC_ARG_WITH([tctidefaultmodule],
             [AS_HELP_STRING([--with-tctidefaultmodule],
-                            [The default tcti module for an Esys context.])],
-            [],
-            [with_tctidefaultmodule=Mssim])
-AC_SUBST([TCTI_DEFAULT_MODULE], [$with_tctidefaultmodule])
+[The default TCTI module for ESAPI. (Default: libtss2-tcti-default.so])],
+            [AC_DEFINE_UNQUOTED([ESYS_TCTI_DEFAULT_MODULE],
+                                [$with_tctidefaultmodule],
+                                ["The default TCTI library file"])],
+            [])
 
 AC_ARG_WITH([tctidefaultconfig],
             [AS_HELP_STRING([--with-tctidefaultconfig],
                             [The default tcti module's configuration.])],
-            [],
-            [with_tctidefaultconfig="tcp://127.0.0.1:2321"])
-AC_SUBST([TCTI_DEFAULT_CONFIG], [$with_tctidefaultconfig])
+            [AC_DEFINE_UNQUOTED([ESYS_TCTI_DEFAULT_CONFIG],
+                                [$with_tctidefaultconfig],
+                                ["The default TCTIs configuration string"])],
+            [])
+
 #
 # simulator binary
 #

--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -28,7 +28,6 @@
 #include <gcrypt.h>
 
 #include "tss2_esys.h"
-#include "sysapi_util.h"
 
 #include "esys_crypto.h"
 #include "esys_iutil.h"

--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -1,58 +1,221 @@
-#include "tss2_mu.h"
-#include "tss2_sys.h"
-#include "tss2_tcti_device.h"
-#include "tss2_tcti_mssim.h"
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include <stdlib.h>
 #include <errno.h>
-#include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#ifndef NO_DL
+#include <dlfcn.h>
+#endif /* NO_DL */
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_device.h"
+#include "tss2_tcti_mssim.h"
 
 #define LOGMODULE esys
 #include "util/log.h"
 
-#ifndef ESYS_TCTI_DEFAULT_MODULE
-#define ESYS_TCTI_DEFAULT_MODULE Mssim
-#endif
-#ifndef ESYS_TCTI_DEFAULT_CONFIG
-#define ESYS_TCTI_DEFAULT_CONFIG tcp://127.0.0.1:2321
-#endif
-
-#define _CONC(a,b,c) a ## b ## c
-#define _XCONC(a,b,c) _CONC(a,b,c)
-#define Tss2_Tcti_Default_Init _XCONC(Tss2_Tcti_, ESYS_TCTI_DEFAULT_MODULE, _Init)
-
 #define _STR(A) #A
 #define _XSTR(A) _STR(A)
 
-/*
- * Initialize a TCTI instance.
- * The caller is returned a TCTI context structure that is allocated by this
- * function. This structure must be freed by the caller.
- */
+#define ARRAY_SIZE(X) (sizeof(X)/sizeof(X[0]))
+
+struct {
+#ifndef NO_DL
+    char *file;
+#endif /* NO_DL */
+    TSS2_TCTI_INIT_FUNC init;
+    char *conf;
+    char *description;
+} tctis[] = {
+#ifndef NO_DL
+    { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" },
+    { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" },
+#endif /* NO_DL */
+    { .init = Tss2_Tcti_Device_Init, .conf = "/dev/tpmrm0",
+      .description = "Access to /dev/tpmrm0" },
+    { .init = Tss2_Tcti_Device_Init, .conf = "/dev/tpm0",
+      .description = "Access to /dev/tpm0" },
+    { .init = Tss2_Tcti_Mssim_Init, .conf = "tcp://127.0.0.1:2321",
+      .description = "Access to Mssim-simulator for tcp://localhost:2321" },
+};
+
+
+static TSS2_RC
+tcti_from_init(TSS2_TCTI_INIT_FUNC init,
+               const char* conf,
+               TSS2_TCTI_CONTEXT **tcti)
+{
+    TSS2_RC r;
+    size_t size;
+
+    LOG_TRACE("Initializing TCTI for config: %s", conf);
+
+    r = init(NULL, &size, conf);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_WARNING("TCTI init for function %p failed with %" PRIx32, init, r);
+        return r;
+    }
+
+    *tcti = (TSS2_TCTI_CONTEXT *) calloc(1, size);
+    if (*tcti == NULL) {
+        LOG_ERROR("Memory allocation for tcti failed: %s", strerror(errno));
+        return TSS2_ESYS_RC_MEMORY;
+    }
+
+    r = init(*tcti, &size, conf);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_WARNING("TCTI init for function %p failed with %" PRIx32, init, r);
+        free(*tcti);
+        *tcti=NULL;
+        return r;
+    }
+
+    LOG_DEBUG("Initialized TCTI for config: %s", conf);
+
+    return TSS2_RC_SUCCESS;
+}
+
+static TSS2_RC
+tcti_from_info(TSS2_TCTI_INFO_FUNC infof,
+               const char* conf,
+               TSS2_TCTI_CONTEXT **tcti)
+{
+    TSS2_RC r;
+    LOG_TRACE("Attemting to load TCTI info");
+
+    const TSS2_TCTI_INFO* info = infof();
+    if (info == NULL) {
+        LOG_ERROR("TCTI info function failed");
+        return TSS2_ESYS_RC_GENERAL_FAILURE;
+    }
+    LOG_TRACE("Loaded TCTI info named: %s", info->name);
+    LOG_TRACE("TCTI description: %s", info->description);
+    LOG_TRACE("TCTI config_help: %s", info->config_help);
+
+    r = tcti_from_init(info->init, conf, tcti);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_WARNING("Could not initialize TCTI named: %s", info->name);
+        return r;
+    }
+
+    LOG_DEBUG("Initialized TCTI named: %s", info->name);
+
+    return TSS2_RC_SUCCESS;
+}
+
+#ifndef NO_DL
+static TSS2_RC
+tcti_from_file(const char *file,
+               const char* conf,
+               TSS2_TCTI_CONTEXT **tcti)
+{
+    TSS2_RC r;
+    void *handle;
+    TSS2_TCTI_INFO_FUNC infof;
+
+    LOG_TRACE("Attemting to load TCTI file: %s", file);
+
+    handle = dlopen(file, RTLD_NOW);
+    if (handle == NULL) {
+        LOG_WARNING("Could not load TCTI file: %s", file);
+        return TSS2_ESYS_RC_BAD_REFERENCE;
+    }
+
+    infof = (TSS2_TCTI_INFO_FUNC) dlsym(handle, TSS2_TCTI_INFO_SYMBOL);
+    if (infof == NULL) {
+        LOG_ERROR("Info not found in TCTI file: %s", file);
+        dlclose(handle);
+        return TSS2_ESYS_RC_BAD_REFERENCE;
+    }
+
+    r = tcti_from_info(infof, conf, tcti);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Could not initialize TCTI file: %s", file);
+        dlclose(handle);
+        return r;
+    }
+
+    LOG_DEBUG("Initialized TCTI file: %s", file);
+
+    return TSS2_RC_SUCCESS;
+}
+#endif /* NO_DL */
+
 TSS2_RC
 get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext)
 {
-    size_t size;
-    TSS2_RC rc;
-    TSS2_TCTI_CONTEXT *tcti_ctx;
+    if (tcticontext == NULL) {
+        LOG_ERROR("tcticontext must not be NULL");
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+    *tcticontext = NULL;
+#ifdef ESYS_TCTI_DEFAULT_MODULE
 
-    rc = Tss2_Tcti_Default_Init(NULL, &size, _XSTR(ESYS_TCTI_DEFAULT_CONFIG));
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR("Failed to get allocation size for tcti context: 0x%x\n", rc);
-        return rc;
+#ifdef ESYS_TCTI_DEFAULT_CONFIG
+    const char *config = _XSTR(ESYS_TCTI_DEFAULT_CONFIG);
+#else /* ESYS_TCTI_DEFAULT_CONFIG */
+    const char *config = NULL;
+#endif /* ESYS_TCTI_DEFAULT_CONFIG */
+
+    LOG_DEBUG("Attempting to initialize TCTI defined during compilation: %s:%s",
+              ESYS_TCTI_DEFAULT_MODULE, config);
+    return tcti_from_file(ESYS_TCTI_DEFAULT_MODULE, config, tcticontext);
+
+#else /* ESYS_TCTI_DEFAULT_MODULE */
+
+    TSS2_RC r;
+
+    for (int i = 0; i < ARRAY_SIZE(tctis); i++) {
+        LOG_DEBUG("Attempting to connect using standard TCTI: %s",
+                  tctis[i].description);
+
+        if (tctis[i].init != NULL) {
+            r = tcti_from_init(tctis[i].init, tctis[i].conf, tcticontext);
+            if (r == TSS2_RC_SUCCESS)
+                return TSS2_RC_SUCCESS;
+            LOG_DEBUG("Failed to load standard TCTI number %i", i);
+#ifndef NO_DL
+        } else if (tctis[i].file != NULL) {
+            r = tcti_from_file(tctis[i].file, tctis[i].conf, tcticontext);
+            if (r == TSS2_RC_SUCCESS)
+                return TSS2_RC_SUCCESS;
+            LOG_DEBUG("Failed to load standard TCTI number %i", i);
+#endif /* NO_DL */
+        } else {
+            LOG_ERROR("Errorous entry in standard TCTIs");
+            return TSS2_ESYS_RC_GENERAL_FAILURE;
+        }
+
     }
-    tcti_ctx = (TSS2_TCTI_CONTEXT *) calloc(1, size);
-    if (tcti_ctx == NULL) {
-        LOG_ERROR("Allocation for tcti context failed: %s\n",
-                strerror(errno));
-        return TSS2_BASE_RC_MEMORY;
-    }
-    rc = Tss2_Tcti_Default_Init(tcti_ctx, &size, _XSTR(ESYS_TCTI_DEFAULT_CONFIG));
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR("Failed to initialize tcti context: 0x%x\n", rc);
-        free(tcti_ctx);
-        return rc;
-    }
-    *tcticontext = tcti_ctx;
-    return TSS2_RC_SUCCESS;
+
+    LOG_ERROR("No standard TCTI could be loaded");
+    return TSS2_ESYS_RC_NOT_IMPLEMENTED;
+
+#endif /* ESYS_TCTI_DEFAULT_MODULE */
 }

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -38,6 +38,7 @@ typedef enum {
 
 static const char *log_strings[] COMPILER_ATTR(unused) = {
     "none",
+    "(unused)",
     "ERROR",
     "WARNING",
     "info",

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -1,0 +1,407 @@
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include <dlfcn.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+
+#include "esys_tcti_default.h"
+#define LOGMODULE test
+#include "util/log.h"
+
+#ifndef ESYS_TCTI_DEFAULT_MODULE
+
+void *
+__wrap_dlopen(const char *filename, int flags)
+{
+    LOG_TRACE("Called with filename %s and flags %x", filename, flags);
+    check_expected_ptr(filename);
+    check_expected(flags);
+    return mock_type(void *);
+}
+
+int
+__wrap_dlclose(void *handle)
+{
+    LOG_TRACE("Called with handle %p", handle);
+    check_expected_ptr(handle);
+    return mock_type(int);
+}
+
+void *
+__wrap_dlsym(void *handle, const char *symbol)
+{
+    LOG_TRACE("Called with handle %p and symbol %s", handle, symbol);
+    check_expected_ptr(handle);
+    check_expected_ptr(symbol);
+    return mock_type(void *);
+}
+
+TSS2_RC
+__wrap_Tss2_Tcti_Fake_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
+                           const char *config)
+{
+    LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
+              size, config);
+    check_expected(tctiContext);
+    check_expected_ptr(size);
+    check_expected_ptr(config);
+    *size = mock_type(size_t);
+    return mock_type(TSS2_RC);
+}
+
+TSS2_TCTI_INFO *
+__wrap_Tss2_Tcti_Fake_Info(void)
+{
+    LOG_TRACE("Called.");
+    return mock_type(TSS2_TCTI_INFO *);
+}
+
+TSS2_RC
+__wrap_Tss2_Tcti_Device_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
+                             const char *config)
+{
+    LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
+              size, config);
+    check_expected_ptr(tctiContext);
+    check_expected_ptr(size);
+    check_expected_ptr(config);
+    *size = mock_type(size_t);
+    return mock_type(TSS2_RC);
+}
+
+TSS2_RC
+__wrap_Tss2_Tcti_Mssim_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
+                            const char *config)
+{
+    LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
+              size, config);
+    check_expected_ptr(tctiContext);
+    check_expected_ptr(size);
+    check_expected_ptr(config);
+    *size = mock_type(size_t);
+    return mock_type(TSS2_RC);
+}
+
+#ifndef NO_DL
+/** Test for tcti
+ * { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" }
+ */
+static void
+test_tcti_default(void **state)
+{
+    size_t lsize = 0x99;
+#define HANDLE (void *)123321
+
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, HANDLE);
+
+    expect_value(__wrap_dlsym, handle, HANDLE);
+    expect_string(__wrap_dlsym, symbol, TSS2_TCTI_INFO_SYMBOL);
+    will_return(__wrap_dlsym, &__wrap_Tss2_Tcti_Fake_Info);
+
+    TSS2_TCTI_INFO fakeInfo = {
+        .version = { 0x123123, 2 },
+        .name = "FakeTCTI",
+        .description = "FakeDesc",
+        .config_help = "FakeHelp",
+        .init = &__wrap_Tss2_Tcti_Fake_Init,
+    };
+    will_return(__wrap_Tss2_Tcti_Fake_Info, &fakeInfo);
+
+    expect_value(__wrap_Tss2_Tcti_Fake_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Fake_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Fake_Init, config, "");
+    will_return(__wrap_Tss2_Tcti_Fake_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
+
+    expect_any(__wrap_Tss2_Tcti_Fake_Init, tctiContext);
+    expect_memory(__wrap_Tss2_Tcti_Fake_Init, size, &lsize, sizeof(lsize));
+    expect_string(__wrap_Tss2_Tcti_Fake_Init, config, "");
+    will_return(__wrap_Tss2_Tcti_Fake_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
+
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti;
+    r = get_tcti_default(&tcti);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    free(tcti);
+}
+
+/** Test for tcti
+ * { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" }
+ */
+static void
+test_tcti_tabrmd(void **state)
+{
+#define HANDLE (void *)123321
+    size_t lsize = 0x99;
+
+    /** Skip over
+     * { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    /** Now test
+     *{ "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so"},
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, HANDLE);
+
+    expect_value(__wrap_dlsym, handle, HANDLE);
+    expect_string(__wrap_dlsym, symbol, TSS2_TCTI_INFO_SYMBOL);
+    will_return(__wrap_dlsym, &__wrap_Tss2_Tcti_Fake_Info);
+
+    TSS2_TCTI_INFO fakeInfo = {
+        .version = { 0x123123, 2 },
+        .name = "FakeTCTI",
+        .description = "FakeDesc",
+        .config_help = "FakeHelp",
+        .init = &__wrap_Tss2_Tcti_Fake_Init,
+    };
+    will_return(__wrap_Tss2_Tcti_Fake_Info, &fakeInfo);
+
+    expect_value(__wrap_Tss2_Tcti_Fake_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Fake_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Fake_Init, config, "");
+    will_return(__wrap_Tss2_Tcti_Fake_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
+
+    expect_any(__wrap_Tss2_Tcti_Fake_Init, tctiContext);
+    expect_memory(__wrap_Tss2_Tcti_Fake_Init, size, &lsize, sizeof(lsize));
+    expect_string(__wrap_Tss2_Tcti_Fake_Init, config, "");
+    will_return(__wrap_Tss2_Tcti_Fake_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
+
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti;
+    r = get_tcti_default(&tcti);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    free(tcti);
+}
+#endif /* NO_DL */
+
+/** Test for tcti
+ * { NULL, Tss2_Tcti_Device_Init, "/dev/tpmrm0", "Access to /dev/tpmrm0" }
+ */
+static void
+test_tcti_tpmrm0(void **state)
+{
+    size_t lsize = 0x99;
+#ifndef NO_DL
+    /** Skip over
+     * { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    /** Skip over
+     * { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+#endif /* NO_DL */
+
+    /** Now test
+     * { NULL, Tss2_Tcti_Device_Init, "/dev/tpmrm0", "Access to /dev/tpmrm0" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Device_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Device_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpmrm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
+
+    expect_any(__wrap_Tss2_Tcti_Device_Init, tctiContext);
+    expect_memory(__wrap_Tss2_Tcti_Device_Init, size, &lsize, sizeof(lsize));
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpmrm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
+
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti;
+    r = get_tcti_default(&tcti);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    free(tcti);
+}
+
+/** Test for tcti
+ * { NULL, Tss2_Tcti_Device_Init, "/dev/tpm0", "Access to /dev/tpm0"},
+ */
+static void
+test_tcti_tpm0(void **state)
+{
+    size_t lsize = 0x99;
+#ifndef NO_DL
+    /** Skip over
+     * { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    /** Skip over
+     * { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+#endif /* NO_DL */
+
+    /** Skip over
+     * { NULL, Tss2_Tcti_Device_Init, "/dev/tpmrm0", "Access to /dev/tpmrm0" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Device_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Device_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpmrm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, 0);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_TCTI_RC_IO_ERROR);
+
+    /** Now test
+     * { NULL, Tss2_Tcti_Device_Init, "/dev/tpmrm0", "Access to /dev/tpm0" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Device_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Device_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
+
+    expect_any(__wrap_Tss2_Tcti_Device_Init, tctiContext);
+    expect_memory(__wrap_Tss2_Tcti_Device_Init, size, &lsize, sizeof(lsize));
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
+
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti;
+    r = get_tcti_default(&tcti);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    free(tcti);
+}
+
+/** Test for tcti
+ * { NULL, Tss2_Tcti_Mssim_Init, "tcp://127.0.0.1:2321",
+ *      "Access to Mssim-simulator for tcp://localhost:2321" }
+ */
+static void
+test_tcti_mssim(void **state)
+{
+    size_t lsize = 0x99;
+#ifndef NO_DL
+    /** Skip over
+     * { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    /** Skip over
+     * { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" }
+     */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+#endif /* NO_DL */
+
+    /** Skip over
+     * { NULL, Tss2_Tcti_Device_Init, "/dev/tpmrm0", "Access to /dev/tpmrm0" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Device_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Device_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpmrm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, 0);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_TCTI_RC_IO_ERROR);
+
+    /** Skip over
+     * { NULL, Tss2_Tcti_Device_Init, "/dev/tpm0", "Access to /dev/tpm0" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Device_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Device_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Device_Init, config, "/dev/tpm0");
+    will_return(__wrap_Tss2_Tcti_Device_Init, 0);
+    will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_TCTI_RC_IO_ERROR);
+
+    /** Now test
+     * { NULL, Tss2_Tcti_Mssim_Init, "tcp://127.0.0.1:2321",
+     *      "Access to Mssim-simulator for tcp://localhost:2321" }
+     */
+    expect_value(__wrap_Tss2_Tcti_Mssim_Init, tctiContext, NULL);
+    expect_any(__wrap_Tss2_Tcti_Mssim_Init, size);
+    expect_string(__wrap_Tss2_Tcti_Mssim_Init, config, "tcp://127.0.0.1:2321");
+    will_return(__wrap_Tss2_Tcti_Mssim_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Mssim_Init, TSS2_RC_SUCCESS);
+
+    expect_any(__wrap_Tss2_Tcti_Mssim_Init, tctiContext);
+    expect_memory(__wrap_Tss2_Tcti_Mssim_Init, size, &lsize, sizeof(lsize));
+    expect_string(__wrap_Tss2_Tcti_Mssim_Init, config, "tcp://127.0.0.1:2321");
+    will_return(__wrap_Tss2_Tcti_Mssim_Init, lsize);
+    will_return(__wrap_Tss2_Tcti_Mssim_Init, TSS2_RC_SUCCESS);
+
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti;
+    r = get_tcti_default(&tcti);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    free(tcti);
+}
+
+#endif /* ESYS_TCTI_DEFAULT_MODULE */
+
+int
+main(void)
+{
+#ifdef ESYS_TCTI_DEFAULT_MODULE
+    LOG_WARNING("ESYS_TCTI_DEFAULT_MODULE was defined during configuration. "
+              "Thus nothing to test here.");
+    return 77;
+
+#else /* ESYS_TCTI_DEFAULT_MODULE */
+
+    const struct CMUnitTest tests[] = {
+#ifndef NO_DL
+        cmocka_unit_test(test_tcti_default),
+        cmocka_unit_test(test_tcti_tabrmd),
+#endif /* NO_DL */
+        cmocka_unit_test(test_tcti_tpmrm0),
+        cmocka_unit_test(test_tcti_tpm0),
+        cmocka_unit_test(test_tcti_mssim),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+
+#endif /* ESYS_TCTI_DEFAULT_MODULE */
+}


### PR DESCRIPTION
Two very minor commit first that I just split out before the actual changes.

The ESAPI gains a new behavior for initializing the
default TCTI.

- The configure flag is now interpreted as a file
  instead of as a partial symbol name.
- If a default tcti is configured only this file is
  loaded.
- If no default tcti is configured, esys will attempt
  to load a tcti in the following order
  - Search for a libtss2-tcti-default.so
  - Search for a libtss2-tcti-tabrmd.so
  - Attempt the linked Tcti_Device for "/dev/tpmrm0"
  - Attempt the linked Tcti_Device for "/dev/tpm0"
  - Attempt the linked Tcti_Mssim for "localhost:2321"

@williamcroberts I'd like to get your opinion from the tpm2-tools perspective as well.