### PR TITLE
SAPI: Fixed a bug in the logging of a response header tag in execute

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_Execute.c
+++ b/src/tss2-sys/api/Tss2_Sys_Execute.c
@@ -80,7 +80,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
             LOG_ERROR("Unsupported device. The device is a TPM 1.2");
             return TSS2_SYS_RC_GENERAL_FAILURE;
         } else {
-            LOG_ERROR("Malformed reponse: Invalid tag in response header: %" PRIx32,
+            LOG_ERROR("Malformed reponse: Invalid tag in response header: %" PRIx16,
                       ctx->rsp_header.tag);
             return TSS2_SYS_RC_MALFORMED_RESPONSE;
         }


### PR DESCRIPTION

In case of an invalid tag in the TPM's response, Tss2_Sys_Execute.c
prints that tag using LOG_ERROR. It uses the platform's format string
for 32-bit varibles. The structure definition of the response header
defines a 16-bit variable for the tag. This leads to format string
warnings on some platforms. Therefore, the format string was changed
from PRIx32 to PRIx16, the platform's format string for 16-bit
variables.

* Changed the format string for the response tag in a call to the logging
function in Tss2_Sys_Execute.c

Signed-off-by: Lukas Jäger <lukas.jaeger@sit.fraunhofer.de>