### PR TITLE
TEST ESYS: Fix error handling and cleanup in ESAPI tests

### DIFF
--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -22,6 +22,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR signHandle = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -102,7 +103,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR signHandle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -141,5 +141,11 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (signHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, signHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup signHandle failed.");
+        }
+    }
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -136,8 +138,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context,signHandle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -22,6 +22,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR signHandle = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -102,7 +103,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR signHandle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -140,5 +140,11 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (signHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, signHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup signHandle failed.");
+        }
+    }
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -135,8 +137,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context,signHandle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -14,7 +17,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR authHandle = ESYS_TR_RH_PLATFORM;
 
@@ -24,10 +27,23 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_PASSWORD,
         ESYS_TR_NONE,
         ESYS_TR_NONE);
+
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_ChangeEPS not supported by TPM.");
+        return  EXIT_SKIP;
+        goto error;
+    }
+
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        return EXIT_SKIP;
+    }
+
     goto_if_error(r, "Error: ChangeEPS", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -34,7 +34,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR auth_handle = ESYS_TR_RH_PLATFORM;
     TPMI_YES_NO disable = TPM2_YES;
@@ -54,8 +56,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error: ClearControl", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-clear.int.c
+++ b/test/integration/esys-clear.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -15,7 +17,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
 #ifdef TEST_SESSION
     ESYS_TR session;
@@ -60,8 +62,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: FlushContext", error);
 #endif
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-clear.int.c
+++ b/test/integration/esys-clear.int.c
@@ -20,7 +20,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
 
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -65,5 +65,14 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -15,7 +17,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
 
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR auth_handle = ESYS_TR_RH_OWNER;
     UINT64 newTime = 0xffffff;
@@ -49,8 +51,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                        &currentTime);
     goto_if_error(r, "Error: ReadClock", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r;
+    TSS2_RC r;
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,
@@ -142,9 +144,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -22,7 +22,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
-    ESYS_TR session;
+    ESYS_TR eccHandle = ESYS_TR_NONE;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,
         .keyBits = { .aes = 128 },
@@ -112,7 +113,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR eccHandle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -141,12 +141,29 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, eccHandle);
     goto_if_error(r, "Flushing context", error);
 
+    eccHandle = ESYS_TR_NONE;
+
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Error: FlushContext", error);
+
+    session = ESYS_TR_NONE;
 
     return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
+
+    if (eccHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, eccHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup eccHandle failed.");
+        }
+    }
+
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -24,6 +24,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -136,7 +137,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -146,19 +146,19 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary,
                            &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+    r = esys_GetResourceObject(esys_context, primaryHandle,
                                &primaryHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
 
     LOG_INFO("Created Primary with handle 0x%08x...",
              primaryHandle_node->rsrc.handle);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
     TPM2B_PUBLIC *outPublic2;
@@ -168,7 +168,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPMT_TK_CREATION *creationTicket2;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     NULL,
                     NULL,
@@ -189,11 +189,17 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         r, "Error esys create finish with NULL context did not fail",
         error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
     return EXIT_SUCCESS;
 
  error:
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "test-esapi.h"
@@ -21,7 +23,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -190,8 +192,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -294,8 +296,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -26,6 +26,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -138,7 +140,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -148,19 +149,19 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE,
                            &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+    r = esys_GetResourceObject(esys_context, primaryHandle,
                                &primaryHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
 
     LOG_INFO("Created Primary with handle 0x%08x...",
              primaryHandle_node->rsrc.handle);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
     TPM2B_AUTH authKey2 = {
@@ -251,7 +252,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPMT_TK_CREATION *creationTicket2;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive2,
                     &inPublic2,
@@ -264,10 +265,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("\nSecond key created.");
 
-    ESYS_TR loadedKeyHandle;
-
     r = Esys_Load(esys_context,
-                  primaryHandle_handle,
+                  primaryHandle,
                   ESYS_TR_PASSWORD,
                   ESYS_TR_NONE,
                   ESYS_TR_NONE, outPrivate2, outPublic2, &loadedKeyHandle);
@@ -290,14 +289,29 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &creationData2, &creationHash2, &creationTicket2);
     goto_if_error(r, "Error esys second create ", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
+    primaryHandle = ESYS_TR_NONE;
     goto_if_error(r, "Error during FlushContext", error);
 
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
+    loadedKeyHandle = ESYS_TR_NONE;
     goto_if_error(r, "Error during FlushContext", error);
 
     return EXIT_SUCCESS;
 
  error:
+
+   if (loadedKeyHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle failed.");
+        }
+    }
+
+    if (primaryHandle != ESYS_TR_NONE) {
+         if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r;
+    TSS2_RC r;
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = { .algorithm = TPM2_ALG_NULL };
 
@@ -168,9 +170,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error during FlushContext", error);
 
     LOG_INFO("Done with handle 0x%08x...", objectHandle_node->rsrc.handle);
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -29,7 +29,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -390,8 +390,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -4,10 +4,13 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 #include "tss2_mu.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -23,7 +26,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     /*
      * First the policy value to be able to use Esys_Duplicate for an object has to be
@@ -372,6 +376,12 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &outDuplicate,
                     &outSymSeed2);
 
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_Rewrap not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
     goto_if_error(r, "Error: Rewrap", error);
 
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
@@ -383,8 +393,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Flushing context", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return failure_return;
 }

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -27,13 +27,17 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR primaryHandle2 = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
+    ESYS_TR policySession = ESYS_TR_NONE;
     int failure_return = EXIT_FAILURE;
 
     /*
      * First the policy value to be able to use Esys_Duplicate for an object has to be
      * determined with a policy trial session.
      */
-    ESYS_TR sessionTrial;
+    ESYS_TR sessionTrial = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetricTrial = {.algorithm = TPM2_ALG_AES,
                                    .keyBits = {.aes = 128},
                                    .mode = {.aes = TPM2_ALG_CFB}
@@ -148,8 +152,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
-    ESYS_TR primaryHandle_handle2;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -159,7 +161,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE,
                            &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
@@ -167,19 +169,19 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE,
                            &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle2,
+                           &outsideInfo, &creationPCR, &primaryHandle2,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+    r = esys_GetResourceObject(esys_context, primaryHandle,
                                &primaryHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
 
     LOG_INFO("Created Primary with handle 0x%08x...",
              primaryHandle_node->rsrc.handle);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
     TPM2B_AUTH authKey2 = {
@@ -256,7 +258,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     inPublic2.publicArea.authPolicy = *policyDigestTrial;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive2,
                     &inPublic2,
@@ -269,10 +271,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("\nSecond key created.");
 
-    ESYS_TR loadedKeyHandle;
-
     r = Esys_Load(esys_context,
-                  primaryHandle_handle,
+                  primaryHandle,
                   ESYS_TR_PASSWORD,
                   ESYS_TR_NONE,
                   ESYS_TR_NONE, outPrivate2, outPublic2, &loadedKeyHandle);
@@ -298,7 +298,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error esys ReadPublic", error);
 
-    ESYS_TR policySession;
     TPMT_SYM_DEF policySymmetric = {.algorithm = TPM2_ALG_AES,
                                     .keyBits = {.aes = 128},
                                     .mode = {.aes = TPM2_ALG_CFB}
@@ -351,7 +350,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_Duplicate(
         esys_context,
         loadedKeyHandle,
-        primaryHandle_handle2,
+        primaryHandle2,
         policySession,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -367,8 +366,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_ENCRYPTED_SECRET *outSymSeed2;
 
     r = Esys_Rewrap(esys_context,
-                    primaryHandle_handle2,
-                    primaryHandle_handle,
+                    primaryHandle2,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     duplicate,
                     keyName,
@@ -384,17 +383,61 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error: Rewrap", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Flushing context", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle2);
+    primaryHandle = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, primaryHandle2);
     goto_if_error(r, "Flushing context", error);
+
+    primaryHandle2 = ESYS_TR_NONE;
 
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Flushing context", error);
 
+    loadedKeyHandle = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, sessionTrial);
+    goto_if_error(r, "Flushing context", error);
+
+    r = Esys_FlushContext(esys_context, policySession);
+    goto_if_error(r, "Flushing context", error);
+
+
     return EXIT_SUCCESS;
 
  error:
+
+    if (policySession != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, policySession) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup policySession failed.");
+        }
+    }
+
+    if (sessionTrial != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, sessionTrial) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup sessionTrial failed.");
+        }
+    }
+
+    if (loadedKeyHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle failed.");
+        }
+    }
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
+    if (primaryHandle2 != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle2) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle2 failed.");
+        }
+    }
+
     return failure_return;
 }

--- a/test/integration/esys-ecc-parameters.int.c
+++ b/test/integration/esys-ecc-parameters.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -14,7 +17,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     TPMI_ECC_CURVE curveID  = TPM2_ECC_NIST_P256;
     TPMS_ALGORITHM_DETAIL_ECC *parameters;
@@ -29,13 +33,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     if (r == TPM2_RC_CURVE + TPM2_RC_P + TPM2_RC_1) {
         LOG_WARNING("Curve TPM2_ECC_NIST_P256 supported by TPM.");
-        r = 77; /* Skip */
+        failure_return = EXIT_SKIP;
         goto error;
     }
     goto_if_error(r, "Error: ECC_Parameters", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return failure_return;
 }

--- a/test/integration/esys-ecdh-keygen.int.c
+++ b/test/integration/esys-ecdh-keygen.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r;
+    TSS2_RC r;
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,.keyBits = {.aes =
                                                                     128},.mode =
@@ -141,9 +143,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, eccHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -21,7 +21,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
-    ESYS_TR session;
+    ESYS_TR eccHandle = ESYS_TR_NONE;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,
         .keyBits = { .aes = 128 },
@@ -110,7 +111,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR eccHandle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -161,9 +161,25 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, eccHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
+    r = Esys_FlushContext(esys_context, session);
+    goto_if_error(r, "Flushing context", error);
+
     return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
+
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+
+    if (eccHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, eccHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup eccHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r;
+    TSS2_RC r;
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,
@@ -159,9 +161,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, eccHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
     LOG_ERROR("\nError Code: %x\n", r);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -4,9 +4,12 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -20,7 +23,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -243,6 +247,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         outData,
         &outData2,
         &ivOut2);
+
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_EncryptDecrypt not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
     goto_if_error(r, "Error: EncryptDecrypt", error);
 
     LOGBLOB_DEBUG(&outData2->buffer[0], outData2->size, "** Decrypted data **");
@@ -259,8 +270,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return failure_return;
 }

--- a/test/integration/esys-event-sequence-complete.int.c
+++ b/test/integration/esys-event-sequence-complete.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -67,8 +69,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &results);
     goto_if_error(r, "Error: EventSequenceComplete", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-evict-control-serialization.int.c
+++ b/test/integration/esys-evict-control-serialization.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -235,8 +237,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                           permanentHandle, &new_primary_handle1);
     goto_if_error(r, "Error Esys EvictControl", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-field-upgrade.int.c
+++ b/test/integration/esys-field-upgrade.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -14,7 +17,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     TPM2B_MAX_BUFFER fuData = {
         .size = 20,
@@ -34,7 +38,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &firstDigest);
     if (r == TPM2_RC_COMMAND_CODE) {
         LOG_INFO("Command TPM2_FieldUpgradeData not supported by TPM.");
-        r = 77; /* Skip */
+        failure_return = EXIT_SKIP;
         goto error;
     }
 
@@ -58,8 +62,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &manifestSignature);
     goto_if_error(r, "Error: FieldUpgradeStart", error);
     */
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return failure_return;
 }

--- a/test/integration/esys-firmware-read.int.c
+++ b/test/integration/esys-firmware-read.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -14,7 +17,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     UINT32 sequenceNumber = 0;
     TPM2B_MAX_BUFFER *fuData;
@@ -28,13 +32,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     if (r == TPM2_RC_COMMAND_CODE) {
         LOG_INFO("Command TPM2_FieldUpgradeData not supported by TPM.");
-        r = 77; /* Skip */
+        failure_return = EXIT_SKIP;
         goto error;
     }
     goto_if_error(r, "Error: FirmwareRead", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return failure_return;
 }

--- a/test/integration/esys-get-capability.int.c
+++ b/test/integration/esys-get-capability.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -17,7 +19,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
     TPM2_CAP                       capability = TPM2_CAP_TPM_PROPERTIES;
     UINT32                         property = TPM2_PT_LOCKOUT_COUNTER;
     UINT32                         propertyCount = 1;
@@ -32,8 +34,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error esys get capability", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-get-random.int.c
+++ b/test/integration/esys-get-random.int.c
@@ -32,7 +32,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("GetRandom Test Passed!");
 
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     const TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,
         .keyBits = {.aes = 128},
@@ -69,7 +69,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("GetRandom with session Test Passed!");
 
-    return 0;
+    r = Esys_FlushContext(esys_context, session);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext with session FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    return EXIT_SUCCESS;
 
  error_cleansession:
     r = Esys_FlushContext(esys_context, session);
@@ -77,5 +83,5 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", r);
     }
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -4,9 +4,12 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -20,7 +23,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -144,10 +148,10 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &timeInfo,
         &signature);
     if (r == TPM2_RC_COMMAND_CODE) {
-        LOG_INFO("Command TPM2_GetTime not supported by TPM.");
+        LOG_WARNING("Command TPM2_GetTime not supported by TPM.");
         r = Esys_FlushContext(esys_context, signHandle);
         goto_if_error(r, "Flushing context", error);
-        r = 77; /* Skip */
+        failure_return = EXIT_SKIP;
         goto error;
     }
     goto_if_error(r, "Error: GetTime", error);
@@ -155,8 +159,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, signHandle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return failure_return;
 }

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -23,7 +23,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
 
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -109,5 +109,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
 #ifdef TEST_SESSION
     ESYS_TR session;
@@ -104,8 +106,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: FlushContext", error);
 #endif
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR authHandle_handle = ESYS_TR_RH_PLATFORM;
     TPMI_RH_ENABLES enable = TPM2_RH_OWNER;
@@ -33,6 +35,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         enable,
         state);
+
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        return EXIT_SKIP;
+    }
+
     goto_if_error(r, "Error: HierarchyControl", error);
 
     ESYS_TR auth_handle = ESYS_TR_RH_OWNER;
@@ -58,8 +67,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         state);
     goto_if_error(r, "Error: HierarchyControl", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -36,7 +36,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         enable,
         state);
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -11,7 +13,7 @@
 #include "util/log.h"
 
 /*
- * This test is intended to test then change of an authorization value of
+ * This test is intended to test the change of an authorization value of
  * a hierarchy.
  * To check whether the change was successful a primary key is created
  * with the handle of this hierarchy and the new authorization.
@@ -22,7 +24,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
     ESYS_TR authHandle_handle = ESYS_TR_RH_OWNER;
     TPM2B_AUTH newAuth = {
         .size = 5,
@@ -137,8 +139,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                                  &emptyAuth);
     goto_if_error(r, "Error: HierarchyChangeAuth", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
 #ifdef TEST_SESSION
     ESYS_TR session;
@@ -165,8 +167,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: FlushContext", error);
 #endif
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -21,9 +21,10 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
 
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -75,7 +76,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         .count = 0,
     };
 
-    ESYS_TR primaryHandle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -170,5 +170,20 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -26,12 +26,16 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR primaryHandle2 = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
+    ESYS_TR policySession = ESYS_TR_NONE;
 
     /*
      * Firth the policy value to be able to use Esys_Duplicate for an object has to be
      * determined with a policy trial session.
      */
-    ESYS_TR sessionTrial;
+    ESYS_TR sessionTrial = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetricTrial = {.algorithm = TPM2_ALG_AES,
                                    .keyBits = {.aes = 128},
                                    .mode = {.aes = TPM2_ALG_CFB}
@@ -146,8 +150,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
-    ESYS_TR primaryHandle_handle2;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -157,7 +159,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE,
                            &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
@@ -165,19 +167,19 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE,
                            &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle2,
+                           &outsideInfo, &creationPCR, &primaryHandle2,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+    r = esys_GetResourceObject(esys_context, primaryHandle,
                                &primaryHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
 
     LOG_INFO("Created Primary with handle 0x%08x...",
              primaryHandle_node->rsrc.handle);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
     TPM2B_AUTH authKey2 = {
@@ -254,7 +256,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     inPublic2.publicArea.authPolicy = *policyDigestTrial;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive2,
                     &inPublic2,
@@ -267,10 +269,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("\nSecond key created.");
 
-    ESYS_TR loadedKeyHandle;
-
     r = Esys_Load(esys_context,
-                  primaryHandle_handle,
+                  primaryHandle,
                   ESYS_TR_PASSWORD,
                   ESYS_TR_NONE,
                   ESYS_TR_NONE, outPrivate2, outPublic2, &loadedKeyHandle);
@@ -296,7 +296,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error esys ReadPublic", error);
 
-    ESYS_TR policySession;
     TPMT_SYM_DEF policySymmetric = {.algorithm = TPM2_ALG_AES,
                                     .keyBits = {.aes = 128},
                                     .mode = {.aes = TPM2_ALG_CFB}
@@ -345,7 +344,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_Duplicate(
         esys_context,
         loadedKeyHandle,
-        primaryHandle_handle2,
+        primaryHandle2,
         policySession,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -370,9 +369,15 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                         &keyQualifiedName);
     goto_if_error(r, "Error: ReadPublic", error);
 
+    r = Esys_FlushContext(esys_context, loadedKeyHandle);
+    goto_if_error(r, "Flushing context", error);
+
+    loadedKeyHandle = ESYS_TR_NONE;
+
+
     r = Esys_Import(
         esys_context,
-        primaryHandle_handle,
+        primaryHandle,
         ESYS_TR_PASSWORD,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -384,17 +389,56 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &outPrivate);
     goto_if_error(r, "Error: Import", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Flushing context", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle2);
+    primaryHandle = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, primaryHandle2);
     goto_if_error(r, "Flushing context", error);
 
-    r = Esys_FlushContext(esys_context, loadedKeyHandle);
+    primaryHandle2 = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, sessionTrial);
+    goto_if_error(r, "Flushing context", error);
+
+    sessionTrial = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, policySession);
     goto_if_error(r, "Flushing context", error);
 
     return EXIT_SUCCESS;
 
  error:
+
+   if (policySession != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, policySession) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup policySession failed.");
+        }
+    }
+
+    if (sessionTrial != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, sessionTrial) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup sessionTrial failed.");
+        }
+    }
+    if (loadedKeyHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle failed.");
+        }
+    }
+
+   if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
+   if (primaryHandle2 != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle2) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle2 failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 #include "tss2_mu.h"
 
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     /*
      * Firth the policy value to be able to use Esys_Duplicate for an object has to be
@@ -391,8 +393,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Flushing context", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -15,7 +18,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     r = Esys_DictionaryAttackLockReset(
         esys_context,
@@ -38,10 +41,16 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_GlobalWriteLock(esys_context, ESYS_TR_RH_PLATFORM,
                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
+
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        return 77;
+    }
     goto_if_error(r, "Error: NV_GlobalWriteLock", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
   error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -19,6 +19,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     r = Esys_DictionaryAttackLockReset(
         esys_context,
@@ -42,15 +43,21 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_NV_GlobalWriteLock(esys_context, ESYS_TR_RH_PLATFORM,
                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_NV_GlobalWriteLock not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
-        return 77;
+        return EXIT_SKIP;
     }
     goto_if_error(r, "Error: NV_GlobalWriteLock", error);
 
     return EXIT_SUCCESS;
 
   error:
-    return EXIT_FAILURE;
+    return failure_return;
 }

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
 #ifdef TEST_SESSION
     ESYS_TR session;
@@ -353,8 +355,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error esys flush context", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -4,9 +4,12 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -19,7 +22,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -183,6 +187,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         0,
         &certifyInfo,
         &signature);
+
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_NV_Certify not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
     goto_if_error(r, "Error: NV_Certify", error);
 
     r = Esys_NV_UndefineSpace(esys_context,
@@ -197,8 +208,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context,signHandle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return failure_return;
 }

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -100,7 +100,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR signHandle;
+    ESYS_TR signHandle = ESYS_TR_NONE;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -113,7 +113,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &creationHash, &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -146,7 +146,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
     goto_if_error(r, "Error esys define nv space", error);
 
     UINT16 offset = 0;
@@ -155,8 +155,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                                                   1, 2, 3, 4, 5, 6, 7, 8, 9}};
 
     r = Esys_NV_Write(esys_context,
-                      nvHandle_handle,
-                      nvHandle_handle,
+                      nvHandle,
+                      nvHandle,
                       ESYS_TR_PASSWORD,
                       ESYS_TR_NONE,
                       ESYS_TR_NONE,
@@ -173,7 +173,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         esys_context,
         signHandle,
         ESYS_TR_RH_OWNER,
-        nvHandle_handle,
+        nvHandle,
         ESYS_TR_PASSWORD,
         ESYS_TR_PASSWORD,
         ESYS_TR_NONE,
@@ -187,7 +187,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_UndefineSpace(esys_context,
                               ESYS_TR_RH_OWNER,
-                              nvHandle_handle,
+                              nvHandle,
                               ESYS_TR_PASSWORD,
                               ESYS_TR_NONE,
                               ESYS_TR_NONE

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -21,8 +21,9 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -44,7 +45,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -195,5 +195,29 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(esys_context,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+#ifdef TEST_SESSION
+                                  session,
+#else
+                                  ESYS_TR_PASSWORD,
+#endif
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 #ifdef TEST_SESSION
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
@@ -190,8 +192,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Error: FlushContext", error);
 #endif
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -42,7 +42,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -79,7 +79,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -87,7 +87,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_NAME *nvName;
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -97,7 +97,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     RSRC_NODE_T *nvHandleNode;
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -106,8 +106,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
     r = Esys_NV_Increment(esys_context,
-                          nvHandle_handle,
-                          nvHandle_handle,
+                          nvHandle,
+                          nvHandle,
 #ifdef TEST_SESSION
                           session,
 #else
@@ -119,7 +119,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv write", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -127,7 +127,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -139,8 +139,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_MAX_NV_BUFFER *nv_test_data;
 
     r = Esys_NV_Read(esys_context,
-                     nvHandle_handle,
-                     nvHandle_handle,
+                     nvHandle,
+                     nvHandle,
 #ifdef TEST_SESSION
                      session,
 #else
@@ -155,7 +155,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv read", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -163,7 +163,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -174,7 +174,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_UndefineSpace(esys_context,
                               ESYS_TR_RH_OWNER,
-                              nvHandle_handle,
+                              nvHandle,
 #ifdef TEST_SESSION
                               session,
 #else

--- a/test/integration/esys-nv-ram-extend-index.int.c
+++ b/test/integration/esys-nv-ram-extend-index.int.c
@@ -44,7 +44,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -82,7 +82,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         &auth,
         &publicInfo,
-        &nvHandle_handle);
+        &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -95,7 +95,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_ReadPublic(
         esys_context,
-        nvHandle_handle,
+        nvHandle,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -105,7 +105,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     RSRC_NODE_T *nvHandleNode;
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -115,8 +115,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
     r = Esys_NV_Extend (
         esys_context,
-        nvHandle_handle,
-        nvHandle_handle,
+        nvHandle,
+        nvHandle,
 #ifdef TEST_SESSION
         session,
 #else
@@ -130,7 +130,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_ReadPublic(
         esys_context,
-        nvHandle_handle,
+        nvHandle,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -138,7 +138,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -149,26 +149,26 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     TPM2B_MAX_NV_BUFFER *nv_test_data2;
 
-r = Esys_NV_Read(
-    esys_context,
-    nvHandle_handle,
-    nvHandle_handle,
+    r = Esys_NV_Read(
+        esys_context,
+        nvHandle,
+        nvHandle,
 #ifdef TEST_SESSION
-    session,
+        session,
 #else
-    ESYS_TR_PASSWORD,
+        ESYS_TR_PASSWORD,
 #endif
-    ESYS_TR_NONE,
-    ESYS_TR_NONE,
-    20,
-    0,
-    &nv_test_data2);
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        20,
+        0,
+        &nv_test_data2);
 
     goto_if_error(r, "Error esys nv read", error);
 
     r = Esys_NV_ReadPublic(
         esys_context,
-        nvHandle_handle,
+        nvHandle,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
         ESYS_TR_NONE,
@@ -176,7 +176,7 @@ r = Esys_NV_Read(
         &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -185,20 +185,18 @@ r = Esys_NV_Read(
         goto error;
     }
 
-    r = Esys_NV_UndefineSpace(
-        esys_context,
-        ESYS_TR_RH_OWNER,
-        nvHandle_handle,
+    r = Esys_NV_UndefineSpace(esys_context,
+                              ESYS_TR_RH_OWNER,
+                              nvHandle,
 #ifdef TEST_SESSION
-        session,
+                              session,
 #else
-        ESYS_TR_PASSWORD,
+                              ESYS_TR_PASSWORD,
 #endif
-        ESYS_TR_NONE,
-        ESYS_TR_NONE
-        );
-
-    goto_if_error(r, "Error esys undefine nv space", error);
+                              ESYS_TR_NONE,
+                              ESYS_TR_NONE
+                              );
+    goto_if_error(r, "Error: NV_UndefineSpace", error);
 
     return 0;
 

--- a/test/integration/esys-nv-ram-extend-index.int.c
+++ b/test/integration/esys-nv-ram-extend-index.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -20,7 +22,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
 
-    uint32_t r = 0;
+    TSS2_RC r;
 #ifdef TEST_SESSION
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
@@ -198,8 +200,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                               );
     goto_if_error(r, "Error: NV_UndefineSpace", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -48,7 +48,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -85,7 +85,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -98,7 +98,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_NAME *nvName;
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -108,7 +108,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     RSRC_NODE_T *nvHandleNode;
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -117,8 +117,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
     r = Esys_NV_Write(esys_context,
-                      nvHandle_handle,
-                      nvHandle_handle,
+                      nvHandle,
+                      nvHandle,
 #ifdef TEST_SESSION
                       session,
 #else
@@ -132,7 +132,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv write", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -140,7 +140,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -152,8 +152,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_MAX_NV_BUFFER *nv_test_data2;
 
     r = Esys_NV_Read(esys_context,
-                     nvHandle_handle,
-                     nvHandle_handle,
+                     nvHandle,
+                     nvHandle,
 #ifdef TEST_SESSION
                      session,
 #else
@@ -168,7 +168,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv read", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -176,7 +176,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -187,8 +187,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
 #ifdef TEST_READ_LOCK
     r = Esys_NV_ReadLock(esys_context,
-                         nvHandle_handle,
-                         nvHandle_handle,
+                         nvHandle,
+                         nvHandle,
 #ifdef TEST_SESSION
                          session,
 #else
@@ -200,7 +200,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: NV_ReadLock", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -208,7 +208,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -218,8 +218,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     r = Esys_NV_Read(esys_context,
-                     nvHandle_handle,
-                     nvHandle_handle,
+                     nvHandle,
+                     nvHandle,
 #ifdef TEST_SESSION
                      session,
 #else
@@ -235,8 +235,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #else /* TEST_READ_LOCK */
 #ifdef TEST_WRITE_LOCK
     r = Esys_NV_WriteLock(esys_context,
-                          nvHandle_handle,
-                          nvHandle_handle,
+                          nvHandle,
+                          nvHandle,
 #ifdef TEST_SESSION
                           session,
 #else
@@ -248,7 +248,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: NV_WriteLock", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -256,7 +256,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: NV_ReadPublic", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -265,8 +265,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
     r = Esys_NV_Write(esys_context,
-                      nvHandle_handle,
-                      nvHandle_handle,
+                      nvHandle,
+                      nvHandle,
 #ifdef TEST_SESSION
                       session,
 #else
@@ -282,7 +282,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_UndefineSpace(esys_context,
                               ESYS_TR_RH_OWNER,
-                              nvHandle_handle,
+                              nvHandle,
 #ifdef TEST_SESSION
                               session,
 #else

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 #ifdef TEST_SESSION
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
@@ -297,8 +299,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Error: FlushContext", error);
 #endif
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -26,8 +26,9 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -50,7 +51,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -302,5 +302,28 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(esys_context,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+#ifdef TEST_SESSION
+                                  session,
+#else
+                                  ESYS_TR_PASSWORD,
+#endif
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-set-bits.int.c
+++ b/test/integration/esys-nv-ram-set-bits.int.c
@@ -42,7 +42,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -79,7 +79,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -87,7 +87,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_NAME *nvName;
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -97,7 +97,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     RSRC_NODE_T *nvHandleNode;
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -109,8 +109,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     UINT64 bits = 0x0102030405060708;
 
     r = Esys_NV_SetBits(esys_context,
-                        nvHandle_handle,
-                        nvHandle_handle,
+                        nvHandle,
+                        nvHandle,
 #ifdef TEST_SESSION
                         session,
 #else
@@ -123,7 +123,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv write", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -131,7 +131,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -143,8 +143,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_MAX_NV_BUFFER *nv_test_data;
 
     r = Esys_NV_Read(esys_context,
-                     nvHandle_handle,
-                     nvHandle_handle,
+                     nvHandle,
+                     nvHandle,
 #ifdef TEST_SESSION
                      session,
 #else
@@ -159,7 +159,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error esys nv read", error);
 
     r = Esys_NV_ReadPublic(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -167,7 +167,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                            &nvName);
     goto_if_error(r, "Error: nv read public", error);
 
-    r = esys_GetResourceObject(esys_context, nvHandle_handle, &nvHandleNode);
+    r = esys_GetResourceObject(esys_context, nvHandle, &nvHandleNode);
     goto_if_error(r, "Error: nv get resource object", error);
 
     if (nvName->size != nvHandleNode->rsrc.name.size ||
@@ -178,7 +178,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_UndefineSpace(esys_context,
                               ESYS_TR_RH_OWNER,
-                              nvHandle_handle,
+                              nvHandle,
 #ifdef TEST_SESSION
                               session,
 #else

--- a/test/integration/esys-nv-ram-set-bits.int.c
+++ b/test/integration/esys-nv-ram-set-bits.int.c
@@ -21,8 +21,9 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
 #ifdef TEST_SESSION
-    ESYS_TR session;
+    ESYS_TR session = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
                               .keyBits = {.aes = 128},
                               .mode = {.aes = TPM2_ALG_CFB}
@@ -44,7 +45,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 #endif /* TEST_SESSION */
 
-    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -199,5 +199,29 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+   if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(esys_context,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+#ifdef TEST_SESSION
+                                  session,
+#else
+                                  ESYS_TR_PASSWORD,
+#endif
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
+#ifdef TEST_SESSION
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+#endif
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-nv-ram-set-bits.int.c
+++ b/test/integration/esys-nv-ram-set-bits.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 #ifdef TEST_SESSION
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES,
@@ -194,8 +196,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: FlushContext", error);
 #endif
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -19,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_PUBLIC inPublic = {
         .size = 0,
@@ -222,8 +224,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -22,6 +22,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
 
     TPM2B_PUBLIC inPublic = {
         .size = 0,
@@ -88,7 +90,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
     TPM2B_DIGEST *creationHash;
@@ -96,12 +97,12 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error esys TR_SetAuth ", error);
 
     TPM2B_AUTH authKey2 = {
@@ -178,7 +179,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPMT_TK_CREATION *creationTicket2;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive2,
                     &inPublic2,
@@ -189,10 +190,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &creationData2, &creationHash2, &creationTicket2);
     goto_if_error(r, "Error esys create ", error);
 
-    ESYS_TR loadedKeyHandle;
-
     r = Esys_Load(esys_context,
-                  primaryHandle_handle,
+                  primaryHandle,
                   ESYS_TR_PASSWORD,
                   ESYS_TR_NONE,
                   ESYS_TR_NONE, outPrivate2, outPublic2, &loadedKeyHandle);
@@ -209,7 +208,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_ObjectChangeAuth(esys_context,
                               loadedKeyHandle,
-                              primaryHandle_handle,
+                              primaryHandle,
                               ESYS_TR_PASSWORD,
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
@@ -221,11 +220,24 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
     return EXIT_SUCCESS;
 
  error:
+
+    if (loadedKeyHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle failed.");
+        }
+    }
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -70,7 +70,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         TPM2_ALG_SHA1,
         pcrHandle_handle);
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -9,6 +9,7 @@
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -21,6 +22,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     ESYS_TR  pcrHandle_handle = 16;
     TPML_DIGEST_VALUES digests
@@ -116,9 +118,10 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &sizeNeeded,
         &sizeAvailable);
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
+        failure_return =  EXIT_SKIP;
     }
 
     goto_if_error(r, "Error: PCR_Allocate", error);
@@ -126,6 +129,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
-    return EXIT_FAILURE;
+    return failure_return;
 
 }

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR  pcrHandle_handle = 16;
     TPML_DIGEST_VALUES digests
@@ -114,11 +116,16 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &sizeNeeded,
         &sizeAvailable);
 
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+    }
+
     goto_if_error(r, "Error: PCR_Allocate", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 
 }

--- a/test/integration/esys-policy-authorize.int.c
+++ b/test/integration/esys-policy-authorize.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 #include "tss2_mu.h"
 
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     /*
      * 1. Create Primary. This primary will be used for PolicyAuthorize.
@@ -179,8 +181,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -74,7 +74,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                              );
     goto_if_error(r, "Error: PolicyGetDigest", error);
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -104,7 +104,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -149,7 +149,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: PolicyCommandCode", error);
 
     r = Esys_NV_ChangeAuth(esys_context,
-                           nvHandle_handle,
+                           nvHandle,
                            policySession,
                            ESYS_TR_NONE,
                            ESYS_TR_NONE,
@@ -159,7 +159,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_NV_UndefineSpace(esys_context,
                               ESYS_TR_RH_OWNER,
-                              nvHandle_handle,
+                              nvHandle,
                               ESYS_TR_PASSWORD,
                               ESYS_TR_NONE,
                               ESYS_TR_NONE

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -24,7 +26,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
     /*
      * Firth the policy value for changing the auth value of an NV index has to be
      * determined with a policy trial session.
@@ -166,8 +168,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                               );
     goto_if_error(r, "Error: NV_UndefineSpace", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -27,11 +27,14 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+    ESYS_TR policySession = ESYS_TR_NONE;
+
     /*
      * Firth the policy value for changing the auth value of an NV index has to be
      * determined with a policy trial session.
      */
-    ESYS_TR sessionTrial;
+    ESYS_TR sessionTrial = ESYS_TR_NONE;
     TPMT_SYM_DEF symmetricTrial = {.algorithm = TPM2_ALG_AES,
                                    .keyBits = {.aes = 128},
                                    .mode = {.aes = TPM2_ALG_CFB}
@@ -76,7 +79,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                              );
     goto_if_error(r, "Error: PolicyGetDigest", error);
 
-    ESYS_TR nvHandle = ESYS_TR_NONE;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -114,7 +116,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                           .buffer={30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
                                    40, 41, 42, 43, 44, 45, 46, 47, 48, 49}};
 
-    ESYS_TR policySession;
     TPMT_SYM_DEF policySymmetric = {.algorithm = TPM2_ALG_AES,
                                     .keyBits = {.aes = 128},
                                     .mode = {.aes = TPM2_ALG_CFB}
@@ -168,8 +169,38 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                               );
     goto_if_error(r, "Error: NV_UndefineSpace", error);
 
+    r = Esys_FlushContext(esys_context, sessionTrial);
+    goto_if_error(r, "Flushing context", error);
+
+    r = Esys_FlushContext(esys_context, policySession);
+    goto_if_error(r, "Flushing context", error);
+
     return EXIT_SUCCESS;
 
  error:
+
+    if (sessionTrial != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, sessionTrial) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup policySession failed.");
+        }
+    }
+
+    if (policySession != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, policySession) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup policySession failed.");
+        }
+    }
+
+    if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(esys_context,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+                                  ESYS_TR_PASSWORD,
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -71,7 +71,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                              );
     goto_if_error(r, "Error: PolicyGetDigest", error);
 
-    ESYS_TR nvHandle_handle;
+    ESYS_TR nvHandle;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
@@ -103,7 +103,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             ESYS_TR_NONE,
                             &auth,
                             &publicInfo,
-                            &nvHandle_handle);
+                            &nvHandle);
 
     goto_if_error(r, "Error esys define nv space", error);
 
@@ -143,7 +143,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: PolicyCommandCode", error);
 
     r = Esys_NV_UndefineSpaceSpecial(esys_context,
-                                     nvHandle_handle,
+                                     nvHandle,
                                      ESYS_TR_RH_PLATFORM,
                                      policySession,
                                      ESYS_TR_PASSWORD,

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -4,9 +4,12 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -21,7 +24,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
     /*
      * First the policy value for NV_UndefineSpaceSpecial has to be
      * determined with a policy trial session.
@@ -149,10 +153,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                                      ESYS_TR_PASSWORD,
                                      ESYS_TR_NONE
                                      );
+
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
     goto_if_error(r, "Error: NV_UndefineSpace", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return failure_return;
 }

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -4,9 +4,12 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -23,7 +26,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
     /*
      * Firth the policy value for changing the auth value of an NV index has to be
      * determined with a policy trial session.
@@ -260,8 +263,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-policy-regression.int.c
+++ b/test/integration/esys-policy-regression.int.c
@@ -31,7 +31,7 @@ cmp_policy_digest(ESYS_CONTEXT * esys_context,
                   char *comment, bool flush_session)
 {
 
-    uint32_t r = 0;
+    TSS2_RC r;
     TPM2B_DIGEST *policyDigest;
 
     r = Esys_PolicyGetDigest(esys_context,
@@ -66,7 +66,7 @@ cmp_policy_digest(ESYS_CONTEXT * esys_context,
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     /* Dummy parameters for trial sessoin  */
     ESYS_TR sessionTrial;

--- a/test/integration/esys-policy-ticket.int.c
+++ b/test/integration/esys-policy-ticket.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 #include "tss2_mu.h"
 
@@ -20,7 +22,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     /*
      * 1. Create Primary. This primary will be used as signing key.
@@ -273,8 +275,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -45,7 +45,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         return EXIT_SUCCESS;
     }
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -20,7 +22,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -157,5 +159,5 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return 0;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -24,6 +24,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -92,7 +93,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -117,18 +117,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                                ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary,
                                &inPublic, &outsideInfo, &creationPCR,
-                               &primaryHandle_handle, &outPublic, &creationData,
+                               &primaryHandle, &outPublic, &creationData,
                                &creationHash, &creationTicket);
         goto_if_error(r, "Error esys create primary", error);
 
-        r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+        r = esys_GetResourceObject(esys_context, primaryHandle,
                                    &primaryHandle_node);
         goto_if_error(r, "Error Esys GetResourceObject", error);
 
         LOG_INFO("Created Primary with handle 0x%08x...",
                  primaryHandle_node->rsrc.handle);
 
-        r = Esys_TR_SetAuth(esys_context, primaryHandle_handle,
+        r = Esys_TR_SetAuth(esys_context, primaryHandle,
                             &authValuePrimary);
         goto_if_error(r, "Error: TR_SetAuth", error);
 
@@ -148,26 +148,34 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
             scheme.scheme = TPM2_ALG_OAEP;
             scheme.details.oaep.hashAlg = TPM2_ALG_SHA1;
         }
-        r = Esys_RSA_Encrypt(esys_context, primaryHandle_handle, ESYS_TR_NONE,
+        r = Esys_RSA_Encrypt(esys_context, primaryHandle, ESYS_TR_NONE,
                              ESYS_TR_NONE, ESYS_TR_NONE, &plain, &scheme,
                              &null_data, &cipher);
         goto_if_error(r, "Error esys rsa encrypt", error);
 
         TPM2B_PUBLIC_KEY_RSA *plain2;
-        r = Esys_RSA_Decrypt(esys_context, primaryHandle_handle,
+        r = Esys_RSA_Decrypt(esys_context, primaryHandle,
                              ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                              cipher, &scheme, &null_data, &plain2);
         goto_if_error(r, "Error esys rsa decrypt", error);
 
-        if (mode > 0 && !memcmp(&plain.buffer[0], &plain2->buffer[0], plain_size)) {
+        if (mode > 0 && memcmp(&plain.buffer[0], &plain2->buffer[0], plain_size)) {
             LOG_ERROR("plain texts are not equal for mode %i", mode);
+            goto error;
         }
 
-        r = Esys_FlushContext(esys_context, primaryHandle_handle);
+        r = Esys_FlushContext(esys_context, primaryHandle);
         goto_if_error(r, "Error: FlushContext", error);
     }
     return EXIT_SUCCESS;
 
  error:
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -21,7 +23,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -164,8 +166,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         r = Esys_FlushContext(esys_context, primaryHandle_handle);
         goto_if_error(r, "Error: FlushContext", error);
     }
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -4,6 +4,8 @@
  * rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -23,7 +25,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -305,8 +307,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle2);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -26,6 +26,9 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle1 = ESYS_TR_NONE;
+    ESYS_TR loadedKeyHandle2 = ESYS_TR_NONE;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -138,7 +141,6 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &authValue);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-    ESYS_TR primaryHandle_handle;
     RSRC_NODE_T *primaryHandle_node;
     TPM2B_PUBLIC *outPublic;
     TPM2B_CREATION_DATA *creationData;
@@ -147,19 +149,19 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
-                           &outsideInfo, &creationPCR, &primaryHandle_handle,
+                           &outsideInfo, &creationPCR, &primaryHandle,
                            &outPublic, &creationData, &creationHash,
                            &creationTicket);
     goto_if_error(r, "Error esys create primary", error);
 
-    r = esys_GetResourceObject(esys_context, primaryHandle_handle,
+    r = esys_GetResourceObject(esys_context, primaryHandle,
                                &primaryHandle_node);
     goto_if_error(r, "Error Esys GetResourceObject", error);
 
     LOG_INFO("Created Primary with handle 0x%08x...",
              primaryHandle_node->rsrc.handle);
 
-    r = Esys_TR_SetAuth(esys_context, primaryHandle_handle, &authValuePrimary);
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
     TPM2B_AUTH authKey2 = {
@@ -250,7 +252,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPMT_TK_CREATION *creationTicket2;
 
     r = Esys_Create(esys_context,
-                    primaryHandle_handle,
+                    primaryHandle,
                     ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive2,
                     &inPublic2,
@@ -263,11 +265,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("\nSecond key created.");
 
-    ESYS_TR loadedKeyHandle1;
-    ESYS_TR loadedKeyHandle2;
-
     r = Esys_Load(esys_context,
-                  primaryHandle_handle,
+                  primaryHandle,
                   ESYS_TR_PASSWORD,
                   ESYS_TR_NONE,
                   ESYS_TR_NONE, outPrivate2, outPublic2, &loadedKeyHandle1);
@@ -282,6 +281,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
     r = Esys_FlushContext(esys_context, loadedKeyHandle1);
     goto_if_error(r, "Error esys flush context", error);
+
+    loadedKeyHandle1 = ESYS_TR_NONE;
 
     r = Esys_ContextLoad(esys_context, context, &loadedKeyHandle2);
     goto_if_error(r, "Error esys context load", error);
@@ -301,8 +302,10 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                     &creationData2, &creationHash2, &creationTicket2);
     goto_if_error(r, "Error esys second create ", error);
 
-    r = Esys_FlushContext(esys_context, primaryHandle_handle);
+    r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Error: FlushContext", error);
+
+    primaryHandle = ESYS_TR_NONE;
 
     r = Esys_FlushContext(esys_context, loadedKeyHandle2);
     goto_if_error(r, "Error: FlushContext", error);
@@ -310,5 +313,24 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
+
+    if (loadedKeyHandle1 != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle1) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle1 failed.");
+        }
+    }
+
+    if (loadedKeyHandle2 != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedKeyHandle2) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedKeyHandle2 failed.");
+        }
+    }
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -4,9 +4,12 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 
@@ -15,7 +18,8 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     UINT32 algorithmSet = 0;
 
@@ -26,10 +30,17 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         ESYS_TR_NONE,
         algorithmSet);
+
+    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        failure_return = EXIT_SKIP;
+    }
+
     goto_if_error(r, "Error: SetAlgorithmSet", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return failure_return;
 }

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -31,7 +31,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         algorithmSet);
 
-    if (r == (TPM2_RC_BAD_AUTH | TPM2_RC_S | TPM2_RC_1)) {
+    if (r == TPM2_RC_COMMAND_CODE) {
+        LOG_WARNING("Command TPM2_SetAlgorithmSet not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+
+    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-stir-random.int.c
+++ b/test/integration/esys-stir-random.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -14,7 +16,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_SENSITIVE_DATA inData  = {
         .size = 20,
@@ -30,8 +32,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &inData);
     goto_if_error(r, "Error: StirRandom", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return r;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-testparms.int.c
+++ b/test/integration/esys-testparms.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 
 #include "esys_iutil.h"
@@ -14,7 +16,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPMT_PUBLIC_PARMS parameters = {
         .type = TPM2_ALG_RSA,
@@ -44,8 +46,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         );
     goto_if_error(r, "Error: TestParms", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-tpm-tests.int.c
+++ b/test/integration/esys-tpm-tests.int.c
@@ -15,7 +15,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     esys_context->state = _ESYS_STATE_INIT;
     r = Esys_SelfTest(esys_context,
@@ -42,8 +42,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error GetTestResult did fail", error);
     free(outData);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -21,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * ectx)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR primaryHandle;
     ESYS_TR keyHandle;
@@ -137,12 +137,12 @@ test_invoke_esapi(ESYS_CONTEXT * ectx)
     free(name1);
     free(name2);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 error_name2:
     free(name2);
 error_name1:
     free(name1);
 error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -22,9 +22,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * ectx)
 {
     TSS2_RC r;
-
-    ESYS_TR primaryHandle;
-    ESYS_TR keyHandle;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR keyHandle = ESYS_TR_NONE;
 
     TPM2B_NAME *name1, *name2;
 
@@ -144,5 +143,20 @@ error_name2:
 error_name1:
     free(name1);
 error:
+
+    if (keyHandle != ESYS_TR_NONE) {
+        if (Esys_EvictControl(ectx, ESYS_TR_RH_OWNER, keyHandle,
+                              ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                              TPM2_PERSISTENT_FIRST, &keyHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup: EvictControl delete");
+        }
+    }
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(ectx, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-tr-fromTpmPublic-nv.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-nv.int.c
@@ -21,7 +21,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * ectx)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     ESYS_TR nvHandle;
     TPM2B_NAME *name1, *name2;
@@ -78,12 +78,12 @@ test_invoke_esapi(ESYS_CONTEXT * ectx)
     free(name1);
     free(name2);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 error_name2:
     free(name2);
 error_name1:
     free(name1);
 error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-tr-fromTpmPublic-nv.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-nv.int.c
@@ -22,8 +22,8 @@ int
 test_invoke_esapi(ESYS_CONTEXT * ectx)
 {
     TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
 
-    ESYS_TR nvHandle;
     TPM2B_NAME *name1, *name2;
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -85,5 +85,18 @@ error_name2:
 error_name1:
     free(name1);
 error:
+
+    if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(ectx,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+                                  ESYS_TR_PASSWORD,
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
+
     return EXIT_FAILURE;
 }

--- a/test/integration/esys-tr-getName-hierarchy.int.c
+++ b/test/integration/esys-tr-getName-hierarchy.int.c
@@ -22,7 +22,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * ectx)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_NAME name1, *name2;
     size_t offset = 0;
@@ -40,13 +40,13 @@ test_invoke_esapi(ESYS_CONTEXT * ectx)
     {
         free(name2);
         LOG_ERROR("Names mismatch between NV_GetPublic and TR_GetName");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     free(name2);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -38,7 +38,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     /*
      * 1. Create Primary
      */
-    uint32_t r = 0;
+    TSS2_RC r;
 
     TPM2B_AUTH authValuePrimary = {
         .size = 5,
@@ -291,8 +291,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, loadedKeyHandle);
     goto_if_error(r, "Error during FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
     error:
-        return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-verify-signature.int.c
+++ b/test/integration/esys-verify-signature.int.c
@@ -4,6 +4,8 @@
  * All rights reserved.
  *******************************************************************************/
 
+#include <stdlib.h>
+
 #include "tss2_esys.h"
 #include "tss2_mu.h"
 
@@ -18,7 +20,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r = 0;
+    TSS2_RC r;
 
     /*
      * 1. Create Primary. This primary will be used as signing key.
@@ -166,8 +168,8 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, primaryHandle_handle);
     goto_if_error(r, "Error: FlushContext", error);
 
-    return 0;
+    return EXIT_SUCCESS;
 
  error:
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -18,7 +18,7 @@
 int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
-    uint32_t r;
+    TSS2_RC r;
     ESYS_TR session;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM2_ALG_AES,

--- a/test/integration/test-esapi.h
+++ b/test/integration/test-esapi.h
@@ -11,6 +11,8 @@
 #define TSS_SAPI_FIRST_FAMILY 2
 #define TSS_SAPI_FIRST_LEVEL 1
 #define TSS_SAPI_FIRST_VERSION 108
+#define EXIT_SKIP 77
+#define EXIT_XFAIL 99
 
 #define goto_error_if_not_failed(rc,msg,label)                          \
     if (rc == TSS2_RC_SUCCESS) {                                        \


### PR DESCRIPTION
As a preparation for tests with physical TPMs according to issue #1030 the test cleanup and error handling was fixed:

* Cleanup for allocated TPM objects was added in all error cases.
* Checks for TPM commands not available were added to skip the tests.
* Checks for platform authorization were added to skip the test if platform authorization is not possible.
* Incorrect returning of TSS error codes instead of the test error code EXIT_FAILURE(1) was fixed.
* Deceptive names were changed. 