### PR TITLE
configure: fix check for doxygen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,7 @@ DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN($PACKAGE_NAME, [Doxyfile], [doxygen-doc])
 AM_CONDITIONAL(DOXYMAN, [test $DX_FLAG_man -eq 1])
 
-AS_IF([test "x$disable_doxygen_doc" != xyes],
+AS_IF([test "x$enable_doxygen_doc" != xno],
       [ERROR_IF_NO_PROG([doxygen])])
 
 AX_CODE_COVERAGE


### PR DESCRIPTION
Fix #1204: The doxygen feature is controlled by the variable <code>$*enable*_doxygen_doc</code>, which is why the current check does not work.