### PR TITLE
SAPI: Fix marshaling of TPM2B parameters in SAPI commands.

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_ActivateCredential.c
+++ b/src/tss2-sys/api/Tss2_Sys_ActivateCredential.c
@@ -54,10 +54,19 @@ TSS2_RC Tss2_Sys_ActivateCredential_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(secret,
-                                                  ctx->cmdBuffer,
-                                                  ctx->maxCmdSize,
-                                                  &ctx->nextData);
+    if (!secret) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(secret,
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Commit.c
+++ b/src/tss2-sys/api/Tss2_Sys_Commit.c
@@ -46,15 +46,33 @@ TSS2_RC Tss2_Sys_Commit_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, ctx->cmdBuffer,
-                                                ctx->maxCmdSize,
-                                                &ctx->nextData);
+    if (!s2) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, ctx->cmdBuffer,
-                                               ctx->maxCmdSize,
-                                               &ctx->nextData);
+    if (!y2) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, ctx->cmdBuffer,
+                                                   ctx->maxCmdSize,
+                                                   &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Create.c
+++ b/src/tss2-sys/api/Tss2_Sys_Create.c
@@ -49,15 +49,33 @@ TSS2_RC Tss2_Sys_Create_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!inPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+    if (!outsideInfo) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_CreateLoaded.c
+++ b/src/tss2-sys/api/Tss2_Sys_CreateLoaded.c
@@ -49,9 +49,18 @@ TSS2_RC Tss2_Sys_CreateLoaded_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_TEMPLATE_Marshal(inPublic, ctx->cmdBuffer,
-                                          ctx->maxCmdSize,
-                                          &ctx->nextData);
+    if (!inPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_TEMPLATE_Marshal(inPublic, ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
+++ b/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
@@ -51,15 +51,33 @@ TSS2_RC Tss2_Sys_CreatePrimary_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!inPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+    if (!outsideInfo) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_ECDH_ZGen.c
+++ b/src/tss2-sys/api/Tss2_Sys_ECDH_ZGen.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_ECDH_ZGen_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, ctx->cmdBuffer,
-                                           ctx->maxCmdSize,
-                                           &ctx->nextData);
+    if (!inPoint) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
@@ -44,15 +44,33 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, ctx->cmdBuffer,
-                                    ctx->maxCmdSize,
-                                    &ctx->nextData);
+    if (!ivIn) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, ctx->cmdBuffer,
-                                            ctx->maxCmdSize,
-                                            &ctx->nextData);
+    if (!inData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
@@ -33,10 +33,19 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare (
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal (inData,
-                                             ctx->cmdBuffer,
-                                             ctx->maxCmdSize,
-                                             &ctx->nextData);
+    if (!inData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal (inData,
+                                                 ctx->cmdBuffer,
+                                                 ctx->maxCmdSize,
+                                                 &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
@@ -54,10 +63,19 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare (
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_IV_Marshal (ivIn,
-                                     ctx->cmdBuffer,
-                                     ctx->maxCmdSize,
-                                     &ctx->nextData);
+    if (!ivIn) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_IV_Marshal (ivIn,
+                                         ctx->cmdBuffer,
+                                         ctx->maxCmdSize,
+                                         &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_EventSequenceComplete.c
+++ b/src/tss2-sys/api/Tss2_Sys_EventSequenceComplete.c
@@ -36,9 +36,18 @@ TSS2_RC Tss2_Sys_EventSequenceComplete_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
-                                            ctx->maxCmdSize,
-                                            &ctx->nextData);
+    if (!buffer) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_FieldUpgradeData.c
+++ b/src/tss2-sys/api/Tss2_Sys_FieldUpgradeData.c
@@ -22,10 +22,19 @@ TSS2_RC Tss2_Sys_FieldUpgradeData_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(fuData,
-                                            ctx->cmdBuffer,
-                                            ctx->maxCmdSize,
-                                            &ctx->nextData);
+    if (!fuData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(fuData,
+                                                ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_HierarchyChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_HierarchyChangeAuth.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+    if (!newAuth) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Import.c
+++ b/src/tss2-sys/api/Tss2_Sys_Import.c
@@ -49,22 +49,49 @@ TSS2_RC Tss2_Sys_Import_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!objectPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, ctx->cmdBuffer,
-                                         ctx->maxCmdSize,
-                                         &ctx->nextData);
+    if (!duplicate) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  ctx->cmdBuffer,
-                                                  ctx->maxCmdSize,
-                                                  &ctx->nextData);
+    if (!inSymSeed) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Load.c
+++ b/src/tss2-sys/api/Tss2_Sys_Load.c
@@ -46,9 +46,18 @@ TSS2_RC Tss2_Sys_Load_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!inPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
+++ b/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
@@ -42,9 +42,18 @@ TSS2_RC Tss2_Sys_LoadExternal_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!inPublic) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_MakeCredential.c
+++ b/src/tss2-sys/api/Tss2_Sys_MakeCredential.c
@@ -46,9 +46,18 @@ TSS2_RC Tss2_Sys_MakeCredential_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, ctx->cmdBuffer,
+    if (!objectName) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_NV_ChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_ChangeAuth.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_NV_ChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+    if (!newAuth) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
@@ -46,9 +46,18 @@ TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, ctx->cmdBuffer,
-                                           ctx->maxCmdSize,
-                                           &ctx->nextData);
+    if (!publicInfo) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_NV_Extend.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Extend.c
@@ -36,9 +36,18 @@ TSS2_RC Tss2_Sys_NV_Extend_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, ctx->cmdBuffer,
-                                               ctx->maxCmdSize,
-                                               &ctx->nextData);
+    if (!data) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, ctx->cmdBuffer,
+                                                   ctx->maxCmdSize,
+                                                   &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_ObjectChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_ObjectChangeAuth.c
@@ -36,9 +36,18 @@ TSS2_RC Tss2_Sys_ObjectChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+    if (!newAuth) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Event.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Event.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_PCR_Event_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, ctx->cmdBuffer,
-                                       ctx->maxCmdSize,
-                                       &ctx->nextData);
+    if (!eventData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthValue.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthValue.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!auth) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyAuthorize.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyAuthorize.c
@@ -48,15 +48,33 @@ TSS2_RC Tss2_Sys_PolicyAuthorize_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
-                                       ctx->maxCmdSize,
-                                       &ctx->nextData);
+    if (!policyRef) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, ctx->cmdBuffer,
+    if (!keySign) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyCpHash.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyCpHash.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_PolicyCpHash_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!cpHashA) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyDuplicationSelect.c
@@ -47,9 +47,18 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, ctx->cmdBuffer,
-                                  ctx->maxCmdSize,
-                                  &ctx->nextData);
+    if (!newParentName) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyNameHash.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyNameHash.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_PolicyNameHash_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!nameHash) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicySigned.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicySigned.c
@@ -56,15 +56,33 @@ TSS2_RC Tss2_Sys_PolicySigned_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!cpHashA) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
-                                       ctx->maxCmdSize,
-                                       &ctx->nextData);
+    if (!policyRef) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyTemplate.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyTemplate.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_PolicyTemplate_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(templateHash, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
+    if (!templateHash) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(templateHash, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_PolicyTicket.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyTicket.c
@@ -49,21 +49,48 @@ TSS2_RC Tss2_Sys_PolicyTicket_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
-                                        ctx->maxCmdSize,
-                                        &ctx->nextData);
-    if (rval)
-        return rval;
-
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
-                                       ctx->maxCmdSize,
-                                       &ctx->nextData);
-    if (rval)
-        return rval;
-
-    rval = Tss2_MU_TPM2B_NAME_Marshal(authName, ctx->cmdBuffer,
+    if (!cpHashA) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
+    }
+
+    if (rval)
+        return rval;
+
+    if (!policyRef) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
+    }
+
+    if (rval)
+        return rval;
+
+    if (!authName) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(authName, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Policy_AC_SendSelect.c
+++ b/src/tss2-sys/api/Tss2_Sys_Policy_AC_SendSelect.c
@@ -47,15 +47,33 @@ TSS2_RC Tss2_Sys_Policy_AC_SendSelect_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(authHandleName, ctx->cmdBuffer,
+    if (!authHandleName) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(authHandleName, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(acName, ctx->cmdBuffer,
+    if (!acName) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(acName, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_RSA_Decrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_RSA_Decrypt.c
@@ -54,9 +54,18 @@ TSS2_RC Tss2_Sys_RSA_Decrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+    if (!label) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_RSA_Encrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_RSA_Encrypt.c
@@ -53,9 +53,18 @@ TSS2_RC Tss2_Sys_RSA_Encrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+    if (!label) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Rewrap.c
+++ b/src/tss2-sys/api/Tss2_Sys_Rewrap.c
@@ -54,16 +54,34 @@ TSS2_RC Tss2_Sys_Rewrap_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(name, ctx->cmdBuffer,
+    if (!name) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_NAME_Marshal(name, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  ctx->cmdBuffer,
-                                                  ctx->maxCmdSize,
-                                                  &ctx->nextData);
+    if (!inSymSeed) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_SequenceUpdate.c
+++ b/src/tss2-sys/api/Tss2_Sys_SequenceUpdate.c
@@ -29,9 +29,18 @@ TSS2_RC Tss2_Sys_SequenceUpdate_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
-                                            ctx->maxCmdSize,
-                                            &ctx->nextData);
+    if (!buffer) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
+++ b/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
@@ -56,10 +56,19 @@ TSS2_RC Tss2_Sys_StartAuthSession_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(encryptedSalt,
-                                                  ctx->cmdBuffer,
-                                                  ctx->maxCmdSize,
-                                                  &ctx->nextData);
+    if (!encryptedSalt) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(encryptedSalt,
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_StirRandom.c
+++ b/src/tss2-sys/api/Tss2_Sys_StirRandom.c
@@ -22,9 +22,18 @@ TSS2_RC Tss2_Sys_StirRandom_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, ctx->cmdBuffer,
-                                                ctx->maxCmdSize,
-                                                &ctx->nextData);
+    if (!inData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_Vendor_TCG_Test.c
+++ b/src/tss2-sys/api/Tss2_Sys_Vendor_TCG_Test.c
@@ -22,9 +22,18 @@ TSS2_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, ctx->cmdBuffer,
+    if (!inputData) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
                                       ctx->maxCmdSize,
                                       &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 

--- a/src/tss2-sys/api/Tss2_Sys_ZGen_2Phase.c
+++ b/src/tss2-sys/api/Tss2_Sys_ZGen_2Phase.c
@@ -48,9 +48,18 @@ TSS2_RC Tss2_Sys_ZGen_2Phase_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, ctx->cmdBuffer,
-                                           ctx->maxCmdSize,
-                                           &ctx->nextData);
+    if (!inQeB) {
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
+
+    } else {
+
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
+    }
+
     if (rval)
         return rval;
 


### PR DESCRIPTION
* TSS Spec (3.8.2.2) states:
   * If any command parameter (after the handles) is a TPM2B:
     If the TPM2B parameter is NULL, the implementation marshals a TPM2B
     with a size of 0.

 So independent of whether the parameter is optional or not 0 has to be
 marshaled, if a NULL pointer is passed.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>