### PR TITLE
TEST ESYS: Fixed test clockset.

### DIFF
--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -44,7 +44,7 @@ test_esys_clockset(ESYS_CONTEXT * esys_context)
                        &currentTime);
     goto_if_error(r, "Error: ReadClock", error);
 
-    UINT64 newTime = currentTime->time + 01000;
+    UINT64 newTime = currentTime->clockInfo.clock + 010000;
 
     r = Esys_ClockSet(esys_context,
                       auth_handle,
@@ -53,7 +53,6 @@ test_esys_clockset(ESYS_CONTEXT * esys_context)
                       ESYS_TR_NONE,
                       newTime
                       );
-    goto_if_error(r, "Error: ClockSet", error);
 
     if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
@@ -61,6 +60,8 @@ test_esys_clockset(ESYS_CONTEXT * esys_context)
         failure_return = EXIT_SKIP;
         goto error;
     }
+
+    goto_if_error(r, "Error: ClockSet", error);
 
     r = Esys_ClockRateAdjust(esys_context,
                              auth_handle,


### PR DESCRIPTION
* The wrong field of the structure TIME_INFO was used to determine the current clock.
* This test  worked with the simulator but did fail with a physical TPM (in most cases).
* Also the error check was fixed.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>