### PR TITLE
ESYS: Fix default value for config string in TCTI default table

### DIFF
--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -37,7 +37,7 @@ struct {
     char *description;
 } tctis[] = {
 #ifndef NO_DL
-    { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" },
+    { "libtss2-tcti-default.so", NULL, NULL, "Access libtss2-tcti-default.so" },
     { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" },
 #endif /* NO_DL */
 #ifdef _WIN32

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -505,8 +505,13 @@ Tss2_Tcti_Mssim_Init (
     char *conf_copy = NULL;
     mssim_conf_t mssim_conf = MSSIM_CONF_DEFAULT_INIT;
 
-    LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
-               (uintptr_t)tctiContext, (uintptr_t)size, conf);
+    if (conf == NULL)
+        LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ""
+                   " default configuration will be used.",
+                   (uintptr_t)tctiContext, (uintptr_t)size);
+    else
+        LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
+                   (uintptr_t)tctiContext, (uintptr_t)size, conf);
     if (size == NULL) {
         return TSS2_TCTI_RC_BAD_VALUE;
     }

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -51,6 +51,10 @@ TSS2_RC
 __wrap_Tss2_Tcti_Fake_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
                            const char *config)
 {
+    char* tcti_default = "";
+
+    if (config == NULL)
+        config = tcti_default;
     LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
               size, config);
     check_expected(tctiContext);
@@ -71,6 +75,10 @@ TSS2_RC
 __wrap_Tss2_Tcti_Device_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
                              const char *config)
 {
+    char* tcti_default = "/dev/tmp0";
+
+    if (config == NULL)
+        config = tcti_default;
     LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
               size, config);
     check_expected_ptr(tctiContext);
@@ -84,6 +92,10 @@ TSS2_RC
 __wrap_Tss2_Tcti_Mssim_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
                             const char *config)
 {
+    char* tcti_default = "host=localhost,port=2321";
+
+    if (config == NULL)
+        config = tcti_default;
     LOG_TRACE("Called with tctiContext %p, size %p and config %s", tctiContext,
               size, config);
     check_expected_ptr(tctiContext);


### PR DESCRIPTION
…fault.

* The config string was set to "" in the ESYS default table. The value now is set to NULL.
  If config string is NULL the used TCTI module will use the default value instead of ""
* The corresponding fake routines in the unit test were adapted to accept a null  pointer
  for config parameter.
* This fix allows changing of the default library without recompiling, which was not
  possible before.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>