### PR TITLE
ESAPI: Fixed unnecessary warning in Esys_Startup.

### DIFF
--- a/src/tss2-esys/api/Esys_Startup.c
+++ b/src/tss2-esys/api/Esys_Startup.c
@@ -211,11 +211,11 @@ Esys_Startup_Finish(
         return r;
     }
     /* The following is the "regular error" handling. */
-    if (r != TSS2_RC_SUCCESS && (r & TSS2_RC_LAYER_MASK) == 0) {
+    if (r != TSS2_RC_SUCCESS && r != TPM2_RC_INITIALIZE && (r & TSS2_RC_LAYER_MASK) == 0) {
         LOG_WARNING("Received TPM Error");
         esysContext->state = _ESYS_STATE_INIT;
         return r;
-    } else if (r != TSS2_RC_SUCCESS) {
+    } else if (r != TSS2_RC_SUCCESS && r != TPM2_RC_INITIALIZE) {
         LOG_ERROR("Received a non-TPM Error");
         esysContext->state = _ESYS_STATE_INTERNALERROR;
         return r;


### PR DESCRIPTION
Addressing #1025.
Receiving TPM2_RC_INITIALIZE after a Startup command is not really an
error (The TPM simply already is in the desired state).
The user does not have to take any further action to interact with
the TPM and thus does not need the log message.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>