### PR TITLE
TEST ESYS: Doxygen documentation added to integration tests.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -781,8 +781,67 @@ INPUT                  = @top_srcdir@/doc/coding_standard_c.md \
                          @top_srcdir@/doc/doxygen.dox \
                          @top_srcdir@/README.md \
                          @top_srcdir@/include/tss2/tss2_esys.h \
-                         @top_srcdir@/src/tss2-esys
-
+                         @top_srcdir@/src/tss2-esys \
+                         @top_srcdir@/test/integration/esys-audit.int.c \
+                         @top_srcdir@/test/integration/esys-certify-creation.int.c \
+                         @top_srcdir@/test/integration/esys-certify.int.c \
+                         @top_srcdir@/test/integration/esys-change-eps.int.c \
+                         @top_srcdir@/test/integration/esys-clear-control.int.c \
+                         @top_srcdir@/test/integration/esys-clear.int.c \
+                         @top_srcdir@/test/integration/esys-clockset.int.c \
+                         @top_srcdir@/test/integration/esys-commit.int.c \
+                         @top_srcdir@/test/integration/esys-create-fail.int.c \
+                         @top_srcdir@/test/integration/esys-create-password-auth.int.c \
+                         @top_srcdir@/test/integration/esys-create-primary-hmac.int.c \
+                         @top_srcdir@/test/integration/esys-create-session-auth.int.c \
+                         @top_srcdir@/test/integration/esys-createloaded.int.c \
+                         @top_srcdir@/test/integration/esys-duplicate.int.c \
+                         @top_srcdir@/test/integration/esys-ecc-parameters.int.c \
+                         @top_srcdir@/test/integration/esys-ecdh-keygen.int.c \
+                         @top_srcdir@/test/integration/esys-ecdh-zgen.int.c \
+                         @top_srcdir@/test/integration/esys-encrypt-decrypt.int.c \
+                         @top_srcdir@/test/integration/esys-event-sequence-complete.int.c \
+                         @top_srcdir@/test/integration/esys-evict-control-serialization.int.c \
+                         @top_srcdir@/test/integration/esys-field-upgrade.int.c \
+                         @top_srcdir@/test/integration/esys-firmware-read.int.c \
+                         @top_srcdir@/test/integration/esys-get-capability.int.c \
+                         @top_srcdir@/test/integration/esys-get-random.int.c \
+                         @top_srcdir@/test/integration/esys-get-time.int.c \
+                         @top_srcdir@/test/integration/esys-hashsequencestart.int.c \
+                         @top_srcdir@/test/integration/esys-hierarchy-control.int.c \
+                         @top_srcdir@/test/integration/esys-hierarchychangeauth.int.c \
+                         @top_srcdir@/test/integration/esys-hmacsequencestart.int.c \
+                         @top_srcdir@/test/integration/esys-import.int.c \
+                         @top_srcdir@/test/integration/esys-lock.int.c \
+                         @top_srcdir@/test/integration/esys-make-credential.int.c \
+                         @top_srcdir@/test/integration/esys-nv-certify.int.c \
+                         @top_srcdir@/test/integration/esys-nv-ram-counter.int.c \
+                         @top_srcdir@/test/integration/esys-nv-ram-extend-index.int.c \
+                         @top_srcdir@/test/integration/esys-nv-ram-ordinary-index.int.c \
+                         @top_srcdir@/test/integration/esys-nv-ram-set-bits.int.c \
+                         @top_srcdir@/test/integration/esys-object-changeauth.int.c \
+                         @top_srcdir@/test/integration/esys-pcr-auth-value.int.c \
+                         @top_srcdir@/test/integration/esys-pcr-basic.int.c \
+                         @top_srcdir@/test/integration/esys-policy-authorize.int.c \
+                         @top_srcdir@/test/integration/esys-policy-nv-changeauth.int.c \
+                         @top_srcdir@/test/integration/esys-policy-nv-undefine-special.int.c \
+                         @top_srcdir@/test/integration/esys-policy-password.int.c \
+                         @top_srcdir@/test/integration/esys-policy-regression.int.c \
+                         @top_srcdir@/test/integration/esys-policy-ticket.int.c \
+                         @top_srcdir@/test/integration/esys-pp-commands.int.c \
+                         @top_srcdir@/test/integration/esys-quote.int.c \
+                         @top_srcdir@/test/integration/esys-rsa-encrypt-decrypt.int.c \
+                         @top_srcdir@/test/integration/esys-save-and-load-context.int.c \
+                         @top_srcdir@/test/integration/esys-set-algorithm-set.int.c \
+                         @top_srcdir@/test/integration/esys-stir-random.int.c \
+                         @top_srcdir@/test/integration/esys-testparms.int.c \
+                         @top_srcdir@/test/integration/esys-tpm-tests.int.c \
+                         @top_srcdir@/test/integration/esys-tr-fromTpmPublic-key.int.c \
+                         @top_srcdir@/test/integration/esys-tr-fromTpmPublic-nv.int.c \
+                         @top_srcdir@/test/integration/esys-tr-getName-hierarchy.int.c \
+                         @top_srcdir@/test/integration/esys-unseal-password-auth.int.c \
+                         @top_srcdir@/test/integration/esys-verify-signature.int.c \
+                         @top_srcdir@/test/integration/esys-zgen-2phase.int.c 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv

--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -1055,8 +1055,87 @@ Both the synchronous and asynchronous API are exposed through a single library: 
 
 /*!
  \defgroup Testgroup Testing
- \todo Description and Documentat of functions \{
+ \{
+ @brief \{
+ For every integration test a function with a name corresponding to the name of the source code
+file of the test is created:
+test_esys_<test_name>(ESYS_CONTEXT * esys_context).
+This function is called by the standard function test_invoke_esapi in every integration test. 
 
+For some tests different test cases can be created with compiler defines to avoid duplicate
+code in different test cases.The following defines are used and listed in the function's
+documentation if used:
+- TEST_ECC Create an ECC key instead of an RSA key.
+- TEST_SESSION Use session authentication instead of password authentication.
+- TEST_READ_LOCK Activate test of Esys_NV_ReadLock.
+- TEST_WRITE_LOCK Activate test of Esys_NV_WriteLock.
+
+The ESAPI command calls which are used in a test are listed in the function's documentation
+and are marked according to the PC Client Profile Revision 01.03 v22:
+- (M) Mandatory
+- (O) Optional
+- (F) Commands added after TPM Specification Rev. 1.16 is integrated. 
+\}
+\{
+\fn test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
+ \fn test_esys_lock(ESYS_CONTEXT * esys_context)
+ \fn test_esys_get_capability(ESYS_CONTEXT * esys_context)
+ \fn test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
+ \fn test_esys_verify_signature(ESYS_CONTEXT * esys_context)
+ \fn test_esys_import(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_ticket(ESYS_CONTEXT * esys_context)
+ \fn test_esys_change_eps(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
+ \fn test_esys_create_fail(ESYS_CONTEXT * esys_context)
+ \fn test_esys_testparms(ESYS_CONTEXT * esys_context)
+ \fn test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
+ \fn test_esys_stir_random(ESYS_CONTEXT * esys_context)
+ \fn test_esys_clockset(ESYS_CONTEXT * esys_context)
+ \fn test_esys_clear_control(ESYS_CONTEXT * esys_context)
+ \fn test_esys_nv_ram_extend_index(ESYS_CONTEXT * esys_context)
+ \fn test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
+ \fn test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
+ \fn test_esys_createloaded(ESYS_CONTEXT * esys_context)
+ \fn test_esys_audit(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_password(ESYS_CONTEXT * esys_context)
+ \fn test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
+ \fn test_esys_tpm_tests(ESYS_CONTEXT * esys_context)
+ \fn test_esys_certify(ESYS_CONTEXT * esys_context)
+ \fn test_esys_pcr_basic(ESYS_CONTEXT * esys_context)
+ \fn test_esys_quote(ESYS_CONTEXT * esys_context)
+ \fn test_esys_tr_getName_hierarchy(ESYS_CONTEXT * ectx)
+ \fn test_esys_field_upgrade(ESYS_CONTEXT * esys_context)
+ \fn test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
+ \fn test_esys_nv_ram_set_bits(ESYS_CONTEXT * esys_context)
+ \fn test_esys_nv_certify(ESYS_CONTEXT * esys_context)
+ \fn test_esys_ecdh_keygen(ESYS_CONTEXT * esys_context)
+ \fn test_esys_tr_fromTpmPublic_key(ESYS_CONTEXT * ectx)
+ \fn test_esys_ecdh_zgen(ESYS_CONTEXT * esys_context)
+ \fn test_esys_certify_creation(ESYS_CONTEXT * esys_context)
+ \fn test_esys_nv_ram_counter(ESYS_CONTEXT * esys_context)
+ \fn test_esys_event_sequence_complete(ESYS_CONTEXT * esys_context)
+ \fn test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
+ \fn test_esys_tr_fromTpmPublic_nv(ESYS_CONTEXT * ectx)
+ \fn test_esys_create_primary_hmac(ESYS_CONTEXT * esys_context)
+ \fn test_esys_firmware_read(ESYS_CONTEXT * esys_context)
+ \fn test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
+ \fn test_esys_ecc_parameters(ESYS_CONTEXT * esys_context)
+ \fn test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
+ \fn test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
+ \fn test_esys_nv_ram_ordinary_index(ESYS_CONTEXT * esys_context)
+ \fn test_esys_duplicate(ESYS_CONTEXT * esys_context)
+ \fn test_esys_rsa_encrypt_decrypt(ESYS_CONTEXT * esys_context)
+ \fn test_esys_set_algorithm_set(ESYS_CONTEXT * esys_context)
+ \fn test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
+ \fn test_esys_pp_commands(ESYS_CONTEXT * esys_context)
+ \fn test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
+ \fn test_esys_clear(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_authorize(ESYS_CONTEXT * esys_context)
+ \fn test_esys_get_time(ESYS_CONTEXT * esys_context)
+ \fn test_esys_make_credential(ESYS_CONTEXT * esys_context)
+ \fn test_esys_commit(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_nv_changeauth(ESYS_CONTEXT * esys_context)
+ \}
  \}
 */
 

--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -13,17 +13,34 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI audit commands.
+/** This test is intended to test the ESAPI audit commands.
+ *
  * First a key for signing the audit digest is computed.
  * A audit session is started, and for the command GetCapability the
  * command audit digest and the session audit digest is computed.
  * (Esys_GetCommandAuditDigest, Esys_GetSessionAuditDigest). In the
  * last test the audit hash alg is changed with Esys_SetCommandCodeAuditStatus.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_GetCapability() (M)
+ *  - Esys_GetCommandAuditDigest() (O)
+ *  - Esys_GetSessionAuditDigest() (M)
+ *  - Esys_SetCommandCodeAuditStatus() (O)
+ *  - Esys_StartAuthSession() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_audit(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR signHandle = ESYS_TR_NONE;
@@ -130,7 +147,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                               NULL,
                               sessionType, &symmetric, authHash, &session);
 
-    goto_if_error(r, "Error Esys_StartAuthSessiony", error);
+    goto_if_error(r, "Error Esys_StartAuthSession", error);
     r = Esys_TRSess_SetAttributes(esys_context, session, sessionAttributes,
                                   0xff);
     goto_if_error(r, "Error Esys_TRSess_SetAttributes", error);
@@ -237,4 +254,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_audit(esys_context);
 }

--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,14 +12,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the command Esys_CertifyCreation.
+/** This test is intended to test the command Esys_CertifyCreation.
+ *
  * We create a RSA primary signing key which will be used as signing key
  * and as object for the certify creation.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CertifyCreation() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_certify_creation(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR signHandle = ESYS_TR_NONE;
@@ -148,4 +157,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_certify_creation(esys_context);
 }

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,14 +12,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the command Esys_Certify.
+/** This test is intended to test the command Esys_Certify.
+ *
  * We create a RSA primary signing key which will be used as signing key
  * and as object for the certify command.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Certify() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_certify(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR signHandle = ESYS_TR_NONE;
@@ -147,4 +156,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_certify(esys_context);
 }

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -13,9 +13,20 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_ChangeEPS */
+/** Test the ESAPI function Esys_ChangeEPS. 
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ChangeEPS() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_change_eps(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -46,4 +57,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_change_eps(esys_context);
 }

--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -13,13 +13,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI function Esys_ClearControl.
+/** Test the ESAPI function Esys_ClearControl.
+ *
  * The clear command will be disabled and with Esys_Clear it will
  * be checked whether clear is disabled.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Clear() (M)
+ *  - Esys_ClearControl() (M)
+ *
+ * *\b Note: platform authorization needed.
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_clear_control(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -68,4 +78,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_clear_control(esys_context);
 }

--- a/test/integration/esys-clear.int.c
+++ b/test/integration/esys-clear.int.c
@@ -12,10 +12,22 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test of the ESAPI function Esys_Clear */
+/** Test of the ESAPI function Esys_Clear. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Clear() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_clear(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -75,4 +87,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #endif
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_clear(esys_context);
 }

--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -13,9 +13,22 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_ClockSet and Esys_ReadClock */
+/** Test the ESAPI function Esys_ClockSet and Esys_ReadClock. 
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ClockRateAdjust() (M)
+ *  - Esys_ClockSet() (M)
+ *  - Esys_ReadClock() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_clockset(ESYS_CONTEXT * esys_context)
 {
 
     TSS2_RC r;
@@ -70,4 +83,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_clockset(esys_context);
 }

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -12,14 +12,24 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test Esys_Commit.  based on an ECC key
+/** This test is intended to test Esys_Commit.
+ *   based on an ECC key
  * created with Esys_CreatePrimary Esys_Commit is called with a point
  * from the primary key.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Commit() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_commit(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR eccHandle = ESYS_TR_NONE;
@@ -166,4 +176,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_commit(esys_context);
 }

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,15 +13,26 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test password authentication.
+/** This test is intended to test password authentication.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * Based in the primary several calls with NULL parameters,
  * which should not be allowed, will be tested.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *
+ * Used compiler defines: TEST_ECC
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_create_fail(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -202,4 +213,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_create_fail(esys_context);
 }

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,18 +12,30 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test password authentication for the ESAPI command
- * Create.
+/** This test is intended to test password authentication for the ESAPI command
+ *  Create.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * Based in the primary a second key with an password define in the sensitive
  * area will be created.
  * This key will be loaded and will be used as parent to create a third key.
  * Password authentication  will be used to create this key.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *
+ * Used compiler defines: TEST_ECC
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -38,13 +50,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         .size = 4,
         .sensitive = {
             .userAuth = {
-                .size = 0,
-                .buffer = {0 },
-            },
+                 .size = 0,
+                 .buffer = {0 },
+             },
             .data = {
-                .size = 0,
-                .buffer = {0},
-            },
+                 .size = 0,
+                 .buffer = {0},
+             },
         },
     };
 
@@ -301,7 +313,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
 
-   if (loadedKeyHandle != ESYS_TR_NONE) {
+    if (loadedKeyHandle != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, loadedKeyHandle) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup loadedKeyHandle failed.");
         }
@@ -314,4 +326,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_create_password_auth(esys_context);
 }

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -12,14 +12,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test Esys_CreatePrimary with hmac verification.
+/** This test is intended to test Esys_CreatePrimary with hmac verification.
+ *
  * The test can be executed with RSA or ECC keys. ECC will be used if
  * ECC is defined.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_ECC
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_create_primary_hmac(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR objectHandle = ESYS_TR_NONE;
@@ -193,4 +204,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_create_primary_hmac(esys_context);
 }

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -11,9 +11,9 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test parameter encryption/decryption, session management,
- * hmac computation, and session key generation.
+/** This test is intended to test parameter encryption/decryption, session management,
+ *  hmac computation, and session key generation.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * The primary key will be used as tpmKey for Esys_StartAuthSession. Parameter
  * encryption and decryption will be activated for the session.
@@ -24,10 +24,25 @@
  * TEST_XOR_OBFUSCATION or TEST_AES_ENCRYPTION.
  * Secret exchange with a ECC key can be activated with the compiler variable
  * -D TEST_ECC.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ContextLoad() (M)
+ *  - Esys_ContextSave() (M)
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_ECC
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -423,4 +438,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_create_session_auth(esys_context);
 }

--- a/test/integration/esys-createloaded.int.c
+++ b/test/integration/esys-createloaded.int.c
@@ -14,14 +14,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI command CreateLoaded.
+/** This test is intended to test the ESAPI command CreateLoaded.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * This primary key will be used as parent key for CreateLoaded.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreateLoaded() (F)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_createloaded(ESYS_CONTEXT * esys_context)
 {
 
     TSS2_RC r;
@@ -259,4 +272,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_createloaded(esys_context);
 }

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -14,17 +14,35 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI commands Duplicate and Rewrap.
+/** This test is intended to test the ESAPI commands Duplicate and Rewrap.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * This primary key will be used as parent key for the Duplicate
  * command. A second primary key will be the parent key of the
  * duplicated key. In the last step the key is rewrapped with the
  * first primary key as parent key.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_Duplicate() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_PolicyAuthValue() (M)
+ *  - Esys_PolicyCommandCode() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_Rewrap() (O)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_duplicate(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -440,4 +458,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_duplicate(esys_context);
 }

--- a/test/integration/esys-ecc-parameters.int.c
+++ b/test/integration/esys-ecc-parameters.int.c
@@ -13,9 +13,18 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_ECC_Parameters */
+/** Test the ESAPI function Esys_ECC_Parameters. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ECC_Parameters() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_ecc_parameters(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -42,4 +51,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_ecc_parameters(esys_context);
 }

--- a/test/integration/esys-ecdh-keygen.int.c
+++ b/test/integration/esys-ecdh-keygen.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -12,13 +12,22 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test Esys_ECDH_KeyGen based on an ECC key
- * created with Esys_CreatePrimary.
+/** This test is intended to test Esys_ECDH_KeyGen based on an ECC key
+ *  created with Esys_CreatePrimary.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_ECDH_KeyGen() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_ecdh_keygen(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR eccHandle = ESYS_TR_NONE;
@@ -158,4 +167,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_ecdh_keygen(esys_context);
 }

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -12,13 +12,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test Esys_ECDH_ZGen.  based on an ECC key
+/** This test is intended to test Esys_ECDH_ZGen.
+ *   based on an ECC key
  * created with Esys_CreatePrimary and a dummy ECC point.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_ECDH_ZGen() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_ecdh_zgen(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR eccHandle = ESYS_TR_NONE;
@@ -182,4 +192,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_ecdh_zgen(esys_context);
 }

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,15 +13,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI function Esys_EncryptDecrypt.
+/** This test is intended to test the ESAPI function Esys_EncryptDecrypt.
+ *
  * First a primary key is generated. This key will be uses as parent fo a
  * symmetric key, which will be used to encrypt and decrypt a tpm2b. The
  * result will be compared.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_EncryptDecrypt() (O)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -38,13 +50,13 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         .size = 4,
         .sensitive = {
             .userAuth = {
-                .size = 0,
-                .buffer = {0 },
-            },
+                 .size = 0,
+                 .buffer = {0 },
+             },
             .data = {
-                .size = 0,
-                .buffer = {0},
-            },
+                 .size = 0,
+                 .buffer = {0},
+             },
         },
     };
 
@@ -295,4 +307,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_encrypt_decrypt(esys_context);
 }

--- a/test/integration/esys-event-sequence-complete.int.c
+++ b/test/integration/esys-event-sequence-complete.int.c
@@ -12,13 +12,21 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI commands HashSequenceStart, SequenceUpdate,
- * and EventSequenceComplete.
+/** Test the ESAPI commands HashSequenceStart, SequenceUpdate,
+ *  and EventSequenceComplete.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_EventSequenceComplete() (M)
+ *  - Esys_HashSequenceStart() (M)
+ *  - Esys_SequenceUpdate() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_event_sequence_complete(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -73,4 +81,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_event_sequence_complete(esys_context);
 }

--- a/test/integration/esys-evict-control-serialization.int.c
+++ b/test/integration/esys-evict-control-serialization.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,18 +12,28 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test EvictControl and ESAPI Serialization.
+/** This test is intended to test EvictControl and ESAPI Serialization.
+ *
  * We start by creating a primary key (Esys_CreatePrimary). Based on this
  * key a persistent object is created (Esys_EvictControl). The resource of
  * this object will be serialized and deserialized with the corresponding
  * ESAPI functions (Esys_TR_Serialize, Esys_TR_Deserialize).
  * To check whether the deserialization was successful a new object will
  * be created with the handle returned by the deserialize function.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_EvictControl() (M)
+ *  - Esys_FlushContext() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -257,4 +267,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_evict_control_serialization(esys_context);
 }

--- a/test/integration/esys-field-upgrade.int.c
+++ b/test/integration/esys-field-upgrade.int.c
@@ -13,9 +13,19 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_FieldUpgradeStart and   Esys_FieldUpgradeData */
+/** Test the ESAPI function Esys_FieldUpgradeStart and   Esys_FieldUpgradeData. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FieldUpgradeData() (O)
+ *  - Esys_FieldUpgradeStart() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_field_upgrade(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -66,4 +76,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_field_upgrade(esys_context);
 }

--- a/test/integration/esys-firmware-read.int.c
+++ b/test/integration/esys-firmware-read.int.c
@@ -13,9 +13,18 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_FirmwareRead */
+/** Test the ESAPI function Esys_FirmwareRead. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FirmwareRead() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_firmware_read(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -41,4 +50,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_firmware_read(esys_context);
 }

--- a/test/integration/esys-get-capability.int.c
+++ b/test/integration/esys-get-capability.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,12 +12,18 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI get capability command.
+/** This test is intended to test the ESAPI get capability command.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_GetCapability() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_get_capability(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     TPM2_CAP                       capability = TPM2_CAP_TPM_PROPERTIES;
@@ -38,4 +44,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_get_capability(esys_context);
 }

--- a/test/integration/esys-get-random.int.c
+++ b/test/integration/esys-get-random.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -12,8 +12,18 @@
 #define LOGMODULE test
 #include "util/log.h"
 
+/** Test the ESAPI function Esys_GetRandom. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_GetRandom() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_get_random(ESYS_CONTEXT * esys_context)
 {
 
     TSS2_RC r;
@@ -84,4 +94,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_get_random(esys_context);
 }

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,15 +13,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the GetTime command with password
- * authentication.
+/** This test is intended to test the GetTime command with password
+ *  authentication.
+ *
  * We create a RSA primary signing key which will be used
  * for signing.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_GetTime() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_get_time(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR signHandle = ESYS_TR_NONE;
@@ -136,7 +146,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     TPM2B_ATTEST *timeInfo;
     TPMT_SIGNATURE *signature;
 
-     r = Esys_GetTime (
+    r = Esys_GetTime (
          esys_context,
          privacyAdminHandle,
          signHandle,
@@ -171,4 +181,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_get_time(esys_context);
 }

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -12,13 +12,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI commands HashSequenceStart, SequenceUpdate,
- * and SequenceComplete.
+/** Test the ESAPI commands HashSequenceStart, SequenceUpdate,
+ *  and SequenceComplete.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HashSequenceStart() (M)
+ *  - Esys_SequenceComplete() (M)
+ *  - Esys_SequenceUpdate() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -118,4 +130,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 #endif
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hashsequencestart(esys_context);
 }

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -13,13 +13,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI function Esys_HierarchyControl.
- * The owner hierarchy will be disabled and with Esys_ClockSet it will
- * be checked whether the owner hierarchy is disabled
+/** Test the ESAPI function Esys_HierarchyControl.
+ *
+ * The owner hierarchy will be disabled and with Esys_CreatePrimary it will
+ * be checked whether the owner hierarchy is disabled.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HierarchyControl() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -47,18 +59,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: HierarchyControl", error);
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-       .size = 4,
-       .sensitive = {
-           .userAuth = {
-                .size = 0,
-                .buffer = {0 },
-            },
-           .data = {
-                .size = 0,
-                .buffer = {0},
-            },
-       },
-   };
+        .size = 4,
+        .sensitive = {
+            .userAuth = {
+                 .size = 0,
+                 .buffer = {0 },
+             },
+            .data = {
+                 .size = 0,
+                 .buffer = {0},
+             },
+        },
+    };
 
       TPM2B_PUBLIC inPublic = {
         .size = 0,
@@ -150,4 +162,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hierarchy_control(esys_context);
 }

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -12,17 +12,26 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the change of an authorization value of
- * a hierarchy.
+/** This test is intended to test the change of an authorization value of
+ *  a hierarchy.
+ *
  * To check whether the change was successful a primary key is created
  * with the handle of this hierarchy and the new authorization.
  * Also second primary is created after a call of Esys_TR_SetAuth with
  * the new auth value.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HierarchyChangeAuth() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -49,18 +58,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     auth_changed = true;
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-       .size = 4,
-       .sensitive = {
-           .userAuth = {
-                .size = 0,
+        .size = 4,
+        .sensitive = {
+            .userAuth = {
+                 .size = 0,
                 .buffer = {0 },
-            },
-           .data = {
-                .size = 0,
+             },
+            .data = {
+                 .size = 0,
                 .buffer = {0},
-            },
-       },
-   };
+             },
+        },
+    };
 
       TPM2B_PUBLIC inPublic = {
         .size = 0,
@@ -169,4 +178,9 @@ error:
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hierarchychangeauth(esys_context);
 }

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -12,13 +12,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI commands: HMAC_Start, SequenceUpdate, and SequenceComplete.
+/** Test the ESAPI commands: HMAC_Start, SequenceUpdate, and SequenceComplete.
+ *
  * The HMAC key is created by using Esys_CreatePrimary.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HMAC_Start() (M)
+ *  - Esys_SequenceComplete() (M)
+ *  - Esys_SequenceUpdate() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -186,4 +200,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #endif
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hmacsequencestart(esys_context);
 }

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -13,17 +13,34 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI commands Duplicate and Import.
+/** This test is intended to test the ESAPI commands Duplicate and Import.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * This primary key will be used as parent key for the Duplicate
  * command. A second primary key will be the parent key of the
  * duplicated key. In the last step the key is imported with the
  * first primary key as parent key (Esys_Import).
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_Duplicate() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Import() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_PolicyAuthValue() (M)
+ *  - Esys_PolicyCommandCode() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_import(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -411,7 +428,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
 
-   if (policySession != ESYS_TR_NONE) {
+    if (policySession != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, policySession) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup policySession failed.");
         }
@@ -428,17 +445,22 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
 
-   if (primaryHandle != ESYS_TR_NONE) {
+    if (primaryHandle != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup primaryHandle failed.");
         }
     }
 
-   if (primaryHandle2 != ESYS_TR_NONE) {
+    if (primaryHandle2 != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, primaryHandle2) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup primaryHandle2 failed.");
         }
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_import(esys_context);
 }

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -13,10 +13,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI functions related to TPM locks  */
+/** Test the ESAPI functions related to TPM locks. 
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_DictionaryAttackLockReset() (M)
+ *  - Esys_DictionaryAttackParameters() (M)
+ *  - Esys_NV_GlobalWriteLock() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_lock(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -60,4 +73,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
   error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_lock(esys_context);
 }

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,18 +12,35 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the function Esys_MakeCredential
- * We start by creating a primary key (Esys_CreatePrimary).
+/** This test is intended to test the function Esys_MakeCredential
+ *  We start by creating a primary key (Esys_CreatePrimary).
+ *
  * Based in the primary a second key will be created.
  * The public part of the key will be loaded by the function
  * Esys_LoadExternal. A credential will be encrypted with this
  * key with the command Esys_MakeCredential. The credential
  * will be activated with Esys_ActivateCredential.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ActivateCredential() (M)
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_LoadExternal() (M)
+ *  - Esys_MakeCredential() (M)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_make_credential(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -372,7 +389,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
 
-   if (session2 != ESYS_TR_NONE) {
+    if (session2 != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, session2) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup session2 failed.");
         }
@@ -392,4 +409,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_make_credential(esys_context);
 }

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,14 +13,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the command Esys_NV_Certify.
+/** This test is intended to test the command Esys_NV_Certify.
+ *
  * We create a RSA primary signing key which will be used as signing key
  * for the NV data.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_Certify() (O)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_NV_Write() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_nv_certify(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR signHandle = ESYS_TR_NONE;
@@ -230,4 +243,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_nv_certify(esys_context);
 }

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,13 +12,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the definition of a counter in NV ram and to
- * test the ESAPI NV_Increment function.
+/** This test is intended to test the definition of a counter in NV ram and to
+ *  test the ESAPI NV_Increment function.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_Increment() (M)
+ *  - Esys_NV_Read() (M)
+ *  - Esys_NV_ReadPublic() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_nv_ram_counter(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -220,4 +234,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #endif
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_nv_ram_counter(esys_context);
 }

--- a/test/integration/esys-nv-ram-extend-index.int.c
+++ b/test/integration/esys-nv-ram-extend-index.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,14 +12,29 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI nv define space, nv extend, and
- * nv read command. The names stored in the ESAPI resource are compared
+/** This test is intended to test the ESAPI nv define space, nv extend, and
+ *  nv read command.
+ *  The names stored in the ESAPI resource are compared
  * with the names delivered from the TPM by the command ReadPublic.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_Extend() (M)
+ *  - Esys_NV_Read() (M)
+ *  - Esys_NV_ReadPublic() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_nv_ram_extend_index(ESYS_CONTEXT * esys_context)
 {
 
     TSS2_RC r;
@@ -52,25 +67,25 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
 
     TPM2B_NV_PUBLIC publicInfo = {
-            .size = 0,
-            .nvPublic = {
-                .nvIndex =TPM2_NV_INDEX_FIRST,
-                .nameAlg = TPM2_ALG_SHA1,
-                .attributes = (
-                    TPMA_NV_OWNERWRITE |
-                    TPMA_NV_AUTHWRITE |
-                    TPMA_NV_WRITE_STCLEAR |
-                    TPMA_NV_AUTHREAD |
-                    TPMA_NV_OWNERREAD |
-                    TPM2_NT_EXTEND << TPMA_NV_TPM2_NT_SHIFT
-                 ),
-                .authPolicy = {
-                         .size = 0,
-                         .buffer = {},
-                     },
-                .dataSize = 20,
-            }
-        };
+        .size = 0,
+        .nvPublic = {
+            .nvIndex =TPM2_NV_INDEX_FIRST,
+            .nameAlg = TPM2_ALG_SHA1,
+            .attributes = (
+                TPMA_NV_OWNERWRITE |
+                TPMA_NV_AUTHWRITE |
+                TPMA_NV_WRITE_STCLEAR |
+                TPMA_NV_AUTHREAD |
+                TPMA_NV_OWNERREAD |
+                TPM2_NT_EXTEND << TPMA_NV_TPM2_NT_SHIFT
+                ),
+            .authPolicy = {
+                 .size = 0,
+                 .buffer = {},
+             },
+            .dataSize = 20,
+        }
+    };
 
     r = Esys_NV_DefineSpace (
         esys_context,
@@ -233,4 +248,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #endif
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_nv_ram_extend_index(esys_context);
 }

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,17 +13,34 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI commands  nv define space, nv write,
- * nv read command, nv lock write and nv lock read, and nv undefine.
+/** This test is intended to test the ESAPI commands  nv define space, nv write,
+ *  nv read command, nv lock write and nv lock read, and nv undefine.
+ *
  * The names stored in the ESAPI resource are compared
  * with the names delivered from the TPM by the command ReadPublic.
  * only one of the tests NV_ReadLock and NV_WriteLock can be activated
  * by the defines TEST_READ_LOCK and TEST_WRITE_LOCK (-D option)
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_Read() (M)
+ *  - Esys_NV_ReadLock() (M)
+ *  - Esys_NV_ReadPublic() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_NV_Write() (M)
+ *  - Esys_NV_WriteLock() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_READ_LOCK TEST_SESSIONi TEST_WRITE_LOCK
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_nv_ram_ordinary_index(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -326,4 +343,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 #endif
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_nv_ram_ordinary_index(esys_context);
 }

--- a/test/integration/esys-nv-ram-set-bits.int.c
+++ b/test/integration/esys-nv-ram-set-bits.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,13 +12,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the definition of a bit field in NV ram and to
- * test the ESAPI NV_SetBits function.
+/** This test is intended to test the definition of a bit field in NV ram and to
+ *  test the ESAPI NV_SetBits function.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_Read() (M)
+ *  - Esys_NV_ReadPublic() (M)
+ *  - Esys_NV_SetBits() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * Used compiler defines: TEST_SESSION
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_nv_ram_set_bits(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -200,7 +214,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
 
-   if (nvHandle != ESYS_TR_NONE) {
+    if (nvHandle != ESYS_TR_NONE) {
         if (Esys_NV_UndefineSpace(esys_context,
                                   ESYS_TR_RH_OWNER,
                                   nvHandle,
@@ -224,4 +238,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 #endif
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_nv_ram_set_bits(esys_context);
 }

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,14 +12,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI command ObjectChangeAuth.
+/** This test is intended to test the ESAPI command ObjectChangeAuth.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * The auth value for this primary will be changed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_ObjectChangeAuth() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -240,4 +251,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_object_changeauth(esys_context);
 }

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -14,12 +14,22 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the commands Esys_PCR_SetAuthValue and Esys_PCR_SetAuthPolicy.
+/** Test the commands Esys_PCR_SetAuthValue and Esys_PCR_SetAuthPolicy.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_PCR_SetAuthPolicy() (O)
+ *  - Esys_PCR_SetAuthValue() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -82,4 +92,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_pcr_auth_value(esys_context);
 }

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -13,13 +13,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the basic commands for PCR processing: Esys_PCR_Extend, Esys_PCR_Read,
- * Esys_PCR_Reset, Esys_PCR_Event, and Esys_PCR_Allocate
+/** Test the basic commands for PCR processing.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_PCR_Allocate() (M)
+ *  - Esys_PCR_Event() (M)
+ *  - Esys_PCR_Extend() (M)
+ *  - Esys_PCR_Read() (M)
+ *  - Esys_PCR_Reset() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_pcr_basic(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -131,4 +143,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
  error:
     return failure_return;
 
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_pcr_basic(esys_context);
 }

--- a/test/integration/esys-policy-authorize.int.c
+++ b/test/integration/esys-policy-authorize.int.c
@@ -13,12 +13,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI policy authorization.
+/** This test is intended to test the ESAPI policy authorization.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_PolicyAuthorize() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_authorize(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -198,4 +209,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_authorize(esys_context);
 }

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,19 +12,33 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI commands PolicyAuthValue,
- * PolicyCommandCode, Esys_PolicyGetDigest, and NV_ChangeAuth.
+/** This test is intended to test the ESAPI commands PolicyAuthValue,
+ *  PolicyCommandCode, Esys_PolicyGetDigest, and NV_ChangeAuth.
+ *
  * First in a trial session the policy value to ensure that the auth value
  * is included in the policy session used for NV_ChangeAuth is
  * computed.
  * A NV ram space with this policy is defined afterwards.
  * With a real policy session  the auth value of this NV ram space
  * will be changed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_ChangeAuth() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_PolicyAuthValue() (M)
+ *  - Esys_PolicyCommandCode() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_nv_changeauth(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -203,4 +217,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_nv_changeauth(esys_context);
 }

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,16 +13,32 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI command Esys_UndefineSpaceSpecial,
- * The NV space attributes TPMA_NV_PLATFORMCREATE and TPMA_NV_POLICY_DELETE
- * have to be set.
+/** This test is intended to test the ESAPI command Esys_NV_UndefineSpaceSpecial,
+ *  The NV space attributes TPMA_NV_PLATFORMCREATE and TPMA_NV_POLICY_DELETE
+ *  have to be set.
+ *
  * A policy has to be defined for the command UndefineSpaceSpecial.
  * The special handling whether the auth value is not used in the HMAC
  * response verification will be checked.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_UndefineSpaceSpecial() (M)
+ *  - Esys_PolicyAuthValue() (M)
+ *  - Esys_PolicyCommandCode() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -193,4 +209,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_nv_undefine_special(esys_context);
 }

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -13,18 +13,30 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI command PolicyPassword.
+/** This test is intended to test the ESAPI command PolicyPassword.
+ *
  * First in a trial session the policy value to ensure that auth value
  * is included in the policy session used for authorization is
  * computed.
  * We start by creating a primary key (Esys_CreatePrimary) with this
  * policy value and a certain authorization. Than a second key it created
  * with a PoliyPassword policy session.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_PolicyPassword() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_password(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -284,4 +296,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_password(esys_context);
 }

--- a/test/integration/esys-policy-regression.int.c
+++ b/test/integration/esys-policy-regression.int.c
@@ -8,18 +8,13 @@
 #include "tss2_mu.h"
 
 #include "esys_iutil.h"
+#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 #include "test-esapi.h"
 
 #define FLUSH true
 #define NOT_FLUSH false
-
-/*
- * This test is intended to test the ESAPI policy commands, not tested
- * in other test cases. When possoble the commands are tested with a
- * trial session and the policy digest is compared with the expected digest.
- */
 
 /*
  * Function to compare policy digest with expected digest.
@@ -65,8 +60,37 @@ cmp_policy_digest(ESYS_CONTEXT * esys_context,
     return false;
 }
 
+/** This test is intended to test the ESAPI policy commands, not tested
+ *  in other test cases.
+ *  When possoble the commands are tested with a
+ * trial session and the policy digest is compared with the expected digest.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_PolicyAuthorizeNV() (F)
+ *  - Esys_PolicyCounterTimer() (M)
+ *  - Esys_PolicyDuplicationSelect() (M)
+ *  - Esys_PolicyGetDigest() (M)
+ *  - Esys_PolicyNV() (M)
+ *  - Esys_PolicyNameHash() (M)
+ *  - Esys_PolicyNvWritten() (M)
+ *  - Esys_PolicyOR() (M)
+ *  - Esys_PolicyPCR() (M)
+ *  - Esys_PolicyPhysicalPresence() (O)
+ *  - Esys_PolicyRestart() (M)
+ *  - Esys_PolicyTemplate() (F)
+ *  - Esys_SetPrimaryPolicy() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_regression(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -551,3 +575,7 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     return failure_return;
 }
 
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_regression(esys_context);
+}

--- a/test/integration/esys-policy-ticket.int.c
+++ b/test/integration/esys-policy-ticket.int.c
@@ -14,14 +14,32 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI policy commands related to
- * signed authorization actions.
+/** This test is intended to test the ESAPI policy commands related to
+ *  signed authorization actions.
+ *
  * Esys_PolicySigned, Esys_PolicyTicket, and Esys_PolicySecret.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HashSequenceStart() (M)
+ *  - Esys_PolicySecret() (M)
+ *  - Esys_PolicySigned() (M)
+ *  - Esys_PolicyTicket() (O)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_SequenceComplete() (M)
+ *  - Esys_SequenceUpdate() (M)
+ *  - Esys_Sign() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_policy_ticket(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -354,4 +372,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_ticket(esys_context);
 }

--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -13,13 +13,23 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * Test the ESAPI function Esys_PP_Commands.
+/** Test the ESAPI function Esys_PP_Commands.
+ *
  * If the test requires physical presence, the test is skipped.
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_PP_Commands() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_pp_commands(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -56,4 +66,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_pp_commands(esys_context);
 }

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,15 +12,24 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the quote command with password
- * authentication.
+/** This test is intended to test the quote command with password
+ *  authentication.
+ *
  * We create a RSA primary signing key which will be used
  * for signing.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Quote() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_quote(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -167,4 +176,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_quote(esys_context);
 }

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,16 +12,26 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test RSA encryption / decryption. with password
+/** This test is intended to test RSA encryption / decryption.
+ *  with password
  * authentication.
  * We create a RSA primary key (Esys_CreatePrimary) for every crypto action
  * This key will be used for encryption/decryption in with the schemes:
  * TPM2_ALG_NULL, TPM2_ALG_RSAES, and TPM2_ALG_OAEP
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_RSA_Decrypt() (M)
+ *  - Esys_RSA_Encrypt() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_rsa_encrypt_decrypt(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -178,4 +188,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_rsa_encrypt_decrypt(esys_context);
 }

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #include <stdlib.h>
@@ -12,18 +12,32 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test context save and load.
+/** This test is intended to test context save and load.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * Based in the primary a second key with an password define in the sensitive
  * area will be created.
  * This key will be loaded and saved with the ContextSave command.
  * After the key is flushed the key will be loaded again with ContextLoad
  * and will be used to create a third key
+ *
+ * Tested ESAPI commands:
+ *  - Esys_ContextLoad() (M)
+ *  - Esys_ContextSave() (M)
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *
+ * Used compiler defines: TEST_ECC
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -36,18 +50,18 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-       .size = 4,
-       .sensitive = {
-           .userAuth = {
-                .size = 0,
-                .buffer = {0 },
-            },
-           .data = {
-                .size = 0,
-                .buffer = {0},
-            },
-       },
-   };
+        .size = 4,
+        .sensitive = {
+            .userAuth = {
+                 .size = 0,
+                 .buffer = {0 },
+             },
+            .data = {
+                 .size = 0,
+                 .buffer = {0},
+             },
+        },
+    };
 
     inSensitivePrimary.sensitive.userAuth = authValuePrimary;
 
@@ -333,4 +347,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_save_and_load_context(esys_context);
 }

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -13,10 +13,21 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_SetAlgorithmSet */
+/** Test the ESAPI function Esys_SetAlgorithmSet. 
+ *
+ *\b Note: platform authorization needed.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_SetAlgorithmSet() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_set_algorithm_set(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
@@ -49,4 +60,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_set_algorithm_set(esys_context);
 }

--- a/test/integration/esys-stir-random.int.c
+++ b/test/integration/esys-stir-random.int.c
@@ -12,9 +12,17 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_StirRandom */
+/** Test the ESAPI function Esys_StirRandom. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_StirRandom() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_stir_random(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -36,4 +44,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_stir_random(esys_context);
 }

--- a/test/integration/esys-testparms.int.c
+++ b/test/integration/esys-testparms.int.c
@@ -12,9 +12,17 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI function Esys_TestParms */
+/** Test the ESAPI function Esys_TestParms. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_TestParms() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_testparms(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -50,4 +58,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_testparms(esys_context);
 }

--- a/test/integration/esys-tpm-tests.int.c
+++ b/test/integration/esys-tpm-tests.int.c
@@ -11,9 +11,19 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/* Test the ESAPI functions for TPM tests */
+/** Test the ESAPI functions for TPM tests. 
+ *
+ * Tested ESAPI commands:
+ *  - Esys_GetTestResult() (M)
+ *  - Esys_IncrementalSelfTest() (M)
+ *  - Esys_SelfTest() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_tpm_tests(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
 
@@ -46,4 +56,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tpm_tests(esys_context);
 }

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 #include <stdlib.h>
 
@@ -11,15 +11,25 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
- * creating an NV Index and then attempting to retrieve an ESYS_TR object for
- * it. Then we call Esys_TR_GetName to see if the correct public name has been
+/** This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
+ *  creating an NV Index and then attempting to retrieve an ESYS_TR object for
+ *  it.
+ *  Then we call Esys_TR_GetName to see if the correct public name has been
  * retrieved.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_EvictControl() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_ReadPublic() (M)
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * ectx)
+test_esys_tr_fromTpmPublic_key(ESYS_CONTEXT * ectx)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -159,4 +169,9 @@ error:
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_fromTpmPublic_key(esys_context);
 }

--- a/test/integration/esys-tr-fromTpmPublic-nv.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-nv.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 #include <stdlib.h>
 
@@ -11,15 +11,24 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
- * creating an NV Index and then attempting to retrieve an ESYS_TR object for
- * it. Then we call Esys_TR_GetName to see if the correct public name has been
+/** This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
+ *  creating an NV Index and then attempting to retrieve an ESYS_TR object for
+ *  it.
+ *  Then we call Esys_TR_GetName to see if the correct public name has been
  * retrieved.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_ReadPublic() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * ectx)
+test_esys_tr_fromTpmPublic_nv(ESYS_CONTEXT * ectx)
 {
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
@@ -99,4 +108,9 @@ error:
 
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_fromTpmPublic_nv(esys_context);
 }

--- a/test/integration/esys-tr-getName-hierarchy.int.c
+++ b/test/integration/esys-tr-getName-hierarchy.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 #include <stdlib.h>
 
@@ -12,15 +12,21 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
- * creating an NV Index and then attempting to retrieve an ESYS_TR object for
- * it. Then we call Esys_TR_GetName to see if the correct public name has been
+/** This tests the Esys_TR_FromTPMPublic and Esys_TR_GetName functions by
+ *  creating an NV Index and then attempting to retrieve an ESYS_TR object for
+ *  it.
+ *  Then we call Esys_TR_GetName to see if the correct public name has been
  * retrieved.
+ *
+ * Tested ESAPI commands:
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * ectx)
+test_esys_tr_getName_hierarchy(ESYS_CONTEXT * ectx)
 {
     TSS2_RC r;
 
@@ -49,4 +55,9 @@ test_invoke_esapi(ESYS_CONTEXT * ectx)
 
  error:
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_getName_hierarchy(esys_context);
 }

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
- * rights reserved.
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
  *******************************************************************************/
 
 #define _GNU_SOURCE
@@ -21,18 +21,29 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the unseal operation for the ESAPI command
- * Unseal.
+/** This test is intended to test the unseal operation for the ESAPI command
+ *  Unseal.
+ *
  * We start by creating a primary key (Esys_CreatePrimary).
  * Based on the primary key a second key with a password and the to be sealed
  * data defined in the sensitive area will be created (Esys_Create).
  * This key will be loaded and the unseal command (Esys_Unseal) will be used
  * to retrieve the sealed data.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Create() (M)
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_Unseal() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
 {
 
     /*
@@ -309,4 +320,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_unseal_password_auth(esys_context);
 }

--- a/test/integration/esys-verify-signature.int.c
+++ b/test/integration/esys-verify-signature.int.c
@@ -13,12 +13,22 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test the ESAPI signing and signature verification.
+/** This test is intended to test the ESAPI signing and signature verification.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_ReadPublic() (M)
+ *  - Esys_Sign() (M)
+ *  - Esys_VerifySignature() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_verify_signature(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
@@ -179,4 +189,9 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
     }
 
     return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_verify_signature(esys_context);
 }

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2 */
 /*******************************************************************************
- * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
  *******************************************************************************/
 
@@ -13,13 +13,27 @@
 #define LOGMODULE test
 #include "util/log.h"
 
-/*
- * This test is intended to test Esys_ECDH_ZGen.  based on an ECC key
- * created with Esys_CreatePrimary and data produce by the command Esys_Ephemeral.
+/** This test is intended to test Esys_ECDH_ZGen.
+ * 
+ * The test is based on an ECC key created with Esys_CreatePrimary
+ * and data produced by the command Esys_EC_Ephemeral.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_ECDH_ZGen() (M)
+ *  - Esys_EC_Ephemeral() (F)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_StartAuthSession() (M)
+ *  - Esys_ZGen_2Phase() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
  */
 
 int
-test_invoke_esapi(ESYS_CONTEXT * esys_context)
+test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
 {
     TSS2_RC r;
     ESYS_TR eccHandle = ESYS_TR_NONE;
@@ -194,11 +208,16 @@ test_invoke_esapi(ESYS_CONTEXT * esys_context)
         }
     }
 
-   if (session != ESYS_TR_NONE) {
+    if (session != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup session failed.");
         }
     }
 
     return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_zgen_2phase(esys_context);
 }


### PR DESCRIPTION
* To be able to generate doxygen documentation for every test case a test case specific function is added.
* The standard test function test_invoke_esapi calls this case specific function. The old test case  documentation is converted into doxygen format.
* A cross reference to used ESAPI commands is added.
* Possible compiler defines to generate different test cases are listed.
* Some indentation errors are fixed.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>