### PR TITLE
SAPI: Fix unused return codes

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_AC_Send.c
+++ b/src/tss2-sys/api/Tss2_Sys_AC_Send.c
@@ -76,6 +76,8 @@ TSS2_RC Tss2_Sys_AC_Send_Prepare(
                                                 ctx->maxCmdSize,
                                                 &ctx->nextData);
     }
+    if (rval)
+        return rval;
 
     ctx->decryptAllowed = 1;
     ctx->encryptAllowed = 0;


### PR DESCRIPTION
Fix a case of unused return codes in Tss2_Sys_AC_Send.
This is the only clang scan-build error currently.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>