### PR TITLE
drop the return value from the context structure

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_Execute.c
+++ b/src/tss2-sys/api/Tss2_Sys_Execute.c
@@ -110,7 +110,6 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
         return rval;
 
     if (ctx->rsp_header.responseSize > ctx->maxCmdSize) {
-        ctx->rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
         return TSS2_SYS_RC_MALFORMED_RESPONSE;
     }
 
@@ -122,11 +121,6 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
         return rval;
 
     rval = ctx->rsp_header.responseCode;
-    /*
-     * NOTE: this is only to maintain state between API calls
-     * It should be eventually removed.
-     */
-    ctx->rval = rval;
 
     /* If we received a TPM error other than CANCELED or if we didn't
      * receive enough response bytes, reset SAPI state machine to

--- a/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
@@ -40,10 +40,7 @@ TSS2_RC Tss2_Sys_GetRpBuffer(
     if (!ctx || !rpBufferUsedSize || !rpBuffer)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    /* NOTE: should this depend on the status of previous
-     * API call? i.e. ctx->rval != TSS2_RC_SUCCESS */
-    if (ctx->previousStage != CMD_STAGE_RECEIVE_RESPONSE ||
-        ctx->rval != TSS2_RC_SUCCESS)
+    if (ctx->previousStage != CMD_STAGE_RECEIVE_RESPONSE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
     /* Calculate the position of the response parameter section within the TPM

--- a/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
@@ -55,7 +55,6 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
     if (!ctx->authAllowed)
         return rval;
 
-    ctx->rval = TSS2_RC_SUCCESS;
     ctx->authsCount = 0;
 
     if (!cmdAuthsArray->count)

--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -40,7 +40,6 @@ void InitSysContextFields(_TSS2_SYS_CONTEXT_BLOB *ctx)
     ctx->decryptNull = 0;
     ctx->authAllowed = 0;
     ctx->nextData = 0;
-    ctx->rval = TSS2_RC_SUCCESS;
 }
 
 void InitSysContextPtrs(
@@ -64,7 +63,6 @@ TSS2_RC CopyCommandHeader(_TSS2_SYS_CONTEXT_BLOB *ctx, TPM2_CC commandCode)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     ctx->nextData = 0;
-    ctx->rval = TSS2_RC_SUCCESS;
 
     rval = Tss2_MU_TPM2_ST_Marshal(TPM2_ST_NO_SESSIONS, ctx->cmdBuffer,
                                   ctx->maxCmdSize,
@@ -132,7 +130,6 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
     rspSize = BE_TO_HOST_32(resp_header_from_cxt(ctx)->responseSize);
 
     if(rspSize > ctx->maxCmdSize) {
-        ctx->rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
         return TSS2_SYS_RC_MALFORMED_RESPONSE;
     }
 
@@ -140,8 +137,7 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
      * NOTE: should this depend on the status of previous
      * API call? i.e. ctx->rval != TSS2_RC_SUCCESS
      */
-    if (ctx->previousStage != CMD_STAGE_RECEIVE_RESPONSE ||
-        ctx->rval != TSS2_RC_SUCCESS)
+    if (ctx->previousStage != CMD_STAGE_RECEIVE_RESPONSE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
     ctx->nextData = (UINT8 *)ctx->rspParamsSize - ctx->cmdBuffer;
@@ -168,9 +164,6 @@ TSS2_RC CommonOneCall(
     TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     TSS2_RC rval;
-
-    if (ctx->rval != TSS2_RC_SUCCESS)
-        return ctx->rval;
 
     if (cmdAuthsArray) {
         rval = Tss2_Sys_SetCmdAuths((TSS2_SYS_CONTEXT *)ctx, cmdAuthsArray);

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -81,9 +81,6 @@ typedef struct {
         UINT16 authAllowed:1;
     };
 
-    /* This doesn't belong here and should be removed*/
-    TSS2_RC rval;
-
     /* Offset to next data in command/response buffer. */
     size_t nextData;
 } _TSS2_SYS_CONTEXT_BLOB;


### PR DESCRIPTION
Following a NOTE that this should be removed and analyzing
it's use, it appears that it can just be safely deleted.

The commonOneCall and *_Finish code both will never get called
if they experience an error in the synchronous cases.

In the async case, all those API calls return errors
and thus the further stages in the state machine should
not be called.

To reset your sapi context, it appears one can just call
Tss2_Sys_Initialize() on the previously established
sapi context.

Signed-off-by: William Roberts <william.c.roberts@intel.com>