### PR TITLE
Fix leak in ESAPI with OpenSSL crypto backend

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -317,7 +317,6 @@ iesys_cryptossl_hmac_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
     TSS2_RC r = TSS2_RC_SUCCESS;
     EVP_PKEY *hkey = NULL;
 
-
     LOG_TRACE("called for context-pointer %p and hmacAlg %d", context, hashAlg);
     LOGBLOB_TRACE(key, size, "Starting  hmac with");
     if (context == NULL || key == NULL) {
@@ -356,6 +355,8 @@ iesys_cryptossl_hmac_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
     mycontext->type = IESYS_CRYPTOSSL_TYPE_HMAC;
 
     *context = (IESYS_CRYPTO_CONTEXT_BLOB *) mycontext;
+
+    EVP_PKEY_free(hkey);
 
     return TSS2_RC_SUCCESS;
 


### PR DESCRIPTION
My ESAPI port of tpm2-tools was causing leaks when using the OpenSSL crypto backend. It took me a while to find that I could use `ASAN_OPTIONS=fast_unwind_on_malloc=0` to print fuller stacktraces and find out where the culprit was:

> =================================================================
> ==21014==ERROR: LeakSanitizer: detected memory leaks
> 
> Direct leak of 72 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a237a78a in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x17478a)
>     #3 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #4 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #5 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #6 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #7 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #8 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #9 0x7fc7a269f6fb in Esys_Load_Finish src/tss2-esys/api/Esys_Load.c:338
>     #10 0x7fc7a269fbc3 in Esys_Load src/tss2-esys/api/Esys_Load.c:108
>     #11 0x40499c in create_ak tools/tpm2_createak.c:345
>     #12 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #13 0x405cc0 in main tools/tpm2_tool.c:169
>     #14 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #15 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Direct leak of 72 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a237a78a in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x17478a)
>     #3 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #4 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #5 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #6 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #7 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #8 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #9 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #10 0x7fc7a26882c1 in Esys_Create_Async src/tss2-esys/api/Esys_Create.c:251
>     #11 0x7fc7a2688e19 in Esys_Create src/tss2-esys/api/Esys_Create.c:129
>     #12 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #13 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #14 0x405cc0 in main tools/tpm2_tool.c:169
>     #15 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #16 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Direct leak of 72 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a237a78a in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x17478a)
>     #3 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #4 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #5 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #6 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #7 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #8 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #9 0x7fc7a26888ea in Esys_Create_Finish src/tss2-esys/api/Esys_Create.c:425
>     #10 0x7fc7a2688e4a in Esys_Create src/tss2-esys/api/Esys_Create.c:145
>     #11 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #12 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #13 0x405cc0 in main tools/tpm2_tool.c:169
>     #14 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #15 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Direct leak of 72 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a237a78a in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x17478a)
>     #3 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #4 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #5 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #6 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #7 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #8 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #9 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #10 0x7fc7a269f210 in Esys_Load_Async src/tss2-esys/api/Esys_Load.c:206
>     #11 0x7fc7a269fb9c in Esys_Load src/tss2-esys/api/Esys_Load.c:93
>     #12 0x40499c in create_ak tools/tpm2_createak.c:345
>     #13 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #14 0x405cc0 in main tools/tpm2_tool.c:169
>     #15 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #16 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 56 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a23f03da in CRYPTO_THREAD_lock_new (/lib64/libcrypto.so.1.1+0x1ea3da)
>     #3 0x7fc7a237a7af in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x1747af)
>     #4 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #5 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #6 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #7 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #8 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #9 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #10 0x7fc7a269f6fb in Esys_Load_Finish src/tss2-esys/api/Esys_Load.c:338
>     #11 0x7fc7a269fbc3 in Esys_Load src/tss2-esys/api/Esys_Load.c:108
>     #12 0x40499c in create_ak tools/tpm2_createak.c:345
>     #13 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #14 0x405cc0 in main tools/tpm2_tool.c:169
>     #15 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #16 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 56 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a23f03da in CRYPTO_THREAD_lock_new (/lib64/libcrypto.so.1.1+0x1ea3da)
>     #3 0x7fc7a237a7af in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x1747af)
>     #4 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #5 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #6 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #7 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #8 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #10 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #11 0x7fc7a269f210 in Esys_Load_Async src/tss2-esys/api/Esys_Load.c:206
>     #12 0x7fc7a269fb9c in Esys_Load src/tss2-esys/api/Esys_Load.c:93
>     #13 0x40499c in create_ak tools/tpm2_createak.c:345
>     #14 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 56 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a23f03da in CRYPTO_THREAD_lock_new (/lib64/libcrypto.so.1.1+0x1ea3da)
>     #3 0x7fc7a237a7af in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x1747af)
>     #4 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #5 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #6 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #7 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #8 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #9 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #10 0x7fc7a26888ea in Esys_Create_Finish src/tss2-esys/api/Esys_Create.c:425
>     #11 0x7fc7a2688e4a in Esys_Create src/tss2-esys/api/Esys_Create.c:145
>     #12 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #13 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #14 0x405cc0 in main tools/tpm2_tool.c:169
>     #15 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #16 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 56 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a23f03da in CRYPTO_THREAD_lock_new (/lib64/libcrypto.so.1.1+0x1ea3da)
>     #3 0x7fc7a237a7af in EVP_PKEY_new (/lib64/libcrypto.so.1.1+0x1747af)
>     #4 0x7fc7a237d4e9 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774e9)
>     #5 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #6 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #7 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #8 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #10 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #11 0x7fc7a26882c1 in Esys_Create_Async src/tss2-esys/api/Esys_Create.c:251
>     #12 0x7fc7a2688e19 in Esys_Create src/tss2-esys/api/Esys_Create.c:129
>     #13 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #14 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 24 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a229ead0 in ASN1_STRING_type_new (/lib64/libcrypto.so.1.1+0x98ad0)
>     #3 0x7fc7a229ebd6 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98bd6)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #10 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #11 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #12 0x7fc7a269f210 in Esys_Load_Async src/tss2-esys/api/Esys_Load.c:206
>     #13 0x7fc7a269fb9c in Esys_Load src/tss2-esys/api/Esys_Load.c:93
>     #14 0x40499c in create_ak tools/tpm2_createak.c:345
>     #15 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #16 0x405cc0 in main tools/tpm2_tool.c:169
>     #17 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #18 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 24 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a229ead0 in ASN1_STRING_type_new (/lib64/libcrypto.so.1.1+0x98ad0)
>     #3 0x7fc7a229ebd6 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98bd6)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #10 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #11 0x7fc7a26888ea in Esys_Create_Finish src/tss2-esys/api/Esys_Create.c:425
>     #12 0x7fc7a2688e4a in Esys_Create src/tss2-esys/api/Esys_Create.c:145
>     #13 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #14 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 24 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a229ead0 in ASN1_STRING_type_new (/lib64/libcrypto.so.1.1+0x98ad0)
>     #3 0x7fc7a229ebd6 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98bd6)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #10 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #11 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #12 0x7fc7a26882c1 in Esys_Create_Async src/tss2-esys/api/Esys_Create.c:251
>     #13 0x7fc7a2688e19 in Esys_Create src/tss2-esys/api/Esys_Create.c:129
>     #14 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #15 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #16 0x405cc0 in main tools/tpm2_tool.c:169
>     #17 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #18 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 24 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a238cc2c in CRYPTO_zalloc (/lib64/libcrypto.so.1.1+0x186c2c)
>     #2 0x7fc7a229ead0 in ASN1_STRING_type_new (/lib64/libcrypto.so.1.1+0x98ad0)
>     #3 0x7fc7a229ebd6 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98bd6)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #10 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #11 0x7fc7a269f6fb in Esys_Load_Finish src/tss2-esys/api/Esys_Load.c:338
>     #12 0x7fc7a269fbc3 in Esys_Load src/tss2-esys/api/Esys_Load.c:108
>     #13 0x40499c in create_ak tools/tpm2_createak.c:345
>     #14 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 1 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a229e9b9 in ASN1_STRING_set (/lib64/libcrypto.so.1.1+0x989b9)
>     #2 0x7fc7a229ea35 in ASN1_STRING_copy (/lib64/libcrypto.so.1.1+0x98a35)
>     #3 0x7fc7a229ebe9 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98be9)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #10 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #11 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #12 0x7fc7a269f210 in Esys_Load_Async src/tss2-esys/api/Esys_Load.c:206
>     #13 0x7fc7a269fb9c in Esys_Load src/tss2-esys/api/Esys_Load.c:93
>     #14 0x40499c in create_ak tools/tpm2_createak.c:345
>     #15 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #16 0x405cc0 in main tools/tpm2_tool.c:169
>     #17 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #18 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 1 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a229e9b9 in ASN1_STRING_set (/lib64/libcrypto.so.1.1+0x989b9)
>     #2 0x7fc7a229ea35 in ASN1_STRING_copy (/lib64/libcrypto.so.1.1+0x98a35)
>     #3 0x7fc7a229ebe9 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98be9)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #10 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #11 0x7fc7a269f6fb in Esys_Load_Finish src/tss2-esys/api/Esys_Load.c:338
>     #12 0x7fc7a269fbc3 in Esys_Load src/tss2-esys/api/Esys_Load.c:108
>     #13 0x40499c in create_ak tools/tpm2_createak.c:345
>     #14 0x40499c in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 1 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a229e9b9 in ASN1_STRING_set (/lib64/libcrypto.so.1.1+0x989b9)
>     #2 0x7fc7a229ea35 in ASN1_STRING_copy (/lib64/libcrypto.so.1.1+0x98a35)
>     #3 0x7fc7a229ebe9 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98be9)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d38b1 in iesys_check_rp_hmacs src/tss2-esys/esys_iutil.c:818
>     #10 0x7fc7a26d48e6 in iesys_check_response src/tss2-esys/esys_iutil.c:1312
>     #11 0x7fc7a26888ea in Esys_Create_Finish src/tss2-esys/api/Esys_Create.c:425
>     #12 0x7fc7a2688e4a in Esys_Create src/tss2-esys/api/Esys_Create.c:145
>     #13 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #14 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #15 0x405cc0 in main tools/tpm2_tool.c:169
>     #16 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #17 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> Indirect leak of 1 byte(s) in 1 object(s) allocated from:
>     #0 0x7fc7a27f5848 in __interceptor_malloc (/lib64/libasan.so.5+0xef848)
>     #1 0x7fc7a229e9b9 in ASN1_STRING_set (/lib64/libcrypto.so.1.1+0x989b9)
>     #2 0x7fc7a229ea35 in ASN1_STRING_copy (/lib64/libcrypto.so.1.1+0x98a35)
>     #3 0x7fc7a229ebe9 in ASN1_STRING_dup (/lib64/libcrypto.so.1.1+0x98be9)
>     #4 0x7fc7a2385eeb  (/lib64/libcrypto.so.1.1+0x17feeb)
>     #5 0x7fc7a237d4b2 in EVP_PKEY_keygen (/lib64/libcrypto.so.1.1+0x1774b2)
>     #6 0x7fc7a237d64d in EVP_PKEY_new_mac_key (/lib64/libcrypto.so.1.1+0x17764d)
>     #7 0x7fc7a26dad7a in iesys_cryptossl_hmac_start src/tss2-esys/esys_crypto_ossl.c:345
>     #8 0x7fc7a26d0413 in iesys_crypto_authHmac src/tss2-esys/esys_crypto.c:182
>     #9 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1139
>     #10 0x7fc7a26d42b7 in iesys_compute_hmac src/tss2-esys/esys_iutil.c:1112
>     #11 0x7fc7a26d4548 in iesys_gen_auths src/tss2-esys/esys_iutil.c:1238
>     #12 0x7fc7a26882c1 in Esys_Create_Async src/tss2-esys/api/Esys_Create.c:251
>     #13 0x7fc7a2688e19 in Esys_Create src/tss2-esys/api/Esys_Create.c:129
>     #14 0x4047b7 in create_ak tools/tpm2_createak.c:289
>     #15 0x4047b7 in tpm2_tool_onrun tools/tpm2_createak.c:635
>     #16 0x405cc0 in main tools/tpm2_tool.c:169
>     #17 0x7fc7a205c412 in __libc_start_main (/lib64/libc.so.6+0x24412)
>     #18 0x40375d in _start (/home/joshuagl/Projects/tpm2-software/tpm2-tools/tools/tpm2_createak+0x40375d)
> 
> SUMMARY: AddressSanitizer: 612 byte(s) leaked in 16 allocation(s).