### PR TITLE
ESYS: Fix leak of dlopen handle and Makefile

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -62,11 +62,12 @@ test_helper_tpm_transientempty_SOURCES = test/helper/tpm_transientempty.c
 endif #ENABLE_INTEGRATION
 
 if ESYS_OSSL
-ESYSLDFLAGS = -lssl -lcrypto
-ESYSCFLAGS = -DOSSL
+ESYSCRY_CFLAGS = -DOSSL
+ESYSCRY_LDFLAGS = -lssl -lcrypto -ldl
 else
 if ESYS_GCRYPT
-ESYSLDFLAGS = -lgcrypt
+ESYSCRY_CFLAGS =
+ESYSCRY_LDFLAGS = -lgcrypt -ldl
 endif
 endif
 
@@ -328,7 +329,7 @@ test_unit_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c
 if ESAPI
 test_unit_esys_context_null_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_context_null_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSLDFLAGS)
+test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
 test_unit_esys_context_null_SOURCES = test/unit/esys-context-null.c
 
 test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
@@ -342,38 +343,38 @@ test_unit_esys_default_tcti_SOURCES = test/unit/esys-default-tcti.c \
 
 test_unit_esys_resubmissions_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_resubmissions_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_resubmissions_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_resubmissions_LDFLAGS = $(TESTS_LDFLAGS)
 test_unit_esys_resubmissions_SOURCES = test/unit/esys-resubmissions.c
 
 test_unit_esys_sequence_finish_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_sequence_finish_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_sequence_finish_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_sequence_finish_LDFLAGS = $(TESTS_LDFLAGS)
 test_unit_esys_sequence_finish_SOURCES = test/unit/esys-sequence-finish.c
 
 test_unit_esys_tcti_rcs_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_tcti_rcs_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_tcti_rcs_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_tcti_rcs_LDFLAGS = $(TESTS_LDFLAGS)
 test_unit_esys_tcti_rcs_SOURCES = test/unit/esys-tcti-rcs.c
 
 test_unit_esys_tpm_rcs_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_tpm_rcs_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_tpm_rcs_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_tpm_rcs_LDFLAGS = $(TESTS_LDFLAGS)
 test_unit_esys_tpm_rcs_SOURCES = test/unit/esys-tpm-rcs.c
 
 test_unit_esys_getpollhandles_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_getpollhandles_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_getpollhandles_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_getpollhandles_LDFLAGS = $(TESTS_LDFLAGS)
 test_unit_esys_getpollhandles_SOURCES = test/unit/esys-getpollhandles.c
 
 test_unit_esys_nulltcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_nulltcti_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_nulltcti_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_unit_esys_nulltcti_LDFLAGS = $(TESTS_LDFLAGS) -ldl
 test_unit_esys_nulltcti_SOURCES = test/unit/esys-nulltcti.c \
         src/tss2-esys/esys_context.c
 
-test_unit_esys_crypto_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(ESYSCFLAGS)
+test_unit_esys_crypto_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
 test_unit_esys_crypto_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_crypto_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS) $(ESYSLDFLAGS)
+test_unit_esys_crypto_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
 test_unit_esys_crypto_SOURCES = test/unit/esys-crypto.c \
         src/tss2-esys/esys_context.c
 
@@ -478,77 +479,77 @@ test_integration_sapi_param_encrypt_decrypt_int_SOURCES = \
 if ESAPI
 test_integration_esys_audit_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_audit_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_audit_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_audit_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_audit_int_SOURCES = \
     test/integration/esys-audit.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_certify_creation_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_certify_creation_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_certify_creation_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_certify_creation_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_certify_creation_int_SOURCES = \
     test/integration/esys-certify-creation.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_certify_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_certify_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_certify_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_certify_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_certify_int_SOURCES = \
     test/integration/esys-certify.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_change_eps_int_CFLAGS = $(TESTS_CFLAGS)
 test_integration_esys_change_eps_int_LDADD = $(TESTS_LDADD)
-test_integration_esys_change_eps_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_change_eps_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_change_eps_int_SOURCES = \
     test/integration/esys-change-eps.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_clear_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_clear_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_clear_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_clear_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_clear_int_SOURCES = \
     test/integration/esys-clear.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_clear_control_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_clear_control_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_clear_control_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_clear_control_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_clear_control_int_SOURCES = \
     test/integration/esys-clear-control.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_clear_session_int_CFLAGS  = $(TESTS_CFLAGS) -DTEST_SESSION
 test_integration_esys_clear_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_clear_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_clear_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_clear_session_int_SOURCES = \
     test/integration/esys-clear.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_clockset_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_clockset_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_clockset_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_clockset_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_clockset_int_SOURCES = \
     test/integration/esys-clockset.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_commit_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_commit_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_commit_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_commit_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_commit_int_SOURCES = \
     test/integration/esys-commit.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_fail_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_create_fail_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_fail_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_fail_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_fail_int_SOURCES = \
     test/integration/esys-create-fail.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_createloaded_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_createloaded_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_createloaded_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_createloaded_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_createloaded_int_SOURCES = \
     test/integration/esys-createloaded.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -556,28 +557,28 @@ test_integration_esys_createloaded_int_SOURCES = \
 test_integration_esys_createloaded_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_createloaded_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_createloaded_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_createloaded_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_createloaded_session_int_SOURCES = \
     test/integration/esys-createloaded.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_password_auth_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_create_password_auth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_password_auth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_password_auth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_password_auth_int_SOURCES = \
     test/integration/esys-create-password-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_primary_ecc_hmac_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_create_primary_ecc_hmac_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_primary_ecc_hmac_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_primary_ecc_hmac_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_primary_ecc_hmac_int_SOURCES = \
     test/integration/esys-create-primary-hmac.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_create_primary_hmac_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_create_primary_hmac_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_primary_hmac_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_primary_hmac_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_primary_hmac_int_SOURCES = \
     test/integration/esys-create-primary-hmac.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -585,7 +586,7 @@ test_integration_esys_create_primary_hmac_int_SOURCES = \
 test_integration_esys_create_session_auth_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_AES_ENCRYPTION
 test_integration_esys_create_session_auth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_session_auth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_session_auth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_session_auth_int_SOURCES = \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -593,7 +594,7 @@ test_integration_esys_create_session_auth_int_SOURCES = \
 test_integration_esys_create_session_auth_bound_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_AES_ENCRYPTION -DTEST_BOUND_SESSION
 test_integration_esys_create_session_auth_bound_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_session_auth_bound_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_session_auth_bound_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_session_auth_bound_int_SOURCES = \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -601,7 +602,7 @@ test_integration_esys_create_session_auth_bound_int_SOURCES = \
 test_integration_esys_create_session_auth_ecc_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_AES_ENCRYPTION -DTEST_ECC
 test_integration_esys_create_session_auth_ecc_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_session_auth_ecc_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_session_auth_ecc_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_session_auth_ecc_int_SOURCES = \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -609,105 +610,105 @@ test_integration_esys_create_session_auth_ecc_int_SOURCES = \
 test_integration_esys_create_session_auth_xor_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_XOR_OBFUSCATION
 test_integration_esys_create_session_auth_xor_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_create_session_auth_xor_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_create_session_auth_xor_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_create_session_auth_xor_int_SOURCES = \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_duplicate_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_duplicate_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_duplicate_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_duplicate_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_duplicate_int_SOURCES = \
     test/integration/esys-duplicate.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_ecc_parameters_int_CFLAGS = $(TESTS_CFLAGS)
 test_integration_esys_ecc_parameters_int_LDADD = $(TESTS_LDADD)
-test_integration_esys_ecc_parameters_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_ecc_parameters_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_ecc_parameters_int_SOURCES = \
     test/integration/esys-ecc-parameters.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_ecdh_keygen_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_ecdh_keygen_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_ecdh_keygen_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_ecdh_keygen_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_ecdh_keygen_int_SOURCES = \
     test/integration/esys-ecdh-keygen.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_ecdh_zgen_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_ecdh_zgen_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_ecdh_zgen_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_ecdh_zgen_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_ecdh_zgen_int_SOURCES = \
     test/integration/esys-ecdh-zgen.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_encrypt_decrypt_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_encrypt_decrypt_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_encrypt_decrypt_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_encrypt_decrypt_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_encrypt_decrypt_int_SOURCES = \
     test/integration/esys-encrypt-decrypt.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_event_sequence_complete_int_CFLAGS = $(TESTS_CFLAGS)
 test_integration_esys_event_sequence_complete_int_LDADD = $(TESTS_LDADD)
-test_integration_esys_event_sequence_complete_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_event_sequence_complete_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_event_sequence_complete_int_SOURCES = \
     test/integration/esys-event-sequence-complete.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_evict_control_serialization_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_evict_control_serialization_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_evict_control_serialization_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_evict_control_serialization_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_evict_control_serialization_int_SOURCES = \
     test/integration/esys-evict-control-serialization.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_field_upgrade_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_field_upgrade_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_field_upgrade_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_field_upgrade_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_field_upgrade_int_SOURCES = \
     test/integration/esys-field-upgrade.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_firmware_read_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_firmware_read_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_firmware_read_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_firmware_read_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_firmware_read_int_SOURCES = \
     test/integration/esys-firmware-read.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_get_capability_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_get_capability_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_get_capability_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_get_capability_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_get_capability_int_SOURCES = \
     test/integration/esys-get-capability.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_get_random_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_get_random_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_get_random_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_get_random_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_get_random_int_SOURCES = \
     test/integration/esys-get-random.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_get_time_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_get_time_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_get_time_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_get_time_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_get_time_int_SOURCES = \
     test/integration/esys-get-time.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hash_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hash_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hash_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hash_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hash_int_SOURCES = \
     test/integration/esys-hash.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hashsequencestart_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hashsequencestart_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hashsequencestart_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hashsequencestart_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hashsequencestart_int_SOURCES = \
     test/integration/esys-hashsequencestart.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -715,28 +716,28 @@ test_integration_esys_hashsequencestart_int_SOURCES = \
 test_integration_esys_hashsequencestart_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_hashsequencestart_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hashsequencestart_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hashsequencestart_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hashsequencestart_session_int_SOURCES = \
     test/integration/esys-hashsequencestart.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hierarchy_control_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hierarchy_control_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hierarchy_control_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hierarchy_control_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hierarchy_control_int_SOURCES = \
     test/integration/esys-hierarchy-control.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hmac_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hmac_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hmac_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hmac_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hmac_int_SOURCES = \
     test/integration/esys-hmac.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hmacsequencestart_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hmacsequencestart_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hmacsequencestart_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hmacsequencestart_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hmacsequencestart_int_SOURCES = \
     test/integration/esys-hmacsequencestart.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -744,35 +745,35 @@ test_integration_esys_hmacsequencestart_int_SOURCES = \
 test_integration_esys_hmacsequencestart_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_hmacsequencestart_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hmacsequencestart_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hmacsequencestart_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hmacsequencestart_session_int_SOURCES = \
     test/integration/esys-hmacsequencestart.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_hierarchychangeauth_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_hierarchychangeauth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_hierarchychangeauth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_hierarchychangeauth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_hierarchychangeauth_int_SOURCES = \
     test/integration/esys-hierarchychangeauth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_import_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_import_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_import_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_import_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_import_int_SOURCES = \
     test/integration/esys-import.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_lock_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_lock_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_lock_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_lock_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_lock_int_SOURCES = \
     test/integration/esys-lock.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_make_credential_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_make_credential_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_make_credential_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_make_credential_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_make_credential_int_SOURCES = \
     test/integration/esys-make-credential.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -780,21 +781,21 @@ test_integration_esys_make_credential_int_SOURCES = \
 test_integration_esys_make_credential_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_make_credential_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_make_credential_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_make_credential_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_make_credential_session_int_SOURCES = \
     test/integration/esys-make-credential.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_nv_certify_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_nv_certify_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_certify_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_certify_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_certify_int_SOURCES = \
     test/integration/esys-nv-certify.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_nv_ram_counter_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_nv_ram_counter_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_counter_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_counter_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_counter_int_SOURCES = \
     test/integration/esys-nv-ram-counter.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -802,14 +803,14 @@ test_integration_esys_nv_ram_counter_int_SOURCES = \
 test_integration_esys_nv_ram_counter_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_nv_ram_counter_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_counter_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_counter_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_counter_session_int_SOURCES = \
     test/integration/esys-nv-ram-counter.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_nv_ram_extend_index_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_nv_ram_extend_index_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_extend_index_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_extend_index_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_extend_index_int_SOURCES = \
     test/integration/esys-nv-ram-extend-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -817,7 +818,7 @@ test_integration_esys_nv_ram_extend_index_int_SOURCES = \
 test_integration_esys_nv_ram_extend_index_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_nv_ram_extend_index_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_extend_index_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_extend_index_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_extend_index_session_int_SOURCES = \
     test/integration/esys-nv-ram-extend-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -826,7 +827,7 @@ test_integration_esys_nv_ram_ordinary_index_rlock_int_CFLAGS  = $(TESTS_CFLAGS) 
     -I. -I$(srcdir)/src/esapi/esapi -I$(srcdir)/include/esapi -I$(srcdir)/test/integration/ \
     -I$(srcdir)/src/esapi/esapi_util -DTEST_READ_LOCK
 test_integration_esys_nv_ram_ordinary_index_rlock_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_ordinary_index_rlock_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_ordinary_index_rlock_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_ordinary_index_rlock_int_SOURCES = \
     test/integration/esys-nv-ram-ordinary-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -835,7 +836,7 @@ test_integration_esys_nv_ram_ordinary_index_rlock_session_int_CFLAGS  = $(TESTS_
     -I. -I$(srcdir)/src/esapi/esapi -I$(srcdir)/include/esapi -I$(srcdir)/include/esapi \
     -I$(srcdir)/src/esapi/esapi_util -DTEST_SESSION -DTEST_READ_LOCK
 test_integration_esys_nv_ram_ordinary_index_rlock_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_ordinary_index_rlock_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_ordinary_index_rlock_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_ordinary_index_rlock_session_int_SOURCES = \
     test/integration/esys-nv-ram-ordinary-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -844,7 +845,7 @@ test_integration_esys_nv_ram_ordinary_index_wlock_int_CFLAGS  = $(TESTS_CFLAGS) 
     -I. -I$(srcdir)/src/esapi/esapi -I$(srcdir)/include/esapi -I$(srcdir)/include/esapi \
     -I$(srcdir)/src/esapi/esapi_util  -DTEST_WRITE_LOCK
 test_integration_esys_nv_ram_ordinary_index_wlock_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_ordinary_index_wlock_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_ordinary_index_wlock_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_ordinary_index_wlock_int_SOURCES = \
     test/integration/esys-nv-ram-ordinary-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -853,14 +854,14 @@ test_integration_esys_nv_ram_ordinary_index_wlock_session_int_CFLAGS  = $(TESTS_
     -I. -I$(srcdir)/src/esapi/esapi -I$(srcdir)/include/esapi -I$(srcdir)/include/esapi \
     -I$(srcdir)/src/esapi/esapi_util -DTEST_SESSION -DTEST_WRITE_LOCK
 test_integration_esys_nv_ram_ordinary_index_wlock_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_ordinary_index_wlock_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_ordinary_index_wlock_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_ordinary_index_wlock_session_int_SOURCES = \
     test/integration/esys-nv-ram-ordinary-index.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_nv_ram_set_bits_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_nv_ram_set_bits_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_set_bits_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_set_bits_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_set_bits_int_SOURCES = \
     test/integration/esys-nv-ram-set-bits.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
@@ -868,21 +869,21 @@ test_integration_esys_nv_ram_set_bits_int_SOURCES = \
 test_integration_esys_nv_ram_set_bits_session_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_SESSION
 test_integration_esys_nv_ram_set_bits_session_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_nv_ram_set_bits_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_nv_ram_set_bits_session_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_nv_ram_set_bits_session_int_SOURCES = \
     test/integration/esys-nv-ram-set-bits.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_object_changeauth_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_object_changeauth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_object_changeauth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_object_changeauth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_object_changeauth_int_SOURCES = \
     test/integration/esys-object-changeauth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
-test_integration_esys_policy_authorize_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCFLAGS)
+test_integration_esys_policy_authorize_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
 test_integration_esys_policy_authorize_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_authorize_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSLDFLAGS)
+test_integration_esys_policy_authorize_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
 test_integration_esys_policy_authorize_int_SOURCES = \
     test/integration/esys-policy-authorize.int.c \
     src/tss2-esys/esys_crypto.c \
@@ -890,21 +891,21 @@ test_integration_esys_policy_authorize_int_SOURCES = \
 
 test_integration_esys_policy_regression_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_policy_regression_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_regression_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_regression_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_regression_int_SOURCES = \
     test/integration/esys-policy-regression.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_policy_regression_opt_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_policy_regression_opt_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_regression_opt_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_regression_opt_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_regression_opt_int_SOURCES = \
     test/integration/esys-policy-regression-opt.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
-test_integration_esys_policy_ticket_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCFLAGS)
+test_integration_esys_policy_ticket_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
 test_integration_esys_policy_ticket_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_ticket_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_ticket_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_ticket_int_SOURCES = \
     test/integration/esys-policy-ticket.int.c \
     src/tss2-esys/esys_crypto.c \
@@ -912,133 +913,133 @@ test_integration_esys_policy_ticket_int_SOURCES = \
 
 test_integration_esys_policy_nv_changeauth_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_policy_nv_changeauth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_nv_changeauth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_nv_changeauth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_nv_changeauth_int_SOURCES = \
     test/integration/esys-policy-nv-changeauth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_policy_nv_undefine_special_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_policy_nv_undefine_special_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_nv_undefine_special_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_nv_undefine_special_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_nv_undefine_special_int_SOURCES = \
     test/integration/esys-policy-nv-undefine-special.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_policy_password_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_policy_password_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_password_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_policy_password_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_password_int_SOURCES = \
     test/integration/esys-policy-password.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_pcr_basic_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_pcr_basic_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_pcr_basic_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_pcr_basic_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_pcr_basic_int_SOURCES = \
     test/integration/esys-pcr-basic.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_pcr_auth_value_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_pcr_auth_value_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_pcr_auth_value_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_pcr_auth_value_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_pcr_auth_value_int_SOURCES = \
     test/integration/esys-pcr-auth-value.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_pp_commands_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_pp_commands_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_pp_commands_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_pp_commands_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_pp_commands_int_SOURCES = \
     test/integration/esys-pp-commands.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_quote_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_quote_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_quote_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_quote_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_quote_int_SOURCES = \
     test/integration/esys-quote.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_rsa_encrypt_decrypt_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_rsa_encrypt_decrypt_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_rsa_encrypt_decrypt_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_rsa_encrypt_decrypt_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_rsa_encrypt_decrypt_int_SOURCES = \
     test/integration/esys-rsa-encrypt-decrypt.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_save_and_load_context_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_save_and_load_context_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_save_and_load_context_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_save_and_load_context_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_save_and_load_context_int_SOURCES = \
     test/integration/esys-save-and-load-context.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_set_algorithm_set_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_set_algorithm_set_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_set_algorithm_set_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_set_algorithm_set_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_set_algorithm_set_int_SOURCES = \
     test/integration/esys-set-algorithm-set.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_stir_random_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_stir_random_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_stir_random_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_stir_random_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_stir_random_int_SOURCES = \
     test/integration/esys-stir-random.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_testparms_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_testparms_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_testparms_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_testparms_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_testparms_int_SOURCES = \
     test/integration/esys-testparms.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_tpm_tests_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_tpm_tests_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_tpm_tests_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_tpm_tests_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tpm_tests_int_SOURCES = \
     test/integration/esys-tpm-tests.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_tr_fromTpmPublic_key_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_tr_fromTpmPublic_key_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_tr_fromTpmPublic_key_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_tr_fromTpmPublic_key_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tr_fromTpmPublic_key_int_SOURCES = \
     test/integration/esys-tr-fromTpmPublic-key.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_tr_fromTpmPublic_nv_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_tr_fromTpmPublic_nv_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_tr_fromTpmPublic_nv_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_tr_fromTpmPublic_nv_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tr_fromTpmPublic_nv_int_SOURCES = \
     test/integration/esys-tr-fromTpmPublic-nv.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_tr_getName_hierarchy_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_tr_getName_hierarchy_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_tr_getName_hierarchy_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_tr_getName_hierarchy_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tr_getName_hierarchy_int_SOURCES = \
     test/integration/esys-tr-getName-hierarchy.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_unseal_password_auth_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_unseal_password_auth_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_unseal_password_auth_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_unseal_password_auth_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_unseal_password_auth_int_SOURCES = \
     test/integration/esys-unseal-password-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_verify_signature_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_verify_signature_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_verify_signature_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_verify_signature_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_verify_signature_int_SOURCES = \
     test/integration/esys-verify-signature.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_zgen_2phase_int_CFLAGS = $(TESTS_CFLAGS)
 test_integration_esys_zgen_2phase_int_LDADD = $(TESTS_LDADD)
-test_integration_esys_zgen_2phase_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSFLAGS)
+test_integration_esys_zgen_2phase_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_zgen_2phase_int_SOURCES = \
     test/integration/esys-zgen-2phase.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -968,6 +968,8 @@ struct ESYS_CONTEXT {
     TSS2_TCTI_CONTEXT *tcti_app_param;/**< The TCTI context provided by the
                                            application during Esys_Initialize()
                                            to be returned from Esys_GetTcti().*/
+    void *dlhandle;              /**< The handle of dlopen if the tcti was
+                                      automatically loaded. */
 };
 
 /** The number of authomatic resubmissions.

--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -123,7 +123,8 @@ tcti_from_info(TSS2_TCTI_INFO_FUNC infof,
 static TSS2_RC
 tcti_from_file(const char *file,
                const char* conf,
-               TSS2_TCTI_CONTEXT **tcti)
+               TSS2_TCTI_CONTEXT **tcti,
+               void **dlhandle)
 {
     TSS2_RC r;
     void *handle;
@@ -151,6 +152,9 @@ tcti_from_file(const char *file,
         return r;
     }
 
+    if (dlhandle)
+        *dlhandle = handle;
+
     LOG_DEBUG("Initialized TCTI file: %s", file);
 
     return TSS2_RC_SUCCESS;
@@ -158,7 +162,7 @@ tcti_from_file(const char *file,
 #endif /* NO_DL */
 
 TSS2_RC
-get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext)
+get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext, void **dlhandle)
 {
     if (tcticontext == NULL) {
         LOG_ERROR("tcticontext must not be NULL");
@@ -175,7 +179,8 @@ get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext)
 
     LOG_DEBUG("Attempting to initialize TCTI defined during compilation: %s:%s",
               ESYS_TCTI_DEFAULT_MODULE, config);
-    return tcti_from_file(ESYS_TCTI_DEFAULT_MODULE, config, tcticontext);
+    return tcti_from_file(ESYS_TCTI_DEFAULT_MODULE, config, tcticontext,
+                          dlhandle);
 
 #else /* ESYS_TCTI_DEFAULT_MODULE */
 
@@ -192,7 +197,8 @@ get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext)
             LOG_DEBUG("Failed to load standard TCTI number %zu", i);
 #ifndef NO_DL
         } else if (tctis[i].file != NULL) {
-            r = tcti_from_file(tctis[i].file, tctis[i].conf, tcticontext);
+            r = tcti_from_file(tctis[i].file, tctis[i].conf, tcticontext,
+                               dlhandle);
             if (r == TSS2_RC_SUCCESS)
                 return TSS2_RC_SUCCESS;
             LOG_DEBUG("Failed to load standard TCTI number %zu", i);

--- a/src/tss2-esys/esys_tcti_default.h
+++ b/src/tss2-esys/esys_tcti_default.h
@@ -6,6 +6,6 @@
 #ifndef     TCTI_DEFAULT_H
 #define     TCTI_DEFAULT_H
 
-TSS2_RC get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext);
+TSS2_RC get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext, void **dlhandle);
 
 #endif

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -96,7 +96,7 @@ __wrap_Tss2_Tcti_Mssim_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
 static void
 test_fail_null(void **state)
 {
-    TSS2_RC r = get_tcti_default(NULL);
+    TSS2_RC r = get_tcti_default(NULL, NULL);
     assert_int_equal(r, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 
@@ -141,7 +141,7 @@ test_tcti_default(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -200,7 +200,7 @@ test_tcti_default_fail_sym(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -264,7 +264,7 @@ test_tcti_default_fail_info(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -340,7 +340,7 @@ test_tcti_default_fail_init(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -395,7 +395,7 @@ test_tcti_tabrmd(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -441,7 +441,7 @@ test_tcti_tpmrm0(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -495,7 +495,7 @@ test_tcti_tpm0(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -560,7 +560,7 @@ test_tcti_mssim(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_RC_SUCCESS);
     free(tcti);
 }
@@ -618,7 +618,7 @@ test_tcti_fail_all(void **state)
 
     TSS2_RC r;
     TSS2_TCTI_CONTEXT *tcti;
-    r = get_tcti_default(&tcti);
+    r = get_tcti_default(&tcti, NULL);
     assert_int_equal(r, TSS2_ESYS_RC_NOT_IMPLEMENTED);
     free(tcti);
 }

--- a/test/unit/esys-nulltcti.c
+++ b/test/unit/esys-nulltcti.c
@@ -29,7 +29,7 @@ tcti_fake_finalize(TSS2_TCTI_CONTEXT *tctiContext)
 }
 
 TSS2_RC
-get_tcti_default(TSS2_TCTI_CONTEXT **tcti) {
+get_tcti_default(TSS2_TCTI_CONTEXT **tcti, void **dlhandle) {
     if (tcti == NULL)
         return TSS2_BASE_RC_GENERAL_FAILURE;
 
@@ -45,6 +45,7 @@ get_tcti_default(TSS2_TCTI_CONTEXT **tcti) {
     TSS2_TCTI_CANCEL(*faketcti) = NULL;
     TSS2_TCTI_GET_POLL_HANDLES(*faketcti) = NULL;
     TSS2_TCTI_SET_LOCALITY(*faketcti) = NULL;
+    *dlhandle = NULL;
 
     return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
- The handle of dlopen used to leak. Save this handle and dlclose on Esys_Finish().
- ESYSFLAGS was actually never set. Probably leftover from an earlier version.