### PR TITLE
Fix number of NULL ptr issues in ESYS

### DIFF
--- a/src/tss2-esys/api/Esys_EventSequenceComplete.c
+++ b/src/tss2-esys/api/Esys_EventSequenceComplete.c
@@ -207,7 +207,8 @@ Esys_EventSequenceComplete_Async(
     iesys_compute_session_value(esysContext->session_tab[0],
                 &pcrHandleNode->rsrc.name, &pcrHandleNode->auth);
     iesys_compute_session_value(esysContext->session_tab[1],
-                &sequenceHandleNode->rsrc.name, &sequenceHandleNode->auth);
+                sequenceHandleNode ? &sequenceHandleNode->rsrc.name : NULL,
+                sequenceHandleNode ? &sequenceHandleNode->auth : NULL);
     iesys_compute_session_value(esysContext->session_tab[2], NULL, NULL);
 
     /* Generate the auth values and set them in the SAPI command buffer */

--- a/src/tss2-esys/api/Esys_SequenceComplete.c
+++ b/src/tss2-esys/api/Esys_SequenceComplete.c
@@ -197,7 +197,8 @@ Esys_SequenceComplete_Async(
     r = init_session_tab(esysContext, shandle1, shandle2, shandle3);
     return_state_if_error(r, _ESYS_STATE_INIT, "Initialize session resources");
     iesys_compute_session_value(esysContext->session_tab[0],
-                &sequenceHandleNode->rsrc.name, &sequenceHandleNode->auth);
+                sequenceHandleNode ? &sequenceHandleNode->rsrc.name : NULL,
+                sequenceHandleNode ? &sequenceHandleNode->auth : NULL);
     iesys_compute_session_value(esysContext->session_tab[1], NULL, NULL);
     iesys_compute_session_value(esysContext->session_tab[2], NULL, NULL);
 

--- a/src/tss2-esys/api/Esys_SequenceUpdate.c
+++ b/src/tss2-esys/api/Esys_SequenceUpdate.c
@@ -189,7 +189,8 @@ Esys_SequenceUpdate_Async(
     r = init_session_tab(esysContext, shandle1, shandle2, shandle3);
     return_state_if_error(r, _ESYS_STATE_INIT, "Initialize session resources");
     iesys_compute_session_value(esysContext->session_tab[0],
-                &sequenceHandleNode->rsrc.name, &sequenceHandleNode->auth);
+                sequenceHandleNode ? &sequenceHandleNode->rsrc.name : NULL,
+                sequenceHandleNode ? &sequenceHandleNode->auth : NULL);
     iesys_compute_session_value(esysContext->session_tab[1], NULL, NULL);
     iesys_compute_session_value(esysContext->session_tab[2], NULL, NULL);
 

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -918,7 +918,7 @@ iesys_compute_session_value(RSRC_NODE_T * session,
 
     session->rsrc.misc.rsrc_session.sizeHmacValue = session->rsrc.misc.rsrc_session.sizeSessionValue;
 
-    if (name == NULL)
+    if (name == NULL || auth_value == NULL)
         return;
 
     /* The auth value is appended to the session key */

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -356,7 +356,8 @@ Esys_TR_Close(ESYS_CONTEXT * esys_context, ESYS_TR * object)
  * every Esys_TR_Deserialize.
  * @param esys_context [in,out] The ESYS_CONTEXT.
  * @param esys_handle [in,out] The ESYS_TR for which to set the auth value.
- * @param authValue [in] The auth value to set for the ESYS_TR.
+ * @param authValue [in] The auth value to set for the ESYS_TR or NULL to zero
+ *        the auth.
  * @retval TSS2_RC_SUCCESS on Success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext is NULL.
  * @retval TSS2_ESYS_RC_BAD_TR if the ESYS_TR object is unknown to the
@@ -372,7 +373,12 @@ Esys_TR_SetAuth(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     if (r != TPM2_RC_SUCCESS)
         return r;
-    esys_object->auth = *authValue;
+
+    if (authValue == NULL)
+        esys_object->auth.size = 0;
+    else
+        esys_object->auth = *authValue;
+
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -255,6 +255,31 @@ test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
 }
 
 int
+test_esys_tr_setauth(ESYS_CONTEXT * esys_context)
+{
+    TSS2_RC r;
+    TPM2B_AUTH auth = {.size = 20,
+                       .buffer={30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                40, 41, 42, 43, 44, 45, 46, 47, 48, 49}};
+
+    r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &auth);
+    return_if_error(r, "Error in Esys_TR_SetAuth");
+
+    r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, NULL);
+    return_if_error(r, "Error in Esys_TR_SetAuth");
+
+    return EXIT_SUCCESS;
+}
+
+int
 test_invoke_esapi(ESYS_CONTEXT * esys_context) {
-    return test_esys_object_changeauth(esys_context);
+    TSS2_RC r;
+
+    r = test_esys_object_changeauth(esys_context);
+    return_if_error(r, "test_esys_object_changeauth");
+
+    r = test_esys_tr_setauth(esys_context);
+    return_if_error(r, "test_esys_tr_setauth");
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
esys: Check for NULL auth in iesys_compute_session_value
esys: Fix NULL ptr auth in Esys_TR_SetAuth
esys: handle NULL sequenceHandleNode
test: esys: Add test for Esys_TR_SetAuth with NULL auth