### PR TITLE
tcti-device: Copy response header to output buffer in receive function.

### DIFF
--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -120,8 +120,8 @@ tcti_device_receive (
                   tcti_intel->header.size);
     }
 
-    *response_size = tcti_intel->header.size;
     if (response_buffer == NULL) {
+        *response_size = tcti_intel->header.size;
         LOG_DEBUG ("response_buffer is null, returning size: %zd", *response_size);
         return TSS2_RC_SUCCESS;
     }
@@ -131,6 +131,8 @@ tcti_device_receive (
                      *response_size, tcti_intel->header.size);
         return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
     }
+    *response_size = tcti_intel->header.size;
+
     rc = header_marshal (&tcti_intel->header, response_buffer);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -112,7 +112,7 @@ tcti_device_receive (
             goto trans_state_out;
         }
         LOGBLOB_DEBUG (header_buf, TPM_HEADER_SIZE, "Response header received");
-        rc = parse_header (header_buf, &tcti_intel->header);
+        rc = header_unmarshal (header_buf, &tcti_intel->header);
         if (rc != TSS2_RC_SUCCESS) {
             return rc;
         }

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -131,9 +131,13 @@ tcti_device_receive (
                      *response_size, tcti_intel->header.size);
         return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
     }
+    rc = header_marshal (&tcti_intel->header, response_buffer);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
     /* Read the rest of the response, minus the header that we already jave. */
     size = read_all (tcti_intel->devFile,
-                     response_buffer,
+                     &response_buffer [TPM_HEADER_SIZE],
                      tcti_intel->header.size - TPM_HEADER_SIZE);
     if (size < 0) {
         LOG_WARNING ("Failed to read response body.");

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -164,7 +164,7 @@ tcti_mssim_transmit (
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
-    rc = parse_header (cmd_buf, &header);
+    rc = header_unmarshal (cmd_buf, &header);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }

--- a/src/tss2-tcti/tcti.c
+++ b/src/tss2-tcti/tcti.c
@@ -140,3 +140,38 @@ parse_header (
     }
     return rc;
 }
+
+TSS2_RC
+header_marshal (
+    const tpm_header_t *header,
+    uint8_t *buf)
+{
+    TSS2_RC rc;
+    size_t offset = 0;
+
+    LOG_TRACE ("Parsing header from buffer: 0x%" PRIxPTR, (uintptr_t)buf);
+    rc = Tss2_MU_TPM2_ST_Marshal (header->tag,
+                                  buf,
+                                  TPM_HEADER_SIZE,
+                                  &offset);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed to marshal tag.");
+        return rc;
+    }
+    rc = Tss2_MU_UINT32_Marshal (header->size,
+                                 buf,
+                                 TPM_HEADER_SIZE,
+                                 &offset);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed to marshal command size.");
+        return rc;
+    }
+    rc = Tss2_MU_UINT32_Marshal (header->code,
+                                 buf,
+                                 TPM_HEADER_SIZE,
+                                 &offset);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed to marshal command code.");
+    }
+    return rc;
+}

--- a/src/tss2-tcti/tcti.c
+++ b/src/tss2-tcti/tcti.c
@@ -107,7 +107,7 @@ tcti_make_sticky_not_implemented (
 }
 
 TSS2_RC
-parse_header (
+header_unmarshal (
     const uint8_t *buf,
     tpm_header_t *header)
 {

--- a/src/tss2-tcti/tcti.h
+++ b/src/tss2-tcti/tcti.h
@@ -173,5 +173,11 @@ TSS2_RC
 parse_header (
     const uint8_t *buf,
     tpm_header_t *header);
+/*
+ */
+TSS2_RC
+header_marshal (
+    const tpm_header_t *header,
+    uint8_t *buf);
 
 #endif

--- a/src/tss2-tcti/tcti.h
+++ b/src/tss2-tcti/tcti.h
@@ -170,7 +170,7 @@ tcti_make_sticky_not_implemented (
  * be at least 10 bytes long.
  */
 TSS2_RC
-parse_header (
+header_unmarshal (
     const uint8_t *buf,
     tpm_header_t *header);
 /*


### PR DESCRIPTION
This commit resolves a bug in the device TCTI where the receive function
read the response header from the TPM but neglects to copy this to the
buffer provided by the caller. The unit tests for this module were
unfortunately not catching this misbehavior.

For this fix we add a function to the tcti module to assist in
marshalling the response header back out to the caller provided buffer.
The unit test for the device TCTI has also been updated to compare the
response buffer received by the client to the pre-canned response buffer
that the mock framework uses when mocking the 'read' function.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>