### PR TITLE
build: Remove use of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   global:
   # COVERITY_SCAN_TOKEN
   - secure: "ZD0KxBhO/CaSE/TOkW+H5nsBbaMolbIPv5DgctcjA1BlTckgc5lK4m+7BIR1Fft6gaeeLOoCY3qUm4kW++Bqk2bTsrx/HvrmVmrzMO572jA74x4E+5lynUnRVaAgBg7cVBcB0hZcUurx8FifNBbgnWlxT/nDWttVnglkz400GCE9/zy+VTJWqt4QAB+6qeKPiG3vRthQdWcHstBI8IIAbvp4rhSUajBBQeZ5ro5RPGNy+iHen+t6tyJmbjiP0Y4qjkKGbfwXHnsseEcuSJQuxSkQ9MWK6t93BFXFSPw5MjHIApMn+4CjRp2JMoVTVfe5fFeZEHxVUmAzy+e5eIeftrUtUlCI293UuxZnw/vpJczn3BWunlhhjqjsCwVeknzGHxlaT+ck8Et1Mdl/3nY/E9dt47/NOzXY2xrAz59GYsdKvvsPoCGgNlAub03Vl0W24I1kjppsmN/zFwazHGqoxIBTwrDOQUmZvPfXA3jAUozrfAdT3YjnRcCG7bbQmacFApqfUm/bqMgapAgozjjxpuBrO1wQSUjjH6NANZsP2Gpk0eAl7FOlBzbVgKPxCQozWCjpKOj3HMnXX458ZQWsboG5J00wwjw9DRNRCkeexLdi832L/BPhUY5JgRlTqqyKr9cr69DvogBF/pLytpSCciF6t9NqqGZYbBomXJLaG84="
-  # COVERALLS_REPO_TOKEN
-  - secure: "BJUO7GJjP+WgMgSwTTteuc2KKum7Na++92pCLDa3hAzwZZ2OA+MbR9Zd25Yp0kT1K7bIPGDVdg0RksMI9P+Lbun3pajqLWfJpXrAF5IywllQx7bT4x1KeJridJeDnHZVSobTn4oAaGl5JrtpGgXAOjzpgLl1ljP0STyZUF+kC4RSK4Wt2DdT2acj5B8PT6cqR3btfStWgWKlm8t2nOFDGxTCbI4YIwcfgFhOG/ATx7Uc/z08MBI3z7lezy0nBt1/o2gDPZVb4Pa5A390P6Gv0g6mFu1te+P2IFmrWR6mF2Jh5GiJFWR7935rX5d2HxCkCNO7uEmncM4WeDk5PE9+TIcg7T2d9G1JR762aLMvNtUcmlfa6JX/EvveZK47ThwAictwvlD3tgfDy1E7Wdb1O6PtLsUIXRx50UocqBMeSQvOfR1330FuF/td9VGNFqxKW0wDWVIyl8QMK+p7t0aE+2py2Hb3IYVQEk98aWnffvEFeYfNPBywOiVD7trsTFEXKusVypAWDF3kvOmNuetL6ADfPnIfzvPw6DxQzwsxPUo0ahM2C2pzY/MavSlDM8+Q/EZiLkw9g39IgxjDsExD2EEu8U9jyz8iSmbKsrK6Z4L3BWO6a0gFakBAfWR1Rsb15UfVPYlJgPwtAdbgQ65ElgVeyTdkDCuE64iby2nZeP4="
   # run coverity scan on gcc build to keep from DOSing coverity
   - coverity_scan_run_condition='"$CC" = gcc'
   - PKG_CONFIG_PATH="$(pwd)/cmocka/lib/pkgconfig:/usr/lib/pkgconfig"
@@ -60,7 +58,6 @@ install:
   - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01 || travis_terminate 1
   - tar xJf autoconf-archive-2017.09.28.tar.xz
   - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
-  - pip install --user cpp-coveralls
 
 before_script:
   - ./bootstrap
@@ -111,7 +108,3 @@ script:
     done
   - cat test/tpmclient/tpmclient.log
   - popd
-  - |
-    if [ "$CC" == "gcc" -a -n "$COVERALLS_REPO_TOKEN" ]; then
-        coveralls --build-root=build --gcov-options '\-lp'
-    fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-tss.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-tss)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/2rdmyn1ndkiavngn?svg=true)](https://ci.appveyor.com/project/tpm2-software/tpm2-tss)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/tpm2-tss)
-[![Coverage Status](https://coveralls.io/repos/github/01org/tpm2-tss/badge.svg?branch=master)](https://coveralls.io/github/01org/tpm2-tss?branch=master)
 
 # Overview
 This repository hosts source code implementing the Trusted Computing Group's (TCG) TPM2 Software Stack (TSS).


### PR DESCRIPTION
Coveralls hasn't been able to recover from our transition from the Intel
01org github org to the new tpm2-software org. Coveralls has started
returning errors for this repo and since I haven't even been able
to login to the coveralls.io website for the last few months debugging
this is impossible.

This commit leaves all of the mechanics of collecting code coverage
metrics intact. It only disables use of the coveralls webservice for
maintaining history and providing an interface to the data. This is a
short term solution to get our builds passing again.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>