### PR TITLE
test: Allow tests that expect an error to fail

### DIFF
--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -66,5 +66,5 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return 0;
 
  error:
-    return r;
+    return 1;
 }

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -70,5 +70,5 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return 0;
 
  error:
-    return r;
+    return 1;
 }


### PR DESCRIPTION
Fixes #1023 
As discussed in the issue, the "r" which is returned in case of an error would always be evaluated to "0", making the whole test impossible to fail.