### PR TITLE
esys_crypto_ossl.c: load engine explicitly

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -1121,6 +1121,7 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t * key,
  */
 TSS2_RC
 iesys_cryptossl_init() {
+    ENGINE_load_builtin_engines();
     OpenSSL_add_all_algorithms();
     return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
In some cases, when built with the `openssl` crypto backend, `ENGINE_by_id("openssl");` fails with the error that no engine named `libopenssl.so` was found in the openssl `engines/` directory.

Specifically, I ran into errors experimenting with `openssl` `s_server` with the `tpm2tss` engine which uses the ESYS API. This was in a container with an Alpine base image. My tss libraries were compiled with the `openssl` crypto backend.

Loading the engine explicitly with a call to `ENGINE_load_builtin_engines` eliminates this error.

