### PR TITLE
Tests: Fix test that is not spec-conform

### DIFF
--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -70,11 +70,11 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         .pcrSelections = {
             { .hash = TPM2_ALG_SHA1,
               .sizeofSelect = 3,
-              .pcrSelect = { 00, 00, 01},
+              .pcrSelect = { 01, 00, 03},
             },
             { .hash = TPM2_ALG_SHA256,
               .sizeofSelect = 3,
-              .pcrSelect = { 00, 00, 01}
+              .pcrSelect = { 01, 00, 03}
             },
         }
     };


### PR DESCRIPTION
This fixes #1028 

TPM Spec Part 4, A.2 names the PCRs 17 and 0 for DRTM and HCRTM.

If DRTM and HCRTM were not defined, adding these PCRs to pcrSelections is unnecessary but harmless. Apart from the PCR_Allocate, only a PCR_Read is performed with this selection.