### PR TITLE
ESAPI: Initialize outputs to NULL.

### DIFF
--- a/src/tss2-esys/api/Esys_Commit.c
+++ b/src/tss2-esys/api/Esys_Commit.c
@@ -290,6 +290,10 @@ Esys_Commit_Finish(
     }
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
+    /* Initialize parameter to avoid unitialized usage */
+    if (E != NULL)
+        *E = NULL;
+
     /* Allocate memory for response parameters */
     if (K != NULL) {
         *K = calloc(sizeof(TPM2B_ECC_POINT), 1);

--- a/src/tss2-esys/api/Esys_Create.c
+++ b/src/tss2-esys/api/Esys_Create.c
@@ -313,6 +313,14 @@ Esys_Create_Finish(
     }
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
+    /* Initialize parameter to avoid unitialized usage */
+    if (creationData != NULL)
+        *creationData = NULL;
+    if (creationHash != NULL)
+        *creationHash = NULL;
+    if (creationTicket != NULL)
+        *creationTicket = NULL;
+
     /* Allocate memory for response parameters */
     if (outPrivate != NULL) {
         *outPrivate = calloc(sizeof(TPM2B_PRIVATE), 1);

--- a/src/tss2-esys/api/Esys_CreatePrimary.c
+++ b/src/tss2-esys/api/Esys_CreatePrimary.c
@@ -314,6 +314,11 @@ Esys_CreatePrimary_Finish(
     TPM2B_NAME name;
     RSRC_NODE_T *objectHandleNode = NULL;
 
+    /* Initialize parameter to avoid unitialized usage */
+    if (creationHash != NULL)
+        *creationHash = NULL;
+    if (creationTicket != NULL)
+        *creationTicket = NULL;
 
     /* Allocate memory for response parameters */
     if (objectHandle == NULL) {

--- a/src/tss2-esys/api/Esys_Duplicate.c
+++ b/src/tss2-esys/api/Esys_Duplicate.c
@@ -281,6 +281,10 @@ Esys_Duplicate_Finish(
     }
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
+    /* Initialize parameter to avoid unitialized usage */
+    if (outSymSeed != NULL)
+        *outSymSeed = NULL;
+
     /* Allocate memory for response parameters */
     if (encryptionKeyOut != NULL) {
         *encryptionKeyOut = calloc(sizeof(TPM2B_DATA), 1);

--- a/src/tss2-esys/api/Esys_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_ReadPublic.c
@@ -236,6 +236,10 @@ Esys_ReadPublic_Finish(
     }
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
+    /* Initialize parameter to avoid unitialized usage */
+    if (qualifiedName != NULL)
+        *qualifiedName = NULL;
+
     /* Allocate memory for response parameters */
     if (outPublic != NULL) {
         *outPublic = calloc(sizeof(TPM2B_PUBLIC), 1);


### PR DESCRIPTION
Initialize the output pointers (starting with the third parameter) to NULL in order to prevent a dereferencing of uninitialized pointers duirng error handling.

Fixes: #981