### PR TITLE
test: Fix Spelling Errors

### DIFF
--- a/test/tpmclient/SessionHmac.c
+++ b/test/tpmclient/SessionHmac.c
@@ -43,7 +43,7 @@ UINT32 TpmComputeSessionHmac(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_AUTH_COMMAND *pSessionDataIn, // Pointer to session input struct
     TPM2_HANDLE entityHandle,             // Used to determine if we're accessing a different
-                                         // resource than the bound resoure.
+                                         // resource than the bound resource.
     TSS2_RC responseCode,                 // Response code for the command, 0xffff for "none" is
                                          // used to indicate that no response code is present
                                          // (used for calculating command HMACs vs response HMACs).
@@ -103,7 +103,7 @@ UINT32 TpmComputeSessionHmac(
     if( ( entityHandle >> TPM2_HR_SHIFT ) == TPM2_HT_NV_INDEX )
     {
         // If NV index, get status wrt to name change.  If name has changed,
-        // we have to treat it as if its not the bound entity, even if it was
+        // we have to treat it as if it's not the bound entity, even if it was
         // the bound entity.
         nvNameChanged = pSession->nvNameChanged;
     }

--- a/test/tpmclient/sample.h
+++ b/test/tpmclient/sample.h
@@ -167,7 +167,7 @@ extern UINT32 ( *ComputeSessionHmacPtr )(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_AUTH_COMMAND *cmdAuth,          // Pointer to session input struct
     TPM2_HANDLE entityHandle,             // Used to determine if we're accessing a different
-                                         // resource than the bound resoure.
+                                         // resource than the bound resource.
     TSS2_RC responseCode,                 // Response code for the command, 0xffff for "none" is
                                          // used to indicate that no response code is present
                                          // (used for calculating command HMACs vs response HMACs).
@@ -205,7 +205,7 @@ UINT32 TpmComputeSessionHmac(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_AUTH_COMMAND *pSessionDataIn, // Pointer to session input struct
     TPM2_HANDLE entityHandle,             // Used to determine if we're accessing a different
-                                         // resource than the bound resoure.
+                                         // resource than the bound resource.
     TSS2_RC responseCode,                 // Response code for the command, 0xffff for "none" is
                                          // used to indicate that no response code is present
                                          // (used for calculating command HMACs vs response HMACs).

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -2524,7 +2524,7 @@ static void TestEncryptDecryptSession()
         // this tests different cases for SetDecryptParam function.
         //
 
-        // Prepare the input parameters, using unencypted
+        // Prepare the input parameters, using unencrypted
         // write data.  This will be encrypted before the
         // command is sent to the TPM.
         rval = Tss2_Sys_NV_Write_Prepare( sysContext,
@@ -2997,7 +2997,7 @@ static void GetSetEncryptParamTests()
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval ); // #5
 
-    // NOTE: add GetCpBuffer tests here, just because its easier.
+    // NOTE: add GetCpBuffer tests here, just because it's easier.
     rval = Tss2_Sys_GetCpBuffer( 0, (size_t *)4, (const uint8_t **)4 );
 	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #6
 

--- a/test/unit/GetNumHandles.c
+++ b/test/unit/GetNumHandles.c
@@ -38,7 +38,7 @@ GetNumResponseHandles_HMAC_Start_unit (void **state)
  * Tests to ensure that GetNumCommandHandles and GetNumResponseHandles
  * returns 0 for unknown command codes.
  * Since 0 is a valid number here it may make more sense to return something
- * to indicate an error condition. Probaly best to catch unknown command
+ * to indicate an error condition. It is probably best to catch unknown command
  * codes as early as possible?
  */
 static void


### PR DESCRIPTION
Fix spelling errors in test directory.

Fixes #938.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>