### PR TITLE
Added support for QNX build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,6 +278,7 @@ nodist_pkgconfig_DATA += lib/tss2-sys.pc
 EXTRA_DIST += lib/tss2-sys.pc.in
 
 src_tss2_sys_libtss2_sys_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/tss2-sys
+src_tss2_sys_libtss2_sys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBSOCKET_LDFLAGS)
 src_tss2_sys_libtss2_sys_la_LIBADD = $(libtss2_mu) $(libutil)
 src_tss2_sys_libtss2_sys_la_SOURCES = $(TSS2_SYS_SRC)
 
@@ -296,12 +297,12 @@ src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \
 if ESYS_OSSL
 TSS2_ESYS_SRC += src/tss2-esys/esys_crypto_ossl.h src/tss2-esys/esys_crypto_ossl.c
 src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys -DOSSL
-src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) -ldl  -lssl -lcrypto
+src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBDL_LDFLAGS) $(LIBSOCKET_LDFLAGS) -lssl -lcrypto
 else
 if ESYS_GCRYPT
 TSS2_ESYS_SRC += src/tss2-esys/esys_crypto_gcrypt.h src/tss2-esys/esys_crypto_gcrypt.c
 src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys
-src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) -ldl -lgcrypt
+src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBDL_LDFLAGS) $(LIBSOCKET_LDFLAGS) -lgcrypt
 endif
 endif
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC)

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,23 @@ AC_CONFIG_FILES([Makefile Doxyfile])
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
 
+AC_CANONICAL_HOST
+
+# Check OS and set library and compile flags accordingly
+case "${host_os}" in
+    *nto-qnx*)
+        ADD_COMPILER_FLAG([-D_QNX_SOURCE])
+        LIBDL_LDFLAGS=""
+        LIBSOCKET_LDFLAGS="-lsocket"
+        ;;
+    *)
+        LIBDL_LDFLAGS="-ldl"
+        LIBSOCKET_LDFLAGS=""
+        ;;
+esac
+AC_SUBST([LIBDL_LDFLAGS])
+AC_SUBST([LIBSOCKET_LDFLAGS])
+
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
                             [build cmocka unit tests (default is no)])],

--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -18,7 +18,7 @@
 #error Version mismatch among TSS2 header files.
 #endif  /* TSS2_API_VERSION_1_2_1_108 */
 
-#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__) || defined (__QNXNTO__)
 #include <poll.h>
 typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 #elif defined(_WIN32)


### PR DESCRIPTION
QNX-specific quirks:
*   Certain "netdb.h" API is only available if __EXT_POSIX1_200112 is
    defined. __EXT_POSIX1_200112 is defined if "_XOPEN_SOURCE" is set
    to 600.
*   Socket api is provided through separate library called "libsocket".
*   Dynamic-library API (e.g. dl_open) is a part of libc. There is no
    "libdl".

Makefile.am:    Replaced hard-coded LDFLAGS, "-ldl" and "-lsocket"
                with variables, LIBDL_LDFLAGS, and LIBSOCKET_LDFLAGS.

configure.ac:   Added "$host_os" case statement to detect QNX targets
                and modify CFLAGS and set the XXX_LDFLAGS as required.

tss2_tcti.h:    Added "__QNXNTO__" to the list of OS-specific flags.

Signed-off-by: Safayet Ahmed <safayet.ahmed@ge.com>