### PR TITLE
esapi: remove unused field from struct

### DIFF
--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -229,7 +229,6 @@ Esys_StartAuthSession_Async(
                                       &encryptedSaltAux);
     return_if_error(r2, "Error in parameter encryption.");
 
-    esysContext->in.StartAuthSession.encryptedSalt = &encryptedSaltAux;
     if (nonceCaller == NULL) {
         r2 = iesys_crypto_hash_get_digest_size(authHash,&authHash_size);
         if (r2 != TSS2_RC_SUCCESS) {

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -53,8 +53,6 @@ typedef struct {
     TPMI_ALG_HASH authHash;
     TPM2B_NONCE *nonceCaller;
     TPM2B_NONCE nonceCallerData;
-    TPM2B_ENCRYPTED_SECRET *encryptedSalt;
-    TPM2B_ENCRYPTED_SECRET encryptedSaltData;
     TPMT_SYM_DEF *symmetric;
     TPMT_SYM_DEF symmetricData;
 } StartAuthSession_IN;


### PR DESCRIPTION
The struct StartAuthSession_IN contained a field
encryptedSaltData that was unused, remove it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>