### PR TITLE
Strict overflow flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,7 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       # work around GCC bug #53119
       #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
       ADD_COMPILER_FLAG([-Wno-missing-braces])
+      ADD_COMPILER_FLAG([-Wstrict-overflow=5])
       ADD_LINK_FLAG([-Wl,--no-undefined])
       ADD_LINK_FLAG([-Wl,-z,noexecstack])
       ADD_LINK_FLAG([-Wl,-z,now])

--- a/src/tss2-sys/api/Tss2_Sys_GetRspAuths.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRspAuths.c
@@ -17,7 +17,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval = TSS2_RC_SUCCESS;
     size_t offset = 0, offset_tmp;
-    int i = 0;
+    unsigned i = 0;
 
     if (!ctx || !rspAuthsArray)
         return TSS2_SYS_RC_BAD_REFERENCE;

--- a/test/integration/sapi-session-util.c
+++ b/test/integration/sapi-session-util.c
@@ -577,8 +577,9 @@ gen_session_key(
 
     iv->size = aes_block_size;
     session_key->size = (session->symmetric.keyBits.sym) / 8;
+    UINT16 total_size = session_key->size + iv->size;
     if (iv->size > sizeof (iv->buffer) ||
-        (session_key->size + iv->size) > TPM2_MAX_DIGEST_BUFFER)
+         (total_size) > TPM2_MAX_DIGEST_BUFFER)
         return TSS2_SYS_RC_GENERAL_FAILURE;
 
     memcpy (iv->buffer, &key.buffer[session_key->size], iv->size);


### PR DESCRIPTION
Add strict signed overflow checking which is an undefined behavior and thus can have weird side-effects based on compiler and compiler settings.