### PR TITLE
build: Add esys_crypto files to ESYS VS Solution

### DIFF
--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -255,6 +255,7 @@
     <ClCompile Include="api\Esys_ZGen_2Phase.c" />
     <ClCompile Include="esys_context.c" />
     <ClCompile Include="esys_crypto.c" />
+    <ClCompile Include="esys_crypto_gcrypt.c" />
     <ClCompile Include="esys_iutil.c" />
     <ClCompile Include="esys_mu.c" />
     <ClCompile Include="esys_tcti_default.c" />
@@ -263,6 +264,7 @@
   <ItemGroup>
     <ClInclude Include="..\util\log.h" />
     <ClInclude Include="esys_crypto.h" />
+    <ClInclude Include="esys_crypto_gcrypt.h" />
     <ClInclude Include="esys_int.h" />
     <ClInclude Include="esys_iutil.h" />
     <ClInclude Include="esys_mu.h" />

--- a/src/tss2-esys/tss2-esys.vcxproj.filters
+++ b/src/tss2-esys/tss2-esys.vcxproj.filters
@@ -375,6 +375,9 @@
     <ClCompile Include="..\util\log.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="esys_crypto_gcrypt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="esys_crypto.h">
@@ -396,6 +399,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\util\log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="esys_crypto_gcrypt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Add new esys_crypto_gcrypt.c/h files to the Visual Studio solution for ESYS
to fix the current Windows build failures.