### PR TITLE
doc: remove unneeded doc/arch.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NOTE: The unit and integration tests can be enabled independently.
 The --enable-unit option controls unit tests, and --enable-integration
 controls the integration tests.
 
-# [Architecture/Block Diagram](doc/arch.md)
+# Architecture/Block Diagram
 SAPI library, TAB/RM, and Test Code Block Diagram:
 ![Architecture Block Diagram](doc/TSS%20block%20diagram.png)
 

--- a/doc/arch.md
+++ b/doc/arch.md
@@ -1,8 +1,0 @@
-##SAPI library, TAB/RM, and Test Code Block Diagram:
-
-
-
-
-
-
-![Block Diagram](TSS block diagram.png)


### PR DESCRIPTION
This file is only used once in README.md, but it is not
needed as the block diagram is linked directly anyway
and the link in the header only confuses doxygen.