### PR TITLE
ESYS: Fix RSA encryption with exponent == 0

### DIFF
--- a/src/tss2-esys/esys_crypto_gcrypt.c
+++ b/src/tss2-esys/esys_crypto_gcrypt.c
@@ -599,8 +599,12 @@ iesys_cryptogcry_pk_encrypt(TPM2B_PUBLIC * key,
         return TSS2_ESYS_RC_BAD_VALUE;
     }
     size_t offset = 0;
-    r = Tss2_MU_UINT32_Marshal(key->publicArea.parameters.rsaDetail.exponent,
-                               &exponent[0], sizeof(UINT32), &offset);
+    UINT32 exp;
+    if (key->publicArea.parameters.rsaDetail.exponent == 0)
+        exp = 65537;
+    else
+        exp = key->publicArea.parameters.rsaDetail.exponent;
+    r = Tss2_MU_UINT32_Marshal(exp, &exponent[0], sizeof(UINT32), &offset);
     if (r != TSS2_RC_SUCCESS) {
         LOG_ERROR("Marshaling");
         return r;

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -656,7 +656,12 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC * pub_tpm_key,
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE, "Illegal RSA scheme", cleanup);
     }
 
-    if(1 != BN_set_word(bne, pub_tpm_key->publicArea.parameters.rsaDetail.exponent)) {
+    UINT32 exp;
+    if (pub_tpm_key->publicArea.parameters.rsaDetail.exponent == 0)
+        exp = 65537;
+    else
+        exp = pub_tpm_key->publicArea.parameters.rsaDetail.exponent;
+    if (1 != BN_set_word(bne, exp)) {
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE, "Could not set exponent.", cleanup);
     }
 


### PR DESCRIPTION
TPM spec part 2 says: When zero, indicates that the exponent is the default of 2**16 + 1.
This default now will be used in the corresponding crypto functions.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>