### PR TITLE
ESYS TEST: Added tests for Esys_HMAC and Esys_Hash and minor fixes.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -137,7 +137,6 @@ if ESAPI
 ESYS_TESTS_INTEGRATION_DESTRUCTIVE = \
     test/integration/esys-clear.int \
     test/integration/esys-clear-session.int \
-    test/integration/esys-clockset.int \
     test/integration/esys-field-upgrade.int \
     test/integration/esys-firmware-read.int \
     test/integration/esys-lock.int \
@@ -147,6 +146,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-certify-creation.int \
     test/integration/esys-certify.int \
     test/integration/esys-clear-control.int \
+    test/integration/esys-clockset.int \
     test/integration/esys-commit.int \
     test/integration/esys-create-fail.int \
     test/integration/esys-create-password-auth.int \
@@ -162,9 +162,11 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-evict-control-serialization.int \
     test/integration/esys-get-capability.int \
     test/integration/esys-get-random.int \
+    test/integration/esys-hash.int \
     test/integration/esys-hashsequencestart.int \
     test/integration/esys-hashsequencestart-session.int \
     test/integration/esys-hierarchychangeauth.int \
+    test/integration/esys-hmac.int \
     test/integration/esys-hmacsequencestart.int \
     test/integration/esys-hmacsequencestart-session.int \
     test/integration/esys-import.int \
@@ -581,7 +583,7 @@ test_integration_esys_create_session_auth_int_SOURCES = \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_session_auth_bound_int_CFLAGS  = $(TESTS_CFLAGS) \
-    -DTEST_AES_ENCRYPTION -DTEST_BOUND_SESSIION
+    -DTEST_AES_ENCRYPTION -DTEST_BOUND_SESSION
 test_integration_esys_create_session_auth_bound_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_create_session_auth_bound_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
 test_integration_esys_create_session_auth_bound_int_SOURCES = \
@@ -688,6 +690,13 @@ test_integration_esys_get_time_int_SOURCES = \
     test/integration/esys-get-time.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
+test_integration_esys_hash_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_hash_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_hash_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hash_int_SOURCES = \
+    test/integration/esys-hash.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
 test_integration_esys_hashsequencestart_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hashsequencestart_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_hashsequencestart_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
@@ -708,6 +717,13 @@ test_integration_esys_hierarchy_control_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_hierarchy_control_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
 test_integration_esys_hierarchy_control_int_SOURCES = \
     test/integration/esys-hierarchy-control.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
+test_integration_esys_hmac_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_hmac_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_hmac_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hmac_int_SOURCES = \
+    test/integration/esys-hmac.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hmacsequencestart_int_CFLAGS  = $(TESTS_CFLAGS)

--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -1069,6 +1069,9 @@ documentation if used:
 - TEST_SESSION Use session authentication instead of password authentication.
 - TEST_READ_LOCK Activate test of Esys_NV_ReadLock.
 - TEST_WRITE_LOCK Activate test of Esys_NV_WriteLock.
+- TEST_XOR_OBFUSCATION Use xor obfuscation for parameter encryption.
+- TEST_AES_ENCRYPTION Use AES for parameter encryption.
+- TEST_BOUND_SESSION Run test with a bound session.
 
 The ESAPI command calls which are used in a test are listed in the function's documentation
 and are marked according to the PC Client Profile Revision 01.03 v22:

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -34,7 +34,8 @@
  *  - Esys_Load() (M)
  *  - Esys_StartAuthSession() (M)
  *
- * Used compiler defines: TEST_ECC
+ * Used compiler defines: TEST_ECC, TEST_AES_ENCRYPTION, TEST_BOUND_SESSION
+ *                        TEST_XOR_OBFUSCATION
  *
  * @param[in,out] esys_context The ESYS_CONTEXT.
  * @retval EXIT_FAILURE
@@ -224,7 +225,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
 
     r = Esys_StartAuthSession(esys_context,
                               primaryHandle_AuthSession,
-#if TEST_BOUND_SESSIION
+#if TEST_BOUND_SESSION
                               primaryHandle_AuthSession,
 #else
                               ESYS_TR_NONE,

--- a/test/integration/esys-ecc-parameters.int.c
+++ b/test/integration/esys-ecc-parameters.int.c
@@ -41,7 +41,7 @@ test_esys_ecc_parameters(ESYS_CONTEXT * esys_context)
         &parameters);
 
     if (r == TPM2_RC_CURVE + TPM2_RC_P + TPM2_RC_1) {
-        LOG_WARNING("Curve TPM2_ECC_NIST_P256 supported by TPM.");
+        LOG_WARNING("Curve TPM2_ECC_NIST_P256 not supported by TPM.");
         failure_return = EXIT_SKIP;
         goto error;
     }

--- a/test/integration/esys-hash.int.c
+++ b/test/integration/esys-hash.int.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+
+/** This test is intended to test the ESAPI command  Esys_HASH.
+ *
+ * The test checks whether the TPM hash function can be used via the ESAPI.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_Hash() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_hash(ESYS_CONTEXT * esys_context)
+{
+    TSS2_RC r;
+    TPM2B_MAX_BUFFER data = { .size = 20,
+                              .buffer={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                                       1, 2, 3, 4, 5, 6, 7, 8, 9}};
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    TPM2B_DIGEST *outHash;
+    TPMT_TK_HASHCHECK *validation;
+
+    r = Esys_Hash(
+        esys_context,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &data,
+        hashAlg,
+        hierarchy,
+        &outHash,
+        &validation);
+    goto_if_error(r, "Error: Hash", error);
+
+    return EXIT_SUCCESS;
+
+ error:
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hash(esys_context);
+}

--- a/test/integration/esys-hmac.int.c
+++ b/test/integration/esys-hmac.int.c
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+
+/** This test is intended to test the ESAPI command  Esys_HMAC with password
+ *  authentication.
+ *
+ * We create a symmetric HMAC key signing key which will be used
+ * for signing. This key will be used to create the HMAC for a test
+ * buffer.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_HMAC() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_hmac(ESYS_CONTEXT * esys_context)
+{
+    TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+
+    TPM2B_AUTH authValuePrimary = {
+        .size = 5,
+        .buffer = {1, 2, 3, 4, 5}
+    };
+
+    TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
+        .size = 4,
+        .sensitive = {
+            .userAuth = {
+                 .size = 0,
+                 .buffer = {0 },
+             },
+            .data = {
+                 .size = 0,
+                 .buffer = {0},
+             },
+        },
+    };
+    inSensitivePrimary.sensitive.userAuth = authValuePrimary;
+    TPM2B_PUBLIC inPublic = { 0 };
+
+    TPM2B_DATA outsideInfo = {
+        .size = 0,
+        .buffer = {},
+    };
+    TPML_PCR_SELECTION creationPCR = {
+        .count = 0,
+    };
+
+    TPM2B_PUBLIC *outPublic;
+    TPM2B_CREATION_DATA *creationData;
+    TPM2B_DIGEST *creationHash;
+    TPMT_TK_CREATION *creationTicket;
+
+    inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
+    inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
+    inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
+    inPublic.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = TPM2_ALG_SHA1;
+
+    r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
+                           ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary,
+                           &inPublic, &outsideInfo, &creationPCR,
+                           &primaryHandle, &outPublic, &creationData,
+                           &creationHash, &creationTicket);
+    goto_if_error(r, "Error: CreatePrimary", error);
+
+    r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
+    goto_if_error(r, "Error: TR_SetAuth", error);
+
+    TPM2B_MAX_BUFFER test_buffer = { .size = 20,
+                                     .buffer={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                                              1, 2, 3, 4, 5, 6, 7, 8, 9}} ;
+    TPM2B_DIGEST *outHMAC;
+
+    r = Esys_HMAC(
+        esys_context,
+        primaryHandle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &test_buffer,
+        TPM2_ALG_SHA1,
+        &outHMAC);
+    goto_if_error(r, "Error: HMAC", error);
+
+    r = Esys_FlushContext(esys_context, primaryHandle);
+    goto_if_error(r, "Error: FlushContext", error);
+
+    return EXIT_SUCCESS;
+
+ error:
+
+    if (primaryHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, primaryHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup primaryHandle failed.");
+        }
+    }
+
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_hmac(esys_context);
+}

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -64,7 +64,7 @@ test_esys_lock(ESYS_CONTEXT * esys_context)
         goto error;
     }
 
-    if  ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         return EXIT_SKIP;

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -32,7 +32,7 @@
  *  - Esys_NV_WriteLock() (M)
  *  - Esys_StartAuthSession() (M)
  *
- * Used compiler defines: TEST_READ_LOCK TEST_SESSIONi TEST_WRITE_LOCK
+ * Used compiler defines: TEST_READ_LOCK TEST_SESSION TEST_WRITE_LOCK
  *
  * @param[in,out] esys_context The ESYS_CONTEXT.
  * @retval EXIT_FAILURE


### PR DESCRIPTION
* The two new integration tests were added to the mandatory tests.
* The test clockset was moved from optional to mandatory tests.
* Doxygen comments were updated.
* Also some minor formatting fixes were added.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>