### PR TITLE
build: Remove 'AX_' prefix from local m4 flag macros.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,18 +189,18 @@ AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 
 gl_LD_VERSION_SCRIPT
 
-AX_ADD_COMPILER_FLAG([-std=c99])
-AX_ADD_COMPILER_FLAG([-Wall])
-AX_ADD_COMPILER_FLAG([-Wextra])
-AX_ADD_COMPILER_FLAG([-Wformat-security])
-AX_ADD_COMPILER_FLAG([-Werror])
-AX_ADD_COMPILER_FLAG([-fstack-protector-all])
-AX_ADD_COMPILER_FLAG([-fpic])
-AX_ADD_COMPILER_FLAG([-fPIC])
+ADD_COMPILER_FLAG([-std=c99])
+ADD_COMPILER_FLAG([-Wall])
+ADD_COMPILER_FLAG([-Wextra])
+ADD_COMPILER_FLAG([-Wformat-security])
+ADD_COMPILER_FLAG([-Werror])
+ADD_COMPILER_FLAG([-fstack-protector-all])
+ADD_COMPILER_FLAG([-fpic])
+ADD_COMPILER_FLAG([-fPIC])
 
-AX_ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
-AX_ADD_PREPROC_FLAG([-D_BSD_SOURCE])
-AX_ADD_PREPROC_FLAG([-D_POSIX_SOURCE])
+ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
+ADD_PREPROC_FLAG([-D_BSD_SOURCE])
+ADD_PREPROC_FLAG([-D_POSIX_SOURCE])
 
 AC_ARG_WITH([maxloglevel],
             [AS_HELP_STRING([--with-maxloglevel={none,error,warning,info,debug,trace}],
@@ -226,20 +226,20 @@ AC_ARG_ENABLE([debug],
                             [build with debug info (default is no)])],
             [enable_debug=$enableval],
             [enable_debug=no])
-AS_IF([test "x$enable_debug" = "xyes"], AX_ADD_COMPILER_FLAG([-ggdb3 -Og]))
-AS_IF([test "x$enable_debug" = "xno"], [AX_ADD_PREPROC_FLAG([-U_FORTIFY_SOURCE])
-                                        AX_ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])
-                                        AX_ADD_COMPILER_FLAG([-g -O2])])
-AX_ADD_LINK_FLAG([-Wl,--no-undefined])
-AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
-AX_ADD_LINK_FLAG([-Wl,-z,now])
-AX_ADD_LINK_FLAG([-Wl,-z,relro])
+AS_IF([test "x$enable_debug" = "xyes"], ADD_COMPILER_FLAG([-ggdb3 -Og]))
+AS_IF([test "x$enable_debug" = "xno"], [ADD_PREPROC_FLAG([-U_FORTIFY_SOURCE])
+                                        ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])
+                                        ADD_COMPILER_FLAG([-g -O2])])
+ADD_LINK_FLAG([-Wl,--no-undefined])
+ADD_LINK_FLAG([-Wl,-z,noexecstack])
+ADD_LINK_FLAG([-Wl,-z,now])
+ADD_LINK_FLAG([-Wl,-z,relro])
 
 AC_SUBST([PATH])
 
 # work around GCC bug #53119
 #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
-AX_ADD_COMPILER_FLAG([-Wno-missing-braces])
+ADD_COMPILER_FLAG([-Wno-missing-braces])
 
 dnl ---------  Physical TPM device -----------------------
 

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -1,10 +1,10 @@
-dnl AX_ADD_COMPILER_FLAG:
+dnl ADD_COMPILER_FLAG:
 dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable. This macro will
 dnl   check to be sure the compiler supports the flag. Flags can be made
 dnl   mandatory (configure will fail).
 dnl $1: C compiler flag to add to EXTRA_CFLAGS.
 dnl $2: Set to "required" to cause configure failure if flag not supported.
-AC_DEFUN([AX_ADD_COMPILER_FLAG],[
+AC_DEFUN([ADD_COMPILER_FLAG],[
     AX_CHECK_COMPILE_FLAG([$1],[
         EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
         AC_SUBST([EXTRA_CFLAGS])],[
@@ -15,7 +15,7 @@ AC_DEFUN([AX_ADD_COMPILER_FLAG],[
         -Wall -Werror]
     )]
 )
-dnl AX_ADD_PREPROC_FLAG:
+dnl ADD_PREPROC_FLAG:
 dnl   Add the provided preprocessor flag to the EXTRA_CFLAGS variable. This
 dnl   macro will check to be sure the preprocessor supports the flag.
 dnl   The flag can be made mandatory by providing the string 'required' as
@@ -23,7 +23,7 @@ dnl   the second parameter.
 dnl $1: Preprocessor flag to add to EXTRA_CFLAGS.
 dnl $2: Set to "required" t ocause configure failure if preprocesor flag
 dnl     is not supported.
-AC_DEFUN([AX_ADD_PREPROC_FLAG],[
+AC_DEFUN([ADD_PREPROC_FLAG],[
     AX_CHECK_PREPROC_FLAG([$1],[
         EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
         AC_SUBST([EXTRA_CFLAGS])],[
@@ -34,13 +34,13 @@ AC_DEFUN([AX_ADD_PREPROC_FLAG],[
         -Wall -Werror]
     )]
 )
-dnl AX_ADD_LINK_FLAG:
+dnl ADD_LINK_FLAG:
 dnl   A macro to add a LDLAG to the EXTRA_LDFLAGS variable. This macro will
 dnl   check to be sure the linker supports the flag. Flags can be made
 dnl   mandatory (configure will fail).
 dnl $1: linker flag to add to EXTRA_LDFLAGS.
 dnl $2: Set to "required" to cause configure failure if flag not supported.
-AC_DEFUN([AX_ADD_LINK_FLAG],[
+AC_DEFUN([ADD_LINK_FLAG],[
     AX_CHECK_LINK_FLAG([$1],[
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS $1"
         AC_SUBST([EXTRA_LDFLAGS])],[


### PR DESCRIPTION
The 'AX_' prefix is the namespace for the autoconf archive macros. We
shouldn't be using a namespace belonging to another project.

Signed-off-by: Philip Tricca <flihp@twobit.org>