### PR TITLE
TEST ESYS: Switch from ECB to CFB mode.

### DIFF
--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -66,7 +66,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -62,7 +62,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -62,7 +62,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -72,7 +72,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDAA,

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -63,7 +63,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -65,7 +65,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -64,7 +64,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -70,7 +70,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDH,

--- a/test/integration/esys-createloaded.int.c
+++ b/test/integration/esys-createloaded.int.c
@@ -163,7 +163,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
              .symmetric = {
                  .algorithm = TPM2_ALG_NULL,
                  .keyBits.aes = 128,
-                 .mode.aes = TPM2_ALG_ECB,
+                 .mode.aes = TPM2_ALG_CFB,
              },
              .scheme = {
                   .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-ecdh-keygen.int.c
+++ b/test/integration/esys-ecdh-keygen.int.c
@@ -71,7 +71,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -70,7 +70,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDH,

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -63,7 +63,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -62,7 +62,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -63,7 +63,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     .symmetric = {
                         .algorithm = TPM2_ALG_NULL,
                         .keyBits.aes = 128,
-                        .mode.aes = TPM2_ALG_ECB,
+                        .mode.aes = TPM2_ALG_CFB,
                         },
                     .scheme = {
                          .scheme = TPM2_ALG_RSASSA,

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -65,7 +65,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDSA,

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -71,7 +71,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                  .symmetric = {
                      .algorithm = TPM2_ALG_NULL,
                      .keyBits.aes = 128,
-                     .mode.aes = TPM2_ALG_ECB,
+                     .mode.aes = TPM2_ALG_CFB,
                  },
                  .scheme = {
                       .scheme = TPM2_ALG_ECDH,


### PR DESCRIPTION
The PC client TPM profile only requires CFB mode for TPMs.
ECB mode is denoted as 'should not'.
This patch changes occurences of ECB mode to CFB mode in
ESYS tests.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>