### PR TITLE
tcti: Port sumulator TCTI to Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,5 +11,5 @@ platform:
   - x64
 build:
   project: tpm2-tss.sln
-  parallel: true
+  parallel: false
   verbosity: normal

--- a/lib/tss2-tcti-mssim.def
+++ b/lib/tss2-tcti-mssim.def
@@ -1,0 +1,5 @@
+LIBRARY tss2-tcti-mssim
+EXPORTS
+    tcti_platform_command
+    Tss2_Tcti_Info
+    Tss2_Tcti_Mssim_Init

--- a/src/tss2-mu/tss2-mu.vcxproj
+++ b/src/tss2-mu/tss2-mu.vcxproj
@@ -43,22 +43,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_clang_c2</PlatformToolset>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_clang_c2</PlatformToolset>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_clang_c2</PlatformToolset>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_clang_c2</PlatformToolset>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />

--- a/src/tss2-sys/tss2-sys.vcxproj
+++ b/src/tss2-sys/tss2-sys.vcxproj
@@ -180,7 +180,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_clang_c2</PlatformToolset>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/src/tss2-tcti/tcti-common.c
+++ b/src/tss2-tcti/tcti-common.c
@@ -8,7 +8,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "tss2_tpm2_types.h"
 #include "tss2_mu.h"

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -148,7 +148,7 @@ tcti_device_receive (
      * operation. If we try to read again before sending another command
      * the kernel will close the file descriptor and we'll get an EOF.
      */
-    size = TEMP_RETRY (read (tcti_dev->fd, response_buffer, *response_size));
+    TEMP_RETRY (size, read (tcti_dev->fd, response_buffer, *response_size));
     if (size < 0) {
         LOG_ERROR ("Failed to read response from fd %d, got errno %d: %s",
                    tcti_dev->fd, errno, strerror (errno));

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -9,9 +9,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <inttypes.h>
+
+#ifndef _WIN32
+#include <sys/time.h>
 #include <unistd.h>
+#endif
 
 #include "tss2_mu.h"
 #include "tss2_tcti_mssim.h"
@@ -83,13 +86,21 @@ TSS2_RC tcti_platform_command (
         return TSS2_TCTI_RC_IO_ERROR;
     }
 
-    read_ret = read (tcti_mssim->platform_sock, buf, sizeof (buf));
+#ifdef _WIN32
+    read_ret = recv (tcti_mssim->platform_sock, (char *) buf, sizeof (buf), 0);
     if (read_ret < (ssize_t) sizeof (buf)) {
-        LOG_ERROR("Failed to get response to platform command, errno %d: %s",
-                  errno, strerror (errno));
+        LOG_ERROR ("Failed to get response to platform command, errno %d: %s",
+                   WSAGetLastError(), strerror (WSAGetLastError()));
         return TSS2_TCTI_RC_IO_ERROR;
     }
-
+#else
+    read_ret = read(tcti_mssim->platform_sock, buf, sizeof (buf));
+    if (read_ret < (ssize_t) sizeof (buf)) {
+        LOG_ERROR ("Failed to get response to platform command, errno %d: %s",
+                   errno, strerror (errno));
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+#endif
     LOGBLOB_DEBUG (buf, sizeof (buf), "Received %zu bytes from socket 0x%"
                    PRIx32 ":", read_ret, tcti_mssim->platform_sock);
     rc = Tss2_MU_UINT32_Unmarshal (buf, sizeof (rsp), NULL, &rsp);

--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -16,7 +16,7 @@
  * longest possible conf string:
  * HOST_NAME_MAX + max char uint16 (5) + strlen ("host=,port=") (11)
  */
-#define TCTI_MSSIM_CONF_MAX (HOST_NAME_MAX + 16)
+#define TCTI_MSSIM_CONF_MAX (_HOST_NAME_MAX + 16)
 #define TCTI_MSSIM_DEFAULT_HOST "localhost"
 #define TCTI_MSSIM_DEFAULT_PORT 2321
 #define MSSIM_CONF_DEFAULT_INIT { \

--- a/src/tss2-tcti/tss2-tcti-mssim.sln
+++ b/src/tss2-tcti/tss2-tcti-mssim.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2026
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tcti-mssim", "tss2-tcti-mssim.vcxproj", "{89B6B774-2886-48CF-B1D0-534AC449E0FD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x64.ActiveCfg = Debug|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x64.Build.0 = Debug|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x86.ActiveCfg = Debug|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x86.Build.0 = Debug|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x64.ActiveCfg = Release|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x64.Build.0 = Release|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x86.ActiveCfg = Release|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C678F689-7045-428B-B240-7A5AB106692D}
+	EndGlobalSection
+EndGlobal

--- a/src/tss2-tcti/tss2-tcti-mssim.vcxproj
+++ b/src/tss2-tcti/tss2-tcti-mssim.vcxproj
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{89B6B774-2886-48CF-B1D0-534AC449E0FD}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_DEBUG;_WINDOWS;_USRDLL;TSS2TCTIMSSIM_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-mssim.def</ModuleDefinitionFile>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;NDEBUG;_WINDOWS;_USRDLL;TSS2TCTIMSSIM_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-mssim.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;_WINSOCKAPI_;_WINDOWS;_USRDLL;TSS2TCTIMSSIM_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-mssim.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;_WINSOCKAPI_;_WINDOWS;_USRDLL;TSS2TCTIMSSIM_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-mssim.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\util\io.c" />
+    <ClCompile Include="..\util\key-value-parse.c" />
+    <ClCompile Include="..\util\log.c" />
+    <ClCompile Include="tcti-common.c" />
+    <ClCompile Include="tcti-mssim.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\util\io.h" />
+    <ClInclude Include="..\util\key-value-parse.h" />
+    <ClInclude Include="..\util\log.h" />
+    <ClInclude Include="tcti-common.h" />
+    <ClInclude Include="tcti-mssim.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/tss2-tcti/tss2-tcti-mssim.vcxproj.filters
+++ b/src/tss2-tcti/tss2-tcti-mssim.vcxproj.filters
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="tcti-common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tcti-mssim.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\util\io.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\util\log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\util\key-value-parse.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="tcti-common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="tcti-mssim.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\util\io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\util\log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\util\key-value-parse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -5,20 +5,42 @@
  */
 #ifndef UTIL_IO_H
 #define UTIL_IO_H
+
+#ifdef _WIN32
+#include <BaseTsd.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+typedef SSIZE_T ssize_t;
+#define _HOST_NAME_MAX MAX_COMPUTERNAME_LENGTH
+
+#else
 #include <arpa/inet.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#define _HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#define SOCKET int
+#define INVALID_SOCKET - 1
+#define SOCKET_ERROR - 1
+#endif
 
 #include "tss2_tpm2_types.h"
 
-#define SOCKET int
-#define TEMP_RETRY(exp) \
-({  int __ret; \
+#ifdef _WIN32
+#define TEMP_RETRY(dest, exp) \
+{   int __ret; \
     do { \
         __ret = exp; \
-    } while (__ret == -1 && errno == EINTR); \
-    __ret; })
+    } while (__ret == SOCKET_ERROR && WSAGetLastError() == WSAEINTR); \
+    dest = __ret; }
+#else
+#define TEMP_RETRY(dest, exp) \
+{   int __ret; \
+    do { \
+        __ret = exp; \
+    } while (__ret == SOCKET_ERROR && errno == EINTR); \
+    dest =__ret; }
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,7 +54,7 @@ extern "C" {
  */
 ssize_t
 read_all (
-    int fd,
+    SOCKET fd,
     uint8_t *data,
     size_t size);
 /*
@@ -43,7 +65,7 @@ read_all (
  */
 ssize_t
 write_all (
-    int fd,
+    SOCKET fd,
     const uint8_t *buf,
     size_t size);
 TSS2_RC
@@ -57,7 +79,7 @@ socket_close (
 ssize_t
 socket_recv_buf (
     SOCKET sock,
-    unsigned char *data,
+    uint8_t *data,
     size_t size);
 TSS2_RC
 socket_xmit_buf (

--- a/tpm2-tss.sln
+++ b/tpm2-tss.sln
@@ -10,6 +10,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-sys", "src\tss2-sys\ts
 		{A6D8F061-6827-492F-80C3-32C4DD4FC52E} = {A6D8F061-6827-492F-80C3-32C4DD4FC52E}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tcti-mssim", "src\tss2-tcti\tss2-tcti-mssim.vcxproj", "{89B6B774-2886-48CF-B1D0-534AC449E0FD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A6D8F061-6827-492F-80C3-32C4DD4FC52E} = {A6D8F061-6827-492F-80C3-32C4DD4FC52E}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -34,6 +39,14 @@ Global
 		{10D9862F-0E36-4ACC-AF19-930B00A88A98}.Release|x64.Build.0 = Release|x64
 		{10D9862F-0E36-4ACC-AF19-930B00A88A98}.Release|x86.ActiveCfg = Release|Win32
 		{10D9862F-0E36-4ACC-AF19-930B00A88A98}.Release|x86.Build.0 = Release|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x64.ActiveCfg = Debug|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x64.Build.0 = Debug|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x86.ActiveCfg = Debug|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Debug|x86.Build.0 = Debug|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x64.ActiveCfg = Release|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x64.Build.0 = Release|x64
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x86.ActiveCfg = Release|Win32
+		{89B6B774-2886-48CF-B1D0-534AC449E0FD}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add conditional inclusion directives to separate POSIX and Windows
specific code.

Replace hard coded -1 values with SOCKET_ERROR and INVALID_SOCKET.

Add Visual Studio solution for Simulator TCTI

Add .def file for building the Simulator TCTI dll

Rewrite the TEMP_RETRY macro. Previously this macro was a stement
expression; statement expressions are part of the non-standard gcc
extension statement-exprs.

When compiling on Windows:
 - Initialize winsock
 - Replace errno with WSAGetLastError()
 - Replace "read" with "recv"
 - Replace "write" with "send"
 - Replace "close" with "closesocket"
 - Set _HOST_NAME_MAX to MAX_COMPUTERNAME_LENGTH instead of
 _POSIX_HOST_NAME_MAX
 - Map strtok_r to strtok_s

Turn off parallel build in Appveyor

Fixes #671, #672

Signed-off-by: David Maria <davidjmaria@fb.com>