### PR TITLE
doc: Remove liburiparser-dev from Ubuntu example in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,6 @@ $ sudo apt -y install \
   m4 \
   libtool \
   automake \
-  liburiparser-dev \
   libgcrypt20-dev \
   libssl-dev \
   autoconf


### PR DESCRIPTION
This dependency was removed some time back but the docs were never
updated.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>