### PR TITLE
Fix integration tests erroring with "Connection refused"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libtool \
     m4 \
-    net-tools \
+    iproute2 \
     pkg-config \
     wget
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ The following are dependencies only required when building test suites.
 * OpenSSL development libraries and header files
 * Unit test suite (see ./configure option --enable-unit):
 * cmocka unit test framework, version >= 1.0
-* netstat executable (usually in the net-tools package)
+* ss executable (usually in the iproute2 package)
 * Code coverage analysis:
 * lcov
 * uthash development libraries and header files
@@ -36,7 +36,7 @@ $ sudo apt -y install \
   autoconf-archive \
   libcmocka0 \
   libcmocka-dev \
-  net-tools \
+  iproute2 \
   build-essential \
   git \
   pkg-config \

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_ARG_ENABLE([integration],
     [enable_integration=no])
 AS_IF([test "x$enable_integration" = "xyes"],
       [ERROR_IF_NO_PROG([tpm_server])
-       ERROR_IF_NO_PROG([netstat])
+       ERROR_IF_NO_PROG([ss])
        ERROR_IF_NO_PROG([ps])
        ERROR_IF_NO_PROG([echo])
        ERROR_IF_NO_PROG([kill])

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ AS_IF([test "x$enable_integration" = "xyes"],
        ERROR_IF_NO_PROG([ps])
        ERROR_IF_NO_PROG([echo])
        ERROR_IF_NO_PROG([kill])
-       ERROR_IF_NO_PROG([nohup])
+       ERROR_IF_NO_PROG([stdbuf])
        ERROR_IF_NO_PROG([sleep])
        ERROR_IF_NO_PROG([cat])
        ERROR_IF_NO_PROG([realpath])

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -71,8 +71,8 @@ sanity_test ()
         exit 1
     fi
 
-    if [ -z "$(which netstat)" ]; then
-        echo "netstat not on PATH; exiting"
+    if [ -z "$(which ss)" ]; then
+        echo "ss not on PATH; exiting"
         exit 1
     fi
 }
@@ -202,9 +202,9 @@ for i in $(seq ${BACKOFF_MAX}); do
     fi
     PID=$(cat ${SIM_PID_FILE})
     echo "simulator PID: ${PID}";
-    netstat -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
+    ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
     ret_data=$?
-    netstat -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
+    ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
     ret_cmd=$?
     if [ \( $ret_data -eq 0 \) -a \( $ret_cmd -eq 0 \) ]; then
         echo "Simulator with PID ${PID} bound to port ${SIM_PORT_DATA} and " \

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -202,9 +202,9 @@ for i in $(seq ${BACKOFF_MAX}); do
     fi
     PID=$(cat ${SIM_PID_FILE})
     echo "simulator PID: ${PID}";
-    netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
+    netstat -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
     ret_data=$?
-    netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
+    netstat -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
     ret_cmd=$?
     if [ \( $ret_data -eq 0 \) -a \( $ret_cmd -eq 0 \) ]; then
         echo "Simulator with PID ${PID} bound to port ${SIM_PORT_DATA} and " \

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -102,7 +102,7 @@ daemon_start ()
     local daemon_pid_file="$4"
     local daemon_env="$5"
 
-    env ${daemon_env} nohup ${daemon_bin} ${daemon_opts} > ${daemon_log_file} 2>&1 &
+    env ${daemon_env} stdbuf -o0 -e0 ${daemon_bin} ${daemon_opts} > ${daemon_log_file} 2>&1 &
     local ret=$?
     local pid=$!
     if [ ${ret} -ne 0 ]; then


### PR DESCRIPTION
I dug a little deeper into #1227, which I can reproduce with some reliability on my machine when running several tests in parallel (e.g. `make -j16 check`). Apparently `tpm_server` sometimes fails to bind to the IPv4 interface, but succeeds in binding to the IPv6 interface, even though I am not entirely sure why that happens (the port doesn't appear to be used by other instances of the simulator or anything else on the system). As the [netstat check whether binding the port succeeded](https://github.com/tpm2-software/tpm2-tss/blob/266af7ffa335b9b0ef59f6e5fe541a774cb203a1/script/int-log-compiler.sh#L205) sees the IPv6 binding, it erroneously thinks that everything has worked fine, resulting in a "Connection refused" error because the tests only connect to the simulator using IPv4.

The problem is easily fixed by restricting the netstat output to IPv4 with the `-4` option. If binding the port fails, it will now be detected correctly and a different port will be tried instead.

As netstat is deprecated in favour of ss [according to its man page](http://net-tools.sourceforge.net/man/netstat.8.html), I also took the opportunity to replace the command, the options are unchanged for this particular use case.

In debugging this issue, I noticed that the `*.int_simulator.log` files are empty on my machine because the simulator is killed before it flushes the stdout buffer. This can be solved by disabling the buffer with [stdbuf](https://www.gnu.org/software/coreutils/manual/html_node/stdbuf-invocation.html) from the GNU Core Utilities. Using nohup is not necessary because the simulator doesn't need to run longer than the `int-log-compiler.sh` helper script, so I removed it. 