### PR TITLE
build: update to ax_code_coverage.m4 version 2019.01.06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 AUTHORS
 tags
 aclocal.m4
+aminclude_static.am
 autom4te.cache/
 [Bb]uild/
 [Dd]ebug/

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ addons:
 
 install:
 # Autoconf archive
-  - wget https://download.01.org/tpm2/autoconf-archive-2017.09.28.tar.xz
-  - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01 || travis_terminate 1
-  - tar xJf autoconf-archive-2017.09.28.tar.xz
-  - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
-  - cp autoconf-archive-2017.09.28/m4/ax_prog_doxygen.m4 m4/
+  - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2019.01.06.tar.xz
+  - sha256sum autoconf-archive-2019.01.06.tar.xz | grep -q 17195c833098da79de5778ee90948f4c5d90ed1a0cf8391b4ab348e2ec511e3f || travis_terminate 1
+  - tar xJf autoconf-archive-2019.01.06.tar.xz
+  - cp autoconf-archive-2019.01.06/m4/ax_code_coverage.m4 m4/
+  - cp autoconf-archive-2019.01.06/m4/ax_prog_doxygen.m4 m4/
 # Coveralls
   - pip install --user cpp-coveralls
 # IBM-TPM

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,13 @@ noinst_PROGRAMS =
 
 ### Add ax_* rules ###
 # ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+dist-clean-local: code-coverage-dist-clean
+else
 @CODE_COVERAGE_RULES@
+endif
 
 # ax_doxygen
 @DX_RULES@

--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,9 @@ AS_IF([test "x$enable_doxygen_doc" != xno],
       [ERROR_IF_NO_PROG([doxygen])])
 
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
 
 AC_OUTPUT
 


### PR DESCRIPTION
When using this project in combination with the freshly released Autoconf Archive 2019.01.06, the build fails with a "missing separator" error in the makefile. This is because upstream made a [breaking change](http://git.savannah.nongnu.org/cgit/autoconf-archive.git/commit/m4/ax_code_coverage.m4?id=b5a2d69f7a7e0133733673586231b88464a98d58) by removing `@CODE_COVERAGE_RULES@` and replacing it with `include $(top_srcdir)/aminclude_static.am`, see the [documentation](https://www.gnu.org/software/autoconf-archive/ax_code_coverage.html) for reference.