### PR TITLE
build: doxygen causes make distcheck to fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ noinst_PROGRAMS =
 
 # ax_doxygen
 @DX_RULES@
+DX_CLEANFILES = doc/doxygen
 MOSTLYCLEANFILES += $(DX_CLEANFILES)
 
 if DOXYMAN
@@ -160,6 +161,9 @@ DOXYMAN3 = \
     doc/man/Esys_VerifySignature.3 \
     doc/man/Esys_ZGen_2Phase.3
 $(DOXYMAN3): doxygen-doc
+EXTRA_DIST += $(DOXYMAN3)
+CLEANFILES += $(DOXYMAN3)
+CLEANFILES += doc/man/* doc/rtf/* doc/html/*
 else #DOXYMAN
 DOXYMAN3 =
 endif #DOXYMAN

--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -547,7 +547,7 @@ doxygen-doc: doxygen-run \$(DX_PS_GOAL) \$(DX_PDF_GOAL)
 ]m4_foreach([DX_i], [DX_loop],
 [[\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag: \$(DX_CONFIG]DX_i[) \$(pkginclude_HEADERS)
 	\$(A""M_V_at)rm -rf \$(DX_DOCDIR]DX_i[)
-	\$(A""M_V_at)mkdir \$(DX_DOCDIR]DX_i[)
+	\$(A""M_V_at)mkdir -p \$(DX_DOCDIR]DX_i[)
 	\$(DX_V_DXGEN)\$(DX_ENV) DOCDIR=\$(DX_DOCDIR]DX_i[) \$(DX_DOXYGEN) \$(DX_CONFIG]DX_i[)
 	\$(A""M_V_at)echo Timestamp >\$][@
 


### PR DESCRIPTION
Number of issues with doxygen encountered on make distcheck.
This change fixes the problems.