### PR TITLE
Document That uthash Development Files Are Now Required

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,7 @@ The following are dependencies only required when building test suites.
 * Code coverage analysis:
 * lcov
 * autoconf-archives
+* uthash development libraries and header files
 
 Most users will not need to install these dependencies.
 


### PR DESCRIPTION
Document that uthash Development Files are required after
the integration of #967.

Fixes #972.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>