### PR TITLE
update TPM2_NUM_PCR_BANKS

### DIFF
--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -41,7 +41,7 @@
 #define TPM2_MAX_SESSION_NUM   3    /* this is the current maximum value */
 
 /* TPM constants for buffer sizes */
-#define TPM2_NUM_PCR_BANKS      3
+#define TPM2_NUM_PCR_BANKS      16
 #define TPM2_MAX_DIGEST_BUFFER  1024
 #define TPM2_MAX_NV_BUFFER_SIZE 2048
 #define TPM2_MAX_PCRS           32


### PR DESCRIPTION
TPM2_NUM_PCR_BANKS needs to be equal to the number of supported
hash algorithms. Currently 8 hash algorithms are defined by the spec:
SHA1, SHA256, SHA384, SHA512, SM3_256, SHA3_256, SHA3_384, SHA3_512.