### PR TITLE
build: Remove --with-simulatorbin, replace with --enable-integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - LD_LIBRARY_PATH="$(pwd)/cmocka/lib:/usr/lib"
   - CMOCKA_CFLAGS="-I$(pwd)/cmocka/include -I/usr/include"
   - CMOCKA_LIBS="-L$(pwd)/cmocka/lib -lcmocka"
+  - PATH="$(pwd)/ibmtpm/src:${PATH}"
 
 addons:
   apt:
@@ -84,7 +85,7 @@ script:
     if [ "$CC" == "gcc" ]; then
       export CONFIGURE_OPTIONS="--enable-code-coverage";
     fi
-  - ../configure --enable-unit $CONFIGURE_OPTIONS --with-simulatorbin=$(pwd)/../ibmtpm/src/tpm_server
+  - ../configure --enable-unit --enable-integration $CONFIGURE_OPTIONS
   - make -j$(nproc) distcheck
   - make -j$(nproc) check
   - cat test-suite.log

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ following sections describe them for the supported platforms.
 * libgcrypt development libraries and header files
 
 The following are dependencies only required when building test suites.
-* Integration test suite (see ./configure option --with-simulatorbin):
+* Integration test suite (see ./configure option --enable-integration):
 * OpenSSL development libraries and header files
 * Unit test suite (see ./configure option --enable-unit):
 * cmocka unit test framework, version >= 1.0

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -34,15 +34,15 @@ TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS) $(libut
 # test harness configuration
 TEST_EXTENSIONS = .int
 INT_LOG_COMPILER = $(srcdir)/script/int-log-compiler.sh
-INT_LOG_FLAGS = --simulator-bin=$(SIMULATOR_BIN)
 EXTRA_DIST += $(INT_LOG_COMPILER)
+AM_TESTS_ENVIRONMENT = PATH="$(PATH)"
 
 check-programs: $(check_PROGRAMS)
 
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(check_PROGRAMS)
 
-if SIMULATOR_BIN
+if ENABLE_INTEGRATION
 noinst_PROGRAMS += test/helper/tpm_startup
 test_helper_tpm_startup_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
 test_helper_tpm_startup_LDFLAGS = $(TESTS_LDFLAGS)
@@ -54,7 +54,7 @@ test_helper_tpm_transientempty_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integra
 test_helper_tpm_transientempty_LDFLAGS = $(TESTS_LDFLAGS)
 test_helper_tpm_transientempty_LDADD = $(TESTS_LDADD)
 test_helper_tpm_transientempty_SOURCES = test/helper/tpm_transientempty.c
-endif #SIMULATOR_BIN
+endif #ENABLE_INTEGRATION
 
 if UNIT
 TESTS_UNIT  = \
@@ -87,7 +87,7 @@ TESTS_UNIT += \
 endif ESAPI
 endif #UNIT
 
-if SIMULATOR_BIN
+if ENABLE_INTEGRATION
 noinst_LTLIBRARIES += test/integration/libtest_utils.la
 TESTS_INTEGRATION = \
     test/integration/sapi-asymmetric-encrypt-decrypt.int \
@@ -187,7 +187,7 @@ TESTS_INTEGRATION += \
     test/integration/esys-verify-signature.int \
     test/integration/esys-zgen-2phase.int
 endif #ESAPI
-endif #SIMULATOR_BIN
+endif #ENABLE_INTEGRATION
 
 CLEANFILES += \
     test/integration/*.log \
@@ -314,7 +314,7 @@ test_unit_esys_getpollhandles_SOURCES = test/unit/esys-getpollhandles.c
 endif # ESAPI
 endif # UNIT
 
-if SIMULATOR_BIN
+if ENABLE_INTEGRATION
 test_tpmclient_tpmclient_int_CFLAGS   = $(AM_CFLAGS) -U_FORTIFY_SOURCE  $(TESTS_CFLAGS)
 test_tpmclient_tpmclient_int_LDADD    = $(TESTS_LDADD)
 test_tpmclient_tpmclient_int_SOURCES  = \
@@ -963,4 +963,4 @@ test_integration_sapi_command_cancel_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_sapi_command_cancel_int_LDADD   = $(TESTS_LDADD)
 test_integration_sapi_command_cancel_int_SOURCES = test/integration/main-sapi.c \
     test/integration/sapi-command-cancel.int.c
-endif #SIMULATOR_BIN
+endif #ENABLE_INTEGRATION

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ simulator will be automatically launched by the tests. Please review the
 dependency list in [INSTALL](INSTALL.md) for dependencies when building
 the test suite.
 ```
-$ ./configure --enable-unit --with-simulatorbin=$HOME/ibmtpm/src/tpm_server
+$ ./configure --enable-unit --enable-integration
 $ make -j$(nproc) check
 ```
 This will generate a file called "test-suite.log" in the root of the build
@@ -70,8 +70,8 @@ directory.
 Please report failures in a Github 'issue' with a full log of the test run.
 
 NOTE: The unit and integration tests can be enabled independently.
-The --enable-unit option controls unit tests, and --with-simulatorbin controls
-the integration tests.
+The --enable-unit option controls unit tests, and --enable-integration
+controls the integration tests.
 
 # [Architecture/Block Diagram](doc/arch.md)
 SAPI library, TAB/RM, and Test Code Block Diagram:

--- a/configure.ac
+++ b/configure.ac
@@ -104,25 +104,21 @@ AC_ARG_WITH([udevrulesprefix],
             [AC_SUBST([udevrulesprefix],[$with_udevrulesprefix])])
 AM_CONDITIONAL(WITH_UDEVRULESPREFIX, [test -n "$with_udevrulesprefix"])
 #
-# simulator binary
+# enable integration tests and check for simulator binary
 #
-AC_MSG_CHECKING([Checking for simulator binary: $with_simulatorbin])
-AC_ARG_WITH([simulatorbin],
-            [AS_HELP_STRING([--with-simulatorbin=tpm_server],[simulator executable])],
-            [AS_IF([test \( -f "$with_simulatorbin" \) -a \( -x "$with_simulatorbin" \)],
-                   [AC_MSG_RESULT([success])
-                    AC_SUBST([SIMULATOR_BIN],[$with_simulatorbin])
-                    AX_NORMALIZE_PATH([with_simulatorbin])
-                    with_simulatorbin_set=yes],
-                   [AC_MSG_ERROR([TPM simulator binary provided does not exist])])],
-            [with_simulatorbin_set=no])
-AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
-
-AS_IF([test "x$with_simulatorbin_set" == xyes],
-      [PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])])
-
-AS_IF([test "x$with_simulatorbin_set" == xyes],
-      [AC_CHECK_HEADER(uthash.h, [], [AC_MSG_ERROR([Can not find uthash.h. Please install uthash-dev])])])
+AC_ARG_ENABLE([integration],
+    [AS_HELP_STRING([--enable-integration],
+        [build and execute integration tests (default is no)])],
+    [enable_integration=$enableval],
+    [enable_integration=no])
+AS_IF([test "x$enable_integration" = "xyes"],
+      [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
+       AS_IF([test "x$tpm_server" != "xyes"],
+             [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])
+       PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])
+       AC_CHECK_HEADER(uthash.h, [], [AC_MSG_ERROR([Can not find uthash.h. Please install uthash-dev])])
+       AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
+AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 
 gl_LD_VERSION_SCRIPT
 
@@ -171,6 +167,8 @@ AX_ADD_LINK_FLAG([-Wl,--no-undefined])
 AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
 AX_ADD_LINK_FLAG([-Wl,-z,now])
 AX_ADD_LINK_FLAG([-Wl,-z,relro])
+
+AC_SUBST([PATH])
 
 # work around GCC bug #53119
 #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -37,16 +37,12 @@ print_usage ()
 {
     cat <<END
 Usage:
-    int-log-compiler.sh --simulator-bin=FILE
-                        TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
-The '--simulator-bin' option is mandatory.
+    int-log-compiler.sh TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
 END
 }
 while test $# -gt 0; do
     case $1 in
     --help) print_usage; exit $?;;
-    -s|--simulator-bin) SIM_BIN=$2; shift;;
-    -s=*|--simulator-bin=*) SIM_BIN="${1#*=}";;
     --) shift; break;;
     -*) usage_error "invalid option: '$1'";;
      *) break;;
@@ -67,6 +63,11 @@ sanity_test ()
     PS_LINES=$(ps -e 2>/dev/null | wc -l)
     if [ "$PS_LINES" -eq 0 ] ; then
         echo "Command ps not listing processes; exiting"
+        exit 1
+    fi
+
+    if [ -z "$(which tpm_server)" ]; then
+        echo "tpm_server not on PATH; exiting"
         exit 1
     fi
 }
@@ -188,7 +189,7 @@ for i in $(seq ${BACKOFF_MAX}); do
     fi
     SIM_PORT_CMD=$((${SIM_PORT_DATA}+1))
     echo "Starting simulator on port ${SIM_PORT_DATA}"
-    simulator_start ${SIM_BIN} ${SIM_PORT_DATA} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
+    simulator_start tpm_server ${SIM_PORT_DATA} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
     sleep 1 # give daemon time to bind to ports
     if [ ! -s ${SIM_PID_FILE} ] ; then
         echo "Simulator PID file is empty or missing. Giving up."


### PR DESCRIPTION
Bill recently integrated the tools integration tests into the test
harness and his approach assumes that the `tpm_server` binary is on the
PATH. This simplifies a few thing and generally it's just cleaner than
requiring the caller to pass the full path to the executable at
configure time.

This patch removes the --with-simulatorbin configure option replacing it
with the --enable-integration option instead. This option takes no
parameters but it does check that the 'tpm_server' binary is on the
callers path. Additionally this patch consolidates the multiple AC_IF
checks for the definition of the associated variable. The corresponding
option to the int-log-compiler.sh script is removed as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>