### PR TITLE
Dockerfile: Add doxygen package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
     autoconf-archive \
     automake \
     build-essential \
+    doxygen \
     g++ \
     gcc \
     git \


### PR DESCRIPTION
Since #1184 `./configure` checks for the presence of doxygen, but the
Docker image does not include it, hence the build failed. (closes

Signed-off-by: Julien Hachenberger <julien.hachenberger@sit.fraunhofer.de>