### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -151,7 +151,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_ECC_POINT *L;
     TPM2B_ECC_POINT *E;
     UINT16 counter;
-    r = Esys_Commit(esys_context, eccHandle, 
+    r = Esys_Commit(esys_context, eccHandle,
                     session, ESYS_TR_NONE, ESYS_TR_NONE,
                     &P1, &s2, &y2,
                     &K, &L, &E, &counter);

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -46,7 +46,7 @@ test_invoke_esapi(ESYS_CONTEXT * ectx)
 
     ESYS_TR primaryHandle;
     ESYS_TR keyHandle;
-    
+
     TPM2B_NAME *name1, *name2;
 
     TPM2B_AUTH authValuePrimary = {

--- a/test/integration/sapi-encrypt-decrypt-2.int.c
+++ b/test/integration/sapi-encrypt-decrypt-2.int.c
@@ -82,7 +82,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         }
         return 77; /* skip */
     }
-        
+
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR("Failed to encrypt buffer: 0x%" PRIx32 "", rc);
         exit(1);

--- a/test/unit/esys-getpollhandles.c
+++ b/test/unit/esys-getpollhandles.c
@@ -116,7 +116,7 @@ setup(void **state)
         return (int)r;
     r = Esys_Initialize(&ectx, tcti, NULL);
     *state = (void *)ectx;
-    return (int)r;    
+    return (int)r;
 }
 
 static int


### PR DESCRIPTION
According to the coding standard, white spaces are prohibited. Fixing #1051 