### PR TITLE
build: install aclocal files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   - coverity_scan_run_condition='"$CC" = gcc'
   - LD_LIBRARY_PATH="$(pwd)/osslinstall/usr/local/lib:/usr/lib"
   - PATH="$(pwd)/ibmtpm/src:${PATH}"
-  - GNULIB_M4="/usr/share/gnulib/m4"
+  - ACLOCAL_PATH="/usr/share/gnulib/m4"
 
 addons:
   apt:
@@ -41,7 +41,7 @@ addons:
       name: "01org/TPM2.0-TSS"
       description: Build submitted via Travis-CI
     notification_email: philip.b.tricca@intel.com
-    build_command_prepend: "./bootstrap -I ${GNULIB_M4} && ./configure"
+    build_command_prepend: "./bootstrap && ./configure"
     build_command: "make --jobs=$(nproc)"
     branch_pattern: coverity_scan
 
@@ -83,7 +83,7 @@ install:
   - cp uthash-2.1.0/src/*.h $(pwd)/osslinstall/usr/local/include/
 
 before_script:
-  - ./bootstrap -I ${GNULIB_M4}
+  - ./bootstrap
 
 script:
 # short-circuit normal build if we've already done a coverity scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,11 +46,12 @@ RUN apt-get install -y \
 # TPM2-TSS
 COPY . /tmp/tpm2-tss/
 WORKDIR /tmp/tpm2-tss
-RUN ./bootstrap -I /usr/share/gnulib/m4 \
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENV ACLOCAL_PATH /usr/share/gnulib/m4
+RUN ./bootstrap \
 	&& ./configure --enable-unit \
 	&& make -j$(nproc) check \
 	&& make install \
 	&& ldconfig
-ENV LD_LIBRARY_PATH /usr/local/lib
 RUN cat test-suite.log
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ $ ./bootstrap
 Any options specified to the bootstrap command are passed to `autoreconf(1)`. This is typically
 useful for specifying 3rd party M4 include paths via the `-I` option. For example on Ubuntu 16.04:
 ```
-$ ./bootstrap -I /usr/share/gnulib/m4
+$ ACLOCAL_PATH="/usr/share/gnulib/m4" ./bootstrap
 ```
 
 ## Configuring the Build

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 
 ### Initialize global variables used throughout the file ###
 INCLUDE_DIRS    = -I$(srcdir)/src -I$(srcdir)/include/tss2
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 


### PR DESCRIPTION
Installing aclocal files enables downstream patches to be applied simpler, as
the macros at build machine's /usr/share/aclocal are copied into package m4/
directory.

For example the ax_code_coverage.m4 broke backward compatibility in recent
version, distributing this within package reduce dependencies and makes it
easier to run autoreconf.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>