### PR TITLE
tss2-sys: Tss2_Sys_Finalize now returns void, remove '_Complete'.

### DIFF
--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -66,7 +66,7 @@ TSS2_RC Tss2_Sys_Initialize(
     TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion);
 
-TSS2_RC Tss2_Sys_Finalize(
+void Tss2_Sys_Finalize(
     TSS2_SYS_CONTEXT *sysContext);
 
 TSS2_RC Tss2_Sys_GetTctiContext(

--- a/lib/tss2-sys.def
+++ b/lib/tss2-sys.def
@@ -87,7 +87,6 @@ EXPORTS
     Tss2_Sys_FieldUpgradeStart_Prepare
     Tss2_Sys_FieldUpgradeStart_Complete
     Tss2_Sys_FieldUpgradeStart
-    Tss2_Sys_Finalize_Complete
     Tss2_Sys_Finalize
     Tss2_Sys_FirmwareRead_Prepare
     Tss2_Sys_FirmwareRead_Complete

--- a/src/tss2-sys/api/Tss2_Sys_Finalize.c
+++ b/src/tss2-sys/api/Tss2_Sys_Finalize.c
@@ -29,20 +29,8 @@
 #include "tss2_mu.h"
 #include "sysapi_util.h"
 
-TSS2_RC Tss2_Sys_Finalize_Complete (
-    TSS2_SYS_CONTEXT *sysContext)
-{
-    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
-
-    if (!ctx)
-        return TSS2_SYS_RC_BAD_REFERENCE;
-
-    return CommonComplete(ctx);
-}
-
-TSS2_RC Tss2_Sys_Finalize(
+void Tss2_Sys_Finalize(
     TSS2_SYS_CONTEXT *sysContext)
 {
     (void)(sysContext);
-    return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
According to the spec `Tss2_Sys_Finalize` returns void. Also the spec
does not include an async version of the Finalize function and so the
`Tss2_Sys_Finalize_Complete` function makes no sense.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>