### PR TITLE
esys_crypto: fix defects reported by Coverity Scan

### DIFF
--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -949,8 +949,13 @@ iesys_cryptogcry_KDFe(TPM2_ALG_ID hashAlg,
 
     LOG_DEBUG("IESYS KDFe hashAlg: %i label: %s bitLength: %i",
               hashAlg, label, bit_size);
-    LOGBLOB_DEBUG(&partyUInfo->buffer[0], partyUInfo->size, "partyUInfo");
-    LOGBLOB_DEBUG(&partyVInfo->buffer[0], partyVInfo->size, "partyVInfo");
+
+    if (partyUInfo != NULL)
+        LOGBLOB_DEBUG(&partyUInfo->buffer[0], partyUInfo->size, "partyUInfo");
+
+    if (partyVInfo != NULL)
+        LOGBLOB_DEBUG(&partyVInfo->buffer[0], partyVInfo->size, "partyVInfo");
+
     r = iesys_crypto_hash_get_digest_size(hashAlg, &hash_len);
     return_if_error(r, "Hash algorithm not supported.");
 


### PR DESCRIPTION
Fix two potential null ptr dereference issues reported by ceverity.

CID 1468838:  Null pointer dereferences  (REVERSE_INULL)
Null-checking "partyUInfo" suggests that it may be null,
but it has already been dereferenced on all paths leading to the check.

CID 1468837:  Null pointer dereferences  (REVERSE_INULL)
Null-checking "partyVInfo" suggests that it may be null,
but it has already been referenced on all paths leading to the check.