### PR TITLE
esapi: fixes for encrypt param function

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -660,9 +660,6 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                                                  &encrypt_buffer[0], paramSize,
                                                  &symKey[aes_off]);
                 return_if_error(r, "AES encryption not possible");
-                r = Tss2_Sys_SetDecryptParam(esys_context->sys, paramSize,
-                                             &encrypt_buffer[0]);
-                return_if_error(r, "Set encrypt parameter not possible");
             }
             /* XOR obfuscation of parameter */
             else if (symDef->algorithm == TPM2_ALG_XOR) {
@@ -674,14 +671,13 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                                                     &encrypt_buffer[0],
                                                     paramSize);
                 return_if_error(r, "XOR obfuscation not possible.");
-                r = Tss2_Sys_SetDecryptParam(esys_context->sys, paramSize,
-                                             &encrypt_buffer[0]);
-                return_if_error(r, "Set encrypt parameter not possible");
-
             } else {
                 return_error(TSS2_ESYS_RC_BAD_VALUE,
                              "Invalid symmetric algorithm (should be XOR or AES)");
             }
+            r = Tss2_Sys_SetDecryptParam(esys_context->sys, paramSize,
+                                         &encrypt_buffer[0]);
+            return_if_error(r, "Set encrypt parameter not possible");
         }
     }
     return r;

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -591,15 +591,11 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                     TPM2B_NONCE ** decryptNonce, int *decryptNonceIdx)
 {
     uint8_t ccBuffer[4];
-    const uint8_t *cpBuffer;
-    size_t cpBuffer_size;
     TPM2B_NONCE *encryptNonce = NULL;
     TSS2_RC r = Tss2_Sys_GetCommandCode(esys_context->sys, &ccBuffer[0]);
     return_if_error(r, "Error: get command code");
     *decryptNonceIdx = 0;
     *decryptNonce = NULL;
-    r = Tss2_Sys_GetCpBuffer(esys_context->sys, &cpBuffer_size, &cpBuffer);
-    return_if_error(r, "Error: get cp buffer");
     for (int i = 0; i < 3; i++) {
         RSRC_NODE_T *session = esys_context->session_tab[i];
         if (session == NULL)

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -627,9 +627,7 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
             const uint8_t *paramBuffer;
             r = Tss2_Sys_GetDecryptParam(esys_context->sys, &paramSize,
                                          &paramBuffer);
-            if (r != TSS2_RC_SUCCESS) {
-                return_error(TSS2_ESYS_RC_NO_DECRYPT_PARAM, "Encryption not possible");
-            }
+            return_if_error(r, "Encryption not possible");
 
             if (paramSize == 0)
                 continue;

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -635,6 +635,9 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                 return_error(TSS2_ESYS_RC_NO_DECRYPT_PARAM, "Encryption not possible");
             }
 
+            if (paramSize == 0)
+                continue;
+
             BYTE encrypt_buffer[paramSize];
             memcpy(&encrypt_buffer[0], paramBuffer, paramSize);
             LOGBLOB_DEBUG(paramBuffer, paramSize, "param to encrypt");

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -590,12 +590,11 @@ TSS2_RC
 iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                     TPM2B_NONCE ** decryptNonce, int *decryptNonceIdx)
 {
-    uint8_t ccBuffer[4];
     TPM2B_NONCE *encryptNonce = NULL;
-    TSS2_RC r = Tss2_Sys_GetCommandCode(esys_context->sys, &ccBuffer[0]);
-    return_if_error(r, "Error: get command code");
     *decryptNonceIdx = 0;
     *decryptNonce = NULL;
+    TSS2_RC r = TSS2_RC_SUCCESS;
+
     for (int i = 0; i < 3; i++) {
         RSRC_NODE_T *session = esys_context->session_tab[i];
         if (session == NULL)


### PR DESCRIPTION
The spec [1] in isection 3.8.2.3 says that if decryptParamSize is 0 then
decryptParamBuffer is unspecified.

[1] https://trustedcomputinggroup.org/wp-content/uploads/TSS_SAPI_v1.1_r21_Public_Review.pdf