### PR TITLE
test: esapi: enable esapi single tests

### DIFF
--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -231,12 +231,18 @@ TSS_SAPI_FIRST_VERSION };
         return 1;
     }
     rc = Esys_Initialize(&esys_context, tcti_context, &abiVersion);
-    if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
+    if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR("Esys_Initialize FAILED! Response Code : 0x%x", rc);
         return 1;
     }
-    rc = Esys_SetTimeout(esys_context, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Esys_Startup(esys_context, TPM2_SU_CLEAR);
     if (rc != TSS2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
+        LOG_ERROR("Esys_Startup FAILED! Response Code : 0x%x", rc);
+        return 1;
+    }
+
+    rc = Esys_SetTimeout(esys_context, TSS2_TCTI_TIMEOUT_BLOCK);
+    if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR("Esys_SetTimeout FAILED! Response Code : 0x%x", rc);
         return 1;
     }

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #define LOGMODULE test
+#include "tss2_sys.h"
 #include "util/log.h"
 #include "test.h"
 #include "test-options.h"
@@ -35,6 +36,12 @@ main (int   argc,
     if (sapi_context == NULL) {
         LOG_ERROR("SAPI context not initialized");
         return 99; /* fatal error */
+    }
+
+    ret = Tss2_Sys_Startup(sapi_context, TPM2_SU_CLEAR);
+    if (ret != TSS2_RC_SUCCESS && ret != TPM2_RC_INITIALIZE) {
+        LOG_ERROR("TPM Startup FAILED! Response Code : 0x%x", ret);
+        exit(1);
     }
 
     ret = test_invoke (sapi_context);


### PR DESCRIPTION
All ESAPI tests are all passing fine as they run it the harness,
but when run as a single tests they all fail with error code 0x00000100:
"TPM not initialized by TPM2_Startup or already initialized"

This is bacause the Tss2_Sys_Startup is only called from main in
test/integration/main.c, but not from main in test/integration/main-esapi.c

Add Esys_Startup() into test/integration/main-esapi.c to enable
invocation of the esapi test as single tests.
