### PR TITLE
build: Add checks for 'netstat' @ configure and integration test time.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ The following are dependencies only required when building test suites.
 * OpenSSL development libraries and header files
 * Unit test suite (see ./configure option --enable-unit):
 * cmocka unit test framework, version >= 1.0
+* netstat executable (usually in the net-tools package)
 * Code coverage analysis:
 * lcov
 * autoconf-archives
@@ -35,6 +36,7 @@ $ sudo apt -y install \
   autoconf-archive \
   libcmocka0 \
   libcmocka-dev \
+  net-tools \
   build-essential \
   git \
   pkg-config \

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,9 @@ AS_IF([test "x$enable_integration" = "xyes"],
       [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
        AS_IF([test "x$tpm_server" != "xyes"],
              [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])
+       AC_CHECK_PROG([netstat], [netstat], [yes], [no])
+       AS_IF([test "x$netstat" != "xyes"],
+             [AC_MSG_ERROR([Integration tests enabled but netstat executable not found.])])
        PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])
        AC_CHECK_HEADER(uthash.h, [], [AC_MSG_ERROR([Can not find uthash.h. Please install uthash-dev])])
        AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -70,6 +70,11 @@ sanity_test ()
         echo "tpm_server not on PATH; exiting"
         exit 1
     fi
+
+    if [ -z "$(which netstat)" ]; then
+        echo "netstat not on PATH; exiting"
+        exit 1
+    fi
 }
 
 # This function takes a PID as a parameter and determines whether or not the


### PR DESCRIPTION
I just ran a full build and integration test run on a fresh build system
installing only things that the configure script tested for. Everything
built fine but the test harness hung. This happened because the netstat
utility was missing. I hadn't installed net-tools (Debian).

This commit adds an explicit check for this tool @ configure time. The
integration test wrapper has also been instrumented to ensure that
netstat is on the PATH as well. This causes tests to fail early instead
of timing out because all checks for simulator port conflicts fail which
cause retries and backoff timeouts.

The INSTALL documentation is also updated to include mention of the need
for netstat / the net-tools package.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>