### PR TITLE
doc: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,11 @@ RUN apt-get update && apt-get install -y \
     automake \
     build-essential \
     doxygen \
-    g++ \
     gcc \
     git \
     gnulib \
     libssl-dev \
     libtool \
-    m4 \
-    iproute2 \
     pkg-config \
     wget
 
@@ -41,11 +38,9 @@ RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 	&& cp tpm_server /usr/local/bin
 
 RUN apt-get install -y \
+    iproute2 \
     libcmocka0 \
     libcmocka-dev \
-    libgcrypt20-dev \
-    libtool \
-    liburiparser-dev \
     uthash-dev
 
 # TPM2-TSS

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,22 +10,23 @@ following sections describe them for the supported platforms.
 * GNU Autoconf Archive, version >= 2017.03.21
 * GNU Automake
 * GNU Libtool
+* Gnulib
 * C compiler
 * C library development libraries and header files
 * pkg-config
-* uriparser development libraries and header files
-* libgcrypt development libraries and header files
-* uthash development libraries and header files
+* doxygen
+* OpenSSL development libraries and header files
 
 The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --enable-integration):
-* OpenSSL development libraries and header files
+    - uthash development libraries and header files
+    - ps executable (usually in the procps package)
+    - ss executable (usually in the iproute2 package)
+    - tpm_server executable (from https://sourceforge.net/projects/ibmswtpm2/)
 * Unit test suite (see ./configure option --enable-unit):
-* cmocka unit test framework, version >= 1.0
-* ss executable (usually in the iproute2 package)
+    - cmocka unit test framework, version >= 1.0
 * Code coverage analysis:
-* lcov
-* uthash development libraries and header files
+    - lcov
 
 Most users will not need to install these dependencies.
 
@@ -36,20 +37,19 @@ $ sudo apt -y install \
   autoconf-archive \
   libcmocka0 \
   libcmocka-dev \
+  procps \
   iproute2 \
   build-essential \
   git \
   pkg-config \
   gcc \
-  g++ \
-  m4 \
   libtool \
   automake \
-  libgcrypt20-dev \
   libssl-dev \
   uthash-dev \
   autoconf \
-  gnulib
+  gnulib \
+  doxygen
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -236,8 +236,8 @@ test_unit_tcti_device_SOURCES = test/unit/tcti-device.c \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
     src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
 
-test_unit_tcti_mssim_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(URIPARSER_CFLAGS)
-test_unit_tcti_mssim_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(URIPARSER_LIBS) $(libutil)
+test_unit_tcti_mssim_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_mssim_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
 test_unit_tcti_mssim_LDFLAGS = -Wl,--wrap=connect,--wrap=read,--wrap=select,--wrap=write
 test_unit_tcti_mssim_SOURCES = test/unit/tcti-mssim.c \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -233,11 +233,11 @@ nodist_pkgconfig_DATA += lib/tss2-tcti-mssim.pc
 EXTRA_DIST += lib/tss2-tcti-mssim.map lib/tss2-tcti-mssim.pc.in
 
 AM_CFLAGS += -DTCTI_MSSIM
-src_tss2_tcti_libtss2_tcti_mssim_la_CFLAGS   = $(AM_CFLAGS) $(URIPARSER_CFLAGS)
+src_tss2_tcti_libtss2_tcti_mssim_la_CFLAGS   = $(AM_CFLAGS)
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_mssim_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-mssim.map
 endif # HAVE_LD_VERSION_SCRIPT
-src_tss2_tcti_libtss2_tcti_mssim_la_LIBADD   = $(libtss2_mu) $(URIPARSER_LIBS) $(libutil)
+src_tss2_tcti_libtss2_tcti_mssim_la_LIBADD   = $(libtss2_mu) $(libutil)
 src_tss2_tcti_libtss2_tcti_mssim_la_SOURCES  = \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
     src/tss2-tcti/tcti-mssim.c src/tss2-tcti/tcti-mssim.h


### PR DESCRIPTION
Following #1246, I had a closer look at the dependency list in [`INSTALL.md`](https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md). I think we should

**Add**
- doxygen, required since #1184.
- Gnulib, required since #1199.
- `ps` executable, required for [`script/int-log-compiler.sh`](https://github.com/tpm2-software/tpm2-tss/blob/3e2c09a38d471ab1f06689422216bbb2305b3657/script/int-log-compiler.sh#L63).
- `tpm_server` executable, required for [`script/int-log-compiler.sh`](https://github.com/tpm2-software/tpm2-tss/blob/3e2c09a38d471ab1f06689422216bbb2305b3657/script/int-log-compiler.sh#L69).

**Move**
- OpenSSL to main requirements because of #1173.
- `ss` executable to integration test suite, it is only needed in [`script/int-log-compiler.sh`](https://github.com/tpm2-software/tpm2-tss/blob/303412cb9a12044525346a0da68d62e00ad5cdd1/script/int-log-compiler.sh#L205).
- uthash to integration test suite, it is only needed in [`test/integration/session-util.h`](https://github.com/tpm2-software/tpm2-tss/blob/83fabe742545b7559dcd5cd7fd2fb6cc6d0022b6/test/integration/session-util.h#L11).

**Remove**
- g++ because there is no need for a C++ compiler.
- libgcrypt because of #1173.
- m4 because it is a hard dependency of autoconf.
- uriparser, removed in #976.

I also made the corresponding changes to `Dockerfile`.