### PR TITLE
api: Fix Spelling Errors

### DIFF
--- a/src/tss2-esys/api/Esys_ActivateCredential.c
+++ b/src/tss2-esys/api/Esys_ActivateCredential.c
@@ -186,7 +186,7 @@ Esys_ActivateCredential_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, activateHandle, keyHandle,
                 credentialBlob,
@@ -335,7 +335,7 @@ Esys_ActivateCredential_finish(
     r = Tss2_Sys_ActivateCredential_Complete(esysContext->sys,
                 (certInfo != NULL) ? *certInfo : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Certify.c
+++ b/src/tss2-esys/api/Esys_Certify.c
@@ -190,7 +190,7 @@ Esys_Certify_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, objectHandle, signHandle,
                 qualifyingData,
@@ -349,7 +349,7 @@ Esys_Certify_finish(
                 (certifyInfo != NULL) ? *certifyInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_CertifyCreation.c
+++ b/src/tss2-esys/api/Esys_CertifyCreation.c
@@ -218,7 +218,7 @@ Esys_CertifyCreation_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, signHandle, objectHandle,
                 qualifyingData,
@@ -382,7 +382,7 @@ Esys_CertifyCreation_finish(
                 (certifyInfo != NULL) ? *certifyInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ChangeEPS.c
+++ b/src/tss2-esys/api/Esys_ChangeEPS.c
@@ -145,7 +145,7 @@ Esys_ChangeEPS_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle);
 
@@ -270,7 +270,7 @@ Esys_ChangeEPS_finish(
      */
     r = Tss2_Sys_ChangeEPS_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ChangePPS.c
+++ b/src/tss2-esys/api/Esys_ChangePPS.c
@@ -145,7 +145,7 @@ Esys_ChangePPS_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle);
 
@@ -270,7 +270,7 @@ Esys_ChangePPS_finish(
      */
     r = Tss2_Sys_ChangePPS_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Clear.c
+++ b/src/tss2-esys/api/Esys_Clear.c
@@ -145,7 +145,7 @@ Esys_Clear_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle);
 
@@ -270,7 +270,7 @@ Esys_Clear_finish(
      */
     r = Tss2_Sys_Clear_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ClearControl.c
+++ b/src/tss2-esys/api/Esys_ClearControl.c
@@ -152,7 +152,7 @@ Esys_ClearControl_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth,
                 disable);
@@ -280,7 +280,7 @@ Esys_ClearControl_finish(
      */
     r = Tss2_Sys_ClearControl_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ClockRateAdjust.c
+++ b/src/tss2-esys/api/Esys_ClockRateAdjust.c
@@ -152,7 +152,7 @@ Esys_ClockRateAdjust_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth,
                 rateAdjust);
@@ -280,7 +280,7 @@ Esys_ClockRateAdjust_finish(
      */
     r = Tss2_Sys_ClockRateAdjust_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ClockSet.c
+++ b/src/tss2-esys/api/Esys_ClockSet.c
@@ -152,7 +152,7 @@ Esys_ClockSet_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth,
                 newTime);
@@ -280,7 +280,7 @@ Esys_ClockSet_finish(
      */
     r = Tss2_Sys_ClockSet_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Commit.c
+++ b/src/tss2-esys/api/Esys_Commit.c
@@ -201,7 +201,7 @@ Esys_Commit_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, signHandle,
                 P1,
@@ -374,7 +374,7 @@ Esys_Commit_finish(
                 (E != NULL) ? *E : NULL,
                 counter);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ContextLoad.c
+++ b/src/tss2-esys/api/Esys_ContextLoad.c
@@ -277,7 +277,7 @@ Esys_ContextLoad_finish(
     r = Tss2_Sys_ContextLoad_Complete(esysContext->sys,
                 &loadedHandleNode->rsrc.handle);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ContextSave.c
+++ b/src/tss2-esys/api/Esys_ContextSave.c
@@ -235,7 +235,7 @@ Esys_ContextSave_finish(
     r = Tss2_Sys_ContextSave_Complete(esysContext->sys,
                 lcontext);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     /* ESYS Special Handling Code: Extend the  context with metadata of the object */
     IESYS_CONTEXT_DATA esyscontextData;

--- a/src/tss2-esys/api/Esys_Create.c
+++ b/src/tss2-esys/api/Esys_Create.c
@@ -219,7 +219,7 @@ Esys_Create_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, parentHandle,
                 inSensitive,
@@ -411,7 +411,7 @@ Esys_Create_finish(
                 (creationHash != NULL) ? *creationHash : NULL,
                 (creationTicket != NULL) ? *creationTicket : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -183,7 +183,7 @@ Esys_CreateLoaded_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, parentHandle,
                 inSensitive,
@@ -362,7 +362,7 @@ Esys_CreateLoaded_finish(
                 loutPublic,
                 &name);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     /* Check name and outPublic for consistency */
     if (!iesys_compare_name(loutPublic, &name))

--- a/src/tss2-esys/api/Esys_CreatePrimary.c
+++ b/src/tss2-esys/api/Esys_CreatePrimary.c
@@ -218,7 +218,7 @@ Esys_CreatePrimary_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, primaryHandle,
                 inSensitive,
@@ -415,7 +415,7 @@ Esys_CreatePrimary_finish(
                 (creationTicket != NULL) ? *creationTicket : NULL,
                 &name);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     /* Check name and outPublic for consistency */
     if (!iesys_compare_name(loutPublic, &name))

--- a/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
@@ -145,7 +145,7 @@ Esys_DictionaryAttackLockReset_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, lockHandle);
 
@@ -270,7 +270,7 @@ Esys_DictionaryAttackLockReset_finish(
      */
     r = Tss2_Sys_DictionaryAttackLockReset_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
@@ -167,7 +167,7 @@ Esys_DictionaryAttackParameters_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, lockHandle,
                 newMaxTries,
@@ -301,7 +301,7 @@ Esys_DictionaryAttackParameters_finish(
      */
     r = Tss2_Sys_DictionaryAttackParameters_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Duplicate.c
+++ b/src/tss2-esys/api/Esys_Duplicate.c
@@ -194,7 +194,7 @@ Esys_Duplicate_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, objectHandle, newParentHandle,
                 encryptionKeyIn,
@@ -364,7 +364,7 @@ Esys_Duplicate_finish(
                 (duplicate != NULL) ? *duplicate : NULL,
                 (outSymSeed != NULL) ? *outSymSeed : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ECC_Parameters.c
+++ b/src/tss2-esys/api/Esys_ECC_Parameters.c
@@ -146,7 +146,7 @@ Esys_ECC_Parameters_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 curveID);
@@ -280,7 +280,7 @@ Esys_ECC_Parameters_finish(
     r = Tss2_Sys_ECC_Parameters_Complete(esysContext->sys,
                 (parameters != NULL) ? *parameters : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ECDH_KeyGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_KeyGen.c
@@ -153,7 +153,7 @@ Esys_ECDH_KeyGen_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle);
 
@@ -300,7 +300,7 @@ Esys_ECDH_KeyGen_finish(
                 (zPoint != NULL) ? *zPoint : NULL,
                 (pubPoint != NULL) ? *pubPoint : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ECDH_ZGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_ZGen.c
@@ -162,7 +162,7 @@ Esys_ECDH_ZGen_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 inPoint);
@@ -303,7 +303,7 @@ Esys_ECDH_ZGen_finish(
     r = Tss2_Sys_ECDH_ZGen_Complete(esysContext->sys,
                 (outPoint != NULL) ? *outPoint : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_EC_Ephemeral.c
+++ b/src/tss2-esys/api/Esys_EC_Ephemeral.c
@@ -150,7 +150,7 @@ Esys_EC_Ephemeral_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 curveID);
@@ -288,7 +288,7 @@ Esys_EC_Ephemeral_finish(
                 (Q != NULL) ? *Q : NULL,
                 counter);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_EncryptDecrypt.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt.c
@@ -195,7 +195,7 @@ Esys_EncryptDecrypt_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 decrypt,
@@ -355,7 +355,7 @@ Esys_EncryptDecrypt_finish(
                 (outData != NULL) ? *outData : NULL,
                 (ivOut != NULL) ? *ivOut : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_EncryptDecrypt2.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt2.c
@@ -195,7 +195,7 @@ Esys_EncryptDecrypt2_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 inData,
@@ -355,7 +355,7 @@ Esys_EncryptDecrypt2_finish(
                 (outData != NULL) ? *outData : NULL,
                 (ivOut != NULL) ? *ivOut : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_EventSequenceComplete.c
+++ b/src/tss2-esys/api/Esys_EventSequenceComplete.c
@@ -173,7 +173,7 @@ Esys_EventSequenceComplete_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, pcrHandle, sequenceHandle,
                 buffer);
@@ -319,7 +319,7 @@ Esys_EventSequenceComplete_finish(
     r = Tss2_Sys_EventSequenceComplete_Complete(esysContext->sys,
                 (results != NULL) ? *results : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_EvictControl.c
+++ b/src/tss2-esys/api/Esys_EvictControl.c
@@ -166,7 +166,7 @@ Esys_EvictControl_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth, objectHandle,
                 persistentHandle);
@@ -319,7 +319,7 @@ Esys_EvictControl_finish(
      */
     r = Tss2_Sys_EvictControl_Complete(esysContext->sys);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     ESYS_TR objectHandle = esysContext->in.EvictControl.objectHandle;
     RSRC_NODE_T *objectHandleNode;
     r = esys_GetResourceObject(esysContext, objectHandle, &objectHandleNode);

--- a/src/tss2-esys/api/Esys_FieldUpgradeData.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeData.c
@@ -156,7 +156,7 @@ Esys_FieldUpgradeData_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 fuData);
@@ -300,7 +300,7 @@ Esys_FieldUpgradeData_finish(
                 (nextDigest != NULL) ? *nextDigest : NULL,
                 (firstDigest != NULL) ? *firstDigest : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_FieldUpgradeStart.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeStart.c
@@ -182,7 +182,7 @@ Esys_FieldUpgradeStart_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authorization, keyHandle,
                 fuDigest,
@@ -317,7 +317,7 @@ Esys_FieldUpgradeStart_finish(
      */
     r = Tss2_Sys_FieldUpgradeStart_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_FirmwareRead.c
+++ b/src/tss2-esys/api/Esys_FirmwareRead.c
@@ -146,7 +146,7 @@ Esys_FirmwareRead_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 sequenceNumber);
@@ -280,7 +280,7 @@ Esys_FirmwareRead_finish(
     r = Tss2_Sys_FirmwareRead_Complete(esysContext->sys,
                 (fuData != NULL) ? *fuData : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_FlushContext.c
+++ b/src/tss2-esys/api/Esys_FlushContext.c
@@ -220,7 +220,7 @@ Esys_FlushContext_finish(
     }
     r = Tss2_Sys_FlushContext_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     /* The ESYS_TR object has to be invalidated */
     r = Esys_TR_Close(esysContext, &esysContext->in.FlushContext.flushHandle);
     return_if_error(r, "invalidate object");

--- a/src/tss2-esys/api/Esys_GetCapability.c
+++ b/src/tss2-esys/api/Esys_GetCapability.c
@@ -165,7 +165,7 @@ Esys_GetCapability_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 capability,
@@ -309,7 +309,7 @@ Esys_GetCapability_finish(
                 moreData,
                 (capabilityData != NULL) ? *capabilityData : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
@@ -190,7 +190,7 @@ Esys_GetCommandAuditDigest_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, privacyHandle, signHandle,
                 qualifyingData,
@@ -349,7 +349,7 @@ Esys_GetCommandAuditDigest_finish(
                 (auditInfo != NULL) ? *auditInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_GetRandom.c
+++ b/src/tss2-esys/api/Esys_GetRandom.c
@@ -146,7 +146,7 @@ Esys_GetRandom_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 bytesRequested);
@@ -280,7 +280,7 @@ Esys_GetRandom_finish(
     r = Tss2_Sys_GetRandom_Complete(esysContext->sys,
                 (randomBytes != NULL) ? *randomBytes : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
@@ -201,7 +201,7 @@ Esys_GetSessionAuditDigest_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, privacyAdminHandle, signHandle, sessionHandle,
                 qualifyingData,
@@ -364,7 +364,7 @@ Esys_GetSessionAuditDigest_finish(
                 (auditInfo != NULL) ? *auditInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_GetTestResult.c
+++ b/src/tss2-esys/api/Esys_GetTestResult.c
@@ -138,7 +138,7 @@ Esys_GetTestResult_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
@@ -272,7 +272,7 @@ Esys_GetTestResult_finish(
                 (outData != NULL) ? *outData : NULL,
                 testResult);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_GetTime.c
+++ b/src/tss2-esys/api/Esys_GetTime.c
@@ -190,7 +190,7 @@ Esys_GetTime_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, privacyAdminHandle, signHandle,
                 qualifyingData,
@@ -349,7 +349,7 @@ Esys_GetTime_finish(
                 (timeInfo != NULL) ? *timeInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HMAC.c
+++ b/src/tss2-esys/api/Esys_HMAC.c
@@ -170,7 +170,7 @@ Esys_HMAC_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, handle,
                 buffer,
@@ -314,7 +314,7 @@ Esys_HMAC_finish(
     r = Tss2_Sys_HMAC_Complete(esysContext->sys,
                 (outHMAC != NULL) ? *outHMAC : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HMAC_Start.c
+++ b/src/tss2-esys/api/Esys_HMAC_Start.c
@@ -169,7 +169,7 @@ Esys_HMAC_Start_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, handle,
                 auth,
@@ -317,7 +317,7 @@ Esys_HMAC_Start_finish(
     r = Tss2_Sys_HMAC_Start_Complete(esysContext->sys,
                 &sequenceHandleNode->rsrc.handle);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     /*  The name of a sequence object is an empty buffer */
     sequenceHandleNode->rsrc.name.size = 0;

--- a/src/tss2-esys/api/Esys_Hash.c
+++ b/src/tss2-esys/api/Esys_Hash.c
@@ -171,7 +171,7 @@ Esys_Hash_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 data,
@@ -321,7 +321,7 @@ Esys_Hash_finish(
                 (outHash != NULL) ? *outHash : NULL,
                 (validation != NULL) ? *validation : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HashSequenceStart.c
+++ b/src/tss2-esys/api/Esys_HashSequenceStart.c
@@ -158,7 +158,7 @@ Esys_HashSequenceStart_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 auth,
@@ -299,7 +299,7 @@ Esys_HashSequenceStart_finish(
     r = Tss2_Sys_HashSequenceStart_Complete(esysContext->sys,
                 &sequenceHandleNode->rsrc.handle);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     sequenceHandleNode->rsrc.name.size = 0;
     esysContext->state = _ESYS_STATE_INIT;

--- a/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
+++ b/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
@@ -158,7 +158,7 @@ Esys_HierarchyChangeAuth_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 newAuth);
@@ -300,7 +300,7 @@ Esys_HierarchyChangeAuth_finish(
      */
     r = Tss2_Sys_HierarchyChangeAuth_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HierarchyControl.c
+++ b/src/tss2-esys/api/Esys_HierarchyControl.c
@@ -160,7 +160,7 @@ Esys_HierarchyControl_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 enable,
@@ -291,7 +291,7 @@ Esys_HierarchyControl_finish(
      */
     r = Tss2_Sys_HierarchyControl_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Import.c
+++ b/src/tss2-esys/api/Esys_Import.c
@@ -217,7 +217,7 @@ Esys_Import_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, parentHandle,
                 encryptionKey,
@@ -370,7 +370,7 @@ Esys_Import_finish(
     r = Tss2_Sys_Import_Complete(esysContext->sys,
                 (outPrivate != NULL) ? *outPrivate : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_IncrementalSelfTest.c
+++ b/src/tss2-esys/api/Esys_IncrementalSelfTest.c
@@ -152,7 +152,7 @@ Esys_IncrementalSelfTest_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 toTest);
@@ -286,7 +286,7 @@ Esys_IncrementalSelfTest_finish(
     r = Tss2_Sys_IncrementalSelfTest_Complete(esysContext->sys,
                 (toDoList != NULL) ? *toDoList : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Load.c
+++ b/src/tss2-esys/api/Esys_Load.c
@@ -175,7 +175,7 @@ Esys_Load_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, parentHandle,
                 inPrivate,
@@ -329,7 +329,7 @@ Esys_Load_finish(
                 &objectHandleNode->rsrc.handle,
                 &name);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
      /* Check name and inPublic for consistency */
      if (!iesys_compare_name(esysContext->in.Load.inPublic, &name)) {

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -172,7 +172,7 @@ Esys_LoadExternal_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 inPrivate,
@@ -320,7 +320,7 @@ Esys_LoadExternal_finish(
                 &objectHandleNode->rsrc.handle,
                 &name);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
      /* check name against inPublic */
      if (!iesys_compare_name(esysContext->in.LoadExternal.inPublic, &name)) {

--- a/src/tss2-esys/api/Esys_MakeCredential.c
+++ b/src/tss2-esys/api/Esys_MakeCredential.c
@@ -180,7 +180,7 @@ Esys_MakeCredential_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, handle,
                 credential,
@@ -333,7 +333,7 @@ Esys_MakeCredential_finish(
                 (credentialBlob != NULL) ? *credentialBlob : NULL,
                 (secret != NULL) ? *secret : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_Certify.c
+++ b/src/tss2-esys/api/Esys_NV_Certify.c
@@ -216,7 +216,7 @@ Esys_NV_Certify_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, signHandle, authHandle, nvIndex,
                 qualifyingData,
@@ -385,7 +385,7 @@ Esys_NV_Certify_finish(
                 (certifyInfo != NULL) ? *certifyInfo : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_ChangeAuth.c
+++ b/src/tss2-esys/api/Esys_NV_ChangeAuth.c
@@ -158,7 +158,7 @@ Esys_NV_ChangeAuth_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, nvIndex,
                 newAuth);
@@ -300,7 +300,7 @@ Esys_NV_ChangeAuth_finish(
      */
     r = Tss2_Sys_NV_ChangeAuth_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_DefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_DefineSpace.c
@@ -185,7 +185,7 @@ Esys_NV_DefineSpace_async(
     }
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 auth,
@@ -332,7 +332,7 @@ Esys_NV_DefineSpace_finish(
      */
     r = Tss2_Sys_NV_DefineSpace_Complete(esysContext->sys);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     /* Update the meta data of the ESYS_TR object */
     nvHandleNode->rsrc.rsrcType = IESYSC_NV_RSRC;
     r = iesys_nv_get_name(esysContext->in.NV_DefineSpace.publicInfo,

--- a/src/tss2-esys/api/Esys_NV_Extend.c
+++ b/src/tss2-esys/api/Esys_NV_Extend.c
@@ -169,7 +169,7 @@ Esys_NV_Extend_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex,
                 data);
@@ -301,7 +301,7 @@ Esys_NV_Extend_finish(
      */
     r = Tss2_Sys_NV_Extend_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
@@ -145,7 +145,7 @@ Esys_NV_GlobalWriteLock_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle);
 
@@ -270,7 +270,7 @@ Esys_NV_GlobalWriteLock_finish(
      */
     r = Tss2_Sys_NV_GlobalWriteLock_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_Increment.c
+++ b/src/tss2-esys/api/Esys_NV_Increment.c
@@ -155,7 +155,7 @@ Esys_NV_Increment_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex);
 
@@ -284,7 +284,7 @@ Esys_NV_Increment_finish(
      */
     r = Tss2_Sys_NV_Increment_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
 
     ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
         RSRC_NODE_T *nvIndexNode;

--- a/src/tss2-esys/api/Esys_NV_Read.c
+++ b/src/tss2-esys/api/Esys_NV_Read.c
@@ -174,7 +174,7 @@ Esys_NV_Read_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex,
                 size,
@@ -322,7 +322,7 @@ Esys_NV_Read_finish(
     r = Tss2_Sys_NV_Read_Complete(esysContext->sys,
                 (data != NULL) ? *data : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_ReadLock.c
+++ b/src/tss2-esys/api/Esys_NV_ReadLock.c
@@ -155,7 +155,7 @@ Esys_NV_ReadLock_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex);
 
@@ -284,7 +284,7 @@ Esys_NV_ReadLock_finish(
      */
     r = Tss2_Sys_NV_ReadLock_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
 
     ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
         RSRC_NODE_T *nvIndexNode;

--- a/src/tss2-esys/api/Esys_NV_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_NV_ReadPublic.c
@@ -153,7 +153,7 @@ Esys_NV_ReadPublic_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, nvIndex);
 
@@ -298,7 +298,7 @@ Esys_NV_ReadPublic_finish(
                 lnvPublic,
                 lnvName);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     /* Update the meta data of the ESYS_TR object */
     ESYS_TR nvIndex = esysContext->in.NV_ReadPublic.nvIndex;

--- a/src/tss2-esys/api/Esys_NV_SetBits.c
+++ b/src/tss2-esys/api/Esys_NV_SetBits.c
@@ -163,7 +163,7 @@ Esys_NV_SetBits_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex,
                 bits);
@@ -295,7 +295,7 @@ Esys_NV_SetBits_finish(
      */
     r = Tss2_Sys_NV_SetBits_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
 
     ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
         RSRC_NODE_T *nvIndexNode;

--- a/src/tss2-esys/api/Esys_NV_UndefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpace.c
@@ -155,7 +155,7 @@ Esys_NV_UndefineSpace_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex);
 
@@ -284,7 +284,7 @@ Esys_NV_UndefineSpace_finish(
      */
     r = Tss2_Sys_NV_UndefineSpace_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     /* The ESYS_TR object (nvIndex) has to be invalidated */
     r = Esys_TR_Close(esysContext, &esysContext->in.NV_UndefineSpace.nvIndex);
     return_if_error(r, "invalidate object");

--- a/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
@@ -155,7 +155,7 @@ Esys_NV_UndefineSpaceSpecial_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, nvIndex, platform);
 
@@ -285,7 +285,7 @@ Esys_NV_UndefineSpaceSpecial_finish(
      */
     r = Tss2_Sys_NV_UndefineSpaceSpecial_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_Write.c
+++ b/src/tss2-esys/api/Esys_NV_Write.c
@@ -176,7 +176,7 @@ Esys_NV_Write_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex,
                 data,
@@ -311,7 +311,7 @@ Esys_NV_Write_finish(
      */
     r = Tss2_Sys_NV_Write_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
 
     ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
     RSRC_NODE_T *nvIndexNode;

--- a/src/tss2-esys/api/Esys_NV_WriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_WriteLock.c
@@ -155,7 +155,7 @@ Esys_NV_WriteLock_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex);
 
@@ -284,7 +284,7 @@ Esys_NV_WriteLock_finish(
      */
     r = Tss2_Sys_NV_WriteLock_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
 
     ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
         RSRC_NODE_T *nvIndexNode;

--- a/src/tss2-esys/api/Esys_ObjectChangeAuth.c
+++ b/src/tss2-esys/api/Esys_ObjectChangeAuth.c
@@ -173,7 +173,7 @@ Esys_ObjectChangeAuth_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, objectHandle, parentHandle,
                 newAuth);
@@ -318,7 +318,7 @@ Esys_ObjectChangeAuth_finish(
     r = Tss2_Sys_ObjectChangeAuth_Complete(esysContext->sys,
                 (outPrivate != NULL) ? *outPrivate : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_Allocate.c
+++ b/src/tss2-esys/api/Esys_PCR_Allocate.c
@@ -174,7 +174,7 @@ Esys_PCR_Allocate_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 pcrAllocation);
@@ -320,7 +320,7 @@ Esys_PCR_Allocate_finish(
                 sizeNeeded,
                 sizeAvailable);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_Event.c
+++ b/src/tss2-esys/api/Esys_PCR_Event.c
@@ -162,7 +162,7 @@ Esys_PCR_Event_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, pcrHandle,
                 eventData);
@@ -303,7 +303,7 @@ Esys_PCR_Event_finish(
     r = Tss2_Sys_PCR_Event_Complete(esysContext->sys,
                 (digests != NULL) ? *digests : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_Extend.c
+++ b/src/tss2-esys/api/Esys_PCR_Extend.c
@@ -158,7 +158,7 @@ Esys_PCR_Extend_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, pcrHandle,
                 digests);
@@ -286,7 +286,7 @@ Esys_PCR_Extend_finish(
      */
     r = Tss2_Sys_PCR_Extend_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_Read.c
+++ b/src/tss2-esys/api/Esys_PCR_Read.c
@@ -160,7 +160,7 @@ Esys_PCR_Read_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 pcrSelectionIn);
@@ -310,7 +310,7 @@ Esys_PCR_Read_finish(
                 (pcrSelectionOut != NULL) ? *pcrSelectionOut : NULL,
                 (pcrValues != NULL) ? *pcrValues : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_Reset.c
+++ b/src/tss2-esys/api/Esys_PCR_Reset.c
@@ -145,7 +145,7 @@ Esys_PCR_Reset_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, pcrHandle);
 
@@ -270,7 +270,7 @@ Esys_PCR_Reset_finish(
      */
     r = Tss2_Sys_PCR_Reset_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
@@ -173,7 +173,7 @@ Esys_PCR_SetAuthPolicy_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 authPolicy,
@@ -307,7 +307,7 @@ Esys_PCR_SetAuthPolicy_finish(
      */
     r = Tss2_Sys_PCR_SetAuthPolicy_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
@@ -158,7 +158,7 @@ Esys_PCR_SetAuthValue_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, pcrHandle,
                 auth);
@@ -286,7 +286,7 @@ Esys_PCR_SetAuthValue_finish(
      */
     r = Tss2_Sys_PCR_SetAuthValue_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PP_Commands.c
+++ b/src/tss2-esys/api/Esys_PP_Commands.c
@@ -172,7 +172,7 @@ Esys_PP_Commands_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth,
                 setList,
@@ -303,7 +303,7 @@ Esys_PP_Commands_finish(
      */
     r = Tss2_Sys_PP_Commands_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyAuthValue.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthValue.c
@@ -145,7 +145,7 @@ Esys_PolicyAuthValue_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
 
@@ -269,7 +269,7 @@ Esys_PolicyAuthValue_finish(
      */
     r = Tss2_Sys_PolicyAuthValue_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     ESYS_TR policySession = esysContext->in.PolicyAuthValue.policySession;
     RSRC_NODE_T *policySessionNode;
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);

--- a/src/tss2-esys/api/Esys_PolicyAuthorize.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthorize.c
@@ -199,7 +199,7 @@ Esys_PolicyAuthorize_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 approvedPolicy,
@@ -335,7 +335,7 @@ Esys_PolicyAuthorize_finish(
      */
     r = Tss2_Sys_PolicyAuthorize_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
@@ -166,7 +166,7 @@ Esys_PolicyAuthorizeNV_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex, policySession);
 
@@ -299,7 +299,7 @@ Esys_PolicyAuthorizeNV_finish(
      */
     r = Tss2_Sys_PolicyAuthorizeNV_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyCommandCode.c
+++ b/src/tss2-esys/api/Esys_PolicyCommandCode.c
@@ -152,7 +152,7 @@ Esys_PolicyCommandCode_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 code);
@@ -279,7 +279,7 @@ Esys_PolicyCommandCode_finish(
      */
     r = Tss2_Sys_PolicyCommandCode_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyCounterTimer.c
+++ b/src/tss2-esys/api/Esys_PolicyCounterTimer.c
@@ -173,7 +173,7 @@ Esys_PolicyCounterTimer_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 operandB,
@@ -306,7 +306,7 @@ Esys_PolicyCounterTimer_finish(
      */
     r = Tss2_Sys_PolicyCounterTimer_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyCpHash.c
+++ b/src/tss2-esys/api/Esys_PolicyCpHash.c
@@ -155,7 +155,7 @@ Esys_PolicyCpHash_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 policySession,
@@ -279,7 +279,7 @@ Esys_PolicyCpHash_finish(
      */
     r = Tss2_Sys_PolicyCpHash_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
+++ b/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
@@ -176,7 +176,7 @@ Esys_PolicyDuplicationSelect_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 policySession,
@@ -306,7 +306,7 @@ Esys_PolicyDuplicationSelect_finish(
      */
     r = Tss2_Sys_PolicyDuplicationSelect_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyGetDigest.c
+++ b/src/tss2-esys/api/Esys_PolicyGetDigest.c
@@ -149,7 +149,7 @@ Esys_PolicyGetDigest_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
 
@@ -286,7 +286,7 @@ Esys_PolicyGetDigest_finish(
     r = Tss2_Sys_PolicyGetDigest_Complete(esysContext->sys,
                 (policyDigest != NULL) ? *policyDigest : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyLocality.c
+++ b/src/tss2-esys/api/Esys_PolicyLocality.c
@@ -149,7 +149,7 @@ Esys_PolicyLocality_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 policySession,
@@ -273,7 +273,7 @@ Esys_PolicyLocality_finish(
      */
     r = Tss2_Sys_PolicyLocality_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyNV.c
+++ b/src/tss2-esys/api/Esys_PolicyNV.c
@@ -195,7 +195,7 @@ Esys_PolicyNV_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, nvIndex, policySession,
                 operandB,
@@ -337,7 +337,7 @@ Esys_PolicyNV_finish(
      */
     r = Tss2_Sys_PolicyNV_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyNameHash.c
+++ b/src/tss2-esys/api/Esys_PolicyNameHash.c
@@ -155,7 +155,7 @@ Esys_PolicyNameHash_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 policySession,
@@ -279,7 +279,7 @@ Esys_PolicyNameHash_finish(
      */
     r = Tss2_Sys_PolicyNameHash_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyNvWritten.c
+++ b/src/tss2-esys/api/Esys_PolicyNvWritten.c
@@ -152,7 +152,7 @@ Esys_PolicyNvWritten_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 writtenSet);
@@ -279,7 +279,7 @@ Esys_PolicyNvWritten_finish(
      */
     r = Tss2_Sys_PolicyNvWritten_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyOR.c
+++ b/src/tss2-esys/api/Esys_PolicyOR.c
@@ -158,7 +158,7 @@ Esys_PolicyOR_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 pHashList);
@@ -285,7 +285,7 @@ Esys_PolicyOR_finish(
      */
     r = Tss2_Sys_PolicyOR_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyPCR.c
+++ b/src/tss2-esys/api/Esys_PolicyPCR.c
@@ -172,7 +172,7 @@ Esys_PolicyPCR_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 pcrDigest,
@@ -302,7 +302,7 @@ Esys_PolicyPCR_finish(
      */
     r = Tss2_Sys_PolicyPCR_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyPassword.c
+++ b/src/tss2-esys/api/Esys_PolicyPassword.c
@@ -145,7 +145,7 @@ Esys_PolicyPassword_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
 
@@ -269,7 +269,7 @@ Esys_PolicyPassword_finish(
      */
     r = Tss2_Sys_PolicyPassword_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     ESYS_TR policySession = esysContext->in.PolicyPassword.policySession;
     RSRC_NODE_T *policySessionNode;
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);

--- a/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
+++ b/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
@@ -145,7 +145,7 @@ Esys_PolicyPhysicalPresence_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
 
@@ -269,7 +269,7 @@ Esys_PolicyPhysicalPresence_finish(
      */
     r = Tss2_Sys_PolicyPhysicalPresence_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyRestart.c
+++ b/src/tss2-esys/api/Esys_PolicyRestart.c
@@ -145,7 +145,7 @@ Esys_PolicyRestart_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, sessionHandle);
 
@@ -269,7 +269,7 @@ Esys_PolicyRestart_finish(
      */
     r = Tss2_Sys_PolicyRestart_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicySecret.c
+++ b/src/tss2-esys/api/Esys_PolicySecret.c
@@ -212,7 +212,7 @@ Esys_PolicySecret_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, policySession,
                 nonceTPM,
@@ -376,7 +376,7 @@ Esys_PolicySecret_finish(
                 (timeout != NULL) ? *timeout : NULL,
                 (policyTicket != NULL) ? *policyTicket : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicySigned.c
+++ b/src/tss2-esys/api/Esys_PolicySigned.c
@@ -225,7 +225,7 @@ Esys_PolicySigned_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authObject, policySession,
                 nonceTPM,
@@ -391,7 +391,7 @@ Esys_PolicySigned_finish(
                 (timeout != NULL) ? *timeout : NULL,
                 (policyTicket != NULL) ? *policyTicket : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyTemplate.c
+++ b/src/tss2-esys/api/Esys_PolicyTemplate.c
@@ -155,7 +155,7 @@ Esys_PolicyTemplate_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 policySession,
@@ -279,7 +279,7 @@ Esys_PolicyTemplate_finish(
      */
     r = Tss2_Sys_PolicyTemplate_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_PolicyTicket.c
+++ b/src/tss2-esys/api/Esys_PolicyTicket.c
@@ -213,7 +213,7 @@ Esys_PolicyTicket_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession,
                 timeout,
@@ -352,7 +352,7 @@ Esys_PolicyTicket_finish(
      */
     r = Tss2_Sys_PolicyTicket_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Quote.c
+++ b/src/tss2-esys/api/Esys_Quote.c
@@ -193,7 +193,7 @@ Esys_Quote_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, signHandle,
                 qualifyingData,
@@ -350,7 +350,7 @@ Esys_Quote_finish(
                 (quoted != NULL) ? *quoted : NULL,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_RSA_Decrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Decrypt.c
@@ -189,7 +189,7 @@ Esys_RSA_Decrypt_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 cipherText,
@@ -336,7 +336,7 @@ Esys_RSA_Decrypt_finish(
     r = Tss2_Sys_RSA_Decrypt_Complete(esysContext->sys,
                 (message != NULL) ? *message : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_RSA_Encrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Encrypt.c
@@ -189,7 +189,7 @@ Esys_RSA_Encrypt_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 message,
@@ -335,7 +335,7 @@ Esys_RSA_Encrypt_finish(
     r = Tss2_Sys_RSA_Encrypt_Complete(esysContext->sys,
                 (outData != NULL) ? *outData : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ReadClock.c
+++ b/src/tss2-esys/api/Esys_ReadClock.c
@@ -134,7 +134,7 @@ Esys_ReadClock_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
@@ -264,7 +264,7 @@ Esys_ReadClock_finish(
     r = Tss2_Sys_ReadClock_Complete(esysContext->sys,
                 (currentTime != NULL) ? *currentTime : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_ReadPublic.c
@@ -157,7 +157,7 @@ Esys_ReadPublic_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, objectHandle);
 
@@ -316,7 +316,7 @@ Esys_ReadPublic_finish(
                 (name != NULL) ? *name : NULL,
                 (qualifiedName != NULL) ? *qualifiedName : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Rewrap.c
+++ b/src/tss2-esys/api/Esys_Rewrap.c
@@ -204,7 +204,7 @@ Esys_Rewrap_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, oldParent, newParent,
                 inDuplicate,
@@ -365,7 +365,7 @@ Esys_Rewrap_finish(
                 (outDuplicate != NULL) ? *outDuplicate : NULL,
                 (outSymSeed != NULL) ? *outSymSeed : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_SelfTest.c
+++ b/src/tss2-esys/api/Esys_SelfTest.c
@@ -142,7 +142,7 @@ Esys_SelfTest_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 fullTest);
@@ -263,7 +263,7 @@ Esys_SelfTest_finish(
      */
     r = Tss2_Sys_SelfTest_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_SequenceComplete.c
+++ b/src/tss2-esys/api/Esys_SequenceComplete.c
@@ -174,7 +174,7 @@ Esys_SequenceComplete_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, sequenceHandle,
                 buffer,
@@ -328,7 +328,7 @@ Esys_SequenceComplete_finish(
                 (result != NULL) ? *result : NULL,
                 (validation != NULL) ? *validation : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     /* The ESYS_TR sequence object has to be invalidated */
     r = Esys_TR_Close(esysContext, &esysContext->in.SequenceComplete.sequenceHandle);
     goto_if_error(r, "invalidate object", error_cleanup);

--- a/src/tss2-esys/api/Esys_SequenceUpdate.c
+++ b/src/tss2-esys/api/Esys_SequenceUpdate.c
@@ -158,7 +158,7 @@ Esys_SequenceUpdate_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, sequenceHandle,
                 buffer);
@@ -286,7 +286,7 @@ Esys_SequenceUpdate_finish(
      */
     r = Tss2_Sys_SequenceUpdate_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_SetAlgorithmSet.c
+++ b/src/tss2-esys/api/Esys_SetAlgorithmSet.c
@@ -152,7 +152,7 @@ Esys_SetAlgorithmSet_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 algorithmSet);
@@ -280,7 +280,7 @@ Esys_SetAlgorithmSet_finish(
      */
     r = Tss2_Sys_SetAlgorithmSet_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
@@ -179,7 +179,7 @@ Esys_SetCommandCodeAuditStatus_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, auth,
                 auditAlg,
@@ -313,7 +313,7 @@ Esys_SetCommandCodeAuditStatus_finish(
      */
     r = Tss2_Sys_SetCommandCodeAuditStatus_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
+++ b/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
@@ -166,7 +166,7 @@ Esys_SetPrimaryPolicy_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle,
                 authPolicy,
@@ -297,7 +297,7 @@ Esys_SetPrimaryPolicy_finish(
      */
     r = Tss2_Sys_SetPrimaryPolicy_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Shutdown.c
+++ b/src/tss2-esys/api/Esys_Shutdown.c
@@ -142,7 +142,7 @@ Esys_Shutdown_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 shutdownType);
@@ -263,7 +263,7 @@ Esys_Shutdown_finish(
      */
     r = Tss2_Sys_Shutdown_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Sign.c
+++ b/src/tss2-esys/api/Esys_Sign.c
@@ -189,7 +189,7 @@ Esys_Sign_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 digest,
@@ -336,7 +336,7 @@ Esys_Sign_finish(
     r = Tss2_Sys_Sign_Complete(esysContext->sys,
                 (signature != NULL) ? *signature : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -209,7 +209,7 @@ Esys_StartAuthSession_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, tpmKey, bind,
                 nonceCaller,
@@ -411,7 +411,7 @@ Esys_StartAuthSession_finish(
                 &sessionHandleNode->rsrc.handle,
                 lnonceTPM);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
 
     sessionHandleNode->rsrc.misc.rsrc_session.nonceTPM = *lnonceTPM;
     sessionHandleNode->rsrc.rsrcType = IESYSC_SESSION_RSRC;

--- a/src/tss2-esys/api/Esys_Startup.c
+++ b/src/tss2-esys/api/Esys_Startup.c
@@ -214,7 +214,7 @@ Esys_Startup_finish(
     }
     r = Tss2_Sys_Startup_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_StirRandom.c
+++ b/src/tss2-esys/api/Esys_StirRandom.c
@@ -148,7 +148,7 @@ Esys_StirRandom_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 inData);
@@ -269,7 +269,7 @@ Esys_StirRandom_finish(
      */
     r = Tss2_Sys_StirRandom_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_TestParms.c
+++ b/src/tss2-esys/api/Esys_TestParms.c
@@ -148,7 +148,7 @@ Esys_TestParms_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 parameters);
@@ -269,7 +269,7 @@ Esys_TestParms_finish(
      */
     r = Tss2_Sys_TestParms_Complete(esysContext->sys);
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" );
+                        " unmarshaling" );
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Unseal.c
+++ b/src/tss2-esys/api/Esys_Unseal.c
@@ -149,7 +149,7 @@ Esys_Unseal_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, itemHandle);
 
@@ -287,7 +287,7 @@ Esys_Unseal_finish(
     r = Tss2_Sys_Unseal_Complete(esysContext->sys,
                 (outData != NULL) ? *outData : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
+++ b/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
@@ -152,7 +152,7 @@ Esys_Vendor_TCG_Test_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext,
                 inputData);
@@ -286,7 +286,7 @@ Esys_Vendor_TCG_Test_finish(
     r = Tss2_Sys_Vendor_TCG_Test_Complete(esysContext->sys,
                 (outputData != NULL) ? *outputData : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_VerifySignature.c
+++ b/src/tss2-esys/api/Esys_VerifySignature.c
@@ -176,7 +176,7 @@ Esys_VerifySignature_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 0);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyHandle,
                 digest,
@@ -319,7 +319,7 @@ Esys_VerifySignature_finish(
     r = Tss2_Sys_VerifySignature_Complete(esysContext->sys,
                 (validation != NULL) ? *validation : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_ZGen_2Phase.c
+++ b/src/tss2-esys/api/Esys_ZGen_2Phase.c
@@ -195,7 +195,7 @@ Esys_ZGen_2Phase_async(
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
     /* Check and store input parameters */
-    r = check_session_feasability(shandle1, shandle2, shandle3, 1);
+    r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, keyA,
                 inQsB,
@@ -355,7 +355,7 @@ Esys_ZGen_2Phase_finish(
                 (outZ1 != NULL) ? *outZ1 : NULL,
                 (outZ2 != NULL) ? *outZ2 : NULL);
     goto_state_if_error(r, _ESYS_STATE_INTERNALERROR, "Received error from SAPI"
-                        " unmarshalling" ,error_cleanup);
+                        " unmarshaling" ,error_cleanup);
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;


### PR DESCRIPTION
Fix spelling errors in src/tss2-esys/api directory.

Fixes #934.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>