### PR TITLE
Add ld-version-script.m4 back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   - coverity_scan_run_condition='"$CC" = gcc'
   - LD_LIBRARY_PATH="$(pwd)/osslinstall/usr/local/lib:/usr/lib"
   - PATH="$(pwd)/ibmtpm/src:${PATH}"
-  - ACLOCAL_PATH="/usr/share/gnulib/m4"
 
 addons:
   apt:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y \
     doxygen \
     gcc \
     git \
-    gnulib \
     libssl-dev \
     libtool \
     pkg-config \
@@ -47,7 +46,6 @@ RUN apt-get install -y \
 COPY . /tmp/tpm2-tss/
 WORKDIR /tmp/tpm2-tss
 ENV LD_LIBRARY_PATH /usr/local/lib
-ENV ACLOCAL_PATH /usr/share/gnulib/m4
 RUN ./bootstrap \
 	&& ./configure --enable-unit \
 	&& make -j$(nproc) check \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,11 +80,7 @@ generates list of source files, and creates the configure script:
 $ ./bootstrap
 ```
 
-Any options specified to the bootstrap command are passed to `autoreconf(1)`. This is typically
-useful for specifying 3rd party M4 include paths via the `-I` option. For example on Ubuntu 16.04:
-```
-$ ACLOCAL_PATH="/usr/share/gnulib/m4" ./bootstrap
-```
+Any options specified to the bootstrap command are passed to `autoreconf(1)`.
 
 ## Configuring the Build
 Then run the configure script, which generates the makefiles:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,6 @@ following sections describe them for the supported platforms.
 * GNU Autoconf Archive, version >= 2017.03.21
 * GNU Automake
 * GNU Libtool
-* Gnulib
 * C compiler
 * C library development libraries and header files
 * pkg-config
@@ -48,7 +47,6 @@ $ sudo apt -y install \
   libssl-dev \
   uthash-dev \
   autoconf \
-  gnulib \
   doxygen
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2019 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])


### PR DESCRIPTION
From the Gnulib website:

> Gnulib takes a different approach. Its components are intended to be shared at the source level, rather than being a library that gets built, installed, and linked against. Thus, there is no distribution tarball; the idea is to copy files from Gnulib into your own source tree.

and thus several distributions (Arch Linux, Clear Linux, openSUSE, etc) don't package it.
Therefore add back `ld-version-script.m4` and update collateral to reflect this.