### PR TITLE
Core Infrastructure Initiative (CII) Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/2rdmyn1ndkiavngn?svg=true)](https://ci.appveyor.com/project/tpm2-software/tpm2-tss)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/tpm2-tss)
 [![Coverage Status](https://coveralls.io/repos/github/tpm2-software/tpm2-tss/badge.svg?branch=master)](https://coveralls.io/github/tpm2-software/tpm2-tss?branch=master)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2332/badge)](https://bestpractices.coreinfrastructure.org/projects/2332)
 
 # Overview
 This repository hosts source code implementing the Trusted Computing Group's (TCG) TPM2 Software Stack (TSS).


### PR DESCRIPTION
The Linux Foundation Core Infrastructure Initiative (CII) Badge is a self-certification program for open source software to assess whether they are following the best practice guidelines for healthy open source projects.
The tpm2-tss is growing in size and influence and is starting to become critical core infrastructure, so it is time to do the self assessment.
The Badge adds a link to the assessment and also shows the progress to our users.

Signed-of-by: Peter Huewe <peterhuewe@gmx.de>