### PR TITLE
Remove SPDX from LICENSE itself

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-SPDX-License-Identifier: BSD-2
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
It seems to confuse some tools if the SPDX appears in the License file - e.g. Github which did not show the LICENSE in the right tab.

Signed-off-by: Peter Huewe <peter.huewe@gmx.de>