### PR TITLE
sys: remove TPM20_ErrorResponse

### DIFF
--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -30,12 +30,6 @@ typedef struct _TPM20_Header_Out {
   UINT32 responseSize;
   UINT32 responseCode;
 } TPM20_Header_Out;
-
-typedef struct _TPM20_ErrorResponse {
-  TPM2_ST tag;
-  UINT32 responseSize;
-  UINT32 responseCode;
-} TPM20_ErrorResponse;
 #pragma pack(pop)
 
 typedef struct {


### PR DESCRIPTION
Remove the definition of unused struct TPM20_ErrorResponse