### PR TITLE
tcti: Remove TSS2_TCTI_VERSION type, replace with simple uint32_t.

### DIFF
--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -58,9 +58,9 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 
 /* Macros to simplify access to values in common TCTI structure */
 #define TSS2_TCTI_MAGIC(tctiContext) \
-    ((TSS2_TCTI_CONTEXT_VERSION*)tctiContext)->magic
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->magic
 #define TSS2_TCTI_VERSION(tctiContext) \
-    ((TSS2_TCTI_CONTEXT_VERSION*)tctiContext)->version
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->version
 #define TSS2_TCTI_TRANSMIT(tctiContext) \
     ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->transmit
 #define TSS2_TCTI_RECEIVE(tctiContext) \
@@ -164,14 +164,6 @@ typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
     size_t *size,
     const char *config);
 
-/* superclass to get the version */
-typedef struct {
-    uint64_t magic;
-    uint32_t version;
-} TSS2_TCTI_VERSION ;
-
-typedef TSS2_TCTI_VERSION TSS2_TCTI_CONTEXT_VERSION;
-
 /* current version #1 known to this implementation */
 typedef struct {
     uint64_t magic;
@@ -194,7 +186,7 @@ typedef TSS2_TCTI_CONTEXT_COMMON_V2 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 #define TSS2_TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
 
 typedef struct {
-    TSS2_TCTI_VERSION version;
+    uint32_t version;
     const char *name;
     const char *description;
     const char *config_help;

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -307,10 +307,7 @@ Tss2_Tcti_Device_Init (
 }
 
 const TSS2_TCTI_INFO tss2_tcti_info = {
-    .version = {
-        .magic = TCTI_DEVICE_MAGIC,
-        .version = TCTI_VERSION,
-    },
+    .version = TCTI_VERSION,
     .name = "tcti-device",
     .description = "TCTI module for communication with Linux kernel interface.",
     .config_help = "Path to TPM character device. Default value is: "

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -594,10 +594,7 @@ fail_out:
 
 /* public info structure */
 const TSS2_TCTI_INFO tss2_tcti_info = {
-    .version = {
-        .magic = TCTI_MSSIM_MAGIC,
-        .version = TCTI_VERSION,
-    },
+    .version = TCTI_VERSION,
     .name = "tcti-socket",
     .description = "TCTI module for communication with the Microsoft TPM2 Simulator.",
     .config_help = "Connection URI in the form tcp://ip_address[:port]. " \

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -133,7 +133,7 @@ test_tcti_default(void **state)
     will_return(__wrap_dlsym, &__wrap_Tss2_Tcti_Fake_Info);
 
     TSS2_TCTI_INFO fakeInfo = {
-        .version = { 0x123123, 2 },
+        .version = 2,
         .name = "FakeTCTI",
         .description = "FakeDesc",
         .config_help = "FakeHelp",
@@ -188,7 +188,7 @@ test_tcti_tabrmd(void **state)
     will_return(__wrap_dlsym, &__wrap_Tss2_Tcti_Fake_Info);
 
     TSS2_TCTI_INFO fakeInfo = {
-        .version = { 0x123123, 2 },
+        .version = 2,
         .name = "FakeTCTI",
         .description = "FakeDesc",
         .config_help = "FakeHelp",


### PR DESCRIPTION
This is based on feedback from TCG TSS2 working group. The 'magic'
field in the INFO structure isn't necessary or useful. This allows us to
remove the VERSION type all together and just use a uint32_t in its
place. The macros in the header are updated as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>