### PR TITLE
fix ERROR_IF_NO_PROG

### DIFF
--- a/m4/misc.m4
+++ b/m4/misc.m4
@@ -3,8 +3,8 @@ dnl   A quick / dirty macro to ensure that a required program / executable
 dnl   is on PATH. If it is not we display an error message using AC_MSG_ERROR.
 dnl $1: program name
 AC_DEFUN([ERROR_IF_NO_PROG],[
-    AC_CHECK_PROG([result], [$1], [yes], [no])
-    AS_IF([test "x$result" != "xyes"], [
+    AC_CHECK_PROG([result_$1], [$1], [yes], [no])
+    AS_IF([test "x$result_$1" != "xyes"], [
         AC_MSG_ERROR([Missing required program '$1': ensure it is installed and on PATH.])
     ])
 ])


### PR DESCRIPTION
ERROR_IF_NO_PROG macro doesn't work as intended.
See https://github.com/tpm2-software/tpm2-tss/issues/1181