### PR TITLE
ESYS: Fix passing of NULL pointers for auth values.

### DIFF
--- a/src/tss2-esys/api/Esys_HMAC_Start.c
+++ b/src/tss2-esys/api/Esys_HMAC_Start.c
@@ -344,8 +344,11 @@ Esys_HMAC_Start_Finish(
 
     /*  The name of a sequence object is an empty buffer */
     sequenceHandleNode->rsrc.name.size = 0;
-    /* Store the auth value parameter in the object meta data */
-    sequenceHandleNode->auth = *esysContext->in.HMAC_Start.auth;
+    /* Store the auth value parameter in the object meta data if passed */
+    if (esysContext->in.HMAC_Start.auth == NULL)
+        sequenceHandleNode->auth.size = 0;
+    else
+        sequenceHandleNode->auth = *esysContext->in.HMAC_Start.auth;
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
+++ b/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
@@ -316,7 +316,10 @@ Esys_HierarchyChangeAuth_Finish(
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
     return_if_error(r, "get resource");
 
-    authHandleNode->auth = *esysContext->in.HierarchyChangeAuth.newAuth;
+    if (esysContext->in.HierarchyChangeAuth.newAuth == NULL)
+        authHandleNode->auth.size = 0;
+    else
+        authHandleNode->auth = *esysContext->in.HierarchyChangeAuth.newAuth;
     iesys_compute_session_value(esysContext->session_tab[0],
                                 &authHandleNode->rsrc.name, &authHandleNode->auth);
 

--- a/src/tss2-esys/api/Esys_NV_ChangeAuth.c
+++ b/src/tss2-esys/api/Esys_NV_ChangeAuth.c
@@ -312,7 +312,10 @@ Esys_NV_ChangeAuth_Finish(
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");
 
-    nvIndexNode->auth = *esysContext->in.NV_ChangeAuth.newAuth;
+    if (esysContext->in.NV_ChangeAuth.newAuth == NULL)
+        nvIndexNode->auth.size = 0;
+    else
+        nvIndexNode->auth = *esysContext->in.NV_ChangeAuth.newAuth;
     iesys_compute_session_value(esysContext->session_tab[0],
                                 &nvIndexNode->rsrc.name, &nvIndexNode->auth);
 

--- a/src/tss2-esys/api/Esys_NV_DefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_DefineSpace.c
@@ -371,7 +371,10 @@ Esys_NV_DefineSpace_Finish(
         esysContext->in.NV_DefineSpace.publicInfo->nvPublic.nvIndex;
     nvHandleNode->rsrc.misc.rsrc_nv_pub =
         *esysContext->in.NV_DefineSpace.publicInfo;
-    nvHandleNode->auth = *esysContext->in.NV_DefineSpace.auth;
+    if (esysContext->in.NV_DefineSpace.auth == NULL)
+        nvHandleNode->auth.size = 0;
+    else
+        nvHandleNode->auth = *esysContext->in.NV_DefineSpace.auth;
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -136,6 +136,8 @@ test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, ESYS_TR_RH_OWNER, &newAuth);
     goto_if_error(r, "Error SetAuth", error);
 
+    /* Check whether HierarchyChangeAuth with auth equal NULL works */
+
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
                            &outsideInfo, &creationPCR, &primaryHandle,
@@ -151,7 +153,7 @@ test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
                                  ESYS_TR_PASSWORD,
                                  ESYS_TR_NONE,
                                  ESYS_TR_NONE,
-                                 &emptyAuth);
+                                 NULL);
     goto_if_error(r, "Error: HierarchyChangeAuth", error);
 
     return EXIT_SUCCESS;

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -174,6 +174,67 @@ test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
                               );
     goto_if_error(r, "Error: SequenceComplete", error);
 
+#ifdef TEST_SESSION
+    r = Esys_FlushContext(esys_context, session);
+    goto_if_error(r, "Error: FlushContext", error);
+#endif
+
+    /* Check HMAC_Start with auth equal NULL */
+
+ #ifdef TEST_SESSION
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              &nonceCaller,
+                              TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA1,
+                              &session);
+
+    goto_if_error(r, "Error: During initialization of session", error);
+#endif /* TEST_SESSION */
+
+    r = Esys_HMAC_Start(esys_context,
+                        primaryHandle,
+#ifdef TEST_SESSION
+                        session,
+#else
+                        ESYS_TR_PASSWORD,
+#endif
+                        ESYS_TR_NONE,
+                        ESYS_TR_NONE,
+                        NULL,
+                        hashAlg,
+                        &sequenceHandle
+                        );
+    goto_if_error(r, "Error: HashSequenceStart", error);
+
+    r = Esys_SequenceUpdate(esys_context,
+                            sequenceHandle,
+#ifdef TEST_SESSION
+                            session,
+#else
+                            ESYS_TR_PASSWORD,
+#endif
+                            ESYS_TR_NONE,
+                            ESYS_TR_NONE,
+                            &buffer
+                            );
+    goto_if_error(r, "Error: SequenceUpdate", error);
+
+    r = Esys_SequenceComplete(esys_context,
+                              sequenceHandle,
+#ifdef TEST_SESSION
+                              session,
+#else
+                              ESYS_TR_PASSWORD,
+#endif
+                              ESYS_TR_NONE,
+                              ESYS_TR_NONE,
+                              &buffer,
+                              TPM2_RH_OWNER,
+                              &result,
+                              &validation
+                              );
+    goto_if_error(r, "Error: SequenceComplete", error);
+
     r = Esys_FlushContext(esys_context, primaryHandle);
     goto_if_error(r, "Error: FlushContext", error);
 


### PR DESCRIPTION
* In some cases in ESAPI a NULL pointer was dereferenced when NULL was passed
  as auth value.
* When a special handling for the auth value is required by ESAPI,
  in these cases the size of the stored auth value will be set to zero.
* The integration tests are modified to cover these cases.

Signed-off-by: Juergen Repp <Juergen.Repp@sit.fraunhofer.de>