### PR TITLE
test: fix tpm2b unit tests failing on big endian

### DIFF
--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -210,17 +210,17 @@ tpm2b_unmarshal_success(void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (dgst.size, 4);
     ptr = (uint32_t *)dgst.buffer;
-    assert_int_equal (*ptr, value);
+    assert_int_equal (le32toh(*ptr), value);
     assert_int_equal (offset, 6);
 
     rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, buffer_size, &offset, &point);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (point.point.x.size, 4);
     ptr = (uint32_t *)point.point.x.buffer;
-    assert_int_equal (*ptr, value);
+    assert_int_equal (le32toh(*ptr), value);
     assert_int_equal (point.point.y.size, 4);
     ptr = (uint32_t *)point.point.y.buffer;
-    assert_int_equal (*ptr, value2);
+    assert_int_equal (le32toh(*ptr), value2);
     assert_int_equal (offset, 20);
 }
 
@@ -251,17 +251,17 @@ tpm2b_unmarshal_success_offset(void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (dgst.size, 4);
     ptr = (uint32_t *)dgst.buffer;
-    assert_int_equal (*ptr, value);
+    assert_int_equal (le32toh(*ptr), value);
     assert_int_equal (offset, 12);
 
     rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, buffer_size, &offset, &point);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (point.point.x.size, 8);
     ptr2 = (uint64_t *)point.point.x.buffer;
-    assert_int_equal (*ptr2, value2);
+    assert_int_equal (le64toh(*ptr2), value2);
     assert_int_equal (point.point.y.size, 4);
     ptr = (uint32_t *)point.point.y.buffer;
-    assert_int_equal (*ptr, value3);
+    assert_int_equal (le32toh(*ptr), value3);
     assert_int_equal (offset, 30);
 }
 


### PR DESCRIPTION
tpm2b unit test fails on big endian machines