### PR TITLE
SAPI: Fix type of marshalling

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_ClockRateAdjust.c
+++ b/src/tss2-sys/api/Tss2_Sys_ClockRateAdjust.c
@@ -49,7 +49,7 @@ TSS2_RC Tss2_Sys_ClockRateAdjust_Prepare(
                                   &ctx->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(rateAdjust, ctx->cmdBuffer,
+    rval = Tss2_MU_UINT8_Marshal(rateAdjust, ctx->cmdBuffer,
                                   ctx->maxCmdSize,
                                   &ctx->nextData);
     if (rval)


### PR DESCRIPTION
Tss2_Sys_ClockRateAdjust falsely marshaled a
UINT32 for rateAdjust, where it should have been
a UINT8.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>