### PR TITLE
test: Reactivate command and hierarchy

### DIFF
--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -63,6 +63,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE);
     goto_error_if_not_failed(r, "Error: ClockSet", error);
 
+    disable = TPM2_NO;
+
+    r = Esys_ClearControl(
+        esys_context,
+        auth_handle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        disable);
+
+    goto_if_error(r, "Error: ClearControl", error);
+
     return 0;
 
  error:

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -67,6 +67,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                       newTime);
     goto_error_if_not_failed(r, "Error: ClockSet", error);
 
+    state = TPM2_YES;
+
+    r = Esys_HierarchyControl(
+        esys_context,
+        authHandle_handle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        enable,
+        state);
+    goto_if_error(r, "Error: HierarchyControl", error);
+
     return 0;
 
  error:


### PR DESCRIPTION
Addressing #1030 
These two tests deactivate a command and a hierarchy. As they do not revert these actions, an error occurs on following tests trying to use this command and hierarchy.