### PR TITLE
[RFC] ESYS: Add esys_free helper function

### DIFF
--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -3220,6 +3220,13 @@ Esys_Vendor_TCG_Test_Finish(
     ESYS_CONTEXT *esysContext,
     TPM2B_DATA **outputData);
 
+/*
+ * TPM 2.0 ESAPI Helper Functions
+ */
+void
+esys_free(
+    void *__ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -89,6 +89,7 @@ EXPORTS
     Esys_FirmwareRead_Async
     Esys_FirmwareRead_Finish
     Esys_FlushContext
+    esys_free
     Esys_FlushContext_Async
     Esys_FlushContext_Finish
     Esys_GetCapability

--- a/src/tss2-esys/esys_free.c
+++ b/src/tss2-esys/esys_free.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-2 */
+#include <stdlib.h>
+
+/*
+ * esys_free is a helper function that is a wrapper around free().
+ * This allows programs that are built using a different version
+ * of the C runtime to free memory that has been allocated by the
+ * esys library on Windows.
+ */
+void esys_free(void *__ptr) {
+    if (__ptr != NULL) {
+        free(__ptr);
+    }
+}

--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -256,6 +256,7 @@
     <ClCompile Include="esys_context.c" />
     <ClCompile Include="esys_crypto.c" />
     <ClCompile Include="esys_crypto_ossl.c" />
+    <ClCompile Include="esys_free.c" />
     <ClCompile Include="esys_iutil.c" />
     <ClCompile Include="esys_mu.c" />
     <ClCompile Include="esys_tcti_default.c" />

--- a/src/tss2-esys/tss2-esys.vcxproj.filters
+++ b/src/tss2-esys/tss2-esys.vcxproj.filters
@@ -378,6 +378,9 @@
     <ClCompile Include="esys_crypto_ossl.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="esys_free.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="esys_crypto.h">


### PR DESCRIPTION
Add esys_free, a wrapper around free(), to ESYS when building on Windows.

Having a wrapper around free is best practice when building libraries
on Windows; this is because there is a high chance that the caller
program will be built using a different version of the C runtime
than the library, which means that the program and the library will have
separate heaps. This is an issue because many of the ESYS functions
allocate memory for the caller and expect the caller to free the memory,
but in the case where the caller was built with a different version of
the C runtime, the caller will not be able to free the memory because
it does not have access to the esys heap. esys_free allows the caller
program to have the library free any memory that the caller didn't allocate.

Signed-off-by: David Maria <davidjmaria@fb.com>