### PR TITLE
src: Fix Spelling Errors

### DIFF
--- a/src/tss2-mu/base-types.c
+++ b/src/tss2-mu/base-types.c
@@ -137,7 +137,7 @@ Tss2_MU_##type##_Unmarshal ( \
     } \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -123,7 +123,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \
@@ -253,7 +253,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \

--- a/src/tss2-mu/tpma-types.c
+++ b/src/tss2-mu/tpma-types.c
@@ -130,7 +130,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \

--- a/src/tss2-mu/tpml-types.c
+++ b/src/tss2-mu/tpml-types.c
@@ -135,7 +135,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -110,7 +110,7 @@ Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     UINT8 i, tmp; \
 \
     LOG_DEBUG( \
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest, (uintptr_t)buffer, \
          offset?*offset:0xffff); \
 \
@@ -197,7 +197,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } \
 \
     LOG_DEBUG( \
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, *offset); \
 \
     return TSS2_RC_SUCCESS; \
@@ -224,7 +224,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
                                    size_t *offset, type *dest) \
 { \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     return fn(buffer, buffer_size, offset, dest ? &dest->m : NULL); \
@@ -273,7 +273,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     type tmp_dest; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -339,7 +339,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -409,7 +409,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -496,7 +496,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         memset(dest, 0, sizeof(*dest)); \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : NULL); \
@@ -574,7 +574,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -673,7 +673,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -780,7 +780,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \
@@ -905,7 +905,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     size_t local_offset = 0; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, offset?*offset:0xffff); \
 \
     if (offset) { \

--- a/src/tss2-mu/tpmt-types.c
+++ b/src/tss2-mu/tpmt-types.c
@@ -84,7 +84,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         return TSS2_MU_RC_BAD_REFERENCE; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     memset(&tmp, '\0', sizeof(tmp)); \
@@ -154,7 +154,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     memset(&tmp, '\0', sizeof(tmp)); \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : &tmp.m1); \
@@ -223,7 +223,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         return TSS2_MU_RC_BAD_REFERENCE; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : NULL); \
@@ -300,7 +300,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     memset(&tmp, '\0', sizeof(tmp)); \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : &tmp.m1); \
@@ -382,7 +382,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         return TSS2_MU_RC_BAD_REFERENCE; \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : NULL); \
@@ -475,7 +475,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     memset(&tmp, '\0', sizeof(tmp)); \
 \
     LOG_DEBUG(\
-         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         "Unmarshaling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, local_offset); \
 \
     ret = fn1(buffer, buffer_size, &local_offset, dest ? &dest->m1 : &tmp.m1); \

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -255,23 +255,23 @@ static TSS2_RC unmarshal_null(uint8_t const buffer[], size_t buffer_size,
  * that can be leveraged to generate the function bodies using macros.
  *
  * The TPMU_MARSHAL macro is used to generate these function bodies. It is
- * used below, once to define the marshalling function for each of the 15
+ * used below, once to define the marshaling function for each of the 15
  * unique TPMU_* types. The parameters are:
- *   type - The type of the TPMU_* being marshalled. This is used to
+ *   type - The type of the TPMU_* being marshaled. This is used to
  *       generate the name of the function and the type of its first
  *       parameter.
  *   The remaining parameters are grouped as 4-tuples. There are 11 of them,
  *       each defined as <selector, operator, member, function> where:
  *       selector - The constant value, typically from a table in some TCG
  *           registry, that the generated function will use to select the
- *           member marshalled / written in network byte order to the buffer.
- *       operator - The member being marshalled may be passed by value or
- *           reference to its marshalling function. If it's by value this
+ *           member marshaled / written in network byte order to the buffer.
+ *       operator - The member being marshaled may be passed by value or
+ *           reference to its marshaling function. If it's by value this
  *           should be 'VAL', if by reference 'ADDR'.
  *       member - The name of the member data from the union passed to the
- *           marshalling function (the next parameter).
- *       function - A function capable of marshalling the 'member' from the
- *           TPMU_* being marshalled.
+ *           marshaling function (the next parameter).
+ *       function - A function capable of marshaling the 'member' from the
+ *           TPMU_* being marshaled.
  *
  * This macro takes 11 such 4-tuples. This is the maximum number of members
  * in the TPMU_* types. All parameters after the first 45 parameters (11*4+1)
@@ -283,9 +283,9 @@ static TSS2_RC unmarshal_null(uint8_t const buffer[], size_t buffer_size,
  * <-X, ADDR, m, marshal_null> where:
  *     -X - A unique negative constant value.
  *     ADDR - The macro defined at the top of this file.
- *     m - Any valid member from the TPMU_* being marshalled.
+ *     m - Any valid member from the TPMU_* being marshaled.
  *     marshal_null - A function defined above that is effectively a
- *         marshalling no-op.
+ *         marshaling no-op.
  */
 #define TPMU_MARSHAL(type, sel, op, m, fn, sel2, op2, m2, fn2, sel3, op3, m3, fn3, \
                      sel4, op4, m4, fn4, sel5, op5, m5, fn5, sel6, op6, m6, fn6, \
@@ -377,7 +377,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
  * operator, member, function> we remove the operator element and have
  * a 3-tuple of <selector, member, function>. The operator element isn't
  * needed because the first parameter to the function element is always a
- * referenece (never a value).
+ * reference (never a value).
  */
 #define TPMU_UNMARSHAL(type, sel, m, fn, sel2, m2, fn2, sel3, m3, fn3, \
                        sel4, m4, fn4, sel5, m5, fn5, sel6, m6, fn6, sel7, m7, fn7, \
@@ -440,7 +440,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
 
 /*
  * Following are invocations of the TPMU_MARSHAL2 and TPMU_UNMARSHAL2 macros.
- * These generate the marshalling and unmarshalling functions for the TPMU_*
+ * These generate the marshaling and unmarshaling functions for the TPMU_*
  * types. They are grouped by TPMU_* with the TPMU_* being the first parameter
  * to each and on the first line with the macro name. The remaining parameters
  * are grouped, one 4-tuple per line for the TPMU_MARSHAL2 macro and one

--- a/src/tss2-sys/api/Tss2_Sys_Execute.c
+++ b/src/tss2-sys/api/Tss2_Sys_Execute.c
@@ -91,7 +91,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
                                      &ctx->nextData,
                                      &ctx->rsp_header.tag);
     if (rval) {
-        LOG_ERROR("Unmarshalling response tag. RC=%" PRIx32, rval);
+        LOG_ERROR("Unmarshaling response tag. RC=%" PRIx32, rval);
         return rval;
     }
 

--- a/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
@@ -44,7 +44,7 @@ TSS2_RC Tss2_Sys_GetRpBuffer(
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
     /* Calculate the position of the response parameter section within the TPM
-     * repsponse as well as its size. Structure is:
+     * response as well as its size. Structure is:
      * Header (tag, responseSize, responseCode)
      * handle(if Command has handles)
      * parameterSize (if TPM_ST_SESSIONS), size of rpArea

--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -144,7 +144,7 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
     if (rval)
         return rval;
 
-    /* Skiping over response params size field */
+    /* Skipping over response params size field */
     if (tag == TPM2_ST_SESSIONS)
         rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
                                         ctx->maxCmdSize,

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -49,9 +49,9 @@
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
  * type for the mssim TCTI context. The only safeguard we have to ensure this
- * operation is possivle is the magic number in the mssim TCTI context.
+ * operation is possible is the magic number in the mssim TCTI context.
  * If passed a NULL context, or the magic number check fails, this function
- * will retrun NULL.
+ * will return NULL.
  */
 TSS2_TCTI_MSSIM_CONTEXT*
 tcti_mssim_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
@@ -75,7 +75,7 @@ tcti_mssim_down_cast (TSS2_TCTI_MSSIM_CONTEXT *tcti_mssim)
 }
 /*
  * This function is for sending one of the MS_SIM_* platform commands to the
- * microsoft simulator. These are sent over the platform socket.
+ * Microsoft TPM2 simulator. These are sent over the platform socket.
  */
 TSS2_RC tcti_platform_command (
     TSS2_TCTI_CONTEXT *tctiContext,
@@ -147,7 +147,7 @@ send_sim_session_end (
 }
 
 /*
- * This fucntion is used to send the simulator a sort of command message
+ * This function is used to send the simulator a sort of command message
  * that tells it we're about to send it a TPM command. This requires that
  * we first send it a 4 byte code that's defined by the simulator. Then
  * another byte identifying the locality and finally the size of the TPM
@@ -407,7 +407,7 @@ out:
  * This function sends the Microsoft simulator the MS_SIM_POWER_ON and
  * MS_SIM_NV_ON commands using the platform command mechanism. Without
  * these the simulator will respond with zero sized buffer which causes
- * the TSS to freak out. Sending this command more than once is harmelss
+ * the TSS to freak out. Sending this command more than once is harmless,
  * so it's advisable to call this function as part of the TCTI context
  * initialization just to be sure.
  *


### PR DESCRIPTION
Fix spelling errors in src directory.

Fixes #936.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>