### PR TITLE
common.h: drop TSS2_DRIVER_RC_LAYER

### DIFF
--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -63,7 +63,6 @@ typedef uint32_t TSS2_RC;
 #define TSS2_TCTI_RC_LAYER            TSS2_RC_LAYER(10)
 #define TSS2_RESMGR_RC_LAYER          TSS2_RC_LAYER(11)
 #define TSS2_RESMGR_TPM_RC_LAYER      TSS2_RC_LAYER(12)
-#define TSS2_DRIVER_RC_LAYER          TSS2_RC_LAYER(13)
 
 /* Base return codes.
  * These base codes indicate the error that occurred. They are

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -84,9 +84,6 @@ static void ErrorHandler(UINT32 rval, char *errorString, int errorStringSize)
         case TSS2_RESMGR_RC_LAYER:
             strcpy(levelString, "Resource Mgr");
             break;
-        case TSS2_DRIVER_RC_LAYER:
-            strcpy(levelString, "Driver");
-            break;
         default:
             strcpy(levelString, "Unknown Level");
             break;


### PR DESCRIPTION
This is not mentioned anywhere in Section 3.4 of the spec:
 - https://trustedcomputinggroup.org/wp-content/uploads/TSS_Overview_Common_Structures_Version-0.9_Revision-03_Review_030918.pdf

Thus remove it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>