### PR TITLE
Updated path in docker command in INSTALL.md file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,7 +174,7 @@ build in a container.
 ```
 $ docker build -t tpm2 .
 $ docker run --name temp tpm2 /bin/true
-$ docker cp temp:/tpm2-tss tpm2-tss
+$ docker cp temp:/tmp/tpm2-tss tpm2-tss
 $ docker rm temp
 ```
 


### PR DESCRIPTION
The commit 14a24001c2c9f3430ac38f40d7748a5cff6ac52c changed the path to the `tpm2-tss` directory inside the docker container from `/tpm2-tss` to `/tmp/tpm2-tss`, but the `INSTALL.md` instructions weren't updated. This PR fixes this.

Signed-off-by: Torben Woltjen torben_w.dev@gmx.de