### PR TITLE
esapi: change mpi2bin to static

### DIFF
--- a/src/tss2-esys/esys_crypto_gcrypt.c
+++ b/src/tss2-esys/esys_crypto_gcrypt.c
@@ -39,8 +39,8 @@ typedef struct _IESYS_CRYPTO_CONTEXT {
 
 
 /* Convert gcrypt mpi number to binary with fixed length */
-gcry_error_t mpi2bin(gcry_mpi_t mpi, unsigned char *bin, size_t  bin_length,
-                     size_t max_out_size)
+static gcry_error_t mpi2bin(gcry_mpi_t mpi, unsigned char *bin,
+		            size_t  bin_length, size_t max_out_size)
 {
     gcry_error_t err;
     size_t size;


### PR DESCRIPTION
The mpi2bin function is local to crypto_gcrypt and should
be defined as static.