### PR TITLE
tcti: Use separate structures for the device and mssim TCTI contexts.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -159,13 +159,15 @@ test_unit_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
 test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,-wrap=write
 test_unit_tcti_device_SOURCES = test/unit/tcti-device.c \
-    src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti.c src/tss2-tcti/tcti.h
+    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
 
 test_unit_tcti_mssim_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(URIPARSER_CFLAGS)
 test_unit_tcti_mssim_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(URIPARSER_LIBS) $(libutil)
 test_unit_tcti_mssim_LDFLAGS = -Wl,--wrap=connect,--wrap=read,--wrap=select,--wrap=write
-test_unit_tcti_mssim_SOURCES = src/tss2-tcti/tcti-mssim.c \
-    test/unit/tcti-mssim.c src/tss2-tcti/tcti.c src/tss2-tcti/tcti.h
+test_unit_tcti_mssim_SOURCES = test/unit/tcti-mssim.c \
+    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-mssim.c src/tss2-tcti/tcti-mssim.h
 
 test_unit_io_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_io_LDADD   = $(CMOCKA_LIBS) $(libutil) $(libtss2_mu)

--- a/Makefile.am
+++ b/Makefile.am
@@ -122,8 +122,9 @@ if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-device.map
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_device_la_LIBADD   = $(libtss2_mu) $(libutil)
-src_tss2_tcti_libtss2_tcti_device_la_SOURCES  = src/tss2-tcti/tcti-device.c \
-    src/tss2-tcti/tcti.c src/tss2-tcti/tcti.h
+src_tss2_tcti_libtss2_tcti_device_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
 
 # tcti library for microsoft simulator
 libtss2_tcti_mssim = src/tss2-tcti/libtss2-tcti-mssim.la
@@ -137,8 +138,9 @@ if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_mssim_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-mssim.map
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_mssim_la_LIBADD   = $(libtss2_mu) $(URIPARSER_LIBS) $(libutil)
-src_tss2_tcti_libtss2_tcti_mssim_la_SOURCES  = src/tss2-tcti/tcti-mssim.c \
-    src/tss2-tcti/tcti.c src/tss2-tcti/tcti.h
+src_tss2_tcti_libtss2_tcti_mssim_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-mssim.c src/tss2-tcti/tcti-mssim.h
 
 ### TCG TSS SAPI spec library ###
 libtss2_sys = src/tss2-sys/libtss2-sys.la

--- a/src/tss2-tcti/tcti-device.h
+++ b/src/tss2-tcti/tcti-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2018, Intel Corporation
+ * Copyright (c) 2018 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,22 +24,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TSS2_TCTI_DEVICE_H
-#define TSS2_TCTI_DEVICE_H
+#ifndef TCTI_DEVICE_H
+#define TCTI_DEVICE_H
 
-#include "tss2_tcti.h"
+#include "tcti-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#define TCTI_DEVICE_MAGIC 0x89205e72e319e5bbULL
 
-TSS2_RC Tss2_Tcti_Device_Init (
-    TSS2_TCTI_CONTEXT *tctiContext,
-    size_t *size,
-    const char *conf);
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    int fd;
+} TSS2_TCTI_DEVICE_CONTEXT;
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* TSS2_TCTI_DEVICE_H */
+#endif /* TCTI_DEVICE_H */

--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2018, Intel Corporation
+ * Copyright (c) 2018 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,22 +24,23 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TSS2_TCTI_DEVICE_H
-#define TSS2_TCTI_DEVICE_H
 
-#include "tss2_tcti.h"
+#ifndef TCTI_MSSIM_H
+#define TCTI_MSSIM_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "tcti-common.h"
+#include "util/io.h"
 
-TSS2_RC Tss2_Tcti_Device_Init (
-    TSS2_TCTI_CONTEXT *tctiContext,
-    size_t *size,
-    const char *conf);
+#define TCTI_MSSIM_MAGIC 0xf05b04cd9f02728dULL
 
-#ifdef __cplusplus
-}
-#endif
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    SOCKET platform_sock;
+    SOCKET tpm_sock;
+/* Flag indicating if a command has been cancelled.
+ * This is a temporary flag, which will be changed into
+ * a tcti state when support for asynch operation will be added */
+    bool cancel;
+} TSS2_TCTI_MSSIM_CONTEXT;
 
-#endif /* TSS2_TCTI_DEVICE_H */
+#endif /* TCTI_MSSIM_H */

--- a/test/integration/sys-initialize.int.c
+++ b/test/integration/sys-initialize.int.c
@@ -3,7 +3,6 @@
 
 #include "tss2_sys.h"
 
-#include "tss2-tcti/tcti.h"
 #include "tss2-sys/sysapi_util.h"
 
 #define LOGMODULE test
@@ -18,7 +17,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     // NOTE: this should never be done in real applications.
     // It is only done here for test purposes.
-    TSS2_TCTI_CONTEXT_INTEL tctiContextIntel;
+    TSS2_TCTI_CONTEXT_COMMON_V2 tctiContext;
 
     LOG_INFO("Sys_Initialize tests started.");
 
@@ -41,20 +40,20 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     // NOTE: don't do this in real applications.
-    TSS2_TCTI_RECEIVE (&tctiContextIntel) = (TSS2_TCTI_RECEIVE_FCN)1;
-    TSS2_TCTI_TRANSMIT (&tctiContextIntel) = (TSS2_TCTI_TRANSMIT_FCN)0;
+    TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)1;
+    TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)0;
 
-    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
+    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
         LOG_ERROR("Sys_Initialize FAILED! Response Code : %x", rc);
         exit(1);
     }
 
     // NOTE: don't do this in real applications.
-    TSS2_TCTI_RECEIVE (&tctiContextIntel) = (TSS2_TCTI_RECEIVE_FCN)0;
-    TSS2_TCTI_TRANSMIT (&tctiContextIntel) = (TSS2_TCTI_TRANSMIT_FCN)1;
+    TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)0;
+    TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)1;
 
-    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContextIntel, (TSS2_ABI_VERSION *)1 );
+    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
         LOG_ERROR("Sys_Initialize FAILED! Response Code : %x", rc);
         exit(1);


### PR DESCRIPTION
Using the same structure for both the device and mssim TCTI was lazy. We
were also using the same magic number for both modules which had the
potential to cause confusion if one library was passed a TCTI
initialized by the other. This patch resolves both of these issues by
breaking the old TSS2_TCTI_CONTEXT_INTEL structure up into the
TSS2_TCTI_COMMON_CONTEXT and a structure specific to the device and
mssim TCTIs.

To accomplish this we rename the old 'tcti' module to 'tcti-common'.
This module defines a context structure containing all of the data
common to both the device and mssim TCTIs. This includes the v2
structure as well as a header structure, the enumeration to track the
state machine as well as the locality. We also create new header files
for the device and mssim TCTI. In these headers we define structures
specific to each module that hold the file descriptor for the device
TCTI and the socket file descriptors for the mssim TCTI.

Another significant change in this commit is the way we're now casting
the TCTI context structures passed into the functions for each TCTI
module. Functions in the device and mssim modules that are passed the
opaque TSS2_TCTI_CONTEXT structure start by first checking the magic
number in the context to be sure it's the right one for the module.
If this succeeds they then "down-cast" the structure to the
TSS2_TCTI_COMMON_CONTEXT and then use this structure to perform all of
the state checks. This reduces the number of unsafe cast operations that
we have to perform.

Finally there are a number of changes in this commit that qualify as
cleanup. This includes some name changes for variable and macro names to
align with the name changes.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>