### PR TITLE
SAPI: Fix marshaling in Tss2_Sys_ECC_Parameters.

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_ECC_Parameters.c
+++ b/src/tss2-sys/api/Tss2_Sys_ECC_Parameters.c
@@ -22,7 +22,7 @@ TSS2_RC Tss2_Sys_ECC_Parameters_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(curveID, ctx->cmdBuffer,
+    rval = Tss2_MU_UINT16_Marshal(curveID, ctx->cmdBuffer,
                                   ctx->maxCmdSize,
                                   &ctx->nextData);
     if (rval)


### PR DESCRIPTION
The base type of TPMI_ECC_CURVE is UNIT16 not UINT32.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>