### PR TITLE
TEST ESYS: Enable tests for physical TPM.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -827,6 +827,7 @@ INPUT                  = @top_srcdir@/doc/coding_standard_c.md \
                          @top_srcdir@/test/integration/esys-policy-nv-undefine-special.int.c \
                          @top_srcdir@/test/integration/esys-policy-password.int.c \
                          @top_srcdir@/test/integration/esys-policy-regression.int.c \
+                         @top_srcdir@/test/integration/esys-policy-regression-opt.int.c \
                          @top_srcdir@/test/integration/esys-policy-ticket.int.c \
                          @top_srcdir@/test/integration/esys-pp-commands.int.c \
                          @top_srcdir@/test/integration/esys-quote.int.c \

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -33,8 +33,13 @@ TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS) $(libut
 
 # test harness configuration
 TEST_EXTENSIONS = .int
+if TESTPTPM
+INT_LOG_COMPILER = $(srcdir)/script/int-log-compiler-ptpm.sh
+INT_LOG_FLAGS = --ptpm=$(PTPM)
+else
 INT_LOG_COMPILER = $(srcdir)/script/int-log-compiler.sh
-EXTRA_DIST += $(INT_LOG_COMPILER)
+endif
+EXTRA_DIST += $(srcdir)/script/int-log-compiler.sh $(srcdir)/script/int-log-compiler-ptpm.sh
 AM_TESTS_ENVIRONMENT = PATH="$(PATH)"
 
 check-programs: $(check_PROGRAMS)
@@ -99,6 +104,11 @@ endif #UNIT
 
 if ENABLE_INTEGRATION
 noinst_LTLIBRARIES += test/integration/libtest_utils.la
+
+if TESTPTPM
+TESTS_INTEGRATION =
+endif
+if !TESTPTPM
 TESTS_INTEGRATION = \
     test/integration/sapi-asymmetric-encrypt-decrypt.int \
     test/integration/sapi-primary-rsa-2K-aes128cfb.int \
@@ -121,50 +131,45 @@ TESTS_INTEGRATION = \
     test/integration/sapi-command-cancel.int \
     test/integration/sapi-param-encrypt-decrypt.int \
     test/tpmclient/tpmclient.int
+endif # !TESTPTPM
+
 if ESAPI
-TESTS_INTEGRATION += \
-    test/integration/esys-audit.int \
-    test/integration/esys-certify-creation.int \
-    test/integration/esys-certify.int \
-    test/integration/esys-change-eps.int \
+ESYS_TESTS_INTEGRATION_DESTRUCTIVE = \
     test/integration/esys-clear.int \
-    test/integration/esys-clear-control.int \
     test/integration/esys-clear-session.int \
     test/integration/esys-clockset.int \
+    test/integration/esys-field-upgrade.int \
+    test/integration/esys-firmware-read.int \
+    test/integration/esys-lock.int \
+    test/integration/esys-set-algorithm-set.int
+
+ESYS_TESTS_INTEGRATION_MANDATORY = \
+    test/integration/esys-certify-creation.int \
+    test/integration/esys-certify.int \
+    test/integration/esys-clear-control.int \
     test/integration/esys-commit.int \
     test/integration/esys-create-fail.int \
-    test/integration/esys-createloaded.int \
-    test/integration/esys-createloaded-session.int \
     test/integration/esys-create-password-auth.int \
     test/integration/esys-create-primary-ecc-hmac.int \
     test/integration/esys-create-primary-hmac.int \
-    test/integration/esys-create-session-auth.int \
     test/integration/esys-create-session-auth-bound.int \
     test/integration/esys-create-session-auth-ecc.int \
+    test/integration/esys-create-session-auth.int \
     test/integration/esys-create-session-auth-xor.int \
-    test/integration/esys-duplicate.int \
     test/integration/esys-ecc-parameters.int \
-    test/integration/esys-ecdh-keygen.int \
     test/integration/esys-ecdh-zgen.int \
-    test/integration/esys-encrypt-decrypt.int \
     test/integration/esys-event-sequence-complete.int \
     test/integration/esys-evict-control-serialization.int \
-    test/integration/esys-field-upgrade.int \
-    test/integration/esys-firmware-read.int \
     test/integration/esys-get-capability.int \
     test/integration/esys-get-random.int \
-    test/integration/esys-get-time.int \
     test/integration/esys-hashsequencestart.int \
     test/integration/esys-hashsequencestart-session.int \
     test/integration/esys-hierarchychangeauth.int \
-    test/integration/esys-hierarchy-control.int \
     test/integration/esys-hmacsequencestart.int \
     test/integration/esys-hmacsequencestart-session.int \
     test/integration/esys-import.int \
-    test/integration/esys-lock.int \
     test/integration/esys-make-credential.int \
     test/integration/esys-make-credential-session.int \
-    test/integration/esys-nv-certify.int \
     test/integration/esys-nv-ram-counter.int \
     test/integration/esys-nv-ram-counter-session.int \
     test/integration/esys-nv-ram-extend-index.int \
@@ -176,19 +181,14 @@ TESTS_INTEGRATION += \
     test/integration/esys-nv-ram-set-bits.int \
     test/integration/esys-nv-ram-set-bits-session.int \
     test/integration/esys-object-changeauth.int \
-    test/integration/esys-pcr-basic.int \
-    test/integration/esys-pcr-auth-value.int \
     test/integration/esys-policy-authorize.int \
-    test/integration/esys-policy-regression.int \
-    test/integration/esys-policy-ticket.int \
     test/integration/esys-policy-nv-changeauth.int \
     test/integration/esys-policy-nv-undefine-special.int \
     test/integration/esys-policy-password.int \
-    test/integration/esys-pp-commands.int \
+    test/integration/esys-policy-regression.int \
     test/integration/esys-quote.int \
     test/integration/esys-rsa-encrypt-decrypt.int \
     test/integration/esys-save-and-load-context.int \
-    test/integration/esys-set-algorithm-set.int \
     test/integration/esys-stir-random.int \
     test/integration/esys-testparms.int \
     test/integration/esys-tpm-tests.int \
@@ -197,7 +197,45 @@ TESTS_INTEGRATION += \
     test/integration/esys-tr-getName-hierarchy.int \
     test/integration/esys-unseal-password-auth.int \
     test/integration/esys-verify-signature.int \
+    test/integration/esys-ecdh-keygen.int \
+    test/integration/esys-policy-ticket.int
+
+ESYS_TESTS_INTEGRATION_OPTIONAL = \
+    test/integration/esys-audit.int \
+    test/integration/esys-change-eps.int \
+    test/integration/esys-createloaded.int \
+    test/integration/esys-createloaded-session.int \
+    test/integration/esys-duplicate.int \
+    test/integration/esys-encrypt-decrypt.int \
+    test/integration/esys-get-time.int \
+    test/integration/esys-hierarchy-control.int \
+    test/integration/esys-nv-certify.int \
+    test/integration/esys-pcr-auth-value.int \
+    test/integration/esys-pcr-basic.int \
+    test/integration/esys-policy-regression-opt.int \
+    test/integration/esys-pp-commands.int \
     test/integration/esys-zgen-2phase.int
+
+if TESTPTPM
+
+if PTPMMANDATORY
+TESTS_INTEGRATION +=  $(ESYS_TESTS_INTEGRATION_MANDATORY)
+endif
+
+if PTPMOPTIONAL
+TESTS_INTEGRATION +=  $(ESYS_TESTS_INTEGRATION_OPTIONAL)
+endif
+
+if PTPMDESTRUCTIVE
+TESTS_INTEGRATION += $(ESYS_TESTS_INTEGRATION_DESTRUCTIVE)
+endif
+
+endif # TESTPTPM
+
+if !TESTPTPM
+TESTS_INTEGRATION += $(ESYS_TESTS_INTEGRATION_MANDATORY) $(ESYS_TESTS_INTEGRATION_OPTIONAL) $(ESYS_TESTS_INTEGRATION_DESTRUCTIVE)
+endif # !TESTPTPM
+
 endif #ESAPI
 endif #ENABLE_INTEGRATION
 
@@ -833,6 +871,13 @@ test_integration_esys_policy_regression_int_SOURCES = \
     test/integration/esys-policy-regression.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
+test_integration_esys_policy_regression_opt_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_policy_regression_opt_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_policy_regression_opt_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_regression_opt_int_SOURCES = \
+    test/integration/esys-policy-regression-opt.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
 test_integration_esys_policy_ticket_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCFLAGS)
 test_integration_esys_policy_ticket_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_policy_ticket_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
@@ -995,3 +1040,6 @@ test_integration_sapi_command_cancel_int_LDADD   = $(TESTS_LDADD)
 test_integration_sapi_command_cancel_int_SOURCES = test/integration/main-sapi.c \
     test/integration/sapi-command-cancel.int.c
 endif #ENABLE_INTEGRATION
+
+check-ptpm:
+	$(MAKE) -j1 check

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,44 @@ AC_SUBST([PATH])
 #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
 AX_ADD_COMPILER_FLAG([-Wno-missing-braces])
 
+dnl ---------  Physical TPM device -----------------------
+
+AC_ARG_WITH([ptpm],
+            [AS_HELP_STRING([--with-ptpm=<device>,[TPM device]])],
+            [AS_IF([test \( -w "$with_ptpm" \)  -a \( -r "$with_ptpm" \)],
+                   [AC_MSG_RESULT([success])
+                    AC_SUBST([PTPM],[$with_ptpm])
+                    AX_NORMALIZE_PATH([with_ptpm])
+                    with_ptpm_set=yes],
+                   [AC_MSG_ERROR([TPM device provided does not exist or is not writable])])],
+            [with_ptpm_set=no])
+AM_CONDITIONAL([PTPM],[test "x$with_ptpm_set" = "xyes"])
+
+AC_ARG_WITH([ptpmtests],
+            [AS_HELP_STRING([--with-ptpmtests=<case>],[Comma-separated values of possible tests: destructive,mandatory,optional] default is mandatory)],
+            [AS_IF([test "x" ==  x$(echo $with_ptpmtests | sed 's/destructive//g'  | sed 's/mandatory//g'  | sed 's/optional//g' | sed 's/,//g') ],
+                   [AC_MSG_RESULT([success])
+                    with_ptpmtests_set=yes],
+                   [AC_MSG_ERROR([Illegal test type for pTPM tests.])])],
+            [with_ptpmtests="mandatory"])
+
+if echo $with_ptpmtests | grep destructive > /dev/null; then
+    enable_ptpm_destructive="yes"
+fi
+AM_CONDITIONAL([PTPMDESTRUCTIVE],[test "x$enable_ptpm_destructive" = "xyes"])
+
+if echo $with_ptpmtests | grep optional > /dev/null; then
+    enable_ptpm_optional="yes"
+fi
+AM_CONDITIONAL([PTPMOPTIONAL],[test "x$enable_ptpm_optional" = "xyes"])
+
+if echo $with_ptpmtests | grep mandatory > /dev/null; then
+    enable_ptpm_mandatory="yes"
+fi
+AM_CONDITIONAL([PTPMMANDATORY],[test "x$enable_ptpm_mandatory" = "xyes"])
+
+AM_CONDITIONAL([TESTPTPM],[test "x$with_ptpm_set" = "xyes" -a "x$with_ptpm_set" = "xyes"])
+
 dnl --------- Doxy Gen -----------------------
 DX_DOXYGEN_FEATURE(ON)
 DX_DOT_FEATURE(OFF)

--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -1083,6 +1083,8 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \fn test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
  \fn test_esys_verify_signature(ESYS_CONTEXT * esys_context)
  \fn test_esys_import(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_regression(ESYS_CONTEXT * esys_context)
+ \fn test_esys_policy_regression_opt(ESYS_CONTEXT * esys_context)
  \fn test_esys_policy_ticket(ESYS_CONTEXT * esys_context)
  \fn test_esys_change_eps(ESYS_CONTEXT * esys_context)
  \fn test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)

--- a/script/int-log-compiler-ptpm.sh
+++ b/script/int-log-compiler-ptpm.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#;**********************************************************************;
+# Copyright (c) 2017 - 2018, Intel Corporation
+# Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
+# All rights reserved.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+set -u
+
+usage_error ()
+{
+    echo "$0: $*" >&2
+    print_usage >&2
+    exit 2
+}
+print_usage ()
+{
+    cat <<END
+Usage:
+    int-log-compiler.sh --ptpm=DEVICE
+                        TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
+The '--simulator-bin' option is mandatory.
+END
+}
+while test $# -gt 0; do
+    case $1 in
+    --help) print_usage; exit $?;;
+    -d|--ptpm) PTPM=$2; shift;;
+    -d=*|--ptpm=*) PTPM="${1#*=}";;
+    --) shift; break;;
+    -*) usage_error "invalid option: '$1'";;
+     *) break;;
+    esac
+    shift
+done
+
+# Verify the running shell and OS environment is sufficient to run these tests.
+sanity_test ()
+{
+    # Check special file
+    if [ ! -e /dev/urandom ]; then
+        echo  "Missing file /dev/urandom; exiting"
+        exit 1
+    fi
+
+    # Check ps
+    PS_LINES=$(ps -e 2>/dev/null | wc -l)
+    if [ "$PS_LINES" -eq 0 ] ; then
+        echo "Command ps not listing processes; exiting"
+        exit 1
+    fi
+}
+
+sanity_test
+
+# Once option processing is done, $@ should be the name of the test executable
+# followed by all of the options passed to the test executable.
+TEST_BIN=$(realpath "$1")
+TEST_DIR=$(dirname "$1")
+TEST_NAME=$(basename "${TEST_BIN}")
+
+while true; do
+
+env TPM20TEST_TCTI_NAME="device" \
+    TPM2OTEST_DEVICE_FILE=${PTPM} \
+    G_MESSAGES_DEBUG=all ./test/helper/tpm_transientempty
+if [ $? -ne 0 ]; then
+    echo "TPM transient area not empty => skipping"
+    ret=77
+    break
+fi
+
+echo "Execute the test script"
+env TPM20TEST_TCTI_NAME="device" \
+    TPM2OTEST_DEVICE_FILE=${PTPM} \
+    G_MESSAGES_DEBUG=all $@
+ret=$?
+echo "Script returned $ret"
+
+env TPM20TEST_TCTI_NAME="device" \
+    TPM2OTEST_DEVICE_FILE=${PTPM} \
+    G_MESSAGES_DEBUG=all ./test/helper/tpm_transientempty
+if [ $? -ne 0 ]; then
+    echo "TPM transient area not empty or generally failed after test"
+    ret=99
+    break
+fi
+
+break
+done
+
+# This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
+# second after the test finishes the simulator will die too. Bug in the
+# simulator?
+sleep 1
+# teardown
+exit $ret

--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -185,7 +185,9 @@ test_esys_audit(ESYS_CONTEXT * esys_context)
         &auditInfo,
         &signature);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_GetCommandAuditDigest not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -39,7 +39,9 @@ test_esys_change_eps(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         ESYS_TR_NONE);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_ChangeEPS not supported by TPM.");
         return  EXIT_SKIP;
         goto error;

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -120,7 +120,7 @@ test_esys_create_fail(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -124,7 +124,7 @@ test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -237,7 +237,7 @@ test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -127,7 +127,7 @@ test_esys_create_primary_hmac(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -132,7 +132,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -333,7 +333,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-createloaded.int.c
+++ b/test/integration/esys-createloaded.int.c
@@ -89,7 +89,7 @@ test_esys_createloaded(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -224,7 +224,9 @@ test_esys_createloaded(ESYS_CONTEXT * esys_context)
         &outPrivate2,
         &outPublic2
         );
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_CreateLoaded not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -144,7 +144,7 @@ test_esys_duplicate(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -247,7 +247,7 @@ test_esys_duplicate(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,
@@ -393,7 +393,9 @@ test_esys_duplicate(ESYS_CONTEXT * esys_context)
                     &outDuplicate,
                     &outSymSeed2);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_Rewrap not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -85,7 +85,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -243,7 +243,9 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
         &outData,
         &ivOut);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_EncryptDecrypt not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;
@@ -267,7 +269,9 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
         &outData2,
         &ivOut2);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_EncryptDecrypt not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-evict-control-serialization.int.c
+++ b/test/integration/esys-evict-control-serialization.int.c
@@ -83,7 +83,7 @@ test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -197,7 +197,7 @@ test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-field-upgrade.int.c
+++ b/test/integration/esys-field-upgrade.int.c
@@ -46,7 +46,9 @@ test_esys_field_upgrade(ESYS_CONTEXT * esys_context)
         &fuData,
         &nextDigest,
         &firstDigest);
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_INFO("Command TPM2_FieldUpgradeData not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-firmware-read.int.c
+++ b/test/integration/esys-firmware-read.int.c
@@ -39,7 +39,9 @@ test_esys_firmware_read(ESYS_CONTEXT * esys_context)
         sequenceNumber,
         &fuData);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_INFO("Command TPM2_FieldUpgradeData not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -157,7 +157,9 @@ test_esys_get_time(ESYS_CONTEXT * esys_context)
          &inScheme,
          &timeInfo,
          &signature);
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_GetTime not supported by TPM.");
         r = Esys_FlushContext(esys_context, signHandle);
         goto_if_error(r, "Flushing context", error);

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -95,7 +95,7 @@ test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -94,7 +94,7 @@ test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -141,7 +141,7 @@ test_esys_import(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -244,7 +244,7 @@ test_esys_import(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -56,7 +56,9 @@ test_esys_lock(ESYS_CONTEXT * esys_context)
     r = Esys_NV_GlobalWriteLock(esys_context, ESYS_TR_RH_PLATFORM,
                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_NV_GlobalWriteLock not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -140,7 +140,7 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -237,7 +237,7 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -201,7 +201,9 @@ test_esys_nv_certify(ESYS_CONTEXT * esys_context)
         &certifyInfo,
         &signature);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_NV_Certify not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -59,7 +59,7 @@ test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -163,7 +163,7 @@ test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -56,7 +56,9 @@ test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
         );
 
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_PCR_SetAuthValue not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-policy-authorize.int.c
+++ b/test/integration/esys-policy-authorize.int.c
@@ -80,7 +80,7 @@ test_esys_policy_authorize(ESYS_CONTEXT * esys_context)
                       }
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -106,7 +106,7 @@ test_esys_policy_password(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -235,7 +235,7 @@ test_esys_policy_password(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-policy-regression-opt.int.c
+++ b/test/integration/esys-policy-regression-opt.int.c
@@ -1,0 +1,313 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+#include "tss2_mu.h"
+
+#include "esys_iutil.h"
+#include "test-esapi.h"
+#define LOGMODULE test
+#include "util/log.h"
+
+#define FLUSH true
+#define NOT_FLUSH false
+
+/*
+ * Function to compare policy digest with expected digest.
+ * The digest is computed with Esys_PolicyGetDigest.
+ */
+bool
+cmp_policy_digest(ESYS_CONTEXT * esys_context,
+                  ESYS_TR * session,
+                  TPM2B_DIGEST * expected_digest,
+                  char *comment, bool flush_session)
+{
+
+    TSS2_RC r;
+    TPM2B_DIGEST *policyDigest;
+
+    r = Esys_PolicyGetDigest(esys_context,
+                             *session,
+                             ESYS_TR_NONE,
+                             ESYS_TR_NONE, ESYS_TR_NONE, &policyDigest);
+    goto_if_error(r, "Error: PolicyGetDigest", error);
+
+    LOGBLOB_DEBUG(&policyDigest->buffer[0], policyDigest->size,
+                  "POLICY DIGEST");
+
+    if (policyDigest->size != 20
+        || memcmp(&policyDigest->buffer[0], &expected_digest->buffer[0],
+                  policyDigest->size)) {
+        free(policyDigest);
+        LOG_ERROR("Error: Policy%s digest did not match expected policy.",
+                  comment);
+        return false;
+    }
+    free(policyDigest);
+    if (flush_session) {
+        r = Esys_FlushContext(esys_context, *session);
+        goto_if_error(r, "Error: PolicyGetDigest", error);
+        *session = ESYS_TR_NONE;
+    }
+
+    return true;
+
+ error:
+    return false;
+}
+
+/** This test is intended to test the ESAPI policy commands, not tested
+ *  in other test cases.
+ *  When possoble the commands are tested with a
+ * trial session and the policy digest is compared with the expected digest.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_FlushContext() (M)
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_PolicyAuthorizeNV() (F)
+ *  - Esys_PolicyNV() (M)
+ *  - Esys_PolicyPhysicalPresence() (O)
+ *  - Esys_PolicyTemplate() (F)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
+int
+test_esys_policy_regression_opt(ESYS_CONTEXT * esys_context)
+{
+    TSS2_RC r;
+    int failure_return = EXIT_FAILURE;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+    ESYS_TR sessionTrialPCR = ESYS_TR_NONE;
+
+    /* Dummy parameters for trial sessoin  */
+    ESYS_TR sessionTrial = ESYS_TR_NONE;
+    TPMT_SYM_DEF symmetricTrial = {.algorithm = TPM2_ALG_AES,
+        .keyBits = {.aes = 128},
+        .mode = {.aes = TPM2_ALG_CFB}
+    };
+    TPM2B_NONCE nonceCallerTrial = {
+        .size = 20,
+        .buffer = {11, 12, 13, 14, 15, 16, 17, 18, 19, 11,
+                   21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+    };
+
+    /* Create valid NV handle */
+    TPM2B_AUTH auth = {.size = 20,
+        .buffer = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                   20, 21, 22, 23, 24, 25, 26, 27, 28, 29}
+    };
+
+    TPM2B_NV_PUBLIC publicInfo = {
+        .size = 0,
+        .nvPublic = {
+                     .nvIndex = TPM2_NV_INDEX_FIRST,
+                     .nameAlg = TPM2_ALG_SHA1,
+                     .attributes = (TPMA_NV_OWNERWRITE |
+                                    TPMA_NV_AUTHWRITE |
+                                    TPMA_NV_WRITE_STCLEAR |
+                                    TPMA_NV_READ_STCLEAR |
+                                    TPMA_NV_AUTHREAD | TPMA_NV_OWNERREAD),
+                     .authPolicy = {
+                                    .size = 0,
+                                    .buffer = {}
+                                    ,
+                                    }
+                     ,
+                     .dataSize = 32,
+                     }
+    };
+
+    r = Esys_NV_DefineSpace(esys_context,
+                            ESYS_TR_RH_OWNER,
+                            ESYS_TR_PASSWORD,
+                            ESYS_TR_NONE,
+                            ESYS_TR_NONE, &auth, &publicInfo, &nvHandle);
+
+    goto_if_error(r, "Error esys define nv space", error);
+
+    /*
+     * Test PolicyNV
+     */
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              &nonceCallerTrial,
+                              TPM2_SE_TRIAL, &symmetricTrial, TPM2_ALG_SHA1,
+                              &sessionTrial);
+    goto_if_error(r, "Error: During initialization of policy trial session",
+                  error);
+
+    UINT16 offset = 0;
+    TPM2_EO operation = TPM2_EO_EQ;
+    TPM2B_OPERAND operandB = {
+        .size = 8,
+        .buffer = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x08, 0x09}
+    };
+
+    r = Esys_PolicyNV(esys_context,
+                      ESYS_TR_RH_OWNER,
+                      nvHandle,
+                      sessionTrial,
+                      ESYS_TR_PASSWORD,
+                      ESYS_TR_NONE, ESYS_TR_NONE, &operandB, offset, operation);
+    goto_if_error(r, "Error: PolicyNV", error);
+
+    TPM2B_DIGEST expectedPolicyNV = {
+        .size = 20,
+        .buffer = {0x09, 0x92, 0x96, 0x4c, 0x18, 0x4c, 0x29, 0xde, 0x53, 0x52,
+                   0xc0, 0x20, 0x86, 0x81, 0xca, 0xe9, 0x94, 0x23, 0x09, 0x24}
+    };
+
+    if (!cmp_policy_digest(esys_context, &sessionTrial, &expectedPolicyNV,
+                           "NV", NOT_FLUSH))
+        goto error;
+
+    /*
+     * Test PolicyAuthorizeNV
+     */
+    r = Esys_PolicyAuthorizeNV(esys_context,
+                               ESYS_TR_RH_OWNER,
+                               nvHandle,
+                               sessionTrial,
+                               ESYS_TR_PASSWORD,
+                               ESYS_TR_NONE, ESYS_TR_NONE);
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
+        LOG_WARNING("Command TPM2_PolicyAuthorizeNV  not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    } else {
+        goto_if_error(r, "Error: PolicyAuthorizeNV", error);
+    }
+
+    /*
+     * Space not needed for further tests.
+     */
+
+    r = Esys_NV_UndefineSpace(esys_context,
+                              ESYS_TR_RH_OWNER,
+                              nvHandle,
+                              ESYS_TR_PASSWORD,
+                              ESYS_TR_NONE,
+                              ESYS_TR_NONE
+                              );
+    goto_if_error(r, "Error: NV_UndefineSpace", error);
+    nvHandle = ESYS_TR_NONE;
+
+    r = Esys_FlushContext(esys_context, sessionTrial);
+    goto_if_error(r, "Error: FlushContext", error);
+    sessionTrial = ESYS_TR_NONE;
+
+
+    /*
+     * Test PolicyTemplate
+     */
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              &nonceCallerTrial,
+                              TPM2_SE_TRIAL, &symmetricTrial, TPM2_ALG_SHA1,
+                              &sessionTrial);
+    goto_if_error(r, "Error: During initialization of policy trial session",
+                  error);
+
+    TPM2B_DIGEST templateHash = {
+        .size = 20,
+        .buffer = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                   11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+    };
+
+    r = Esys_PolicyTemplate(esys_context,
+                            sessionTrial,
+                            ESYS_TR_NONE,
+                            ESYS_TR_NONE, ESYS_TR_NONE, &templateHash);
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
+        LOG_WARNING("Command TPM2_PolicyTemplate  not supported by TPM.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    } else {
+        goto_if_error(r, "Error: PolicyTemplate", error);
+
+        TPM2B_DIGEST expectedPolicyTemplate = {
+            .size = 20,
+            .buffer =
+                {0xf6, 0x6d, 0x2a, 0x9c, 0x6e, 0xa8, 0xdf, 0x1a, 0x49, 0x3c,
+                 0x42, 0xcc, 0xac, 0x6e, 0x3d, 0x08, 0xc0, 0x84, 0xcf, 0x73}
+        };
+
+        if (!cmp_policy_digest
+            (esys_context, &sessionTrial, &expectedPolicyTemplate, "Template",
+             FLUSH))
+            goto error;
+    }
+
+    /*
+     * Test PolicyPhysicalPresence
+     */
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              &nonceCallerTrial,
+                              TPM2_SE_TRIAL, &symmetricTrial, TPM2_ALG_SHA1,
+                              &sessionTrial);
+    goto_if_error(r, "Error: During initialization of policy trial session",
+                  error);
+
+    r = Esys_PolicyPhysicalPresence(esys_context,
+                                    sessionTrial,
+                                    ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE);
+    goto_if_error(r, "Error: PolicyPhysicalPresence", error);
+
+    TPM2B_DIGEST expectedPolicyPhysicalPresence = {
+        .size = 20,
+        .buffer = {0x9a, 0xcb, 0x06, 0x39, 0x5f, 0x83, 0x1f, 0x88, 0xe8, 0x9e,
+                   0xea, 0xc2, 0x94, 0x42, 0xcb, 0x0e, 0xbe, 0x94, 0x85, 0xab}
+    };
+
+    if (!cmp_policy_digest
+        (esys_context, &sessionTrial, &expectedPolicyPhysicalPresence,
+         "PhysicalPresence", FLUSH))
+        goto error;
+
+    return EXIT_SUCCESS;
+
+ error:
+
+    if (sessionTrial != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, sessionTrial) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup sessionTrial failed.");
+        }
+    }
+
+    if (sessionTrialPCR != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, sessionTrialPCR) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup sessionTrialPCR failed.");
+        }
+    }
+
+    if (nvHandle != ESYS_TR_NONE) {
+        if (Esys_NV_UndefineSpace(esys_context,
+                                  ESYS_TR_RH_OWNER,
+                                  nvHandle,
+                                  ESYS_TR_PASSWORD,
+                                  ESYS_TR_NONE,
+                                  ESYS_TR_NONE) != TSS2_RC_SUCCESS) {
+             LOG_ERROR("Cleanup nvHandle failed.");
+        }
+    }
+
+    return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_policy_regression_opt(esys_context);
+}

--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -45,7 +45,9 @@ test_esys_pp_commands(ESYS_CONTEXT * esys_context)
                          ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                          &setList, &clearList);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_PP_Commands not supported by TPM.");
         failure_return = EXIT_SKIP;
     }

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -75,7 +75,7 @@ test_esys_rsa_encrypt_decrypt(ESYS_CONTEXT * esys_context)
                      .algorithm = TPM2_ALG_NULL},
                  .scheme = { .scheme = TPM2_ALG_RSAES },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -127,7 +127,7 @@ test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,
@@ -239,7 +239,7 @@ test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
                  .keyBits = 2048,
-                 .exponent = 65537
+                 .exponent = 0
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -42,7 +42,9 @@ test_esys_set_algorithm_set(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         algorithmSet);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_SetAlgorithmSet not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;

--- a/test/integration/esys-testparms.int.c
+++ b/test/integration/esys-testparms.int.c
@@ -40,7 +40,7 @@ test_esys_testparms(ESYS_CONTEXT * esys_context)
                       TPM2_ALG_NULL,
                   },
              .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              }
         }
     };

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -81,7 +81,7 @@ test_esys_tr_fromTpmPublic_key(ESYS_CONTEXT * ectx)
                       .scheme = TPM2_ALG_NULL
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -97,7 +97,7 @@ test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
                     .scheme = TPM2_ALG_NULL
                 },
                 .keyBits = 2048,
-                .exponent = 65537,
+                .exponent = 0,
             },
             .unique.rsa = {
                 .size = 0,
@@ -201,7 +201,7 @@ test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
                     .scheme = TPM2_ALG_NULL,
                 },
                 .keyBits = 2048,
-                .exponent = 65537
+                .exponent = 0
             },
             .unique.rsa = {
                 .size = 0,

--- a/test/integration/esys-verify-signature.int.c
+++ b/test/integration/esys-verify-signature.int.c
@@ -78,7 +78,7 @@ test_esys_verify_signature(ESYS_CONTEXT * esys_context)
                       }
                   },
                  .keyBits = 2048,
-                 .exponent = 65537,
+                 .exponent = 0,
              },
             .unique.rsa = {
                  .size = 0,

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -153,7 +153,9 @@ test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
         &Q,
         &counter);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_Ephemeral not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;
@@ -183,7 +185,9 @@ test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
         &outZ1,
         &outZ2);
 
-    if (r == TPM2_RC_COMMAND_CODE) {
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_ZGen_2Phase not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;


### PR DESCRIPTION
* To enable tests with a physical TPM the configure options:
     --with-ptpm=[device]
     --with-ptpmtests=[test cases]

   were added. To compile the integration tests --enable-integration has
   to be used. The test cases are a comma separated list of:
   mandatory, optional and destructive. The default is mandatory.
   To avoid parallel usage of the TPM the tests should be executed with:
   make check-ptpm
   or with:
   make check -j 1.
   The compiled integration tests for a simulator test can be used for
   tests with a physical TPM without re-compilation.

* A second int_log compiler script was added to execute these tests.

* Split policy regression tests into two parts. Optional commands are
  moved to the test policy-regression-opt.

* The test policy-ticket will return success if the PolicyTicket command
  is not available, but all other commands in this tests were
  successful.

* Exponent 0 will be used in the ESAPI integration tests.
  Exponent 65537 for RSA keys is optional in TPM spec while exponent
  is mandatory:
  A TPM compatible with this specification and supporting RSA shall
  support two primes and an exponent of zero. Support for other values
  is optional. (Spec Part2 12.2.3.5 TPMS_RSA_PARMS).

* The check whether optional commands are available are adapted for the
  usage with a resource manager TPM.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>