### PR TITLE
[RFC] ESYS: Change behavior of default tcti

### DIFF
--- a/src/tss2-esys/esys_context.c
+++ b/src/tss2-esys/esys_context.c
@@ -79,11 +79,9 @@ Esys_Initialize(ESYS_CONTEXT ** esys_context, TSS2_TCTI_CONTEXT * tcti,
     /* Store the application provided tcti to be return on Esys_GetTcti(). */
     (*esys_context)->tcti_app_param = tcti;
 
-    /* If no tcti was provided, initialize the default one. */
-    if (tcti == NULL) {
-        r = get_tcti_default(&tcti);
-        goto_if_error(r, "Initialize default tcti.", cleanup_return);
-    }
+    /* This function will initialize a default tcti if necessary. */
+    r = get_tcti_default(&tcti);
+    goto_if_error(r, "Initializing tcti.", cleanup_return);
 
     /* Initialize the ESAPI */
     r = Tss2_Sys_Initialize((*esys_context)->sys, syssize, tcti, abiVersion);

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -161,7 +161,7 @@ test_tcti_default(void **state)
     will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -220,7 +220,7 @@ test_tcti_default_fail_sym(void **state)
     will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -284,7 +284,7 @@ test_tcti_default_fail_info(void **state)
     will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -360,7 +360,7 @@ test_tcti_default_fail_init(void **state)
     will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -415,7 +415,7 @@ test_tcti_tabrmd(void **state)
     will_return(__wrap_Tss2_Tcti_Fake_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -461,7 +461,7 @@ test_tcti_tpmrm0(void **state)
     will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -515,7 +515,7 @@ test_tcti_tpm0(void **state)
     will_return(__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -580,7 +580,7 @@ test_tcti_mssim(void **state)
     will_return(__wrap_Tss2_Tcti_Mssim_Init, TSS2_RC_SUCCESS);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
@@ -638,7 +638,7 @@ test_tcti_fail_all(void **state)
     will_return(__wrap_Tss2_Tcti_Mssim_Init, TSS2_TCTI_RC_IO_ERROR);
 
     TSS2_RC r;
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     r = get_tcti_default(&tcti);
     assert_int_equal(r, TSS2_ESYS_RC_NOT_IMPLEMENTED);
     free(tcti);


### PR DESCRIPTION
Now the ESYS first checks for en environment variable TSS2_TCTI=<tctilibrary>[:config].
Then it will use the application provided tcti. Then it will initialize the standard tctis.

See this as an RFC to be merged if people like the behavior.

Fixes: #1035 