### PR TITLE
Fix esys session handling

### DIFF
--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -450,11 +450,11 @@ Esys_StartAuthSession_Finish(
             secret_size += keyHash_size;
         if (bind != ESYS_TR_NONE && bindNode != NULL)
             secret_size += bindNode->auth.size;
-        if (secret_size == 0) {
-            return_error(TSS2_ESYS_RC_GENERAL_FAILURE,
-                         "Invalid secret size (0).");
-        }
-        uint8_t *secret = malloc(secret_size);
+        /* 
+         * A non null pointer for secret is required by the subsequent functions,
+         * hence a malloc is called with size 1 if secret_size is zero.
+         */
+        uint8_t *secret = malloc(secret_size ? secret_size : 1);
         if (secret == NULL) {
             LOG_ERROR("Out of memory.");
             return TSS2_ESYS_RC_MEMORY;

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -911,14 +911,15 @@ iesys_compute_session_value(RSRC_NODE_T * session,
            &session->rsrc.misc.rsrc_session.sessionKey.buffer[0],
            session->rsrc.misc.rsrc_session.sessionKey.size);
 
-    if (name == NULL)
-        return;
-    /* This requires an HMAC Session and not a password session */
+     /* This requires an HMAC Session and not a password session */
     if (session->rsrc.misc.rsrc_session.sessionType != TPM2_SE_HMAC &&
         session->rsrc.misc.rsrc_session.sessionType != TPM2_SE_POLICY)
         return;
 
     session->rsrc.misc.rsrc_session.sizeHmacValue = session->rsrc.misc.rsrc_session.sizeSessionValue;
+
+    if (name == NULL)
+        return;
 
     /* The auth value is appended to the session key */
     memcpy(&session->rsrc.misc.rsrc_session.

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -483,6 +483,8 @@ Esys_TRSess_SetAttributes(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     TSS2_RC r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
 
+    return_if_null(esys_context, "Object not found", TSS2_ESYS_RC_BAD_VALUE);
+
     if (esys_object->rsrc.rsrcType != IESYSC_SESSION_RSRC)
         return_error(TSS2_ESYS_RC_BAD_TR, "Object is not a session object");
     esys_object->rsrc.misc.rsrc_session.sessionAttributes =


### PR DESCRIPTION
* In the function  Esys_TRSess_SetAttributes a Null pointer check was added
  because the function esys_GetResourceObject returns TSS2_RC_SUCCESS for the handle
   ESYS_TR_NONE and a null pointer for the session object.
*  The size of an hmac value of a session was only set for objects with authorization.
* An unnecessary size check in StartAuthSession was removed.
   The check whether the secret size is zero can be removed because  size zero is
   possible if no tpmKey for encryption is used and the authValue of the bind
   object has length 0.
    
