### PR TITLE
ESYS: Fix default tcti configuration

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -331,7 +331,8 @@ test_unit_esys_context_null_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSLDFLAGS)
 test_unit_esys_context_null_SOURCES = test/unit/esys-context-null.c
 
-test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) \
+        -UESYS_TCTI_DEFAULT_MODULE -UESYS_TCTI_DEFAUT_CONFIG
 test_unit_esys_default_tcti_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_esys_default_tcti_LDFLAGS = \
         -Wl,--wrap=dlopen -Wl,-wrap=dlclose -Wl,-wrap=dlsym \

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ AC_ARG_WITH([tctidefaultmodule],
             [AS_HELP_STRING([--with-tctidefaultmodule],
 [The default TCTI module for ESAPI. (Default: libtss2-tcti-default.so])],
             [AC_DEFINE_UNQUOTED([ESYS_TCTI_DEFAULT_MODULE],
-                                [$with_tctidefaultmodule],
+                                ["$with_tctidefaultmodule"],
                                 ["The default TCTI library file"])],
             [])
 
@@ -126,7 +126,7 @@ AC_ARG_WITH([tctidefaultconfig],
             [AS_HELP_STRING([--with-tctidefaultconfig],
                             [The default tcti module's configuration.])],
             [AC_DEFINE_UNQUOTED([ESYS_TCTI_DEFAULT_CONFIG],
-                                [$with_tctidefaultconfig],
+                                ["$with_tctidefaultconfig"],
                                 ["The default TCTIs configuration string"])],
             [])
 


### PR DESCRIPTION
Fix default tcti configuration setting passing and the corresponding unit test.