### PR TITLE
test: Add GetPollHandle test for both TCTIs.

### DIFF
--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -107,6 +107,23 @@ tcti_device_teardown (void **state)
 
 }
 /*
+ * This test ensures that the GetPollHandles function in the device TCTI
+ * returns the expected value. Since this TCTI does not support async I/O
+ * on account of limitations in the kernel it just returns the
+ * NOT_IMPLEMENTED response code.
+ */
+static void
+tcti_device_get_poll_handles_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    size_t num_handles = 5;
+    TSS2_TCTI_POLL_HANDLE handles [5] = { 0 };
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_GetPollHandles (ctx, handles, &num_handles);
+    assert_int_equal (rc, TSS2_TCTI_RC_NOT_IMPLEMENTED);
+}
+/*
  */
 static void
 tcti_device_receive_null_size_test (void **state)
@@ -249,6 +266,9 @@ main(int argc, char* argv[])
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_device_init_all_null_test),
         cmocka_unit_test(tcti_device_init_size_test),
+        cmocka_unit_test_setup_teardown (tcti_device_get_poll_handles_test,
+                                         tcti_device_setup,
+                                         tcti_device_teardown),
         cmocka_unit_test_setup_teardown (tcti_device_receive_null_size_test,
                                          tcti_device_setup,
                                          tcti_device_teardown),

--- a/test/unit/tcti-mssim.c
+++ b/test/unit/tcti-mssim.c
@@ -288,6 +288,23 @@ tcti_socket_teardown (void **state)
     return 0;
 }
 /*
+ * This test ensures that the GetPollHandles function in the device TCTI
+ * returns the expected value. Since this TCTI does not support async I/O
+ * on account of limitations in the kernel it just returns the
+ * NOT_IMPLEMENTED response code.
+ */
+static void
+tcti_mssim_get_poll_handles_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    size_t num_handles = 5;
+    TSS2_TCTI_POLL_HANDLE handles [5] = { 0 };
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_GetPollHandles (ctx, handles, &num_handles);
+    assert_int_equal (rc, TSS2_TCTI_RC_NOT_IMPLEMENTED);
+}
+/*
  */
 static void
 tcti_socket_receive_null_size_test (void **state)
@@ -432,6 +449,9 @@ main (int   argc,
         cmocka_unit_test (tcti_socket_init_all_null_test),
         cmocka_unit_test (tcti_socket_init_size_test),
         cmocka_unit_test (tcti_socket_init_null_conf_test),
+        cmocka_unit_test_setup_teardown (tcti_mssim_get_poll_handles_test,
+                                         tcti_socket_setup,
+                                         tcti_socket_teardown),
         cmocka_unit_test_setup_teardown (tcti_socket_receive_null_size_test,
                                          tcti_socket_setup,
                                          tcti_socket_teardown),


### PR DESCRIPTION
Since neither of the TCTIs support async I/O yet both test cases just
make sure that they return the NOT_IMPLEMENTED response code. This will
likely be the case for the device TCTI indefinitely since the kernel
would have to support async I/O over the TPM device node. The mssim
TCTI could support this in the future however and so this test will need
to be updated when that work happens.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>