### PR TITLE
tests: Add fuzz testing for libfuzzer and oss fuzz

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+test/fuzz/*.fuzz*

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ Doxyfile
 doc/rtf
 m4/
 config.h*
+
+# ignore fuzzing files
+Makefile-fuzz-generated.am
+test/fuzz/*.fuzz*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   matrix:
   - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_0_2-stable COVERALLS=send
   - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_1_0-stable COVERALLS=send
+  - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_1_0-stable FUZZING=1
   - WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE
   - WITH_TCTI_ASYNC=yes WITH_TCTI_PARTIAL=yes WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE COVERALLS=send
   - WITH_TCTI_ASYNC=yes WITH_TCTI_PARTIAL=no WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE
@@ -112,6 +113,15 @@ script:
     if [ "$CC" == "clang" ]; then
       scan-build --status-bugs make -j$(nproc) check
     else
+      make -j$(nproc) check
+    fi
+# check fuzz targets
+  - |
+    if [ "$CC" == "clang" ] && [ "x$FUZZING" == "x1" ]; then
+      ../configure --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --with-fuzzing=libfuzzer --enable-tcti-fuzzing --enable-tcti-device=no --enable-tcti-mssim=no --disable-shared --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
+    fi
+  - |
+    if [ "$CC" == "clang" ] && [ "x$FUZZING" == "x1" ]; then
       make -j$(nproc) check
     fi
   - |

--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-2
+# Copyright (c) 2019 Intel Corporation
+# All rights reserved.
+
+INCLUDE_DIRS += -I$(srcdir)/test/fuzz/tcti
+
+# tcti library used for fuzzing
+if ENABLE_TCTI_FUZZING
+libtss2_tcti_fuzzing = test/fuzz/tcti/libtss2-tcti-fuzzing.la
+noinst_LTLIBRARIES += $(libtss2_tcti_fuzzing)
+
+test_fuzz_tcti_libtss2_tcti_fuzzing_la_CFLAGS   = $(AM_CFLAGS)
+test_fuzz_tcti_libtss2_tcti_fuzzing_la_LIBADD   = $(libtss2_mu) $(libutil)
+test_fuzz_tcti_libtss2_tcti_fuzzing_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    test/fuzz/tcti/tcti-fuzzing.c test/fuzz/tcti/tcti-fuzzing.h
+endif # ENABLE_TCTI_FUZZING

--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -2,6 +2,8 @@
 # Copyright (c) 2019 Intel Corporation
 # All rights reserved.
 
+TEST_EXTENSIONS += .fuzz
+FUZZ_LOG_COMPILER = $(srcdir)/script/fuzz-log-compiler.sh
 INCLUDE_DIRS += -I$(srcdir)/test/fuzz/tcti
 
 # tcti library used for fuzzing
@@ -15,3 +17,25 @@ test_fuzz_tcti_libtss2_tcti_fuzzing_la_SOURCES  = \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
     test/fuzz/tcti/tcti-fuzzing.c test/fuzz/tcti/tcti-fuzzing.h
 endif # ENABLE_TCTI_FUZZING
+
+if ENABLE_FUZZING
+FUZZ_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
+FUZZ_CPPFLAGS = $(INCLUDE_DIRS) -I$(srcdir)/test/integration \
+  $(LIB_FUZZING_ENGINE)
+FUZZ_LDADD = $(TESTS_LDADD) $(FUZZ_LDFLAGS)
+
+noinst_LTLIBRARIES += test/fuzz/libfuzz_utils.la
+test_fuzz_libfuzz_utils_la_CFLAGS = $(AM_CFLAGS) $(FUZZ_CFLAGS)
+test_fuzz_libfuzz_utils_la_SOURCES = \
+    test/integration/sapi-context-util.c test/integration/context-util.h \
+    test/integration/sapi-test-options.c test/integration/test-options.h
+
+fuzzdir = $(srcdir)
+fuzz-targets: $(fuzz_PROGRAMS)
+
+check_PROGRAMS += $(TESTS_FUZZ)
+fuzz_PROGRAMS = $(TESTS_FUZZ)
+FUZZ = $(check_PROGRAMS)
+
+include Makefile-fuzz-generated.am
+endif # ENABLE_FUZZING

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,9 @@ include src_vars.mk
 # Add test definitions
 include Makefile-test.am
 
+# Add fuzz definitions
+include Makefile-fuzz.am
+
 ### Distribution files ###
 # Add udev rule
 udevrules_DATA   = dist/tpm-udev.rules

--- a/bootstrap
+++ b/bootstrap
@@ -63,4 +63,12 @@ echo "Generating file lists: ${VARS_FILE}"
   printf "TSS2_MU_SRC = \$(TSS2_MU_C) \$(TSS2_MU_H)"
 ) > ${VARS_FILE}
 
+# Do not generate fuzz tests unless environment variable GEN_FUZZ is set to 1
+if test "${GEN_FUZZ}0" -eq 10; then
+  echo "Generating fuzz tests"
+  script/gen_fuzz.py
+else
+  touch Makefile-fuzz-generated.am
+fi
+
 ${AUTORECONF} --install --sym $@

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_INIT([tpm2-tss],
         [https://github.com/tpm2-software/tpm2-tss])
 AC_CONFIG_MACRO_DIR([m4])
 : ${CFLAGS=""}
+AC_PROG_CXX
 AC_PROG_CC
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign
@@ -205,6 +206,29 @@ AS_IF([test "x$enable_integration" = "xyes"],
               AC_MSG_ERROR([Integration tests can not be enabled without the TCTI_MSSIM module]))
        AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
+#
+# fuzz testing
+#
+AC_ARG_WITH([fuzzing],
+            [AS_HELP_STRING([--with-fuzzing={none,libfuzzer,ossfuzz}],
+                            [fuzzing to build with (default is none)])],
+            [],
+            [with_fuzzing=none])
+AS_CASE(["x$with_fuzzing"],
+        ["xnone"],
+        [],
+        ["xlibfuzzer"],
+        [ADD_FUZZING_FLAG([-fsanitize=fuzzer])],
+        ["xossfuzz"],
+        [AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"],
+               AC_MSG_ERROR([OSS Fuzz testing requires LIB_FUZZING_ENGINE environment variable be set]))
+         ADD_FUZZING_FLAG([-lFuzzingEngine])],
+        [AC_MSG_ERROR([Bad value for --with-fuzzing])])
+AM_CONDITIONAL([ENABLE_FUZZING],[test "x$with_fuzzing" != "xnone"])
+AS_IF([test "x$with_fuzzing" != "xnone"],
+      [ADD_COMPILER_FLAG([-fsanitize=fuzzer-no-link], [required])
+       AS_IF([test "x$enable_tcti_fuzzng" = "xno"],
+             AC_MSG_ERROR([Fuzz tests can not be enabled without the TCTI_FUZZING module]))])
 
 AX_VALGRIND_CHECK
 
@@ -354,6 +378,7 @@ AC_MSG_RESULT([
     tctidefaultmodule:  $with_tctidefaultmodule
     tctidefaultconfig:  $with_tctidefaultconfig
     unit:               $enable_unit
+    fuzzing:            $with_fuzzing
     debug:              $enable_debug
     maxloglevel:        $with_maxloglevel
     doxygen:            $DX_FLAG_doc $enable_doxygen_doc

--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,8 @@ AC_ARG_ENABLE([tcti-device],
             [enable_tcti_device=$enableval],
             [enable_tcti_device=yes])
 AM_CONDITIONAL([ENABLE_TCTI_DEVICE], [test "x$enable_tcti_device" != xno])
+AS_IF([test "x$enable_tcti_device" = "xyes"],
+	AC_DEFINE([TCTI_DEVICE],[1], [TCTI FOR DEV TPM]))
 
 AC_ARG_ENABLE([tcti-mssim],
             [AS_HELP_STRING([--enable-tcti-mssim],
@@ -147,6 +149,15 @@ AC_ARG_ENABLE([tcti-mssim],
 AM_CONDITIONAL([ENABLE_TCTI_MSSIM], [test "x$enable_tcti_mssim" != xno])
 AS_IF([test "x$enable_tcti_mssim" = "xyes"],
 	AC_DEFINE([TCTI_MSSIM],[1], [TCTI FOR MS SIMULATOR]))
+
+AC_ARG_ENABLE([tcti-fuzzing],
+            [AS_HELP_STRING([--enable-tcti-fuzzing],
+                            [build the tcti-fuzzing module (default is no)])],
+            [enable_tcti_fuzzing=$enableval],
+            [enable_tcti_fuzzing=no])
+AM_CONDITIONAL([ENABLE_TCTI_FUZZING], [test "x$enable_tcti_fuzzing" != xno])
+AS_IF([test "x$enable_tcti_fuzzing" = "xyes"],
+	AC_DEFINE([TCTI_FUZZING],[1], [TCTI FOR FUZZING]))
 
 #
 # udev
@@ -327,7 +338,15 @@ AC_OUTPUT
 
 AM_COND_IF([ENABLE_TCTI_DEVICE], [],
            [AM_COND_IF([ENABLE_TCTI_MSSIM], [],
-                       [AC_MSG_WARN("No build-in TCTI module enabled")])])
+                       [AM_COND_IF([ENABLE_TCTI_FUZZING], [],
+                                   [AC_MSG_WARN("No build-in TCTI module enabled")])])])
+
+AM_COND_IF([ENABLE_TCTI_FUZZING], [
+            AM_COND_IF([ENABLE_TCTI_DEVICE],
+                       AC_MSG_ERROR("Fuzzing TCTI is meant to be built as the only TCTI"), [])
+            AM_COND_IF([ENABLE_TCTI_MSSIM],
+                       AC_MSG_ERROR("Fuzzing TCTI is meant to be built as the only TCTI"), [])
+            ], [])
 
 AC_MSG_RESULT([
     $PACKAGE_NAME $VERSION

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -1,0 +1,98 @@
+# Fuzzing
+
+Fuzz tests use [libFuzzer](http://llvm.org/docs/LibFuzzer.html) to test the SAPI
+`_Prepare` and `_Complete` functions.
+
+Building fuzz tests can be enabled using the `--with-fuzzing=` option. For which
+there are two possible values.
+
+- [libfuzzer](#libfuzzer)
+- [ossfuzz](#oss-fuzz)
+
+## libFuzzer
+
+libFuzzer tests can be built natively or using the docker `fuzzing` target.
+
+### Natively
+
+Build the fuzz tests by setting `--with-fuzzing=libfuzzer` and statically
+linking to the fuzzing TCTI.
+
+```console
+export LD_LIBRARY_PATH=/usr/local/bin
+GEN_FUZZ=1 ./bootstrap
+./configure \
+  CC=clang \
+  CXX=clang++ \
+  --enable-debug \
+  --with-fuzzing=libfuzzer \
+  --enable-tcti-fuzzing \
+  --enable-tcti-device=no \
+  --enable-tcti-mssim=no \
+  --with-maxloglevel=none \
+  --disable-shared
+make -j $(nproc) check
+```
+
+Run the fuzz tests by executing any binary ending in `.fuzz` in `test/fuzz/`.
+
+```console
+./test/fuzz/Tss2_Sys_ZGen_2Phase_Prepare.fuzz
+```
+
+### Docker
+
+Build the fuzz targets and check that they work by building the `fuzzing` docker
+target.
+
+```console
+docker build --target fuzzing -t tpm2-tss:fuzzing .
+```
+
+Run a fuzz target and mount a directory as a volume into the container where it
+should store its findings should it produce any.
+
+```console
+docker run --rm -ti tpm2-tss:fuzzing \
+   -v "${PWD}/findings_dir":/artifacts \
+   ./test/fuzz/Tss2_Sys_PolicyPhysicalPresence_Prepare.fuzz \
+  -artifact_prefix=/artifacts
+```
+
+## OSS Fuzz
+
+OSS fuzz integration can be found under the
+[tpm2-tss](https://github.com/google/oss-fuzz/tree/master/projects/tpm2-tss)
+project in OSS Fuzz.
+
+The `Dockerfile` there builds the dependencies. `build.sh` Runs the compilation
+as seen under the `fuzzing` target of the `Dockerfile` in this repo, only
+`--with-fuzzing=ossfuzz`.
+
+## Hacking
+
+Currently only fuzz targets for the System API have been implemented.
+
+### TCTI
+
+The fuzzing TCTI is used as a temporary storage location for the `Data` and
+`Size` arguments of `LLVMFuzzerTestOneInput`.
+
+For `_Complete` calls the TCTI uses `Data` and `Size` as the response buffer and
+response size for `TSS2_TCTI_RECEIVE`.
+
+### SAPI
+
+Fuzz tests are generated via `script/gen_fuzz.py`.
+
+Setting `GEN_FUZZ=1` when running `bootstrap` will run `script/gen_fuzz.py`.
+
+```console
+GEN_FUZZ=1 ./bootstrap
+```
+
+`script/gen_fuzz.py` reads the SAPI header file and generates a fuzz target for
+each `_Prepare` and `_Complete` call using similar templates.
+
+For `_Prepare` calls the `fuzz_fill` function in the fuzzing TCTI will fill each
+TPM2 structure used can copy from `LLVMFuzzerTestOneInput`'s `Data` into it.

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -50,3 +50,10 @@ AC_DEFUN([ADD_LINK_FLAG],[
         )]
     )]
 )
+dnl ADD_FUZZING_FLAG:
+dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable.
+dnl $1: C++ linker flag to add to FUZZ_LDFLAGS.
+AC_DEFUN([ADD_FUZZING_FLAG],[
+    FUZZ_LDFLAGS="$FUZZ_LDFLAGS $1"
+    AC_SUBST([FUZZ_LDFLAGS])
+])

--- a/script/fuzz-log-compiler.sh
+++ b/script/fuzz-log-compiler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2
+# Copyright (c) 2019, Intel Corporation
+set -exu
+
+# Check that the fuzz target does something by passing its own data as if it was
+# random fuzz data
+$1 $1

--- a/script/gen_fuzz.py
+++ b/script/gen_fuzz.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2
+import os
+import argparse
+import itertools
+
+# Makefile-fuzz-generated.am is created from this template.
+MAKEFILE_FUZZ = '''# SPDX-License-Identifier: BSD-2
+# Copyright (c) 2018 Intel Corporation
+# All rights reserved.
+
+if ENABLE_TCTI_FUZZING
+TESTS_FUZZ = %s
+%s
+endif # ENABLE_TCTI_FUZZING
+'''
+# Each fuzz target in Makefile-fuzz-generated.am is created from this template.
+MAKEFILE_FUZZ_TARGET = '''
+noinst_PROGRAMS += test/fuzz/%s.fuzz
+test_fuzz_%s_fuzz_CPPFLAGS = $(FUZZ_CPPFLAGS)
+test_fuzz_%s_fuzz_LDADD    = $(FUZZ_LDADD)
+test_fuzz_%s_fuzz_SOURCES  = test/fuzz/main-sapi.cpp \\
+        test/fuzz/%s.fuzz.cpp'''
+# Common include definitions needed for fuzzing an SAPI call
+SAPI_TEMPLATE_HEADER = '''/* SPDX-License-Identifier: BSD-2 */
+/***********************************************************************
+ * Copyright (c) 2018, Intel Corporation
+ *
+ * All rights reserved.
+ ***********************************************************************/
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <poll.h>
+#include <stdarg.h>
+
+#include <setjmp.h>
+
+extern "C" {
+#include "tss2_mu.h"
+#include "tss2_sys.h"
+#include "tss2_tcti_device.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-device.h"
+
+#define LOGMODULE fuzz
+#include "tss2_tcti.h"
+#include "util/log.h"
+#include "test.h"
+#include "test-options.h"
+#include "context-util.h"
+#include "tss2-sys/sysapi_util.h"
+#include "tcti/tcti-fuzzing.h"
+}
+
+extern "C"
+int
+test_invoke (
+        TSS2_SYS_CONTEXT *sysContext)'''
+# Template to call a SAPI _Complete function which takes no arguments
+SAPI_COMPLETE_TEMPLATE_NO_ARGS = SAPI_TEMPLATE_HEADER + '''
+{
+    %s (sysContext);
+
+    return EXIT_SUCCESS;
+}
+'''
+# Template to call a SAPI _Complete function which takes arguments
+SAPI_COMPLETE_TEMPLATE_HAS_ARGS = SAPI_TEMPLATE_HEADER + '''
+{
+    %s
+
+    %s (
+        sysContext,
+        %s
+    );
+
+    return EXIT_SUCCESS;
+}
+'''
+# Template to call a SAPI _Prepare function
+SAPI_PREPARE_TEMPLATE_HAS_ARGS = SAPI_TEMPLATE_HEADER + '''
+{
+    int ret;
+    %s
+
+    ret = fuzz_fill (
+        sysContext,
+        %d,
+        %s
+    );
+    if (ret) {
+        return ret;
+    }
+
+    %s (
+        sysContext,
+        %s
+    );
+
+    return EXIT_SUCCESS;
+}
+'''
+
+def gen_file(function):
+    '''
+    Generate a cpp file used as the fuzz target given the function definition
+    from a header file.
+    '''
+    # Parse the function name from the function definition
+    function_name = function.split('\n')[0]\
+                            .replace('TSS2_RC', '')\
+                            .replace('(', '')\
+                            .strip()
+    # Parse the function arguments into an array. Do not include sysContext.
+    args = [arg.strip() \
+            for arg in function[function.index('(') + 1:function.index(');')]\
+            .split(',') \
+            if not 'TSS2_SYS_CONTEXT' in arg]
+    # Prepare and Complete functions require different methods of generation.
+    # Call the appropriate function to generate a cpp target specific to that
+    # type of function.
+    if '_Complete' in function_name:
+        return gen_complete(function, function_name, args)
+    if '_Prepare' in function_name:
+        return gen_prepare(function, function_name, args)
+    raise NotImplementedError('Unknown function type %r' % (function_name,))
+
+def gen_complete(function, function_name, args):
+    '''
+    Generate the cpp fuzz target for a SAPI _Complete call
+    '''
+    if not args:
+        # Fill in the no args template. Simple case.
+        return function_name, SAPI_COMPLETE_TEMPLATE_NO_ARGS % (function_name)
+    # Generate the cpp variable definitions.
+    arg_definitions = (';\n' + ' ' * 4).join([
+        arg.replace('*', '') for arg in args]) + ';'
+    # Generate the cpp arguments. For arguments that are pointers find replace *
+    # with & so that we pass a pointer to the definition which has been
+    # allocated on the stack.
+    arg_call = (',\n' + ' ' * 8).join([
+        arg.replace('*', '&').split()[-1] for arg in args])
+    # Fill in the template
+    return function_name, SAPI_COMPLETE_TEMPLATE_HAS_ARGS % (arg_definitions,
+                                                             function_name,
+                                                             arg_call)
+
+def gen_prepare(function, function_name, args):
+    '''
+    Generate the cpp fuzz target for a SAPI _Prepare call
+    '''
+    if not args:
+        return function_name, None
+    # Generate the cpp variable definitions. Make sure to initialize to empty
+    # structs (works for initializing anything) or cpp compiler will complain.
+    arg_definitions = (' = {0};\n' + ' ' * 4).join([
+        arg.replace('*', '').replace('const', '') for arg in args]) + ' = {0};'
+    # Generate the cpp arguments. For arguments that are pointers find replace *
+    # with & so that we pass a pointer to the definition which has been
+    # allocated on the stack.
+    arg_call = (',\n' + ' ' * 8).join([
+        arg.replace('*', '&').split()[-1] for arg in args])
+    # Generate the call to fuzz_fill. The call should be the sysContext, double
+    # the number of arguments for the _Prepare call, and then for each _Prepare
+    # argument pass two to fuzz_fill, the sizeof the _Prepare argument, and a
+    # pointer to it.
+    fill_fuzz_args = (',\n' + ' ' * 8).join([
+        ('sizeof (%s), &%s' % \
+                tuple([arg.replace('*', '').split()[-1]] * 2)) \
+        for arg in args])
+    # Fill in the template
+    return function_name, SAPI_PREPARE_TEMPLATE_HAS_ARGS % (arg_definitions,
+                                                            len(args) * 2,
+                                                            fill_fuzz_args,
+                                                            function_name,
+                                                            arg_call)
+
+def functions_from_include(header):
+    '''
+    Parse out and yield each function definition from a header file.
+    '''
+    with open(header, 'r') as header_fd:
+        current_function = ''
+        for line in header_fd:
+            # Functions we are interested in start with _Complete or _Prepare
+            if '_Complete' in line or '_Prepare' in line:
+                # Set the current_function to this line
+                current_function = line
+            elif current_function and ');' in line:
+                # When we reach the closing parenthesis yield the function
+                yield current_function + line.rstrip()
+                current_function = ''
+            elif current_function:
+                # Add all the arguments to the function
+                current_function += line
+
+def gen_files(header):
+    # Generate a fuzz target cpp file from each function in the header file
+    for current_function in functions_from_include(header):
+        function_name, contents = gen_file(current_function)
+        # Skip the yield if there is no fuzz target that can be generated
+        if contents is None:
+            continue
+        # Yield the function name and the contents of its generated file
+        yield function_name, contents
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate libfuzzer for sapi')
+    parser.add_argument('--header', default='include/tss2/tss2_sys.h',
+            help='Header file to look in (default include/tss2/tss2_sys.h)')
+    args = parser.parse_args()
+
+    functions = dict(gen_files(args.header))
+    # Write the generated target to the file for its function name
+    for function_name, contents in functions.items():
+        filepath = os.path.join('test', 'fuzz', function_name + '.fuzz.cpp')
+        with open(filepath, 'w') as fuzzer_fd:
+            fuzzer_fd.write(contents)
+    # Fill in the Makefile-fuzz-generated.am template using the function names.
+    # Create a list of the compiled fuzz targets
+    files = ' \\\n    '.join(['test/fuzz/%s.fuzz' % (function) \
+                              for function in functions])
+    # Create the Makefile targets for each generated file
+    targets = '\n'.join([MAKEFILE_FUZZ_TARGET % tuple(list(itertools.chain(\
+            ([function] * 5)))) for function in functions])
+    # Write out the Makefile-fuzz-generated.am file
+    with open('Makefile-fuzz-generated.am', 'w') as makefile_fd:
+        makefile_fd.write(MAKEFILE_FUZZ % (files, targets))
+
+if __name__ == '__main__':
+    main()

--- a/test/fuzz/main-sapi.cpp
+++ b/test/fuzz/main-sapi.cpp
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: BSD-2 */
+/***********************************************************************
+ * Copyright (c) 2018, Intel Corporation
+ *
+ * All rights reserved.
+ ***********************************************************************/
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define LOGMODULE test
+extern "C" {
+#include "tss2_sys.h"
+#include "tss2_tcti.h"
+#include "util/log.h"
+#include "test.h"
+#include "test-options.h"
+#include "context-util.h"
+#include "tss2-sys/sysapi_util.h"
+#include "tcti/tcti-fuzzing.h"
+}
+
+extern "C"
+int
+LLVMFuzzerTestOneInput (
+        const uint8_t *Data,
+        size_t Size)
+{
+    int ret;
+    TSS2_SYS_CONTEXT *sapi_context;
+    _TSS2_SYS_CONTEXT_BLOB *ctx = NULL;
+    TSS2_TCTI_FUZZING_CONTEXT *tcti_fuzzing = NULL;
+
+    /* Use the fuzzing tcti */
+    test_opts_t opts = {
+        .tcti_type      = FUZZING_TCTI,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+    };
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0) {
+        LOG_ERROR("Checking test options");
+        exit(1); /* fatal error */
+    }
+
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        LOG_ERROR("SAPI context not initialized");
+        exit(1); /* fatal error */
+    }
+
+    ctx = syscontext_cast (sapi_context);
+    tcti_fuzzing = tcti_fuzzing_context_cast (ctx->tctiContext);
+    tcti_fuzzing->data = Data;
+    tcti_fuzzing->size = Size;
+
+    ret = test_invoke (sapi_context);
+
+    sapi_teardown_full (sapi_context);
+
+    if (ret) {
+        LOG_ERROR("Test failed");
+        exit(1); /* fatal error */
+    }
+
+    return 0;  // Non-zero return values are reserved for future use.
+}

--- a/test/fuzz/tcti/tcti-fuzzing.c
+++ b/test/fuzz/tcti/tcti-fuzzing.c
@@ -60,12 +60,12 @@ fuzz_fill (
 {
     va_list ap;
     const uint8_t *data = NULL;
-    const uint8_t *curr = NULL;
+    const uint8_t *pointer_into_data = NULL;
     size_t size = 0U;
     size_t i = 0U;
-    void *dest;
-    size_t length = 0U;
-    size_t combined = 0U;
+    void *copy_into_type;
+    size_t copy_into_length = 0U;
+    size_t data_used = 0U;
     _TSS2_SYS_CONTEXT_BLOB *ctx = NULL;
     TSS2_TCTI_FUZZING_CONTEXT *tcti_fuzzing = NULL;
 
@@ -77,12 +77,12 @@ fuzz_fill (
     va_start (ap, count);
 
     for (i = 0U; i < (count / 2); ++i) {
-        length = va_arg (ap, size_t);
-        dest = va_arg (ap, void *);
-        if (size > (combined + length)) {
-            curr = &data[combined];
-            combined += length;
-            memcpy (dest, curr, length);
+        copy_into_length = va_arg (ap, size_t);
+        copy_into_type = va_arg (ap, void *);
+        if (size > (data_used + copy_into_length)) {
+            pointer_into_data = &data[data_used];
+            data_used += copy_into_length;
+            memcpy (copy_into_type, pointer_into_data, copy_into_length);
         }
     }
 

--- a/test/fuzz/tcti/tcti-fuzzing.c
+++ b/test/fuzz/tcti/tcti-fuzzing.c
@@ -1,0 +1,274 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ */
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <sys/time.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "tss2_mu.h"
+#include "tss2_tcti_fuzzing.h"
+
+#include "tcti-fuzzing.h"
+#include "tss2-tcti/tcti-common.h"
+#include "util/key-value-parse.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+/*
+ * Using the data and size fields of the fuzzing TCTI memcpy the data into the
+ * structures given via va_list. Caller will pass the sysContext and number of
+ * arguments that follow. Following the count of arguments caller should pass
+ * the sizeof the next argument, which shall be a pointer to the structure to be
+ * filled.
+ *
+ * Example:
+ *
+ *     TPMI_DH_OBJECT keyA = {0};
+ *     TPM2B_ECC_POINT inQsB = {0};
+ *     TPM2B_ECC_POINT inQeB = {0};
+ *     TPMI_ECC_KEY_EXCHANGE inScheme = {0};
+ *     UINT16 counter = {0};
+ *
+ *     ret = fuzz_fill (
+ *         sysContext,
+ *         10,
+ *         sizeof (keyA), &keyA,
+ *         sizeof (inQsB), &inQsB,
+ *         sizeof (inQeB), &inQeB,
+ *         sizeof (inScheme), &inScheme,
+ *         sizeof (counter), &counter
+ *     );
+ *     if (ret) {
+ *         ... handle failure
+ *     }
+ */
+int
+fuzz_fill (
+        TSS2_SYS_CONTEXT *sysContext,
+        size_t count,
+        ...)
+{
+    va_list ap;
+    const uint8_t *data = NULL;
+    const uint8_t *curr = NULL;
+    size_t size = 0U;
+    size_t i = 0U;
+    void *dest;
+    size_t length = 0U;
+    size_t combined = 0U;
+    _TSS2_SYS_CONTEXT_BLOB *ctx = NULL;
+    TSS2_TCTI_FUZZING_CONTEXT *tcti_fuzzing = NULL;
+
+    ctx = syscontext_cast (sysContext);
+    tcti_fuzzing = tcti_fuzzing_context_cast (ctx->tctiContext);
+    data = tcti_fuzzing->data;
+    size = tcti_fuzzing->size;
+
+    va_start (ap, count);
+
+    for (i = 0U; i < (count / 2); ++i) {
+        length = va_arg (ap, size_t);
+        dest = va_arg (ap, void *);
+        if (size > (combined + length)) {
+            curr = &data[combined];
+            combined += length;
+            memcpy (dest, curr, length);
+        }
+    }
+
+    va_end (ap);
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the fuzzing TCTI context. The only safeguard we have to ensure this
+ * operation is possible is the magic number in the fuzzing TCTI context.
+ * If passed a NULL context, or the magic number check fails, this function
+ * will return NULL.
+ */
+TSS2_TCTI_FUZZING_CONTEXT*
+tcti_fuzzing_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_FUZZING_MAGIC) {
+        return (TSS2_TCTI_FUZZING_CONTEXT*)tcti_ctx;
+    }
+    return NULL;
+}
+
+/*
+ * This function down-casts the fuzzing TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+TSS2_TCTI_COMMON_CONTEXT*
+tcti_fuzzing_down_cast (TSS2_TCTI_FUZZING_CONTEXT *tcti_fuzzing)
+{
+    if (tcti_fuzzing == NULL) {
+        return NULL;
+    }
+    return &tcti_fuzzing->common;
+}
+
+TSS2_RC
+tcti_fuzzing_transmit (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t size,
+    const uint8_t *cmd_buf)
+{
+    (void) tcti_ctx;
+    (void) size;
+    (void) cmd_buf;
+    ((TSS2_TCTI_FUZZING_CONTEXT*) tcti_ctx)->common.state = TCTI_STATE_RECEIVE;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_fuzzing_cancel (
+    TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    (void) tcti_ctx;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_fuzzing_set_locality (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    uint8_t locality)
+{
+    (void) tcti_ctx;
+    (void) locality;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_fuzzing_get_poll_handles (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    (void)(tcti_ctx);
+    (void)(handles);
+    (void)(num_handles);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+void
+tcti_fuzzing_finalize(
+    TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    (void)(tcti_ctx);
+}
+
+TSS2_RC
+tcti_fuzzing_receive (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t *response_size,
+    unsigned char *response_buffer,
+    int32_t timeout)
+{
+    TSS2_TCTI_FUZZING_CONTEXT *tcti_fuzzing = tcti_fuzzing_context_cast (tcti_ctx);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_fuzzing_down_cast (tcti_fuzzing);
+    TSS2_RC rc;
+
+    rc = tcti_common_receive_checks (tcti_common, response_size);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    if (timeout != TSS2_TCTI_TIMEOUT_BLOCK) {
+        LOG_WARNING ("The underlying IPC mechanism does not support "
+                     "asynchronous I/O. The 'timeout' parameter must be "
+                     "TSS2_TCTI_TIMEOUT_BLOCK");
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    if (response_buffer == NULL) {
+        LOG_DEBUG ("Caller queried for size but linux kernel doesn't allow this. "
+                   "Returning 4k which is the max size for a response buffer.");
+        *response_size = tcti_fuzzing->size;
+        return TSS2_RC_SUCCESS;
+    }
+    if (*response_size < tcti_fuzzing->size) {
+        LOG_INFO ("Caller provided buffer that *may* not be large enough to "
+                  "hold the response buffer.");
+    }
+
+    /* Receive the TPM response. */
+    *response_size = tcti_fuzzing->size;
+    tcti_common->header.size = 0;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    memcpy(response_buffer, tcti_fuzzing->data, *response_size);
+
+    return rc;
+}
+
+void
+tcti_fuzzing_init_context_data (
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common)
+{
+    TSS2_TCTI_MAGIC (tcti_common) = TCTI_FUZZING_MAGIC;
+    TSS2_TCTI_VERSION (tcti_common) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tcti_common) = tcti_fuzzing_transmit;
+    TSS2_TCTI_RECEIVE (tcti_common) = tcti_fuzzing_receive;
+    TSS2_TCTI_FINALIZE (tcti_common) = tcti_fuzzing_finalize;
+    TSS2_TCTI_CANCEL (tcti_common) = tcti_fuzzing_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tcti_common) = tcti_fuzzing_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_fuzzing_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tcti_common) = tcti_make_sticky_not_implemented;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    tcti_common->locality = 3;
+    memset (&tcti_common->header, 0, sizeof (tcti_common->header));
+}
+
+/*
+ * This is an implementation of the standard TCTI initialization function for
+ * this module.
+ */
+TSS2_RC
+Tss2_Tcti_Fuzzing_Init (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t *size,
+    const char *conf)
+{
+    (void) conf;
+
+    if (size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    if (tcti_ctx == NULL) {
+        *size = sizeof (TSS2_TCTI_FUZZING_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+    if (*size != sizeof (TSS2_TCTI_FUZZING_CONTEXT)) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    tcti_fuzzing_init_context_data (
+            &(((TSS2_TCTI_FUZZING_CONTEXT*) tcti_ctx)->common));
+
+    return TSS2_RC_SUCCESS;
+}
+
+/* public info structure */
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-fuzzing",
+    .description = "TCTI module for fuzzing the System API.",
+    .config_help = "Takes no configuration.",
+    .init = Tss2_Tcti_Fuzzing_Init,
+};
+
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/test/fuzz/tcti/tcti-fuzzing.h
+++ b/test/fuzz/tcti/tcti-fuzzing.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ */
+
+#ifndef TCTI_FUZZING_H
+#define TCTI_FUZZING_H
+
+#include <limits.h>
+
+#include "tss2-tcti/tcti-common.h"
+#include "util/io.h"
+#include "tss2-sys/sysapi_util.h"
+
+#define TCTI_FUZZING_MAGIC 0x66757a7a696e6700ULL
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    const uint8_t *data;
+    size_t size;
+} TSS2_TCTI_FUZZING_CONTEXT;
+
+TSS2_TCTI_FUZZING_CONTEXT*
+tcti_fuzzing_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx);
+
+int
+fuzz_fill (
+        TSS2_SYS_CONTEXT *sysContext,
+        size_t count,
+        ...);
+
+#endif /* TCTI_FUZZING_H */

--- a/test/fuzz/tcti/tss2_tcti_fuzzing.h
+++ b/test/fuzz/tcti/tss2_tcti_fuzzing.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ */
+#ifndef TSS2_TCTI_FUZZING_H
+#define TSS2_TCTI_FUZZING_H
+
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Fuzzing_Init (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t *size,
+    const char *conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_FUZZING_H */

--- a/test/integration/sapi-context-util.c
+++ b/test/integration/sapi-context-util.c
@@ -9,13 +9,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <config.h>
 
 #include "tss2_tcti_device.h"
 #include "tss2_tcti_mssim.h"
+#ifdef TCTI_FUZZING
+#include "tss2_tcti_fuzzing.h"
+#endif /* TCTI_FUZZING */
 
 #include "context-util.h"
 #include "tss2-tcti/tcti-mssim.h"
 
+#ifdef TCTI_DEVICE
 /*
  * Initialize a TSS2_TCTI_CONTEXT for the device TCTI.
  */
@@ -48,7 +53,9 @@ tcti_device_init(char const *device_path)
     }
     return tcti_ctx;
 }
+#endif /* TCTI_DEVICE */
 
+#ifdef TCTI_MSSIM
 /*
  * Initialize a socket TCTI instance using the provided options structure.
  * The hostname and port are the only configuration options used.
@@ -84,6 +91,43 @@ tcti_socket_init(char const *host, uint16_t port)
     }
     return tcti_ctx;
 }
+#endif /* TCTI_MSSIM */
+
+#ifdef TCTI_FUZZING
+/*
+ * Initialize a fuzzing TCTI instance using the provided options structure.
+ * The fuzzing_lengths.log file is the only configuration option used.
+ * The caller is returned a TCTI context structure that is allocated by this
+ * function. This structure must be freed by the caller.
+ */
+TSS2_TCTI_CONTEXT *
+tcti_fuzzing_init()
+{
+    size_t size;
+    TSS2_RC rc;
+    TSS2_TCTI_CONTEXT *tcti_ctx;
+
+    rc = Tss2_Tcti_Fuzzing_Init(NULL, &size, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        fprintf(stderr, "Faled to get allocation size for tcti context: "
+                "0x%x\n", rc);
+        return NULL;
+    }
+    tcti_ctx = (TSS2_TCTI_CONTEXT *) calloc(1, size);
+    if (tcti_ctx == NULL) {
+        fprintf(stderr, "Allocation for tcti context failed: %s\n",
+                strerror(errno));
+        return NULL;
+    }
+    rc = Tss2_Tcti_Fuzzing_Init(tcti_ctx, &size, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        fprintf(stderr, "Failed to initialize tcti context: 0x%x\n", rc);
+        free(tcti_ctx);
+        return NULL;
+    }
+    return tcti_ctx;
+}
+#endif /* TCTI_FUZZING */
 
 /*
  * Initialize a SAPI context using the TCTI context provided by the caller.
@@ -147,10 +191,18 @@ TSS2_TCTI_CONTEXT *
 tcti_init_from_opts(test_opts_t * options)
 {
     switch (options->tcti_type) {
+#ifdef TCTI_DEVICE
     case DEVICE_TCTI:
         return tcti_device_init(options->device_file);
+#endif /* TCTI_DEVICE */
+#ifdef TCTI_MSSIM
     case SOCKET_TCTI:
         return tcti_socket_init(options->socket_address, options->socket_port);
+#endif /* TCTI_MSSIM */
+#ifdef TCTI_FUZZING
+    case FUZZING_TCTI:
+        return tcti_fuzzing_init();
+#endif /* TCTI_FUZZING */
     default:
         return NULL;
     }

--- a/test/integration/sapi-test-options.c
+++ b/test/integration/sapi-test-options.c
@@ -32,6 +32,10 @@ tcti_map_entry_t tcti_map_table[] = {
      .type = SOCKET_TCTI,
      },
     {
+     .name = "fuzzing",
+     .type = FUZZING_TCTI,
+     },
+    {
      .name = "unknown",
      .type = UNKNOWN_TCTI,
      },
@@ -85,6 +89,8 @@ sanity_check_test_opts(test_opts_t * opts)
                     "socket_address or socket_port is NULL, check env\n");
             return 1;
         }
+        break;
+    case FUZZING_TCTI:
         break;
     default:
         fprintf(stderr, "unknown TCTI type, check env\n");

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -30,6 +30,7 @@ typedef enum {
     UNKNOWN_TCTI,
     DEVICE_TCTI,
     SOCKET_TCTI,
+    FUZZING_TCTI,
     N_TCTI,
 } TCTI_TYPE;
 


### PR DESCRIPTION
* Removed struct TSS2_SYS_CONTEXT definition from
  src/tss2-sys/sysapi_util.h as it caused errors with C++ build.
* travis will build fuzz tests to make sure they don't bit rot if
  building with clang.
* Dockerfile uses targets and can build just fuzz tests.
* Added Makefile-fuzz.am and generating Makefile-fuzz-generated.am
  which build fuzz tests.
* Added python script gen_fuzz.py which reads include/tss2/tss2_sys.h
  and generates a fuzz target for all Prepare and Complete calls.
* Added test/fuzz/main-sapi.cpp which defines a libfuzzer target used to
  fuzz SAPI calls.
* Added a TCTI for fuzzing which stores fuzzer generated data which
  populates structures used for SAPI Prepare calls or feed to Complete
  and subsequently unmarshalled.
* Modified integration sapi context util to enable static linking
  against a TCTI.
* Modified integration test options to add the fuzzing TCTI type.


- [x] See about MAINTAINERS path required review with github. https://blog.github.com/2017-07-06-introducing-code-owners/
  - Serarate change. SHould probably be in separate PR
- [x] Investigate ifdefs in `sapi-context-util.c` and why John has decided
  to disable other tctis in order to build the fuzzing tcti.
  - On link `multiple definition of 'tss2_tcti_info'` error when more than one tcti is enabled
    and `--disable-shared` is given to configure (+@flihp)
- [x] Review where comments need to be added.
- [x] Do not generate fuzz tests by default in `bootstrap`
- [x] `struct TSS2_SYS_CONTEXT;` remove from `sysapi_util.h` in seperate PR (#1244)
- [x] Split into separate commits