### PR TITLE
test: Add integration test for StirRandom

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -119,6 +119,7 @@ TESTS_INTEGRATION = \
     test/integration/sapi-encrypt-decrypt-2.int \
     test/integration/sapi-evict-ctrl.int \
     test/integration/sapi-get-random.int \
+    test/integration/sapi-stir-random.int \
     test/integration/sapi-hierarchy-change-auth.int \
     test/integration/sapi-abi-version.int \
     test/integration/sapi-pcr-extension.int \
@@ -430,6 +431,11 @@ test_integration_sapi_evict_ctrl_int_SOURCES = \
 test_integration_sapi_sys_initialize_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_sapi_sys_initialize_int_LDADD   = $(TESTS_LDADD)
 test_integration_sapi_sys_initialize_int_SOURCES = test/integration/sapi-sys-initialize.int.c \
+    test/integration/main-sapi.c
+
+test_integration_sapi_stir_random_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_sapi_stir_random_int_LDADD   = $(TESTS_LDADD)
+test_integration_sapi_stir_random_int_SOURCES = test/integration/sapi-stir-random.int.c \
     test/integration/main-sapi.c
 
 test_integration_sapi_get_random_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)

--- a/test/integration/sapi-stir-random.int.c
+++ b/test/integration/sapi-stir-random.int.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: BSD-2 */
+/***********************************************************************
+ * Copyright (c) 2017-2018, Intel Corporation
+ *
+ * All rights reserved.
+ ***********************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tss2_sys.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "test.h"
+
+/**
+ * This program contains integration test for SAPI Tss2_Sys_StirRandom.
+ * Since StirRandom is quite simple we can only check for success if we
+ * supply correct parameters.
+ */
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context)
+{
+    TSS2_RC rc;
+    TPM2B_SENSITIVE_DATA inData  = {
+        .size = 20,
+        .buffer = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                   11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+    };
+
+    LOG_INFO("StirRandom tests started.");
+    /* Check invalid context */
+    rc = Tss2_Sys_StirRandom(NULL, 0, NULL, 0);
+    if (rc != TSS2_SYS_RC_BAD_REFERENCE) {
+        LOG_ERROR("StirRandom (ctx) FAILED! Response Code : %x", rc);
+        exit(1);
+    }
+
+    /* check empty input data */
+    rc = Tss2_Sys_StirRandom(sapi_context, 0, NULL, 0);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("StirRandom (empty) FAILED! Response Code : %x", rc);
+        exit(1);
+    }
+
+    /* check with correct input data*/
+    rc = Tss2_Sys_StirRandom(sapi_context, 0, &inData, 0);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("StirRandom (indata) FAILED! Response Code : %x", rc);
+        exit(1);
+    }
+    LOG_INFO("StirRandom Test Passed!");
+    return 0;
+}


### PR DESCRIPTION
Add a simple test for StirRandom to increase code coverage.
It does only check whether the command itself works and returns success
for suitable input data.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>