### PR TITLE
util: fix a format warning that can occur on some platforms

### DIFF
--- a/src/util/io.c
+++ b/src/util/io.c
@@ -81,7 +81,7 @@ write_all (
     do {
         LOG_DEBUG("writing %zu bytes starting at 0x%" PRIxPTR " to fd %d",
                   size - written_total,
-                  (uintptr_t)buf + written_total,
+                  (uintptr_t)(buf + written_total),
                   fd);
 #ifdef _WIN32
         TEMP_RETRY (written, send (fd,


### PR DESCRIPTION
When building for the s390 architecture the following warning occurs
which leads to a build error:

```
src/util/io.c:70:9: error: format '%x' expects argument of type 'unsigned int', but argument 10 has type 'long unsigned int' [-Werror=format=]
          LOG_DEBUG("writing %zu bytes starting at 0x%" PRIxPTR " to fd %d",
```

size_t is of a different type than uintptr_t on s390. Due do integer
type promotion the type won't match the PRIxPTR specifier any more after
adding to it.

Arithmetic should be done with the pointer, not the uintptr_t. This will
fix will the warning.

Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>