### PR TITLE
integration: Fix Spelling Errors

### DIFF
--- a/test/integration/asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/asymmetric-encrypt-decrypt.int.c
@@ -11,7 +11,7 @@
 #include "test.h"
 #include "sapi-util.h"
 /**
- * This program contains integration test for asymetric encrypt and
+ * This program contains integration test for asymmetric encrypt and
  * decrypt use case that has SAPIs Tss2_Sys_CreatePrimary,
  * Tss2_Sys_Create, Tss2_Sys_Load, Tss2_Sys_RSA_Encrypt and
  * Tss2_Sys_RSA_Decrypt. First, the program creates the object and load
@@ -131,14 +131,14 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         LOG_ERROR("RSA_Encrypt FAILED! Response Code : 0x%x", rc);
         exit(1);
     }
-    LOG_INFO("Encrypt successed.");
+    LOG_INFO("Encrypt successful.");
 
     rc = Tss2_Sys_RSA_Decrypt(sapi_context, loaded_sym_handle, &sessions_data, &output_data, &in_scheme, &outside_info, &output_message, &sessions_data_out);
     if(rc != TPM2_RC_SUCCESS) {
         LOG_ERROR("RSA_Decrypt FAILED! Response Code : 0x%x", rc);
         exit(1);
     }
-    LOG_INFO("Decrypt successed.");
+    LOG_INFO("Decrypt successful.");
 
     LOG_INFO("Asymmetric Encryption and Decryption Test Passed!");
 

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -162,7 +162,7 @@ tcti_teardown(TSS2_TCTI_CONTEXT * tcti_context)
 }
 
 /*
- * Teardown and free the resoruces associted with a SAPI context structure.
+ * Teardown and free the resources associated with a SAPI context structure.
  * This includes tearing down the TCTI as well.
  */
 void

--- a/test/integration/encrypt-decrypt-2.int.c
+++ b/test/integration/encrypt-decrypt-2.int.c
@@ -10,7 +10,7 @@
 #define ENC_STR "test-data-test-data-test-data"
 
 /*
- * This test is inteded to exercise the EncryptDecrypt2 command.
+ * This test is intended to exercise the EncryptDecrypt2 command.
  */
 int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)

--- a/test/integration/encrypt-decrypt.int.c
+++ b/test/integration/encrypt-decrypt.int.c
@@ -10,7 +10,7 @@
 #define ENC_STR "test-data-test-data-test-data"
 
 /*
- * This test is inteded to exercise the EncryptDecrypt2 command. We start by
+ * This test is intended to exercise the EncryptDecrypt2 command. We start by
  * creating a primary key, then a 128 bit AES key in CFB mode under it. We
  * then encrypt a well known string with this key, and then decrypt that same
  * string. The test is successful if the original string and the decrypted

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -205,7 +205,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &creationData2, &creationHash2, &creationTicket2);
 
     goto_error_if_not_failed(
-        r, "Error esys create finish wiht NULL context did not fail",
+        r, "Error esys create finish with NULL context did not fail",
         error);
 
     r = Esys_FlushContext(esys_context, primaryHandle_handle);

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -33,7 +33,7 @@
 
 /*
  * This test is intended to test Esys_CreatePrimary with hmac verification.
- * The test can be executed wiht RSA or ECC keys. ECC will bei used if
+ * The test can be executed with RSA or ECC keys. ECC will be used if
  * ECC is defined.
  */
 

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -33,9 +33,9 @@
 
 /*
  * This test is intended to test then change of an authorization value of
- * a hiearachy.
+ * a hierarchy.
  * To check whether the change was successful a primary key is created
- * with the handle of this hierarchie and the new authorization.
+ * with the handle of this hierarchy and the new authorization.
  * Also second primary is created after a call of Esys_TR_SetAuth with
  * the new auth value.
  */

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -292,7 +292,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                           outPublic2,
                           TPM2_RH_OWNER,
                           &loadedKeyHandle);
-    goto_if_error(r, "Error esys load exernal", error);
+    goto_if_error(r, "Error esys load external", error);
 
     TPM2B_PUBLIC *primaryKeyPublic;
     TPM2B_NAME *primaryKeyName;

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -125,7 +125,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
         memcmp(&nvName->name, &nvHandleNode->rsrc.name.name, nvName->size) != 0) {
-        LOG_ERROR("Error: define space name not equalt");
+        LOG_ERROR("Error: define space name not equal");
         goto error;
     }
     r = Esys_NV_Increment(esys_context,

--- a/test/integration/esys-nv-ram-extend-index.int.c
+++ b/test/integration/esys-nv-ram-extend-index.int.c
@@ -133,7 +133,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
    if (nvName->size != nvHandleNode->rsrc.name.size ||
        memcmp(&nvName->name, &nvHandleNode->rsrc.name.name, nvName->size) != 0) {
-       LOG_ERROR("Error: define space name not equalt");
+       LOG_ERROR("Error: define space name not equal");
        goto error;
    }
    r = Esys_NV_Extend (

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -134,7 +134,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
         memcmp(&nvName->name, &nvHandleNode->rsrc.name.name, nvName->size) != 0) {
-        LOG_ERROR("Error: define space name not equalt");
+        LOG_ERROR("Error: define space name not equal");
         goto error;
     }
     r = Esys_NV_Write(esys_context,

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -34,7 +34,7 @@
 /*
  * This test is intended to test the ESAPI commands PolicyAuthValue,
  * PolicyCommandCode, Esys_PolicyGetDigest, and NV_ChangeAuth.
- * First in a trial session the policy value to ensure tha auth value
+ * First in a trial session the policy value to ensure that the auth value
  * is included in the policy session used for NV_ChangeAuth is
  * computed.
  * A NV ram space with this policy is defined afterwards.

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -170,7 +170,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                    ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                    &qualifyingData, &sig_scheme, &pcr_selection,
                    &attest, &signature);
-    goto_if_error(r, "Error esys quiote", error);
+    goto_if_error(r, "Error Esys Quote", error);
 
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error: FlushContext", error);

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -35,7 +35,7 @@
  * This test is intended to test RSA encryption / decryption. with password
  * authentication.
  * We create a RSA primary key (Esys_CreatePrimary) for every crypto action
- * This key will be used for encrytion/decryption in with the schemes:
+ * This key will be used for encryption/decryption in with the schemes:
  * TPM2_ALG_NULL, TPM2_ALG_RSAES, and TPM2_ALG_OAEP
  */
 

--- a/test/integration/evict-ctrl.int.c
+++ b/test/integration/evict-ctrl.int.c
@@ -46,7 +46,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                                 0x81000000,
                                 &sessions_rsp);
     if (rc != TSS2_RC_SUCCESS) {
-        LOG_INFO("failed to make key 0x%" PRIx32 " unpersistent: 0x%" PRIx32,
+        LOG_INFO("failed to make key 0x%" PRIx32 " nonpersistent: 0x%" PRIx32,
                    primary_handle, rc);
         return 1;
     }

--- a/test/integration/get-random.int.c
+++ b/test/integration/get-random.int.c
@@ -15,7 +15,7 @@
  * Second, the SAPI is called twice to make sure the return randomBytes
  * are different by comparing the two randomBytes through memcmp.
  * It might not be the best test for random bytes generator but
- * at least this test shows the return randomBytes are differen.
+ * at least this test shows the return randomBytes are different.
  */
 int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)

--- a/test/integration/pcr-extension.int.c
+++ b/test/integration/pcr-extension.int.c
@@ -12,7 +12,7 @@
 /**
  * This program contains integration test for SAPI Tss2_Sys_PCR_Read
  * and Tss2_Sys_PCR_Extend. This is an use case scenario on PCR extend.
- * First, we will get the list of PCR avaliable through getcapability
+ * First, we will get the list of PCR available through getcapability
  * SAPI. Then, PCR_Read SAPI is called to list out the PCR value and
  * PCR_Extend SAPI is called next to update the PCR value. Last,
  * PCR_Read SAPI is called again to check the PCR values are changed.

--- a/test/integration/policy-authorizeNV.int.c
+++ b/test/integration/policy-authorizeNV.int.c
@@ -146,7 +146,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TPM2B_NAME              name            = TPM2B_NAME_INIT;
     TPM2_HANDLE             object_handle   = 0;
 
-    /* Use precomputed authPolicy for simplicty */
+    /* Use precomputed authPolicy for simplicity */
     char auth[] = {0x06, 0x3a, 0x24, 0xdc, 0x2f, 0xc9, 0x32, 0xc3,
                    0xb8, 0xa0, 0x85, 0xca, 0x67, 0x27, 0x3c, 0x03,
                    0xa6, 0x7c, 0x11, 0x39, 0x8f, 0x2a, 0x4a, 0x13,
@@ -209,7 +209,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
 
     /* Call encrypt using the key object using the password session */
-    LOG_INFO("Calling EncryptDecrypt using paswd session 0x%x", TPM2_RS_PW);
+    LOG_INFO("Calling EncryptDecrypt using password session 0x%x", TPM2_RS_PW);
     LOGBLOB_DEBUG(data_in.buffer, 32, "%s", "First 32 bytes of plain text:");
     rc = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt (sapi_context,
                                                  object_handle,
@@ -256,7 +256,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     cmd_auth.auths[0].sessionHandle = TPM2_RS_PW;
     cmd_auth.auths[0].hmac.size = 0;
 
-    /* Kill the NV index - this should invalidete the policy */
+    /* Kill the NV index - this should invalidate the policy */
     rc = Tss2_Sys_NV_UndefineSpace(sapi_context,
                                    TPM2_RH_OWNER,
                                    nv_index,
@@ -273,7 +273,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
      * This should fail because the NV index is destroyed */
     cmd_auth.auths[0].sessionHandle = session_handle;
     memset(data_out.buffer, '\0', TPM2_MAX_DIGEST_BUFFER);
-    LOG_INFO("Calling EncryptDecrypt again with policy session after destroing"
+    LOG_INFO("Calling EncryptDecrypt again with policy session after destroying"
              " the NV index This should fail with RC_POLICY_FAIL");
     rc = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context,
                                                 object_handle,

--- a/test/integration/policy-template.int.c
+++ b/test/integration/policy-template.int.c
@@ -111,7 +111,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     LOGBLOB_DEBUG(tmp_buff + 2, template_size - 2, "%s", "in_public:");
     LOGBLOB_DEBUG(templ_dgst.buffer, templ_dgst.size, "%s", "template digest:");
 
-    /* Set the tempalte digest on the session.
+    /* Set the template digest on the session.
      * After that all objects created for this session will be limited
      * to this particular template
      */

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -33,7 +33,7 @@ tcti_map_entry_t tcti_map_table[] = {
 
 /*
  * Convert from a string to an element in the TCTI_TYPE enumeration.
- * An unkonwn name / string will map to UNKNOWN_TCTI.
+ * An unknown name / string will map to UNKNOWN_TCTI.
  */
 TCTI_TYPE
 tcti_type_from_name(char const *tcti_str)

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -10,7 +10,7 @@
 /* Defaults for Device TCTI */
 #define DEVICE_PATH_DEFAULT "/dev/tpm0"
 
-/* Deafults for Socket TCTI connections */
+/* Defaults for Socket TCTI connections */
 #define HOSTNAME_DEFAULT "127.0.0.1"
 #define PORT_DEFAULT     2321
 


### PR DESCRIPTION
Fix spelling errors in test/integration directory.

Fixes #937.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>