### PR TITLE
tss2-esys: Fix Error Handling in get_tcti_default()

### DIFF
--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -7,6 +7,9 @@
 #include <string.h>
 #include <inttypes.h>
 
+#define LOGMODULE esys
+#include "util/log.h"
+
 #ifndef ESYS_TCTI_DEFAULT_MODULE
 #define ESYS_TCTI_DEFAULT_MODULE Mssim
 #endif
@@ -35,19 +38,18 @@ get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext)
 
     rc = Tss2_Tcti_Default_Init(NULL, &size, _XSTR(ESYS_TCTI_DEFAULT_CONFIG));
     if (rc != TSS2_RC_SUCCESS) {
-        fprintf(stderr, "Faled to get allocation size for tcti context: "
-                "0x%x\n", rc);
+        LOG_ERROR("Failed to get allocation size for tcti context: 0x%x\n", rc);
         return rc;
     }
     tcti_ctx = (TSS2_TCTI_CONTEXT *) calloc(1, size);
     if (tcti_ctx == NULL) {
-        fprintf(stderr, "Allocation for tcti context failed: %s\n",
+        LOG_ERROR("Allocation for tcti context failed: %s\n",
                 strerror(errno));
-        return rc;
+        return TSS2_BASE_RC_MEMORY;
     }
     rc = Tss2_Tcti_Default_Init(tcti_ctx, &size, _XSTR(ESYS_TCTI_DEFAULT_CONFIG));
     if (rc != TSS2_RC_SUCCESS) {
-        fprintf(stderr, "Failed to initialize tcti context: 0x%x\n", rc);
+        LOG_ERROR("Failed to initialize tcti context: 0x%x\n", rc);
         free(tcti_ctx);
         return rc;
     }


### PR DESCRIPTION
There are multiple problems with the error handling in
tpm2-tss/src/tss2-esys/esys_tcti_default.c get_tcti_default():

1. LOG_ERROR or LOG_WARNING should be used instead of fprintf().
2. Typo: s/Faled/Failed/
3. The rc value returned after calloc() fails is always TSS2_RC_SUCCESS

Fixes #885.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>