### PR TITLE
Rework tests wrt transient objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ doc/man/
 tpm2-tss-2.0.0-dev.tar.gz
 tpm2-tss-2.0.0-dev/
 
+test/helper/tpm_startup

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ tpm2-tss-2.0.0-dev.tar.gz
 tpm2-tss-2.0.0-dev/
 
 test/helper/tpm_startup
+test/helper/tpm_transientempty

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -41,6 +41,14 @@ check-programs: $(check_PROGRAMS)
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(check_PROGRAMS)
 
+if SIMULATOR_BIN
+noinst_PROGRAMS += test/helper/tpm_startup
+test_helper_tpm_startup_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
+test_helper_tpm_startup_LDFLAGS = $(TESTS_LDFLAGS)
+test_helper_tpm_startup_LDADD = $(TESTS_LDADD)
+test_helper_tpm_startup_SOURCES = test/helper/tpm_startup.c
+endif #SIMULATOR_BIN
+
 if UNIT
 TESTS_UNIT  = \
     test/unit/CommonPreparePrologue \

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -49,6 +49,12 @@ test_helper_tpm_startup_LDADD = $(TESTS_LDADD)
 test_helper_tpm_startup_SOURCES = test/helper/tpm_startup.c
 endif #SIMULATOR_BIN
 
+noinst_PROGRAMS += test/helper/tpm_transientempty
+test_helper_tpm_transientempty_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
+test_helper_tpm_transientempty_LDFLAGS = $(TESTS_LDFLAGS)
+test_helper_tpm_transientempty_LDADD = $(TESTS_LDADD)
+test_helper_tpm_transientempty_SOURCES = test/helper/tpm_transientempty.c
+
 if UNIT
 TESTS_UNIT  = \
     test/unit/CommonPreparePrologue \

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ noinst_LTLIBRARIES =
 EXTRA_DIST =
 CLEANFILES =
 MOSTLYCLEANFILES =
+noinst_PROGRAMS =
 
 ### Add ax_* rules ###
 # ax_code_coverage

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -229,6 +229,16 @@ if [ $? -ne 0 ]; then
     break
 fi
 
+env TPM20TEST_TCTI_NAME="socket" \
+    TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
+    TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
+    G_MESSAGES_DEBUG=all ./test/helper/tpm_transientempty
+if [ $? -ne 0 ]; then
+    echo "TPM transient area not empty => skipping"
+    ret=77
+    break
+fi
+
 echo "Execute the test script"
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -217,12 +217,28 @@ for i in $(seq ${BACKOFF_MAX}); do
     fi
 done
 
-# execute the test script
+while true; do
+
+env TPM20TEST_TCTI_NAME="socket" \
+    TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
+    TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
+    G_MESSAGES_DEBUG=all ./test/helper/tpm_startup
+if [ $? -ne 0 ]; then
+    echo "TPM_StartUp failed"
+    ret=99
+    break
+fi
+
+echo "Execute the test script"
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
     G_MESSAGES_DEBUG=all $@
 ret=$?
+echo "Script returned $ret"
+
+break
+done
 
 # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
 # second after the test finishes the simulator will die too. Bug in the

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -247,6 +247,16 @@ env TPM20TEST_TCTI_NAME="socket" \
 ret=$?
 echo "Script returned $ret"
 
+env TPM20TEST_TCTI_NAME="socket" \
+    TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
+    TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
+    G_MESSAGES_DEBUG=all ./test/helper/tpm_transientempty
+if [ $? -ne 0 ]; then
+    echo "TPM transient area not empty or generally failed after test"
+    ret=99
+    break
+fi
+
 break
 done
 

--- a/test/helper/tpm_startup.c
+++ b/test/helper/tpm_startup.c
@@ -1,0 +1,40 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "tss2_sys.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "test-options.h"
+#include "context-util.h"
+
+int
+main (int argc, char *argv[])
+{
+    TSS2_RC rc;
+    TSS2_SYS_CONTEXT *sapi_context;
+
+    test_opts_t opts = {
+        .tcti_type      = TCTI_DEFAULT,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+    };
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0)
+        exit (1);
+
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL)
+        exit (1);
+
+    rc = Tss2_Sys_Startup(sapi_context, TPM2_SU_CLEAR);
+    if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
+        LOG_ERROR("TPM Startup FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+
+    sapi_teardown_full (sapi_context);
+    return 0;
+}

--- a/test/helper/tpm_transientempty.c
+++ b/test/helper/tpm_transientempty.c
@@ -1,0 +1,47 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "tss2_sys.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "test-options.h"
+#include "context-util.h"
+
+int
+main (int argc, char *argv[])
+{
+    TSS2_RC rc;
+    TSS2_SYS_CONTEXT *sapi_context;
+
+    test_opts_t opts = {
+        .tcti_type      = TCTI_DEFAULT,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+    };
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0)
+        exit (1);
+
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL)
+        exit (1);
+
+    TPMI_YES_NO more;
+    rc = Tss2_Sys_GetCapability(sapi_context, NULL, TPM2_CAP_HANDLES,
+                                TPM2_HR_TRANSIENT, 0, &more, NULL, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("TPM GetCapabilities FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+
+    sapi_teardown_full (sapi_context);
+
+    if (more) {
+        LOG_ERROR("TPM contains transient entries");
+        return 1;
+    }
+    return 0;
+}

--- a/test/integration/asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/asymmetric-encrypt-decrypt.int.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "tss2_tcti.h"
 #include "tss2_sys.h"
@@ -140,6 +141,17 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     LOG_INFO("Decrypt successed.");
 
     LOG_INFO("Asymmetric Encryption and Decryption Test Passed!");
+
+    rc = Tss2_Sys_FlushContext(sapi_context, sym_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+    rc = Tss2_Sys_FlushContext(sapi_context, loaded_sym_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
     return 0;
 }
 

--- a/test/integration/create-keyedhash-sha1-hmac.int.c
+++ b/test/integration/create-keyedhash-sha1-hmac.int.c
@@ -40,7 +40,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     if (rc == TSS2_RC_SUCCESS) {
         LOG_INFO("primary created successfully: 0x%" PRIx32, parent_handle);
     } else {
-       return rc;
+        LOG_ERROR("CreatePrimary failed with 0x%" PRIx32, rc);
+        return 99; /* fatal error */
     }
 
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
@@ -68,8 +69,14 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         LOG_INFO("success");
     } else {
         LOG_ERROR("Create FAILED! Response Code : 0x%x", rc);
-        exit(1);
+        return 1;
     }
 
-    return rc;
+    rc = Tss2_Sys_FlushContext(sapi_context, parent_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+
+    return 0;
 }

--- a/test/integration/create-primary-rsa-2048-aes-128-cfb.int.c
+++ b/test/integration/create-primary-rsa-2048-aes-128-cfb.int.c
@@ -23,6 +23,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <inttypes.h>
+
 #define LOGMODULE test
 #include "util/log.h"
 #include "sapi-util.h"
@@ -31,7 +33,20 @@
 int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
-    TPM2_HANDLE handle = 0;
+    TSS2_RC rc;
+    TPM2_HANDLE handle;
 
-    return create_primary_rsa_2048_aes_128_cfb (sapi_context, &handle);
+    rc = create_primary_rsa_2048_aes_128_cfb (sapi_context, &handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("CreatePrimary failed with 0x%"PRIx32, rc);
+        return 1;
+    }
+
+    rc = Tss2_Sys_FlushContext(sapi_context, handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+
+    return 0;
 }

--- a/test/integration/encrypt-decrypt.int.c
+++ b/test/integration/encrypt-decrypt.int.c
@@ -44,10 +44,27 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     LOG_INFO("Encrypting data: \"%s\" with key handle: 0x%08" PRIx32,
                data_in.buffer, handle);
     rc = encrypt_cfb (sapi_context, handle, &data_in, &data_encrypt);
+
+    if (rc == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Encrypt/Decrypt 2 not supported by TPM");
+        rc = Tss2_Sys_FlushContext(sapi_context, handle_parent);
+        if (rc != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+            return 99; /* fatal error */
+        }
+        rc = Tss2_Sys_FlushContext(sapi_context, handle);
+        if (rc != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+            return 99; /* fatal error */
+        }
+        return 77; /* skip */
+    }
+
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR("Failed to encrypt buffer: 0x%" PRIx32 "", rc);
         exit(1);
     }
+
     rc = decrypt_cfb (sapi_context, handle, &data_encrypt, &data_decrypt);
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR("Failed to encrypt buffer: 0x%" PRIx32 "", rc);
@@ -59,5 +76,17 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         LOG_ERROR("Decrypt succeeded but decrypted data != to input data");
         exit(1);
     }
+
+    rc = Tss2_Sys_FlushContext(sapi_context, handle_parent);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+    rc = Tss2_Sys_FlushContext(sapi_context, handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+
     return 0;
 }

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -179,6 +179,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                               );
     goto_if_error(r, "Error: SequenceComplete", error);
 
+    r = Esys_FlushContext(esys_context, primaryHandle);
+    goto_if_error(r, "Error: FlushContext", error);
+
 #ifdef TEST_SESSION
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Error: FlushContext", error);

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -281,6 +281,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &creationData2, &creationHash2, &creationTicket2);
     goto_if_error(r, "Error esys create ", error);
 
+    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    goto_if_error(r, "Error: FlushContext", error);
+
     return 0;
 
  error:

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -172,6 +172,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                    &attest, &signature);
     goto_if_error(r, "Error esys quiote", error);
 
+    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    goto_if_error(r, "Error: FlushContext", error);
+
     return 0;
 
  error:

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -181,6 +181,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         if (mode > 0 && !memcmp(&plain.buffer[0], &plain2->buffer[0], plain_size)) {
             LOG_ERROR("plain texts are not equal for mode %i", mode);
         }
+
+        r = Esys_FlushContext(esys_context, primaryHandle_handle);
+        goto_if_error(r, "Error: FlushContext", error);
     }
     return 0;
 

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -320,6 +320,12 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &creationData2, &creationHash2, &creationTicket2);
     goto_if_error(r, "Error esys second create ", error);
 
+    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    goto_if_error(r, "Error: FlushContext", error);
+
+    r = Esys_FlushContext(esys_context, loadedKeyHandle2);
+    goto_if_error(r, "Error: FlushContext", error);
+
     return 0;
 
  error:

--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -240,11 +240,7 @@ TSS_SAPI_FIRST_VERSION };
         LOG_ERROR("Esys_SetTimeout FAILED! Response Code : 0x%x", rc);
         return 1;
     }
-    rc = Tss2_Sys_Startup(esys_context->sys, TPM2_SU_CLEAR);
-    if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
-        LOG_ERROR("TPM Startup FAILED! Response Code : 0x%x", rc);
-        return 1;
-    }
+
     ret = test_invoke_esapi(esys_context);
 
     Esys_Finalize(&esys_context);

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -17,7 +17,6 @@ int
 main (int   argc,
       char *argv[])
 {
-    TSS2_RC rc;
     TSS2_SYS_CONTEXT *sapi_context;
     int ret;
     test_opts_t opts = {
@@ -28,17 +27,19 @@ main (int   argc,
     };
 
     get_test_opts_from_env (&opts);
-    if (sanity_check_test_opts (&opts) != 0)
-        exit (1);
-    sapi_context = sapi_init_from_opts (&opts);
-    if (sapi_context == NULL)
-        exit (1);
-    rc = Tss2_Sys_Startup(sapi_context, TPM2_SU_CLEAR);
-    if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
-        LOG_ERROR("TPM Startup FAILED! Response Code : 0x%x", rc);
-        exit(1);
+    if (sanity_check_test_opts (&opts) != 0) {
+        LOG_ERROR("Checking test options");
+        return 99; /* fatal error */
     }
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        LOG_ERROR("SAPI context not initialized");
+        return 99; /* fatal error */
+    }
+
     ret = test_invoke (sapi_context);
+
     sapi_teardown_full (sapi_context);
+
     return ret;
 }

--- a/test/integration/policy-template.int.c
+++ b/test/integration/policy-template.int.c
@@ -183,6 +183,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         exit(1);
     }
 
+    rc = Tss2_Sys_FlushContext(sapi_context, object_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Tss2_Sys_FlushContext failed with 0x%"PRIx32, rc);
+        return 99; /* fatal error */
+    }
+
     object_handle = 0;
     TPM2B_DATA              outside_info2    = { 0 };
     TPML_PCR_SELECTION      creation_pcr2    = { 0 };

--- a/test/integration/system-api.int.c
+++ b/test/integration/system-api.int.c
@@ -263,6 +263,13 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
     /* CheckFailed(rc, TSS2_SYS_RC_BAD_SEQUENCE); */
 
+    /* Execute the command synchronously. */
+    rc = Tss2_Sys_ExecuteFinish(sapi_context, TSS2_TCTI_TIMEOUT_BLOCK);
+    if (rc != TPM2_RC_VALUE + TPM2_RC_1) {
+        LOG_ERROR("SAPI test FAILED! Response Code : 0x%x", rc);
+        exit(1);
+    }
+
     /* Test one-call for null sapi_context pointer. */
     rc = Tss2_Sys_Startup(0, TPM2_SU_CLEAR);
     if (rc != TSS2_SYS_RC_BAD_REFERENCE) {

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -3958,6 +3958,5 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     rval = Tss2_Sys_FlushContext( sysContext, loadedSha1KeyHandle );
     CheckPassed( rval );
 
-    tcti_platform_command( resMgrTctiContext, MS_SIM_POWER_OFF );
     return 0;
 }


### PR DESCRIPTION
This is the very first step towards having the tests run on actual TPMs.
In this step we
- Fix leaking integration tests
- Move TPM_startup into the simulator test harness
- Add a guard around integrations tests to look for transent objects before  and after the test.