### PR TITLE
doc: specify minimum required version for autoconf-archive

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ following sections describe them for the supported platforms.
 
 ## GNU/Linux:
 * GNU Autoconf
-* GNU Autoconf archive
+* GNU Autoconf Archive, version >= 2017.03.21
 * GNU Automake
 * GNU Libtool
 * C compiler
@@ -25,7 +25,6 @@ The following are dependencies only required when building test suites.
 * netstat executable (usually in the net-tools package)
 * Code coverage analysis:
 * lcov
-* autoconf-archives
 * uthash development libraries and header files
 
 Most users will not need to install these dependencies.
@@ -52,7 +51,7 @@ $ sudo apt -y install \
   autoconf \
   gnulib
 ```
-Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. Recommend downloading autoconf-archives directly from upstream and copy ax_code_coverage.m4.
+Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 
 ### Fedora
 


### PR DESCRIPTION
We need at least version 2017.03.21 because we rely on
- [`DX_RULES`](https://github.com/tpm2-software/tpm2-tss/blob/6751b3c1ec21710e0d54ae38d28b3940f0499c18/Makefile.am#L25) from `ax_prog_doxygen.m4`, which was [introduced in version 2016.03.20](https://github.com/autoconf-archive/autoconf-archive/commit/5ef1e0b754692f089fa031100deeca1d05693fe6) and
- [`CODE_COVERAGE_LIBS`](https://github.com/tpm2-software/tpm2-tss/blob/6751b3c1ec21710e0d54ae38d28b3940f0499c18/Makefile.am#L10) from `ax_code_coverage.m4`, which was [introduced/renamed in version 2016.03.20](https://github.com/autoconf-archive/autoconf-archive/commit/b812cb0104efaa25ce2f067a950fbf2abc36ebe5), but [fixed in **2017.03.21**](https://github.com/autoconf-archive/autoconf-archive/commit/79faac8a16841490a729fd22e7711696435ec6f8).

The still supported Ubuntu 16.04 LTS ships version 2015.09.25, so this might be an issue for some people, see e.g. #1212.

Note that Travis CI [uses the slightly newer version 2017.09.28](https://github.com/tpm2-software/tpm2-tss/blob/6751b3c1ec21710e0d54ae38d28b3940f0499c18/.travis.yml#L63) for testing, but that version [does not introduce changes relevant for us](https://github.com/autoconf-archive/autoconf-archive/compare/v2017.03.21...v2017.09.28).