### PR TITLE
Esys ossl cleanup

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -287,7 +287,7 @@ test_unit_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c
 if ESAPI
 test_unit_esys_context_null_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_context_null_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) -lgcrypt
+test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSLDFLAGS)
 test_unit_esys_context_null_SOURCES = test/unit/esys-context-null.c
 
 test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)

--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -6,7 +6,6 @@
 
 #define _GNU_SOURCE
 
-#include <gcrypt.h>
 #include <stdio.h>
 
 #include "tss2_esys.h"


### PR DESCRIPTION
Minor fixes to allow building tss2-esys with the openssl crypto backend without installing grcypt.