### PR TITLE
Fix Spelling Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ reproducible builds.
 ### Fixed
 - NULL dereference bugs in TCTI modules.
 - Cleanup & structure initialization to keep coverity scans happy.
-- Fixed memory leak in integraton test harness.
+- Fixed memory leak in integration test harness.
 
 ## [1.1.0] - 2017-05-10
 ### Changed
@@ -160,7 +160,7 @@ parameters.
 - Added code to RM and simDriver to support timeout on receive calls.
 - Added code to properly handle TPM errors in ExecuteFinish. Previously it was
 ignoring these errors, which meant that the rest of the _Complete call would
-try to unmarshall non-existent response data. Added test case for this.
+try to unmarshal non-existent response data. Added test case for this.
 - Added support for cancel commands and tests for this.
 - Added help text for command line options.
 - Added code to reset dictionary attacks to start of tpmclient tests: this
@@ -217,7 +217,7 @@ that hadn't been received. Caused seg faults under Linux.
 - Fixed timeout for async Startup test.
 - Fixed SocketReceiveTpmResponse for blocking case.
 - Fixed bug in ExecuteFinish: BAD_SEQUENCE error generated early in function
-was getting overwritten by INSUFFICENT_RESPONSE error.
+was getting overwritten by INSUFFICIENT_RESPONSE error.
 - Fixed bug in ExecuteFinish: it was always setting timeout to 0 instead of
 TSS2_TCTI_TIMEOUT_BLOCK.
 - Fixed bug in resource manager: error level for non-TPM errors was getting
@@ -306,8 +306,8 @@ command).
 - Replaced the fixed length arrays of RM structures with linked list
 structures and appropriate functions.
 - Fixed some cases of using pointers before checking that they're not NULL.
-- Fixed bugs in marshalling/unmarshalling routines and added some missing
-unmarshalling functions.
+- Fixed bugs in marshaling/unmarshaling routines and added some missing
+unmarshaling functions.
 - Fixed hash sequence test.
 - Fixed bugs in CopyCapabilityDataOut function for algorithms.
 - Fixed bug with ExecuteAsync: passed in BE size to transmit call. Needs to be
@@ -347,7 +347,7 @@ systems.
 inherently rolled in preparation for first command. Now the RollNonces routine
 will need to be called before the first command. This makes handling of the
 nonces consistent for all code that needs to roll them.
-- Fixed bug in StartAuthSession: wasn't marshalling symmetric parameter
+- Fixed bug in StartAuthSession: wasn't marshaling symmetric parameter
 properly if algorithm was TPM_ALG_XOR.
 - Fixed bug in SetDecryptParam: when inserting a decrypt param, the code
 wasn't updating the command size field.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ consider this the window for comments.
 ## Patch requirements
 * All tests must pass on Travis CI for the merge to occur.
 * All changes must not introduce superfluous changes or whitespace errors.
-* All commits should adhere to the git commit message guidlines described
+* All commits should adhere to the git commit message guidelines described
 here: https://chris.beams.io/posts/git-commit/ with the following exceptions.
  * We allow commit subject lines up to 80 characters.
  * Commit subject lines should be prefixed with a string identifying the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,7 @@ $ sudo dnf builddep tpm2-tss
 ## Windows
 Windows dlls built using the Clang/LLVM "Platform Toolset" are currently
 prototypes. We have only tested using Visual Studio 2017 with the Universal
-C Runtime (UCRT) version 10.0.16299.0. Building the type marshalling library
+C Runtime (UCRT) version 10.0.16299.0. Building the type marshaling library
 (tss2-mu.dll) and the system API (tss2-sapi.dll) should be as simple as
 loading the tpm2-tss solution (tpm2-tss.sln) with a compatible and properly
 configured version of Visual Studio 2017 and pressing the 'build' button.

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,7 @@ include src_vars.mk
 # Add test definitions
 include Makefile-test.am
 
-### Distributiuon files ###
+### Distribution files ###
 # Adding user and developer information
 EXTRA_DIST += \
     CHANGELOG.md \
@@ -96,7 +96,7 @@ noinst_LTLIBRARIES += $(libutil)
 libutil_la_CFLAGS = $(AM_CFLAGS)
 libutil_la_SOURCES = $(UTIL_SRC)
 
-### TCG TSS Marshaling/Unmarshalling spec library ###
+### TCG TSS Marshaling/Unmarshaling spec library ###
 libtss2_mu = src/tss2-mu/libtss2-mu.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_mu.h
 lib_LTLIBRARIES += $(libtss2_mu)
@@ -126,7 +126,7 @@ src_tss2_tcti_libtss2_tcti_device_la_SOURCES  = \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
     src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
 
-# tcti library for microsoft simulator
+# tcti library for Microsoft TPM2 simulator
 libtss2_tcti_mssim = src/tss2-tcti/libtss2-tcti-mssim.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_mssim.h
 lib_LTLIBRARIES += $(libtss2_tcti_mssim)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,7 +44,7 @@ We do not however encourage users to build from git unless they intend to modify
 For the end user we provide release "tarballs" following the GNU conventions as closely as possible.
 
 To make a release tarball use the `distcheck` make target.
-This target incldues a number of sanity checks that are extremely helpful.
+This target includes a number of sanity checks that are extremely helpful.
 For more information on `automake` and release tarballs see: https://www.gnu.org/software/automake/manual/html_node/Dist.html#Dist
 
 ## Hosting Releases on Github


### PR DESCRIPTION
Fix spelling errors in documentation, messages and comments.

Fixes #926.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>