### PR TITLE
ci: Stop manually dumping test logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,16 +95,4 @@ script:
     else
       make -j$(nproc) check
     fi
-  - cat test-suite.log
-  - |
-    for LOG in $(ls -1 test/unit/*.log); do
-        echo "${LOG}"
-        cat ${LOG}
-    done
-  - |
-    for LOG in $(ls -1 test/integration/*.log); do
-        echo "${LOG}"
-        cat ${LOG}
-    done
-  - cat test/tpmclient/tpmclient.log
   - popd


### PR DESCRIPTION
The test harness will dump the output from failing tests by default.
Doing this manually is redundant, and dumping the output from successful
tests clutters the output unnecessarily.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>