### PR TITLE
Windows def name symbols

### DIFF
--- a/lib/tss2-sys.def
+++ b/lib/tss2-sys.def
@@ -1,4 +1,4 @@
-LIBRARY tss2-sapi
+LIBRARY tss2-sys
 EXPORTS
     Tss2_Sys_ActivateCredential_Prepare
     Tss2_Sys_ActivateCredential_Complete

--- a/lib/tss2-sys.def
+++ b/lib/tss2-sys.def
@@ -101,6 +101,7 @@ EXPORTS
     Tss2_Sys_GetCommandAuditDigest_Prepare
     Tss2_Sys_GetCommandAuditDigest_Complete
     Tss2_Sys_GetCommandAuditDigest
+    Tss2_Sys_GetContextSize
     Tss2_Sys_GetRandom_Prepare
     Tss2_Sys_GetRandom_Complete
     Tss2_Sys_GetRandom
@@ -137,6 +138,7 @@ EXPORTS
     Tss2_Sys_IncrementalSelfTest_Prepare
     Tss2_Sys_IncrementalSelfTest_Complete
     Tss2_Sys_IncrementalSelfTest
+    Tss2_Sys_Initialize
     Tss2_Sys_Load_Prepare
     Tss2_Sys_Load_Complete
     Tss2_Sys_Load


### PR DESCRIPTION
This PR resolves #916 and #900. Just some meta-data that got messed up in the Windows linker module definition file.