### PR TITLE
RFC ESAPI helper functions

### DIFF
--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -3229,6 +3229,12 @@ Esys_Free(
     void *__ptr);
 
 TSS2_RC
+esys_tr_get_tpm_handle(
+    ESYS_CONTEXT *esysContext,
+    ESYS_TR handle,
+    TPM2_HANDLE *tpmHandle);
+
+TSS2_RC
 esys_handle_to_tpm_handle(
     ESYS_TR handle,
     TPM2_HANDLE *tpmHandle);

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -3228,6 +3228,11 @@ void
 Esys_Free(
     void *__ptr);
 
+TSS2_RC
+esys_handle_to_tpm_handle(
+    ESYS_TR handle,
+    TPM2_HANDLE *tpmHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -341,6 +341,7 @@ EXPORTS
     Esys_TR_GetName
     Esys_TR_Serialize
     Esys_TR_SetAuth
+    esys_handle_to_tpm_handle
     Esys_TestParms
     Esys_TestParms_Async
     Esys_TestParms_Finish

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -341,6 +341,7 @@ EXPORTS
     Esys_TR_GetName
     Esys_TR_Serialize
     Esys_TR_SetAuth
+    esys_tr_get_tpm_handle
     esys_handle_to_tpm_handle
     Esys_TestParms
     Esys_TestParms_Async

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -534,3 +534,18 @@ Esys_TRSess_GetNonceTPM(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     SAFE_FREE(*nonceTPM);
     return r;
 }
+
+/** Compute tpm handle for standard esys handles.
+ *
+ * The tpm handle is computed for esys handles representing pcr registers and
+ * hierarchies.
+ * @parm esys_handle [in] The esys handle.
+ * @parm tpm_handle [out] The corresponding tpm handle.
+ * @retval TSS2_RC_SUCCESS on success.
+ * @retval TSS2_ESYS_RC_BAD_VALUE if no standard handle is passed.
+ */
+TSS2_RC
+esys_handle_to_tpm_handle(ESYS_TR handle, TPM2_HANDLE *tpmHandle)
+{
+  return iesys_handle_to_tpm_handle(handle, tpmHandle);
+}

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -535,6 +535,33 @@ Esys_TRSess_GetNonceTPM(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     return r;
 }
 
+/** Get the tpm handle for an esys handle
+ *
+ * Get the underlying tpm handle which the esys object wraps.
+ * @param esys_context [in,out] The ESYS_CONTEXT.
+ * @param esys_handle [in,out] The ESYS_TR for which to retrieve the tpm handle.
+ * @param tpmHandle [out] The underlying tpm handle.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_ESYS_RC_MEMORY if needed memory can't be allocated.
+ * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext is NULL.
+ * @retval TSS2_SYS_RC_* for SAPI errors.
+ */
+TSS2_RC
+esys_tr_get_tpm_handle(ESYS_CONTEXT *esysContext, ESYS_TR handle,
+		     TPM2_HANDLE *tpmHandle)
+{
+  RSRC_NODE_T *esys_object;
+  TSS2_RC r;
+  _ESYS_ASSERT_NON_NULL(esysContext);
+
+  r = esys_GetResourceObject(esysContext, handle, &esys_object);
+  return_if_error(r, "Object not found");
+  *tpmHandle = esys_object->rsrc.handle;
+
+  return r;
+}
+
 /** Compute tpm handle for standard esys handles.
  *
  * The tpm handle is computed for esys handles representing pcr registers and


### PR DESCRIPTION
I'm working on porting the tpm2-tools to the ESAPI and have ended up making a couple of changes to the TSS, per this RFC PR.

The first patch was implemented because I found myself carrying a similar, though less complete, function to `iesys_handle_to_tpm_handle()` in the tpm2-tools library code. I suspect if this change is acceptable there will need to be some modifications, it's currently a path of least resistance patch to expose existing functionality.

The second patch was implemented in order to maintain the _tpm2_evictcontrol_'s ability to detect when a passed handle is persistent: https://github.com/tpm2-software/tpm2-tools/blob/master/tools/tpm2_evictcontrol.c#L138
Perhaps there's a more appropriate way to do that in an ESYS world?