### PR TITLE
test/unit/tcti-device.c: fix unit test fail on armel, armhf, mipsel

### DIFF
--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -186,10 +186,14 @@ tcti_device_setup_with_command (void **state)
 static int
 tcti_device_teardown (void **state)
 {
-    TSS2_TCTI_CONTEXT *ctx = *state;
+    data_t *data;
+    data = (data_t *)(*state);
+    TSS2_TCTI_CONTEXT *ctx = data->ctx;
 
     tss2_tcti_finalize (ctx);
     free (ctx);
+    free (*state);
+    *state = NULL;
     return 0;
 }
 /*


### PR DESCRIPTION
Inside the teardown function, it converts a pointer to wrong type.
This commit fixes the bug.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>