### PR TITLE
build: Fix udev rule when no file prefix is provided.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,9 +57,7 @@ include Makefile-test.am
 
 ### Distribution files ###
 # Add udev rule
-if WITH_UDEVRULESPREFIX
 udevrules_DATA   = dist/tpm-udev.rules
-endif
 
 # Adding user and developer information
 EXTRA_DIST += \


### PR DESCRIPTION
With the assignment / definition of the udevrules_DATA wrapped in a
conditional checking for WITH_UDEVRULESPREFIX then we only have a _DATA
variable defined when the configure script was provided with a prefix.
This prevents the installation of the udev rules under the most common
configure case: ./configure && make && make install

The fix is trivial: remove the conditional.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>