### PR TITLE
build: disable default -O2 flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ AC_INIT([tpm2-tss],
         [],
         [https://github.com/tpm2-software/tpm2-tss])
 AC_CONFIG_MACRO_DIR([m4])
+${CFLAGS=""}
 AC_PROG_CC
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign
@@ -149,9 +150,10 @@ AC_ARG_ENABLE([debug],
                             [build with debug info (default is no)])],
             [enable_debug=$enableval],
             [enable_debug=no])
-AS_IF([test "x$enable_debug" = "xyes"], AX_ADD_COMPILER_FLAG([-ggdb3 -O0]))
+AS_IF([test "x$enable_debug" = "xyes"], AX_ADD_COMPILER_FLAG([-ggdb3 -Og]))
 AS_IF([test "x$enable_debug" = "xno"], [AX_ADD_PREPROC_FLAG([-U_FORTIFY_SOURCE])
-                                        AX_ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])])
+                                        AX_ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])
+                                        AX_ADD_COMPILER_FLAG([-g -O2])])
 AX_ADD_LINK_FLAG([-Wl,--no-undefined])
 AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
 AX_ADD_LINK_FLAG([-Wl,-z,now])


### PR DESCRIPTION
To build binaries with debug info the configure script takes
--enable-debug=yes flag (default no). This produces makefiles
with EXTRA_CFLAGS = -Og flag. The problem is that autotools
still produces CFLAGS = -g -O2 by default, which affects
the debug info. To swith off the default optimization flags
we need to set CFLAGS="" before AC_PROG_CC macro, and then
add optimizations to EXTRA_CFLAGS if debug is not enabled.

See AC_PROG_CC section in:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html
