### PR TITLE
TEST ESYS: Fix wrong check of bad authorization.

### DIFF
--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -204,7 +204,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &setList,
         &clearList);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return =  EXIT_SKIP;

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -34,7 +34,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -22,6 +22,7 @@ int
 test_invoke_esapi(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
 
     ESYS_TR auth_handle = ESYS_TR_RH_PLATFORM;
     TPMI_YES_NO disable = TPM2_YES;
@@ -33,6 +34,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         ESYS_TR_NONE,
         disable);
+
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        failure_return =  EXIT_SKIP;
+        goto error;
+    }
 
     goto_if_error(r, "Error: ClearControl", error);
 
@@ -59,5 +67,5 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return EXIT_SUCCESS;
 
  error:
-    return EXIT_FAILURE;
+    return failure_return;
 }

--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -42,7 +42,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                       );
     goto_if_error(r, "Error: ClockSet", error);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -38,7 +38,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         enable,
         state);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -49,7 +49,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if  ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -70,7 +70,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         TPM2_ALG_SHA1,
         pcrHandle_handle);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -118,7 +118,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         &sizeNeeded,
         &sizeAvailable);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return =  EXIT_SKIP;

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -110,7 +110,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                             &publicInfo,
                             &nvHandle);
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;
@@ -161,7 +161,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                                      ESYS_TR_NONE
                                      );
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -45,7 +45,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         return EXIT_SUCCESS;
     }
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -37,7 +37,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         goto error;
     }
 
-    if ((r & (~TPM2_RC_N_MASK & ~TPM2_RC_H & ~TPM2_RC_S & ~TPM2_RC_P)) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;


### PR DESCRIPTION
The usage of the mask to get the return code was fixed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>