### PR TITLE
build: Fix breakage when --with-maxloglevel is not 'trace'.

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -505,13 +505,14 @@ Tss2_Tcti_Mssim_Init (
     char *conf_copy = NULL;
     mssim_conf_t mssim_conf = MSSIM_CONF_DEFAULT_INIT;
 
-    if (conf == NULL)
+    if (conf == NULL) {
         LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ""
                    " default configuration will be used.",
                    (uintptr_t)tctiContext, (uintptr_t)size);
-    else
+    } else {
         LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
                    (uintptr_t)tctiContext, (uintptr_t)size, conf);
+    }
     if (size == NULL) {
         return TSS2_TCTI_RC_BAD_VALUE;
     }


### PR DESCRIPTION
Commit 54090544832a00fb78c65a91fc45e67c77fbd936 broke the build for all
loglevels other than 'trace':

src/tss2-tcti/tcti-mssim.c: In function ‘Tss2_Tcti_Mssim_Init’:
src/tss2-tcti/tcti-mssim.c:512:5: error: ‘else’ without a previous ‘if’
     else
     ^~~~

Explicitly enclosing the scope of this conditional with curly braces
is the most simple solution.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>