### PR TITLE
tcti: add support for partial reads

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,17 @@ AC_ARG_ENABLE([esapi],
     [enable_esapi="yes"])
 AM_CONDITIONAL(ESAPI, test "x$enable_esapi" = "xyes")
 
+AC_ARG_ENABLE([tcti-partial-reads],
+    AS_HELP_STRING([--enable-tcti-partial-reads],
+	           [Enable partial reads for TCTI device
+		    (note: This needs to be
+		     supported by the kernel driver). default is no]),
+    [enable_tcti_partial_reads=$enableval],
+    [enable_tcti_partial_reads=no])
+AM_CONDITIONAL(TCTI_PARTIAL_READ, test "x$enable_tcti_partial_reads" = "xyes")
+AS_IF([test "x$enable_tcti_partial_reads" = "xyes"],
+	AC_DEFINE([TCTI_PARTIAL_READ],[1]))
+
 AC_ARG_WITH([crypto],
             [AS_HELP_STRING([--with-crypto={gcrypt,ossl}],
                             [sets the ESAPI crypto backend (default is gcrypt)])],
@@ -267,5 +278,5 @@ AC_MSG_RESULT([
     simulatorbin:       $with_simulatorbin
     maxloglevel:        $with_maxloglevel
     doxygen:            $DX_FLAG_doc $enable_doxygen_doc
+    tcti-partial-read:  $enable_tcti_partial_reads
 ])
-    

--- a/src/tss2-tcti/tcti-common.h
+++ b/src/tss2-tcti/tcti-common.h
@@ -57,6 +57,7 @@ typedef struct {
     tcti_state_t state;
     tpm_header_t header;
     uint8_t locality;
+    bool partial;
 } TSS2_TCTI_COMMON_CONTEXT;
 
 /*

--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -98,10 +98,11 @@ tcti_proxy_receive(
 
     if (tcti_proxy->state == intercepting) {
         *response_size = sizeof(yielded_response);
-        if (response_buffer != NULL)
-            memcpy(response_buffer, &yielded_response[0], sizeof(yielded_response));
 
-        tcti_proxy->state = forwarding;
+        if (response_buffer != NULL) {
+            memcpy(response_buffer, &yielded_response[0], sizeof(yielded_response));
+            tcti_proxy->state = forwarding;
+        }
         return TSS2_RC_SUCCESS;
     }
 
@@ -112,7 +113,10 @@ tcti_proxy_receive(
         return rval;
     }
 
-    tcti_proxy->state = intercepting;
+    /* First read with response buffer == NULL is to get the size of the
+     * response. The subsequent read needs to be forwarded also */
+    if (response_buffer != NULL)
+        tcti_proxy->state = intercepting;
 
     return rval;
 }

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -97,10 +97,11 @@ static void
 read_all_twice_eof (void **state)
 {
     ssize_t ret;
+    uint8_t buf [10];
 
     will_return (__wrap_read, 5);
     will_return (__wrap_read, 0);
-    ret = read_all (10, NULL, 10);
+    ret = read_all (10, buf, 10);
     assert_int_equal (ret, 5);
 }
 /* When passed all NULL values ensure that we get back the expected RC. */


### PR DESCRIPTION
This enables partial reads in tcti-device.
The feature has dependecy on the same being enable in the driver
so it is disabled by default. It can be enabled by a new configure
time option --enable-tcti-partial-reads=yes