### PR TITLE
Build: Fix autotools warning on _LDFLAGS

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -62,12 +62,12 @@ test_helper_tpm_transientempty_SOURCES = test/helper/tpm_transientempty.c
 endif #ENABLE_INTEGRATION
 
 if ESYS_OSSL
-ESYSCRY_CFLAGS = -DOSSL
-ESYSCRY_LDFLAGS = -lssl -lcrypto -ldl
+esyscryCFLAGS = -DOSSL
+esyscryLDFLAGS = -lssl -lcrypto -ldl
 else
 if ESYS_GCRYPT
-ESYSCRY_CFLAGS =
-ESYSCRY_LDFLAGS = -lgcrypt -ldl
+esyscryCFLAGS =
+esyscryLDFLAGS = -lgcrypt -ldl
 endif
 endif
 
@@ -329,7 +329,7 @@ test_unit_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c
 if ESAPI
 test_unit_esys_context_null_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_esys_context_null_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
+test_unit_esys_context_null_LDFLAGS = $(TESTS_LDFLAGS) $(esyscryLDFLAGS)
 test_unit_esys_context_null_SOURCES = test/unit/esys-context-null.c
 
 test_unit_esys_default_tcti_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) \
@@ -373,9 +373,9 @@ test_unit_esys_nulltcti_LDFLAGS = $(TESTS_LDFLAGS) -ldl
 test_unit_esys_nulltcti_SOURCES = test/unit/esys-nulltcti.c \
         src/tss2-esys/esys_context.c
 
-test_unit_esys_crypto_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
+test_unit_esys_crypto_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(esyscryCFLAGS)
 test_unit_esys_crypto_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_esys_crypto_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
+test_unit_esys_crypto_LDFLAGS = $(TESTS_LDFLAGS) $(esyscryLDFLAGS)
 test_unit_esys_crypto_SOURCES = test/unit/esys-crypto.c \
         src/tss2-esys/esys_context.c
 
@@ -882,9 +882,9 @@ test_integration_esys_object_changeauth_int_SOURCES = \
     test/integration/esys-object-changeauth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
-test_integration_esys_policy_authorize_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
+test_integration_esys_policy_authorize_int_CFLAGS  = $(TESTS_CFLAGS) $(esyscryCFLAGS)
 test_integration_esys_policy_authorize_int_LDADD   = $(TESTS_LDADD)
-test_integration_esys_policy_authorize_int_LDFLAGS = $(TESTS_LDFLAGS) $(ESYSCRY_LDFLAGS)
+test_integration_esys_policy_authorize_int_LDFLAGS = $(TESTS_LDFLAGS) $(esyscryLDFLAGS)
 test_integration_esys_policy_authorize_int_SOURCES = \
     test/integration/esys-policy-authorize.int.c \
     src/tss2-esys/esys_crypto.c \
@@ -904,7 +904,7 @@ test_integration_esys_policy_regression_opt_int_SOURCES = \
     test/integration/esys-policy-regression-opt.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
-test_integration_esys_policy_ticket_int_CFLAGS  = $(TESTS_CFLAGS) $(ESYSCRY_CFLAGS)
+test_integration_esys_policy_ticket_int_CFLAGS  = $(TESTS_CFLAGS) $(esyscryCFLAGS)
 test_integration_esys_policy_ticket_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_policy_ticket_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_policy_ticket_int_SOURCES = \


### PR DESCRIPTION
autotools does not like variables to end on _LDFLAGS and spits out
warnings. So we rename the variable.

Addresses issue posted in #1159 review.