### PR TITLE
Skip the command cancel test if no simulator is used

### DIFF
--- a/test/integration/sapi-command-cancel.int.c
+++ b/test/integration/sapi-command-cancel.int.c
@@ -97,7 +97,10 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     LOG_DEBUG("FlushContext SUCCESS!");
 
     rc = tcti_platform_command(tcti_context, MS_SIM_CANCEL_ON);
-    if (rc != TPM2_RC_SUCCESS) {
+    if (rc == TSS2_TCTI_RC_BAD_CONTEXT) {
+        LOG_DEBUG("tcti_context not suitable for command! Skipping test");
+        exit(77); /* Skip */
+    } else if (rc != TPM2_RC_SUCCESS) {
         LOG_ERROR("tcti_platform_command FAILED! Response Code : 0x%x", rc);
         exit(1);
     }


### PR DESCRIPTION
Since the command that raised the error is designed specifically for the simulator, it can be expected to fail on anything else.
This fixes #1037 