### PR TITLE
Replace C++ Comments in C Source Code with C comments

### DIFF
--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -876,8 +876,7 @@ iesys_crypto_KDFa(TPM2_ALG_ID hashAlg,
      /* Fill outKey with results from KDFaHmac */
     for (; bytes > 0; subKey = &subKey[hlen], bytes = bytes - hlen) {
         LOG_TRACE("IESYS KDFa hmac key bytes: %i", bytes);
-        //if(bytes < (INT32)hlen)
-        //    hlen = bytes;
+        /* if (bytes < (INT32)hlen) hlen = bytes; */
         counter++;
         r = iesys_crypto_KDFaHmac(hashAlg, hmacKey,
                                   hmacKeySize, counter, label, contextU,
@@ -1182,7 +1181,7 @@ iesys_cryptogcry_get_ecdh_point(TPM2B_PUBLIC *key,
     gcry_sexp_t ekey_spec = NULL, ekey_pair = NULL;
     { /* scope for sexp_ecc_key */
         char sexp_ecc_key [sizeof(SEXP_GENKEY_ECC)+strlen(curveId)
-                           -1];  // -1 = (-2 for %s +1 for \0)
+                           -1];  /* -1 = (-2 for %s +1 for \0) */
 
         if (sprintf(&sexp_ecc_key[0], SEXP_GENKEY_ECC, curveId) < 1) {
             goto_error(r, TSS2_ESYS_RC_MEMORY, "asprintf", cleanup);

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1066,7 +1066,7 @@ iesys_check_sequence_async(ESYS_CONTEXT * esys_context)
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
-//TODO: Check if RESUBMISSION BELONGS HERE OR RATHER INTO THE FINISH METHOD.
+    /* TODO: Check if RESUBMISSION BELONGS HERE OR IN THE FINISH METHOD. */
     if (esys_context->state == _ESYS_STATE_RESUBMISSION) {
         esys_context->submissionCount++;
         LOG_DEBUG("The command will be resubmitted for the %i time.",

--- a/src/util/log.c
+++ b/src/util/log.c
@@ -80,7 +80,7 @@ doLog(log_level loglevel, const char *module, log_level logdefault,
     va_list vaargs;
     va_start(vaargs, msg);
     vfprintf (stderr, fmt,
-        //log_strings[loglevel], module, file, func, line,
+        /* log_strings[loglevel], module, file, func, line, */
         vaargs);
     va_end(vaargs);
 }

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -136,7 +136,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         },
     };
     LOG_INFO("\nRSA key will be created.");
-#endif // TEST_ECC
+#endif /* TEST_ECC */
 
     TPM2B_DATA outsideInfo = {
         .size = 0,

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -138,7 +138,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         },
     };
     LOG_INFO("\nRSA key will be created.");
-#endif // TEST_ECC
+#endif /* TEST_ECC */
 
     TPM2B_DATA outsideInfo = {
         .size = 0,

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -138,7 +138,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         },
     };
     LOG_INFO("\nRSA key will be created.");
-#endif // TEST_ECC
+#endif /* TEST_ECC */
 
     TPM2B_DATA outsideInfo = {
         .size = 0,

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -184,16 +184,16 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_PUBLIC inPublic2 = {
         .size = 0,
         .publicArea = {
-            //.type = TPM2_ALG_RSA,
+            /* type = TPM2_ALG_RSA, */
             .type = TPM2_ALG_KEYEDHASH,
             .nameAlg = TPM2_ALG_SHA256,
             .objectAttributes = (
                 TPMA_OBJECT_USERWITHAUTH |
-                //TPMA_OBJECT_RESTRICTED |
-                //TPMA_OBJECT_DECRYPT |
+                /* TPMA_OBJECT_RESTRICTED | */
+                /* TPMA_OBJECT_DECRYPT | */
                 TPMA_OBJECT_FIXEDTPM |
                 TPMA_OBJECT_FIXEDPARENT
-                //TPMA_OBJECT_SENSITIVEDATAORIGIN
+                /* TPMA_OBJECT_SENSITIVEDATAORIGIN */
             ),
 
             .authPolicy = {

--- a/test/integration/sapi-abi-version.int.c
+++ b/test/integration/sapi-abi-version.int.c
@@ -51,7 +51,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     LOG_INFO( "ABI NEGOTIATION TESTS" );
 
-    // Get the size needed for sapi context structure.
+    /* Get the size needed for sapi context structure. */
     contextSize = Tss2_Sys_GetContextSize( 0 );
 
     rc = Tss2_Sys_GetTctiContext (sapi_context, &tcti_context);
@@ -61,7 +61,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         exit(1);
     }
 
-    // Initialized the system context structure.
+    /* Initialize the system context structure. */
     tstAbiVersion.tssCreator = 0xF0000000;
     rc = Tss2_Sys_Initialize( sapi_context, contextSize, tcti_context, &tstAbiVersion );
     if( rc != TSS2_SYS_RC_ABI_MISMATCH )

--- a/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
@@ -122,7 +122,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     in_public.publicArea.parameters.rsaDetail.exponent = 0;
     in_public.publicArea.unique.rsa.size = 0;
 
-    // First clear attributes bit field.
+    /* First clear attributes bit field. */
     *(UINT32 *)&(in_public.publicArea.objectAttributes) = 0;
     in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_RESTRICTED;
     in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;

--- a/test/integration/sapi-sys-initialize.int.c
+++ b/test/integration/sapi-sys-initialize.int.c
@@ -42,8 +42,9 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
     TSS2_RC rc;
 
-    // NOTE: this should never be done in real applications.
-    // It is only done here for test purposes.
+    /* NOTE: this should never be done in real applications.
+     * It is only done here for test purposes.
+     */
     TSS2_TCTI_CONTEXT_COMMON_V2 tctiContext;
 
     LOG_INFO("Sys_Initialize tests started.");
@@ -66,7 +67,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         exit(1);
     }
 
-    // NOTE: don't do this in real applications.
+    /* NOTE: don't do this in real applications. */
     TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)1;
     TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)0;
 
@@ -76,7 +77,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         exit(1);
     }
 
-    // NOTE: don't do this in real applications.
+    /* NOTE: don't do this in real applications. */
     TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)0;
     TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)1;
 

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -1,29 +1,30 @@
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-//**********************************************************************;
+/***********************************************************************;
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ ***********************************************************************;
+ */
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -43,15 +44,15 @@
 #define LOGMODULE testtpmclient
 #include "util/log.h"
 
-//
-// TPM indices and sizes
-//
+/*
+ * TPM indices and sizes
+ */
 #define NV_AUX_INDEX_SIZE     96
 #define NV_PS_INDEX_SIZE      34
 
-#define INDEX_AUX                       0x01800003 // NV Storage
-#define INDEX_LCP_OWN                   0x01400001 // Launch Policy Owner
-#define INDEX_LCP_SUP                   0x01800001 // Launch Policy Default (Supplier)
+#define INDEX_AUX                       0x01800003 /* NV Storage */
+#define INDEX_LCP_OWN                   0x01400001 /* Launch Policy Owner */
+#define INDEX_LCP_SUP                   0x01800001 /* Launch Policy Default (Supplier) */
 #define TPM20_INDEX_TEST1               0x01500015
 #define TPM20_INDEX_TEST2               0x01500016
 #define TPM20_INDEX_PASSWORD_TEST       0x01500020
@@ -204,7 +205,7 @@ static TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
     salt.size = 0;
     symmetric.algorithm = TPM2_ALG_NULL;
 
-    // Create policy session
+    /* Create policy session */
     INIT_SIMPLE_TPM2B_SIZE( nonceTpm );
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM2_RH_NULL, TPM2_RH_NULL, 0, &nonceCaller, &salt,
             TPM2_SE_POLICY, &symmetric, TPM2_ALG_SHA1, sessionHandle, &nonceTpm, 0 );
@@ -217,59 +218,61 @@ static void TestTpmStartup()
 
     LOG_INFO("STARTUP TESTS:" );
 
-    //
-    // First test the one-call interface.
-    //
+    /*
+     * First test the one-call interface.
+     */
 
-    // First must do TPM reset.
+    /* First must do TPM reset. */
     rval = TpmReset();
     CheckPassed(rval);
 
-    // This one should pass.
+    /* This one should pass. */
     rval = Tss2_Sys_Startup( sysContext, TPM2_SU_CLEAR );
     CheckPassed(rval);
 
-    // This one should fail.
+    /* This one should fail. */
     rval = Tss2_Sys_Startup( sysContext, TPM2_SU_CLEAR );
     CheckFailed( rval, TPM2_RC_INITIALIZE );
 
 
-    // Cycle power using simulator interface.
+    /* Cycle power using simulator interface. */
     rval = tcti_platform_command( resMgrTctiContext, MS_SIM_POWER_OFF );
     CheckPassed( rval );
     rval = tcti_platform_command( resMgrTctiContext, MS_SIM_POWER_ON );
     CheckPassed( rval );
 
 
-    //
-    // Now test the synchronous, non-one-call interface.
-    //
+    /*
+     * Now test the synchronous, non-one-call interface.
+     */
     rval = Tss2_Sys_Startup_Prepare( sysContext, TPM2_SU_CLEAR );
     CheckPassed(rval);
 
-    // Execute the command synchronously.
+    /* Execute the command synchronously. */
     rval = Tss2_Sys_Execute( sysContext );
     CheckPassed( rval );
 
-    // Cycle power using simulator interface.
+    /* Cycle power using simulator interface. */
     rval = tcti_platform_command( resMgrTctiContext, MS_SIM_POWER_OFF );
     CheckPassed( rval );
     rval = tcti_platform_command( resMgrTctiContext, MS_SIM_POWER_ON );
     CheckPassed( rval );
 
 
-    //
-    // Now test the asynchronous, non-one-call interface.
-    //
+    /*
+     * Now test the asynchronous, non-one-call interface.
+     */
     rval = Tss2_Sys_Startup_Prepare( sysContext, TPM2_SU_CLEAR );
     CheckPassed(rval);
 
-    // Execute the command asynchronously.
+    /* Execute the command asynchronously. */
     rval = Tss2_Sys_ExecuteAsync( sysContext );
     CheckPassed(rval);
 
-    // Get the command response. Wait a maximum of 20ms
-    // for response.
+    /*
+     * Get the command response. Wait a maximum of 20ms
+     * for response.
+     */
     rval = Tss2_Sys_ExecuteFinish( sysContext, TSS2_TCTI_TIMEOUT_BLOCK );
     CheckPassed(rval);
 }
@@ -379,18 +382,18 @@ static void TestStartAuthSession()
     TPM2B_AUTH      hmac;
 
 
-    // Init sessionHandle
+    /* Init sessionHandle */
     sessionData.sessionHandle = badSessionHandle;
 
-    // Init nonce.
+    /* Init nonce. */
     nonce.size = 0;
     sessionData.nonce = nonce;
 
-    // init hmac
+    /* init hmac */
     hmac.size = 0;
     sessionData.hmac = hmac;
 
-    // Init session attributes
+    /* Init session attributes */
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     encryptedSalt.size = 0;
@@ -405,7 +408,7 @@ static void TestStartAuthSession()
 
     encryptedSalt.size = 0;
 
-     // Init session
+     /* Init session */
     rval = create_auth_session(&authSession, TPM2_RH_NULL, 0, TPM2_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM2_SE_POLICY, &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 
@@ -413,20 +416,22 @@ static void TestStartAuthSession()
     CheckPassed( rval );
     end_auth_session( authSession );
 
-    // Init session
+    /* Init session */
     rval = create_auth_session(&authSession, TPM2_RH_NULL, 0, TPM2_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, 0xff, &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     CheckFailed( rval, TPM2_RC_VALUE + TPM2_RC_P + TPM2_RC_3 );
 
-    // Try starting a bunch to see if resource manager handles this correctly.
+    /*
+     * Try starting a bunch to see if resource manager handles this correctly.
+     */
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *) ); i++ )
     {
-        // Init session struct
+        /* Init session struct */
         rval = create_auth_session(&sessions[i], TPM2_RH_NULL, 0, TPM2_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM2_SE_POLICY, &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
         CheckPassed( rval );
         LOG_INFO("Number of sessions created: %d", i+1 );
 
     }
-    // clean up the sessions that I don't want here.
+    /* clean up the sessions that I don't want here. */
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *)); i++ )
     {
         rval = Tss2_Sys_FlushContext( sysContext, sessions[i]->sessionHandle );
@@ -435,7 +440,7 @@ static void TestStartAuthSession()
         end_auth_session(sessions[i]);
     }
 
-    // Now do some gap tests.
+    /* Now do some gap tests. */
     rval = create_auth_session(&sessions[0], TPM2_RH_NULL, 0, TPM2_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM2_SE_POLICY, &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 
@@ -514,7 +519,7 @@ static void TestHierarchyChangeAuth()
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
-    // Init new auth
+    /* Init new auth */
     newAuth.size = 20;
     for( i = 0; i < newAuth.size; i++ )
         newAuth.buffer[i] = i;
@@ -526,7 +531,7 @@ static void TestHierarchyChangeAuth()
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
-    // Init new auth
+    /* Init new auth */
     newAuth.size = 0;
 
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
@@ -582,7 +587,7 @@ static void TestPcrExtend()
 
     LOG_INFO("PCR_EXTEND, PCR_EVENT, PCR_ALLOCATE, and PCR_READ TESTS:" );
 
-    // Init digests
+    /* Init digests */
     digests.count = 1;
     digests.digests[0].hashAlg = TPM2_ALG_SHA1;
     digestSize = GetDigestSize( digests.digests[0].hashAlg );
@@ -596,12 +601,12 @@ static void TestPcrExtend()
     pcrSelection.pcrSelections[0].hash = TPM2_ALG_SHA1;
     pcrSelection.pcrSelections[0].sizeofSelect = 3;
 
-    // Clear out PCR select bit field
+    /* Clear out PCR select bit field */
     pcrSelection.pcrSelections[0].pcrSelect[0] = 0;
     pcrSelection.pcrSelections[0].pcrSelect[1] = 0;
     pcrSelection.pcrSelections[0].pcrSelect[2] = 0;
 
-    // Now set the PCR you want to read
+    /* Now set the PCR you want to read */
     SET_PCR_SELECT_BIT( pcrSelection.pcrSelections[0], PCR_17 );
 
     rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrSelection, &pcrUpdateCounterBeforeExtend, &pcrSelectionOut, &pcrValues, 0 );
@@ -695,10 +700,10 @@ static void TestNV()
     publicInfo.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
-    // First zero out attributes.
+    /* First zero out attributes. */
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     publicInfo.nvPublic.attributes |= TPMA_NV_PPREAD;
     publicInfo.nvPublic.attributes |= TPMA_NV_PPWRITE;
     publicInfo.nvPublic.attributes |= TPMA_NV_WRITE_STCLEAR;
@@ -723,7 +728,7 @@ static void TestNV()
     rval = Tss2_Sys_NV_Read( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_NV_UNINITIALIZED );
 
-    // Should fail since index is already defined.
+    /* Should fail since index is already defined. */
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_NV_DEFINED );
 
@@ -732,21 +737,23 @@ static void TestNV()
         nvWriteData.buffer[i] = 0xff - i;
 
 #if 1
-    //
-    // Following, at one point, was commented out so that NVDefine will work on successive
-    // invocations of client app.
-    //
-    // Noticed on 12/13/12, this doesn't seem to be necessary anymore.  Maybe something else
-    // I did fixed it.
-    //
-    // Seems to be a bug in TPM 2.0 simulator that if:
-    //   First pass of tpmclient.exe after restarting TPM 2.0 simulator will work fine.
-    //   If NVWrite is done, subsequent invocations of tpmclient.exe will ALWAYS fail on
-    //      first call to Tpm2NVDefineSpace with 0x2cb error. Removing NVWrite removes this.
-    //      And restarting TPM 2.0 simulator will make it work the first time and fail
-    //      subsequent times.
-    //      Removing NVWrite works around this problem.
-    //
+    /*
+     * The following, at one point, was commented out so that NVDefine will
+     * work on successive invocations of client app.
+     *
+     * Noticed on 12/13/12, this doesn't seem to be necessary anymore.
+     * Maybe something else fixed it.
+     *
+     * Seems to be a bug in TPM 2.0 simulator that if:
+     *   First pass of tpmclient.exe after restarting TPM 2.0 simulator will
+     *       work fine.
+     *   If NVWrite is done, subsequent invocations of tpmclient.exe will
+     *      ALWAYS fail on the first call to Tpm2NVDefineSpace with 0x2cb error.
+     *      Removing NVWrite fixes this.
+     *      And restarting TPM 2.0 simulator will make it work the first time
+     *      and fail subsequent times.
+     *      Removing NVWrite works around this problem.
+     */
     rval = Tss2_Sys_NV_Write( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -761,14 +768,14 @@ static void TestNV()
     CheckFailed( rval, TPM2_RC_NV_LOCKED );
 #endif
 
-    // Now undefine the index.
+    /* Now undefine the index. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
 
-    // Now undefine the index so that next run will work correctly.
+    /* Now undefine the index so that next run will work correctly. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
 
@@ -791,14 +798,14 @@ static void TestNV()
     rval = Tss2_Sys_NV_Read( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST2, &sessionsData, 32, 0, &nvData, 0 );
     CheckFailed( rval, TPM2_RC_NV_AUTHORIZATION );
 
-    // Now undefine the index.
+    /* Now undefine the index. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_OWNER, TPM20_INDEX_TEST2, &sessionsData, 0 );
     CheckPassed( rval );
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_OWNER, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
 
-    // Now undefine the index so that next run will work correctly.
+    /* Now undefine the index so that next run will work correctly. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_OWNER, TPM20_INDEX_TEST2, &sessionsData, 0 );
     CheckPassed( rval );
 }
@@ -833,10 +840,10 @@ static void TestHierarchyControl()
     publicInfo.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
-    // First zero out attributes.
+    /* First zero out attributes. */
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     publicInfo.nvPublic.attributes |= TPMA_NV_PPREAD;
     publicInfo.nvPublic.attributes |= TPMA_NV_PPWRITE;
     publicInfo.nvPublic.attributes |= TPMA_NV_PPWRITE;
@@ -849,7 +856,7 @@ static void TestHierarchyControl()
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
 
-    // Test SAPI for case where nvPublic.size != 0
+    /* Test SAPI for case where nvPublic.size != 0 */
     nvPublic.size = 0xff;
     INIT_SIMPLE_TPM2B_SIZE( nvName );
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST1, 0, &nvPublic, &nvName, 0 );
@@ -872,7 +879,7 @@ static void TestHierarchyControl()
     rval = Tss2_Sys_HierarchyControl( sysContext, TPM2_RH_PLATFORM, &sessionsData, TPM2_RH_PLATFORM, YES, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_1 + TPM2_RC_HIERARCHY );
 
-    // Need to do TPM reset and Startup to re-enable platform hierarchy.
+    /* Need to do TPM reset and Startup to re-enable platform hierarchy. */
     rval = TpmReset();
     CheckPassed(rval);
 
@@ -882,7 +889,7 @@ static void TestHierarchyControl()
     rval = Tss2_Sys_HierarchyControl( sysContext, TPM2_RH_PLATFORM, &sessionsData, TPM2_RH_PLATFORM, YES, &sessionsDataOut );
     CheckPassed( rval );
 
-    // Now undefine the index so that next run will work correctly.
+    /* Now undefine the index so that next run will work correctly. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
 }
@@ -893,7 +900,7 @@ static TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION
     TSS2_RC rval = TPM2_RC_SUCCESS;
     TPM2B_NV_PUBLIC publicInfo;
 
-    // Command and response session data structures.
+    /* Command and response session data structures. */
     TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
         .sessionHandle = TPM2_RS_PW,
@@ -903,7 +910,7 @@ static TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION
 
     attributes |= TPMA_NV_ORDERLY;
 
-    // Init public info structure.
+    /* Init public info structure. */
     publicInfo.nvPublic.attributes = attributes;
     CopySizedByteBuffer((TPM2B *)&publicInfo.nvPublic.authPolicy, (TPM2B *)authPolicy);
     publicInfo.nvPublic.dataSize = size;
@@ -913,7 +920,7 @@ static TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION
     publicInfo.nvPublic.nvIndex = nvIndex;
     publicInfo.nvPublic.nameAlg = nameAlg;
 
-    // Create the index
+    /* Create the index */
     rval = Tss2_Sys_NV_DefineSpace( sysContext, authHandle, &sessionsData, auth, &publicInfo, &sessionsDataOut );
 
     return rval;
@@ -930,8 +937,10 @@ static TSS2_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySessio
     TSS2_RC (*buildPolicyFn )( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession, TPM2B_DIGEST *policyDigest ),
     TPM2B_DIGEST *policyDigest, bool trialSession )
 {
-    // NOTE:  this policySession will be either a trial or normal policy session
-    // depending on the value of the passed in trialSession parameter.
+    /*
+     * NOTE:  this policySession will be either a trial or normal policy session
+     * depending on the value of the passed in trialSession parameter.
+     */
     TPM2B_ENCRYPTED_SECRET  encryptedSalt = {0,};
     TPMT_SYM_DEF symmetric;
     TSS2_RC rval;
@@ -939,17 +948,17 @@ static TSS2_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySessio
 
     nonceCaller.size = 0;
 
-    // Start policy session.
+    /* Start policy session. */
     symmetric.algorithm = TPM2_ALG_NULL;
     rval = create_auth_session(policySession, TPM2_RH_NULL, 0, TPM2_RH_NULL, 0, &nonceCaller, &encryptedSalt, trialSession ? TPM2_SE_TRIAL : TPM2_SE_POLICY , &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     if( rval != TPM2_RC_SUCCESS )
         return rval;
 
-    // Send policy command.
+    /* Send policy command. */
     rval = ( *buildPolicyFn )( sysContext, *policySession, policyDigest );
     CheckPassed( rval );
 
-    // Get policy hash.
+    /* Get policy hash. */
     INIT_SIMPLE_TPM2B_SIZE( *policyDigest );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, (*policySession)->sessionHandle,
             0, policyDigest, 0 );
@@ -957,11 +966,11 @@ static TSS2_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySessio
 
     if( trialSession )
     {
-        // Need to flush the session here.
+        /* Need to flush the session here. */
         rval = Tss2_Sys_FlushContext( sysContext, (*policySession)->sessionHandle );
         CheckPassed( rval );
 
-        // And remove the session from sessions table.
+        /* And remove the session from sessions table. */
         end_auth_session( *policySession );
     }
 
@@ -980,24 +989,26 @@ static TSS2_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySess
 
     nonceCaller.size = 0;
 
-    // Since locality is a fairly simple command and we can guarantee
-    // its correctness, we don't need a trial session for this.
+    /*
+     * Since locality is a fairly simple command and we can guarantee
+     * its correctness, we don't need a trial session for this.
+     */
 
-    // Start real policy session
+    /* Start real policy session */
     symmetric.algorithm = TPM2_ALG_NULL;
     rval = create_auth_session(policySession, TPM2_RH_NULL,
             0, TPM2_RH_NULL, 0, &nonceCaller, &encryptedSalt, TPM2_SE_POLICY,
             &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 
-    // Send PolicyLocality command
+    /* Send PolicyLocality command */
     *(UINT8 *)( (void *)&locality ) = 0;
     locality |= TPMA_LOCALITY_TPM2_LOC_THREE;
     rval = Tss2_Sys_PolicyLocality( sysContext, (*policySession)->sessionHandle,
             0, locality, 0 );
     CheckPassed( rval );
 
-    // Read policyHash
+    /* Read policyHash */
     INIT_SIMPLE_TPM2B_SIZE( *policyDigest );
     rval = Tss2_Sys_PolicyGetDigest( sysContext,
             (*policySession)->sessionHandle, 0, policyDigest, 0 );
@@ -1005,7 +1016,7 @@ static TSS2_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySess
 
     nvAuth.size = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
     nvAttributes |= TPMA_NV_POLICYREAD;
     nvAttributes |= TPMA_NV_POLICYWRITE;
@@ -1035,7 +1046,7 @@ static TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySessio
         .hmac = {.size = 0}}}};
 
 
-    // Init write data.
+    /* Init write data. */
     nvWriteData.size = 0;
 
     rval = Tss2_Sys_GetTctiContext(sysContext, &tctiContext);
@@ -1044,7 +1055,7 @@ static TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySessio
     rval = Tss2_Tcti_SetLocality(tctiContext, 2);
     CheckPassed(rval);
 
-    // Do NV write using open session's policy.
+    /* Do NV write using open session's policy. */
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0, &sessionsDataOut );
@@ -1053,25 +1064,25 @@ static TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySessio
     rval = Tss2_Tcti_SetLocality(tctiContext, 3);
     CheckPassed( rval );
 
-    // Do NV write using open session's policy.
+    /* Do NV write using open session's policy. */
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckPassed( rval );
 
-    // Do another NV write using open session's policy.
+    /* Do another NV write using open session's policy. */
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_POLICY_FAIL + TPM2_RC_S + TPM2_RC_1 );
 
-    // Delete NV index
+    /* Delete NV index */
     sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
     sessionsData.auths[0].nonce.size = 0;
     sessionsData.auths[0].nonce.buffer[0] = 0xa5;
     sessionsData.auths[0].hmac.size = 0;
 
-    // Now undefine the index.
+    /* Now undefine the index. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM,
             TPM20_INDEX_PASSWORD_TEST, &sessionsData, 0 );
     CheckPassed( rval );
@@ -1178,7 +1189,7 @@ static TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySes
             &creationTicket, 0 );
     CheckPassed( rval );
 
-    // Now we need to load the object.
+    /* Now we need to load the object. */
     INIT_SIMPLE_TPM2B_SIZE( blobName );
     rval = Tss2_Sys_Load( sysContext, srkHandle, &cmdAuthArray, &outPrivate, &outPublic, &blobHandle, &blobName, 0 );
     CheckPassed( rval );
@@ -1196,27 +1207,33 @@ static TSS2_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySess
         .nonce = {.size = 0},
         .hmac = {.size = 0}}}};
 
-    // Now try to unseal the blob without setting the password.
-    // This test should fail.
+    /*
+     * Now try to unseal the blob without setting the password.
+     * This test should fail.
+     */
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckFailed( rval, TPM2_RC_S + TPM2_RC_1 + TPM2_RC_AUTH_FAIL );
 
-    // Clear DA lockout.
+    /* Clear DA lockout. */
     TestDictionaryAttackLockReset();
 
-    // Now try to unseal the blob after setting the password.
-    // This test should pass.
+    /*
+     * Now try to unseal the blob after setting the password.
+     * This test should pass.
+     */
     INIT_SIMPLE_TPM2B_SIZE( outData );
     cmdAuthArray.auths[0].hmac.size = sizeof( passwordPCRTestPassword );
     memcpy( &cmdAuthArray.auths[0].hmac.buffer, passwordPCRTestPassword, sizeof( passwordPCRTestPassword ) );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckPassed( rval );
 
-    // Add test to make sure we unsealed correctly.
+    /* Add test to make sure we unsealed correctly. */
 
-    // Now we'll want to flush the data blob and remove it
-    // from resource manager tables.
+    /*
+     * Now we'll want to flush the data blob and remove it
+     * from resource manager tables.
+     */
     rval = Tss2_Sys_FlushContext( sysContext, blobHandle );
     CheckPassed( rval );
 
@@ -1225,10 +1242,12 @@ static TSS2_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySess
 
 POLICY_TEST_SETUP policyTestSetups[] =
 {
-    // NOTE:  Since locality is a fairly simple command and we
-    // can guarantee its correctness, we don't need a trial
-    // session for this. buildPolicyFn pointer can be 0 in
-    // this case.
+    /*
+     * NOTE:  Since locality is a fairly simple command and we
+     * can guarantee its correctness, we don't need a trial
+     * session for this. buildPolicyFn pointer can be 0 in
+     * this case.
+     */
     { "LOCALITY", 0, CreateNVIndex, TestLocality },
     { "PASSWORD", BuildPasswordPolicy, CreateDataBlob, PasswordUnseal },
 };
@@ -1251,7 +1270,7 @@ static void TestPolicy()
 
         LOG_INFO("Policy Test: %s", policyTestSetups[i].name );
 
-        // Create trial policy session and run policy commands, in order to create policyDigest.
+        /* Create trial policy session and run policy commands, in order to create policyDigest. */
         if( policyTestSetups[i].buildPolicyFn != 0)
         {
             rval = BuildPolicy( sysContext, &policySession, policyTestSetups[i].buildPolicyFn, &policyDigest, true );
@@ -1259,7 +1278,7 @@ static void TestPolicy()
             LOGBLOB_DEBUG(&(policyDigest.buffer[0]), policyDigest.size, "Built policy digest:");
         }
 
-        // Create entity that will use that policyDigest as authPolicy.
+        /* Create entity that will use that policyDigest as authPolicy. */
         if( policyTestSetups[i].createObjectFn != 0 )
         {
             LOGBLOB_DEBUG(&(policyDigest.buffer[0]), policyDigest.size,
@@ -1269,8 +1288,10 @@ static void TestPolicy()
             CheckPassed( rval );
         }
 
-        // Create real policy session and run policy commands; after this we're ready
-        // to authorize actions on the entity.
+        /*
+         * Create real policy session and run policy commands; after this
+         * we're ready to authorize actions on the entity.
+         */
         if( policyTestSetups[i].buildPolicyFn != 0)
         {
             rval = BuildPolicy( sysContext, &policySession, policyTestSetups[i].buildPolicyFn, &policyDigest, false );
@@ -1281,15 +1302,15 @@ static void TestPolicy()
 
         if( policySession )
         {
-            // Now do tests by authorizing actions on the entity.
+            /* Now do tests by authorizing actions on the entity. */
             rval = ( *policyTestSetups[i].testPolicyFn)( sysContext, policySession );
             CheckPassed( rval );
 
-            // Need to flush the session here.
+            /* Need to flush the session here. */
             rval = Tss2_Sys_FlushContext( sysContext, policySession->sessionHandle );
             CheckPassed( rval );
 
-            // And remove the session from test app session table.
+            /* And remove the session from test app session table. */
             end_auth_session( policySession );
         }
         else
@@ -1410,7 +1431,7 @@ static void TestHash()
             TPM2_RH_PLATFORM, &result, &validation, &sessionsDataOut );
     CheckPassed( rval );
 
-    // Test the resulting hash.
+    /* Test the resulting hash. */
     if (memcmp(result.buffer, goodHashValue, result.size)) {
         LOG_ERROR("ERROR!! resulting hash is incorrect." );
         Cleanup();
@@ -1448,12 +1469,12 @@ static void TestQuote()
     pcrSelection.pcrSelections[0].hash = TPM2_ALG_SHA256;
     pcrSelection.pcrSelections[0].sizeofSelect = 3;
 
-    // Clear out PCR select bit field
+    /* Clear out PCR select bit field */
     pcrSelection.pcrSelections[0].pcrSelect[0] = 0;
     pcrSelection.pcrSelections[0].pcrSelect[1] = 0;
     pcrSelection.pcrSelections[0].pcrSelect[2] = 0;
 
-    // Now set the PCR you want
+    /* Now set the PCR you want */
     pcrSelection.pcrSelections[0].pcrSelect[( PCR_17/8 )] = ( 1 << ( PCR_18 % 8) );
 
     rval = create_primary_rsa_2048_aes_128_cfb(sysContext, &handle_parent);
@@ -1462,7 +1483,7 @@ static void TestQuote()
     rval = create_keyedhash_key (sysContext, handle_parent, &handle);
     CheckPassed( rval );
 
-    // Test with wrong type of key.
+    /* Test with wrong type of key. */
     INIT_SIMPLE_TPM2B_SIZE( quoted );
     rval = Tss2_Sys_Quote ( sysContext, handle, &sessionsData, &qualifyingData, &inScheme,
             &pcrSelection,  &quoted, &signature, &sessionsDataOut );
@@ -1491,27 +1512,27 @@ static void ProvisionOtherIndices()
 
     LOG_INFO("PROVISION OTHER NV INDICES:" );
 
-    //
-    // AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
-    // Do this by setting up two policies and ORing them together when creating AuxIndex:
-    // 1.  PolicyLocality(3) && PolicyCommand(NVWrite)
-    // 2.  EmptyAuth policy && PolicyCommand(NVRead)
-    // Page 126 of Part 1 describes how to do this.
-    //
+    /*
+     * AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
+     * Do this by setting up two policies and ORing them together when creating AuxIndex:
+     * 1.  PolicyLocality(3) && PolicyCommand(NVWrite)
+     * 2.  EmptyAuth policy && PolicyCommand(NVRead)
+     * Page 126 of Part 1 describes how to do this.
+     */
 
-    // Steps:
+    /* Steps: */
     rval = StartPolicySession( &otherIndicesPolicyAuthHandle );
     CheckPassed( rval );
 
-    // 3.  GetPolicyDigest and save it
+    /* 3.  GetPolicyDigest and save it */
     INIT_SIMPLE_TPM2B_SIZE( nvPolicyHash );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, otherIndicesPolicyAuthHandle, 0, &nvPolicyHash, 0 );
     CheckPassed( rval );
 
-    // Now save the policy digest from the first OR branch.
+    /* Now save the policy digest from the first OR branch. */
     LOGBLOB_INFO(&( nvPolicyHash.buffer[0] ), nvPolicyHash.size, "nvPolicyHash");
 
-    // init nvAuth
+    /* init nvAuth */
     nvAuth.size = 0;
 
     publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
@@ -1520,15 +1541,15 @@ static void ProvisionOtherIndices()
     publicInfo.nvPublic.nvIndex = INDEX_LCP_SUP;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
-    // First zero out attributes.
+    /* First zero out attributes. */
     publicInfo.nvPublic.attributes = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     publicInfo.nvPublic.attributes |= TPMA_NV_AUTHREAD;
     publicInfo.nvPublic.attributes |= TPMA_NV_AUTHWRITE;
     publicInfo.nvPublic.attributes |= TPMA_NV_PLATFORMCREATE;
-    // Following commented out for convenience during development.
-    // publicInfo.nvPublic.attributes |= TPMA_NV_POLICY_DELETE;
+    /* Following commented out for convenience during development. */
+    /* publicInfo.nvPublic.attributes |= TPMA_NV_POLICY_DELETE; */
     publicInfo.nvPublic.attributes |= TPMA_NV_WRITEDEFINE;
     publicInfo.nvPublic.attributes |= TPMA_NV_ORDERLY;
 
@@ -1544,7 +1565,7 @@ static void ProvisionOtherIndices()
             &nvAuth, &publicInfo, &otherIndicesSessionsDataOut );
     CheckPassed( rval );
 
-    // Now teardown session
+    /* Now teardown session */
     rval = Tss2_Sys_FlushContext( sysContext, otherIndicesPolicyAuthHandle );
     CheckPassed( rval );
 }
@@ -1558,7 +1579,7 @@ static TSS2_RC InitNvAuxPolicySession( TPMI_SH_AUTH_SESSION *nvAuxPolicySessionH
     rval = StartPolicySession( nvAuxPolicySessionHandle );
     CheckPassed( rval );
 
-    // 2.  PolicyLocality(3)
+    /* 2.  PolicyLocality(3) */
     *(UINT8 *)((void *)&locality) = 0;
     locality |= TPMA_LOCALITY_TPM2_LOC_THREE;
     locality |= TPMA_LOCALITY_TPM2_LOC_FOUR;
@@ -1583,27 +1604,29 @@ static void ProvisionNvAux()
 
     LOG_INFO("PROVISION NV AUX:" );
 
-    //
-    // AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
-    // Do this by setting up two policies and ORing them together when creating AuxIndex:
-    // 1.  PolicyLocality(3) && PolicyCommand(NVWrite)
-    // 2.  EmptyAuth policy && PolicyCommand(NVRead)
-    // Page 126 of Part 1 describes how to do this.
-    //
+    /*
+     * AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled
+     * by authValue and is unrestricted since authValue is set to emptyBuffer
+     * Do this by setting up two policies and ORing them together when creating
+     * AuxIndex:
+     * 1.  PolicyLocality(3) && PolicyCommand(NVWrite)
+     * 2.  EmptyAuth policy && PolicyCommand(NVRead)
+     * Page 126 of Part 1 describes how to do this.
+     */
 
-    // Steps:
+    /* Steps: */
     rval = InitNvAuxPolicySession( &nvAuxPolicyAuthHandle );
     CheckPassed( rval );
 
-    // 3.  GetPolicyDigest and save it
+    /* 3.  GetPolicyDigest and save it */
     INIT_SIMPLE_TPM2B_SIZE( nvPolicyHash );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, nvAuxPolicyAuthHandle, 0, &nvPolicyHash, 0 );
     CheckPassed( rval );
 
-    // Now save the policy digest.
+    /* Now save the policy digest. */
     LOGBLOB_INFO(&( nvPolicyHash.buffer[0] ), nvPolicyHash.size, "nvPolicyHash");
 
-    // init nvAuth
+    /* init nvAuth */
     nvAuth.size = 0;
 
     publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
@@ -1612,15 +1635,15 @@ static void ProvisionNvAux()
     publicInfo.nvPublic.nvIndex = INDEX_AUX;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
-    // First zero out attributes.
+    /* First zero out attributes. */
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     publicInfo.nvPublic.attributes |= TPMA_NV_AUTHREAD;
     publicInfo.nvPublic.attributes |= TPMA_NV_POLICYWRITE;
     publicInfo.nvPublic.attributes |= TPMA_NV_PLATFORMCREATE;
-    // Following commented out for convenience during development.
-    // publicInfo.nvPublic.attributes.TPMA_NV_POLICY_DELETE = 1;
+    /* Following commented out for convenience during development. */
+    /* publicInfo.nvPublic.attributes.TPMA_NV_POLICY_DELETE = 1; */
 
     publicInfo.nvPublic.authPolicy.size = GetDigestSize( TPM2_ALG_SHA1 );
     memcpy( (UINT8 *)&( publicInfo.nvPublic.authPolicy.buffer ), (UINT8 *)&(nvPolicyHash.buffer[0]),
@@ -1632,7 +1655,7 @@ static void ProvisionNvAux()
             &nvAuth, &publicInfo, &nvAuxSessionsDataOut );
     CheckPassed( rval );
 
-    // Now teardown session
+    /* Now teardown session */
     rval = Tss2_Sys_FlushContext( sysContext, nvAuxPolicyAuthHandle );
     CheckPassed( rval );
 }
@@ -1653,14 +1676,14 @@ static void TpmAuxWrite(int locality)
     rval = InitNvAuxPolicySession( &nvAuxPolicyAuthHandle );
     CheckPassed( rval );
 
-    // Now we're going to test it.
+    /* Now we're going to test it. */
     nvWriteData.size = 4;
     for( i = 0; i < nvWriteData.size; i++ )
         nvWriteData.buffer[i] = 0xff - i;
 
     nullSessionsData.auths[0].sessionHandle = nvAuxPolicyAuthHandle;
 
-    // Make sure that session terminates after NVWrite completes.
+    /* Make sure that session terminates after NVWrite completes. */
     nullSessionsData.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     rval = Tss2_Sys_GetTctiContext(sysContext, &tctiContext);
@@ -1683,14 +1706,16 @@ static void TpmAuxWrite(int locality)
     {
         CheckPassed( rval );
 
-        // No teardown of session needed, since the authorization was
-        // successful.
+        /*
+         * No teardown of session needed, since the authorization was
+         * successful.
+         */
     }
     else
     {
         CheckFailed( rval, TPM2_RC_LOCALITY );
 
-        // Now teardown session
+        /* Now teardown session */
         rval = Tss2_Sys_FlushContext( sysContext, nvAuxPolicyAuthHandle );
         CheckPassed( rval );
     }
@@ -1707,7 +1732,7 @@ static void TpmAuxReadWriteTest()
 
     nullSessionsData.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
-    // Try writing it from all localities.  Only locality 3 should work.
+    /* Try writing it from all localities.  Only locality 3 should work. */
     for( testLocality = 0; testLocality < 5; testLocality++ )
     {
         TpmAuxWrite( testLocality );
@@ -1717,7 +1742,7 @@ static void TpmAuxReadWriteTest()
     rval = Tss2_Sys_GetTctiContext(sysContext, &tctiContext);
     CheckPassed(rval);
 
-    // Try reading it from all localities.  They all should work.
+    /* Try reading it from all localities.  They all should work. */
     for( testLocality = 0; testLocality < 5; testLocality++ )
     {
         rval = Tss2_Tcti_SetLocality(tctiContext, testLocality);
@@ -1769,11 +1794,17 @@ static void NvIndexProto()
     LOG_INFO("NV INDEX PROTOTYPE TESTS:" );
 
 
-    // AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
-    // PS index: Write and read are unrestricted until TPM2_WriteLock. After that content is write protected
-    // PO index: Write is restricted by ownerAuth; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
+    /*
+     * AUX index: Write is controlled by TPM2_PolicyLocality;
+     * Read is controlled by authValue and is unrestricted since authValue is
+     * set to emptyBuffer.
+     * PS index: Write and read are unrestricted until TPM2_WriteLock.
+     * After that content is write protected.
+     * PO index: Write is restricted by ownerAuth; Read is controlled by
+     * authValue and is unrestricted since authValue is set to emptyBuffer.
+     */
 
-    // Now we need to configure NV indices
+    /* Now we need to configure NV indices */
     ProvisionNvAux();
 
     ProvisionOtherIndices();
@@ -1782,11 +1813,13 @@ static void NvIndexProto()
 
     TpmOtherIndicesReadWriteTest();
 
-    // Now undefine the aux index, so that subsequent test passes will work.
+    /* Now undefine the aux index, so that subsequent test passes will work. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, INDEX_AUX, &nullSessionsData, &nullSessionsDataOut );
     CheckPassed( rval );
 
-    // Now undefine the other indices, so that subsequent test passes will work.
+    /*
+     * Now undefine the other indices, so that subsequent test passes will work.
+     */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, INDEX_LCP_SUP, &nullSessionsData, &nullSessionsDataOut );
     CheckPassed( rval );
 
@@ -1964,10 +1997,10 @@ static void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
     publicInfo.nvPublic.nvIndex = nvIndex;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
-    // First zero out attributes.
+    /* First zero out attributes. */
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     publicInfo.nvPublic.attributes |= TPMA_NV_AUTHREAD;
     publicInfo.nvPublic.attributes |= TPMA_NV_AUTHWRITE;
     publicInfo.nvPublic.attributes |= TPMA_NV_PLATFORMCREATE;
@@ -1986,10 +2019,10 @@ static void PasswordTest()
     UINT32 rval;
     int i;
 
-    // Authorization array for response.
+    /* Authorization array for response. */
     TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    // Authorization array for command (only has one auth structure).
+    /* Authorization array for command (only has one auth structure). */
     TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
         .sessionHandle = TPM2_RS_PW,
         .sessionAttributes = 0,
@@ -2000,50 +2033,59 @@ static void PasswordTest()
 
     LOG_INFO("PASSWORD TESTS:" );
 
-    // Create an NV index that will use password
-    // authorizations the password will be
-    // "test password".
+    /*
+     * Create an NV index that will use password authorizations.
+     * The password will be "test password".
+     */
     CreatePasswordTestNV( TPM20_INDEX_PASSWORD_TEST, password );
 
-    // Init password (HMAC field in authorization structure).
+    /* Init password (HMAC field in authorization structure). */
     sessionsData.auths[0].hmac.size = strlen( password );
     memcpy( &( sessionsData.auths[0].hmac.buffer[0] ),
             &( password[0] ), sessionsData.auths[0].hmac.size );
 
-    // Initialize write data.
+    /* Initialize write data. */
     nvWriteData.size = 4;
     for( i = 0; i < nvWriteData.size; i++ )
         nvWriteData.buffer[i] = 0xff - i;
 
-    // Attempt write with the correct password.
-    // It should pass.
+    /*
+     * Attempt write with the correct password.
+     * It should pass.
+     */
     rval = Tss2_Sys_NV_Write( sysContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0,
             &sessionsDataOut );
-    // Check that the function passed as
-    // expected.  Otherwise, exit.
+    /*
+     * Check that the function passed as
+     * expected.  Otherwise, exit.
+     */
     CheckPassed( rval );
 
-    // Alter the password so it's incorrect.
+    /* Alter the password so it's incorrect. */
     sessionsData.auths[0].hmac.buffer[4] = 0xff;
     rval = Tss2_Sys_NV_Write( sysContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0,
             &sessionsDataOut );
-    // Check that the function failed as expected,
-    // since password was incorrect.  If wrong
-    // response code received, exit.
+    /*
+     * Check that the function failed as expected,
+     * since password was incorrect.  If wrong
+     * response code received, exit.
+     */
     CheckFailed( rval,
             TPM2_RC_S + TPM2_RC_1 + TPM2_RC_AUTH_FAIL );
 
-    // Change hmac to null one, since null auth is
-    // used to undefine the index.
+    /*
+     * Change hmac to null one, since null auth is
+     * used to undefine the index.
+     */
     sessionsData.auths[0].hmac.size = 0;
 
-    // Now undefine the index.
+    /* Now undefine the index. */
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM,
             TPM20_INDEX_PASSWORD_TEST, &sessionsData, 0 );
     CheckPassed( rval );
@@ -2068,10 +2110,10 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
     char testStringHmac[] = "HMAC";
     char testStringPolicy[] = "POLICY";
 
-    // Response authorization area.
+    /* Response authorization area. */
     TSS2L_SYS_AUTH_RESPONSE nvRspAuths;
 
-    // Command authorization area: one password session.
+    /* Command authorization area: one password session. */
     TSS2L_SYS_AUTH_COMMAND nvCmdAuths = { .count = 1, .auths= {{
         .sessionHandle = TPM2_RS_PW,
         .sessionAttributes = 0,
@@ -2092,46 +2134,50 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
     /* If LOG_INFO is not compiled in, this variable is unused */
     (void)(testString);
 
-    // Create sysContext structure.
+    /* Create sysContext structure. */
     simpleTestContext = sapi_init_from_tcti_ctx(resMgrTctiContext);
     if (simpleTestContext == NULL)
         InitSysContextFailure();
 
-    // Setup the NV index's authorization value.
+    /* Setup the NV index's authorization value. */
     nvAuth.size = strlen( sharedSecret );
     for( i = 0; i < nvAuth.size; i++ )
         nvAuth.buffer[i] = sharedSecret[i];
 
-    //
-    // Create NV index.
-    //
+    /*
+     * Create NV index.
+     */
     if( hmacTest )
     {
-        // Setup the NV index's authorization value.
+        /* Setup the NV index's authorization value. */
         nvAuth.size = strlen( sharedSecret );
         for( i = 0; i < nvAuth.size; i++ )
             nvAuth.buffer[i] = sharedSecret[i];
 
-        // Set NV index's authorization policy
-        // to zero sized policy since we won't be
-        // using policy to authorize.
+        /*
+         * Set NV index's authorization policy
+         * to zero sized policy since we won't be
+         * using policy to authorize.
+         */
 
         authPolicy.size = 0;
     }
     else
     {
-        // Zero sized encrypted salt, since the session
-        // is unsalted.
+        /*
+         * Zero sized encrypted salt, since the session
+         * is unsalted.
+         */
 
         encryptedSalt.size = 0;
 
-        // No symmetric algorithm.
+        /* No symmetric algorithm. */
         symmetric.algorithm = TPM2_ALG_NULL;
 
-        //
-        // Create the NV index's authorization policy
-        // using a trial policy session.
-        //
+        /*
+         * Create the NV index's authorization policy
+         * using a trial policy session.
+         */
         rval = create_auth_session(&trialPolicySession,
                 TPM2_RH_NULL, 0, TPM2_RH_NULL, 0, &nonceCaller, &encryptedSalt,
                 TPM2_SE_TRIAL,
@@ -2142,25 +2188,29 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
                 trialPolicySession->sessionHandle, 0, 0 );
         CheckPassed( rval );
 
-        // Get policy digest.
+        /* Get policy digest. */
         INIT_SIMPLE_TPM2B_SIZE( authPolicy );
         rval = Tss2_Sys_PolicyGetDigest( simpleTestContext,
                 trialPolicySession->sessionHandle,
                 0, &authPolicy, 0 );
         CheckPassed( rval );
 
-        // End the trial session by flushing it.
+        /* End the trial session by flushing it. */
         rval = Tss2_Sys_FlushContext( simpleTestContext,
                 trialPolicySession->sessionHandle );
         CheckPassed( rval );
 
-        // And remove the trial policy session from
-        // sessions table.
+        /*
+         * And remove the trial policy session from
+         * sessions table.
+         */
         end_auth_session( trialPolicySession );
     }
 
-    // Now set the NV index's attributes:
-    // policyRead, authWrite, and platormCreate.
+    /*
+     * Now set the NV index's attributes:
+     * policyRead, authWrite, and platormCreate.
+     */
     *(UINT32 *)( &nvAttributes ) = 0;
     if( hmacTest )
     {
@@ -2174,19 +2224,21 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
     }
     nvAttributes |= TPMA_NV_PLATFORMCREATE;
 
-    // Create the NV index.
+    /* Create the NV index. */
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW,
             &nvAuth, &authPolicy, TPM20_INDEX_PASSWORD_TEST,
             TPM2_ALG_SHA256, nvAttributes, 32  );
     CheckPassed( rval );
 
-    // Add index and associated authorization value to
-    // entity table.  This helps when we need
-    // to calculate HMACs.
+    /*
+     * Add index and associated authorization value to
+     * entity table.  This helps when we need
+     * to calculate HMACs.
+     */
     rval = AddEntity(TPM20_INDEX_PASSWORD_TEST, &nvAuth);
     CheckPassed(rval);
 
-    // Get the name of the NV index.
+    /* Get the name of the NV index. */
     rval = tpm_handle_to_name(
             resMgrTctiContext,
             TPM20_INDEX_PASSWORD_TEST,
@@ -2194,24 +2246,28 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
     CheckPassed( rval );
 
 
-    //
-    // Start HMAC or real (non-trial) policy authorization session:
-    // it's an unbound and unsalted session, no symmetric
-    // encryption algorithm, and SHA256 is the session's
-    // hash algorithm.
-    //
+    /*
+     * Start HMAC or real (non-trial) policy authorization session:
+     * it's an unbound and unsalted session, no symmetric
+     * encryption algorithm, and SHA256 is the session's
+     * hash algorithm.
+     */
 
-    // Zero sized encrypted salt, since the session
-    // is unsalted.
+    /*
+     * Zero sized encrypted salt, since the session
+     * is unsalted.
+     */
     encryptedSalt.size = 0;
 
-    // No symmetric algorithm.
+    /* No symmetric algorithm. */
     symmetric.algorithm = TPM2_ALG_NULL;
 
-    // Create the session, hmac or policy depending
-    // on hmacTest.
-    // Session state (session handle, nonces, etc.) gets
-    // saved into nvSession structure for later use.
+    /*
+     * Create the session, hmac or policy depending
+     * on hmacTest.
+     * Session state (session handle, nonces, etc.) gets
+     * saved into nvSession structure for later use.
+     */
     if( hmacTest )
         tpmSe = TPM2_SE_HMAC;
     else
@@ -2222,50 +2278,54 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
             &symmetric, TPM2_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 
-    // Get the name of the session and save it in
-    // the nvSession structure.
+    /*
+     * Get the name of the session and save it in
+     * the nvSession structure.
+     */
     rval = tpm_handle_to_name(
             resMgrTctiContext,
             nvSession->sessionHandle,
             &(nvSession->name) );
     CheckPassed( rval );
 
-    // Initialize NV write data.
+    /* Initialize NV write data. */
     nvWriteData.size = sizeof( dataToWrite );
     for( i = 0; i < nvWriteData.size; i++ )
     {
         nvWriteData.buffer[i] = dataToWrite[i];
     }
 
-    //
-    // Now setup for writing the NV index.
-    //
+    /*
+     * Now setup for writing the NV index.
+     */
     if( !hmacTest )
     {
-        // Send policy command.
+        /* Send policy command. */
         rval = Tss2_Sys_PolicyAuthValue( simpleTestContext,
                 nvSession->sessionHandle, 0, 0 );
         CheckPassed( rval );
     }
 
-    // First call prepare in order to create cpBuffer.
+    /* First call prepare in order to create cpBuffer. */
     rval = Tss2_Sys_NV_Write_Prepare( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval );
 
-    // Configure command authorization area, except for HMAC.
+    /* Configure command authorization area, except for HMAC. */
     nvCmdAuths.auths[0].sessionHandle = nvSession->sessionHandle;
     nvCmdAuths.auths[0].nonce.size = 1;
     nvCmdAuths.auths[0].nonce.buffer[0] = 0xa5;
     nvCmdAuths.auths[0].sessionAttributes = 0;
     nvCmdAuths.auths[0].sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
-    // Roll nonces for command
+    /* Roll nonces for command */
     roll_nonces(nvSession, &nvCmdAuths.auths[0].nonce );
 
-    // Complete command authorization area, by computing
-    // HMAC and setting it in nvCmdAuths.
+    /*
+     * Complete command authorization area, by computing
+     * HMAC and setting it in nvCmdAuths.
+     */
     rval = compute_command_hmac(
             simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
@@ -2273,22 +2333,27 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
             TPM2_RH_NULL,
             &nvCmdAuths);
     CheckPassed(rval);
-    // Finally!!  Write the data to the NV index.
-    // If the command is successful, the command
-    // HMAC was correct.
+
+    /*
+     * Finally!!  Write the data to the NV index.
+     * If the command is successful, the command
+     * HMAC was correct.
+     */
     sessionCmdRval = Tss2_Sys_NV_Write(simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &nvCmdAuths, &nvWriteData, 0, &nvRspAuths);
     CheckPassed(sessionCmdRval);
 
-    // Roll nonces for response
+    /* Roll nonces for response */
     roll_nonces(nvSession, &nvRspAuths.auths[0].nonce );
 
     if (sessionCmdRval == TPM2_RC_SUCCESS) {
-        // If the command was successful, check the
-        // response HMAC to make sure that the
-        // response was received correctly.
+        /*
+         * If the command was successful, check the
+         * response HMAC to make sure that the
+         * response was received correctly.
+         */
         rval = check_response_hmac(
                 simpleTestContext,
                 &nvCmdAuths,
@@ -2301,26 +2366,29 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
 
     if( !hmacTest )
     {
-        // Send policy command.
+        /* Send policy command. */
         rval = Tss2_Sys_PolicyAuthValue( simpleTestContext,
                 nvSession->sessionHandle, 0, 0 );
         CheckPassed( rval );
     }
-    // First call prepare in order to create cpBuffer.
+
+    /* First call prepare in order to create cpBuffer. */
     rval = Tss2_Sys_NV_Read_Prepare( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             sizeof( dataToWrite ), 0 );
     CheckPassed( rval );
 
-    // Roll nonces for command
+    /* Roll nonces for command */
     roll_nonces(nvSession, &nvCmdAuths.auths[0].nonce );
 
-    // End the session after next command.
+    /* End the session after next command. */
     nvCmdAuths.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
-    // Complete command authorization area, by computing
-    // HMAC and setting it in nvCmdAuths.
+    /*
+     * Complete command authorization area, by computing
+     * HMAC and setting it in nvCmdAuths.
+     */
     rval = compute_command_hmac(
             simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
@@ -2329,9 +2397,11 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
             &nvCmdAuths);
     CheckPassed(rval);
 
-    // And now read the data back.
-    // If the command is successful, the command
-    // HMAC was correct.
+    /*
+     * And now read the data back.
+     * If the command is successful, the command
+     * HMAC was correct.
+     */
     INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     sessionCmdRval = Tss2_Sys_NV_Read( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
@@ -2340,13 +2410,15 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
             &nvReadData, &nvRspAuths );
     CheckPassed( sessionCmdRval );
 
-    // Roll nonces for response
+    /* Roll nonces for response */
     roll_nonces(nvSession, &nvRspAuths.auths[0].nonce );
 
     if (sessionCmdRval == TPM2_RC_SUCCESS) {
-        // If the command was successful, check the
-        // response HMAC to make sure that the
-        // response was received correctly.
+        /*
+         * If the command was successful, check the
+         * response HMAC to make sure that the
+         * response was received correctly.
+         */
         rval = check_response_hmac(
                 simpleTestContext,
                 &nvCmdAuths,
@@ -2357,7 +2429,7 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
         CheckPassed(rval);
     }
 
-    // Check that write and read data are equal.
+    /* Check that write and read data are equal. */
     if( memcmp( (void *)&nvReadData.buffer[0],
             (void *)&nvWriteData.buffer[0], nvReadData.size ) )
     {
@@ -2365,26 +2437,26 @@ static void SimpleHmacOrPolicyTest( bool hmacTest )
         Cleanup();
     }
 
-    //
-    // Now cleanup:  undefine the NV index and delete
-    // the NV index's entity table entry.
-    //
+    /*
+     * Now cleanup:  undefine the NV index and delete
+     * the NV index's entity table entry.
+     */
 
-    // Setup authorization for undefining the NV index.
+    /* Setup authorization for undefining the NV index. */
     nvCmdAuths.auths[0].sessionHandle = TPM2_RS_PW;
     nvCmdAuths.auths[0].nonce.size = 0;
     nvCmdAuths.auths[0].hmac.size = 0;
 
-    // Undefine the NV index.
+    /* Undefine the NV index. */
     rval = Tss2_Sys_NV_UndefineSpace( simpleTestContext,
             TPM2_RH_PLATFORM, TPM20_INDEX_PASSWORD_TEST,
             &nvCmdAuths, 0 );
     CheckPassed( rval );
 
-    // Delete the NV index's entry in the entity table.
+    /* Delete the NV index's entry in the entity table. */
     DeleteEntity(TPM20_INDEX_PASSWORD_TEST);
 
-    // Remove the real session from sessions table.
+    /* Remove the real session from sessions table. */
     end_auth_session( nvSession );
 
     sapi_teardown(simpleTestContext);
@@ -2404,28 +2476,31 @@ static void GetSetDecryptParamTests()
 
     LOG_INFO("GET/SET DECRYPT PARAM TESTS:" );
 
-    // Create two sysContext structures.
+    /* Create two sysContext structures. */
     decryptParamTestSysContext = sapi_init_from_tcti_ctx(resMgrTctiContext);
     if (decryptParamTestSysContext == NULL)
         InitSysContextFailure();
 
-    // Test for bad sequence:  Tss2_Sys_GetDecryptParam
+    /* Test for bad sequence:  Tss2_Sys_GetDecryptParam */
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE );
 
-    // Test for bad sequence:  Tss2_Sys_SetDecryptParam
+    /* Test for bad sequence:  Tss2_Sys_SetDecryptParam */
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 4, &( nvWriteData.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE );
 
-    // NOTE:  Two tests for BAD_SEQUENCE for GetDecryptParam and SetDecryptParam after ExecuteAsync
-    // are in the GetSetEncryptParamTests function, just because it's easier to do this way.
+    /*
+     * NOTE:  Two tests for BAD_SEQUENCE for GetDecryptParam and
+     * SetDecryptParam after ExecuteAsync are in the GetSetEncryptParamTests
+     * function, just because it's easier to do this way.
+     */
 
-    // Do Prepare.
+    /* Do Prepare. */
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa );
     CheckPassed( rval );
 
-    // Test for bad reference:  Tss2_Sys_GetDecryptParam
+    /* Test for bad reference:  Tss2_Sys_GetDecryptParam */
     rval = Tss2_Sys_GetDecryptParam( 0, &decryptParamSize, &decryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
@@ -2436,7 +2511,7 @@ static void GetSetDecryptParamTests()
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
 
-    // Test for bad reference:  Tss2_Sys_SetDecryptParam
+    /* Test for bad reference:  Tss2_Sys_SetDecryptParam */
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 4, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
@@ -2444,18 +2519,18 @@ static void GetSetDecryptParamTests()
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
 
-    // Test for bad size.
+    /* Test for bad size. */
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 5, &( nvWriteData.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE );
 
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 3, &( nvWriteData.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE );
 
-    // Test for good size.
+    /* Test for good size. */
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 4, &( nvWriteData.buffer[0] ) );
     CheckPassed( rval );
 
-    // Make sure that the set operation really did the right thing.
+    /* Make sure that the set operation really did the right thing. */
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
     CheckPassed( rval );
     for( i = 0; i < 4; i++ )
@@ -2472,7 +2547,7 @@ static void GetSetDecryptParamTests()
 
     LOGBLOB_DEBUG((UINT8 *)cpBuffer1, cpBufferUsedSize1, "cpBuffer = ");
 
-    // Test for no decrypt param.
+    /* Test for no decrypt param. */
     rval = Tss2_Sys_NV_Read_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( nvWriteData ) - 2, 0 );
     CheckPassed( rval );
 
@@ -2482,7 +2557,7 @@ static void GetSetDecryptParamTests()
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 4, &( nvWriteData.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_NO_DECRYPT_PARAM );
 
-    // Null decrypt param.
+    /* Null decrypt param. */
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, 0, 0x55aa );
     CheckPassed( rval );
@@ -2490,14 +2565,14 @@ static void GetSetDecryptParamTests()
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
     CheckPassed( rval );
 
-    // Check that size == 0.
+    /* Check that size == 0. */
     if( decryptParamSize != 0 )
     {
         LOG_ERROR("ERROR!!  decryptParamSize s/b: 0, was: %u", (unsigned int)decryptParamSize );
         Cleanup();
     }
 
-    // Test for insufficient size.
+    /* Test for insufficient size. */
     rval = Tss2_Sys_GetCpBuffer(decryptParamTestSysContext, &cpBufferUsedSize2, &cpBuffer2);
     CheckPassed(rval);
     nvWriteData.size = TPM2_MAX_COMMAND_SIZE -
@@ -2506,7 +2581,10 @@ static void GetSetDecryptParamTests()
     rval = Tss2_Sys_SetDecryptParam(decryptParamTestSysContext, nvWriteData.size, nvWriteData.buffer);
     CheckFailed(rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT);
 
-    // Test that one less will work.  This tests that we're checking the correct corner case.
+    /*
+     * Test that one less will work.
+     * This tests that we're checking the correct corner case.
+     */
     nvWriteData.size -= 1;
     rval = Tss2_Sys_SetDecryptParam(decryptParamTestSysContext, nvWriteData.size, nvWriteData.buffer);
     CheckPassed(rval);
@@ -2540,7 +2618,7 @@ static void GetSetDecryptParamTests()
         }
     }
 
-    // Test case of zero sized decrypt param, another case of bad size.
+    /* Test case of zero sized decrypt param, another case of bad size. */
     nvWriteData1.size = 0;
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa );
@@ -2558,7 +2636,7 @@ static void SysFinalizeTests()
 
     Tss2_Sys_Finalize( 0 );
 
-    // Note:  other cases tested by other tests.
+    /* Note:  other cases tested by other tests. */
 }
 
 static void GetContextSizeTests()
@@ -2623,25 +2701,25 @@ static void GetSetEncryptParamTests()
 
     LOG_INFO("GET/SET ENCRYPT PARAM TESTS:" );
 
-    // Do Prepare.
+    /* Do Prepare. */
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
-    CheckPassed( rval ); // #1
+    CheckPassed( rval ); /* #1 */
 
-    // Test for bad sequence
+    /* Test for bad sequence */
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #2
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #2 */
 
     rval = Tss2_Sys_SetEncryptParam( sysContext, 4, &( nvWriteData.buffer[0] ) );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #3
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #3 */
 
-    // Create NV index
+    /* Create NV index */
 
-    // Set empty policy and auth value.
+    /* Set empty policy and auth value. */
     authPolicy.size = 0;
     nvAuth.size = 0;
 
-    // Now set the attributes.
+    /* Now set the attributes. */
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
     nvAttributes |= TPMA_NV_AUTHREAD;
     nvAttributes |= TPMA_NV_AUTHWRITE;
@@ -2649,86 +2727,92 @@ static void GetSetEncryptParamTests()
 
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW, &nvAuth, &authPolicy,
             TPM20_INDEX_PASSWORD_TEST, TPM2_ALG_SHA1, nvAttributes, 32  );
-    CheckPassed( rval ); // #4
+    CheckPassed( rval ); /* #4 */
 
-    // Write the index.
+    /* Write the index. */
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
-    CheckPassed( rval ); // #5
+    CheckPassed( rval ); /* #5 */
 
-    // NOTE: add GetCpBuffer tests here, just because it's easier.
+    /* NOTE: add GetCpBuffer tests here, just because it's easier. */
     rval = Tss2_Sys_GetCpBuffer( 0, (size_t *)4, (const uint8_t **)4 );
-	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #6
+	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #6 */
 
     rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)0, (const uint8_t **)4 );
-	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #7
+	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #7 */
 
     rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)4, (const uint8_t **)0 );
-	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #8
+	CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #8 */
 
 
     rval = Tss2_Sys_SetCmdAuths( sysContext, &sessionsData );
-    CheckPassed( rval ); // #9
+    CheckPassed( rval ); /* #9 */
 
     rval = Tss2_Sys_ExecuteAsync( sysContext );
-    CheckPassed( rval ); // #10
+    CheckPassed( rval ); /* #10 */
 
-    // NOTE: Stick two tests for BAD_SEQUENCE for GetDecryptParam and SetDecryptParam here, just
-    // because it's easier to do this way.
+    /*
+     * NOTE: Stick two tests for BAD_SEQUENCE for GetDecryptParam and
+     * SetDecryptParam here, just because it's easier to do this way.
+     */
     rval = Tss2_Sys_GetDecryptParam( sysContext, (size_t *)4, (const uint8_t **)4 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #11
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #11 */
 
     rval = Tss2_Sys_SetDecryptParam( sysContext, 10, (uint8_t *)4 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #12
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #12 */
 
-    // NOTE: Stick test for BAD_SEQUENCE for GetCpBuffer here, just
-    // because it's easier to do this way.
+    /*
+     * NOTE: Stick test for BAD_SEQUENCE for GetCpBuffer here, just
+     * because it's easier to do this way.
+     */
     rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)4, &cpBuffer );
-	CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #13
+	CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #13 */
 
-    // Now finish the write command so that TPM isn't stuck trying
-    // to send a response.
+    /*
+     * Now finish the write command so that TPM isn't stuck trying
+     * to send a response.
+     */
     rval = Tss2_Sys_ExecuteFinish( sysContext, -1 );
-    CheckPassed( rval ); // #14
+    CheckPassed( rval ); /* #14 */
 
-    // Test GetEncryptParam for no encrypt param case.
+    /* Test GetEncryptParam for no encrypt param case. */
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); // #15
+    CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); /* #15 */
 
-    // Test SetEncryptParam for no encrypt param case.
+    /* Test SetEncryptParam for no encrypt param case. */
     rval = Tss2_Sys_SetEncryptParam( sysContext, encryptParamSize, encryptParamBuffer1 );
-    CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); // #16
+    CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); /* #16 */
 
-    // Now read it and do tests on get/set encrypt functions
+    /* Now read it and do tests on get/set encrypt functions */
     rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, 4, 0 );
-    CheckPassed( rval ); // #17
+    CheckPassed( rval ); /* #17 */
 
     INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &sessionsData, 4, 0, &nvReadData, &sessionsDataOut );
-    CheckPassed( rval ); // #18
+    CheckPassed( rval ); /* #18 */
 
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
-    CheckPassed( rval ); // #19
+    CheckPassed( rval ); /* #19 */
 
-    // Test case of encryptParamSize being too small.
+    /* Test case of encryptParamSize being too small. */
     encryptParamSize--;
     rval = Tss2_Sys_SetEncryptParam( sysContext, encryptParamSize, encryptParamBuffer1 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE ); // #20
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE ); /* #20 */
     encryptParamSize += 2;
 
-    // Size too large...
+    /* Size too large... */
     rval = Tss2_Sys_SetEncryptParam( sysContext, encryptParamSize, encryptParamBuffer1 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE ); // #21
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SIZE ); /* #21 */
 
     encryptParamSize--;
     rval = Tss2_Sys_SetEncryptParam( sysContext, encryptParamSize, encryptParamBuffer1 );
-    CheckPassed( rval ); // #22
+    CheckPassed( rval ); /* #22 */
 
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
-    CheckPassed( rval ); // #23
+    CheckPassed( rval ); /* #23 */
 
-    // Test that encryptParamBuffer is the same as encryptParamBuffer1
+    /* Test that encryptParamBuffer is the same as encryptParamBuffer1 */
     for( i = 0; i < 4; i++ )
     {
         if( encryptParamBuffer[i] != encryptParamBuffer1[i] )
@@ -2739,24 +2823,24 @@ static void GetSetEncryptParamTests()
     }
 
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_PASSWORD_TEST, &sessionsData, 0 );
-    CheckPassed( rval ); // #24
+    CheckPassed( rval ); /* #24 */
 
 
-    // Test for bad reference
+    /* Test for bad reference */
     rval = Tss2_Sys_GetEncryptParam( 0, &encryptParamSize, &encryptParamBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #25
+    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #25 */
 
     rval = Tss2_Sys_GetEncryptParam( sysContext, 0, &encryptParamBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #26
+    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #26 */
 
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, 0 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #27
+    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #27 */
 
     rval = Tss2_Sys_SetEncryptParam( sysContext, 4, 0 );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #28
+    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #28 */
 
     rval = Tss2_Sys_SetEncryptParam( 0, 4, encryptParamBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #29
+    CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); /* #29 */
 }
 
 static void EcEphemeralTest()
@@ -2767,7 +2851,7 @@ static void EcEphemeralTest()
 
     LOG_INFO("EC Ephemeral TESTS:" );
 
-    // Test SAPI for case of Q size field not being set to 0.
+    /* Test SAPI for case of Q size field not being set to 0. */
     INIT_SIMPLE_TPM2B_SIZE( Q );
     rval = Tss2_Sys_EC_Ephemeral( sysContext, 0, TPM2_ECC_BN_P256, &Q, &counter, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_VALUE );
@@ -2813,10 +2897,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     TestTpmStartup();
 
-    // Run this directly after Startup tests to test for
-    // a resource mgr corner case with SaveContext.
+    /*
+     * Run this directly after Startup tests to test for
+     * a resource mgr corner case with SaveContext.
+     */
     TestStartAuthSession();
-    // Clear DA lockout.
+    /* Clear DA lockout. */
     TestDictionaryAttackLockReset();
     TestDictionaryAttackLockReset();
     TestHierarchyControl();


### PR DESCRIPTION
Replace
    // C++ comments
in C source code with
    /* C comments. */

Fixes #1009.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>