### PR TITLE
build: Add 'Release' builds to .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ skip_tags: true
 image: Visual Studio 2017
 configuration:
   - Debug
+  - Release
 platform:
   - x86
   - x64


### PR DESCRIPTION
Dan fixed the release builds a while back but the AppVeyor yml file was
never updated to get these on the build matrix.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>