### PR TITLE
sys: add mechanism to disable weak crypto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,8 +257,15 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       ADD_LINK_FLAG([-Wl,-z,relro])
       ])
 
-AC_SUBST([PATH])
+AC_ARG_ENABLE([weakcrypto],
+    [AS_HELP_STRING([--disable-weakcrypto],
+	           [Disable crypto algorithms considered weak])],
+    [enable_weakcrypto=yes],
+    [enable_weakcrypto=no])
+AS_IF([test "x$enable_weakcrypto" = "xyes"],
+	AC_DEFINE([DISABLE_WEAK_CRYPTO],[1],[DISABLE WEAK CRYPTO ALGORITHMS]))
 
+AC_SUBST([PATH])
 
 dnl ---------  Physical TPM device -----------------------
 

--- a/src/tss2-sys/api/Tss2_Sys_Create.c
+++ b/src/tss2-sys/api/Tss2_Sys_Create.c
@@ -22,6 +22,10 @@ TSS2_RC Tss2_Sys_Create_Prepare(
     if (!ctx || !creationPCR)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    rval = ValidateTPML_PCR_SELECTION(creationPCR);
+    if (rval)
+        return rval;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_Create);
     if (rval)
         return rval;
@@ -55,6 +59,11 @@ TSS2_RC Tss2_Sys_Create_Prepare(
                                       &ctx->nextData);
 
     } else {
+
+        rval = ValidatePublicTemplate(inPublic);
+
+        if (rval)
+            return rval;
 
         rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
                                             ctx->maxCmdSize,

--- a/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
+++ b/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
@@ -57,6 +57,10 @@ TSS2_RC Tss2_Sys_CreatePrimary_Prepare(
                                       &ctx->nextData);
 
     } else {
+        rval = ValidatePublicTemplate(inPublic);
+
+        if (rval)
+            return rval;
 
         rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
                                             ctx->maxCmdSize,

--- a/src/tss2-sys/api/Tss2_Sys_HMAC.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC.c
@@ -20,6 +20,9 @@ TSS2_RC Tss2_Sys_HMAC_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
@@ -20,6 +20,8 @@ TSS2_RC Tss2_Sys_HMAC_Start_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC_Start);
     if (rval)

--- a/src/tss2-sys/api/Tss2_Sys_Hash.c
+++ b/src/tss2-sys/api/Tss2_Sys_Hash.c
@@ -20,6 +20,9 @@ TSS2_RC Tss2_Sys_Hash_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_Hash);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
+++ b/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
@@ -19,6 +19,9 @@ TSS2_RC Tss2_Sys_HashSequenceStart_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_HashSequenceStart);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_Import.c
+++ b/src/tss2-sys/api/Tss2_Sys_Import.c
@@ -55,7 +55,10 @@ TSS2_RC Tss2_Sys_Import_Prepare(
                                       &ctx->nextData);
 
     } else {
+        rval = ValidatePublicTemplate(objectPublic);
 
+        if (rval)
+            return rval;
         rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, ctx->cmdBuffer,
                                             ctx->maxCmdSize,
                                             &ctx->nextData);

--- a/src/tss2-sys/api/Tss2_Sys_Load.c
+++ b/src/tss2-sys/api/Tss2_Sys_Load.c
@@ -52,6 +52,10 @@ TSS2_RC Tss2_Sys_Load_Prepare(
                                       &ctx->nextData);
 
     } else {
+        rval = ValidatePublicTemplate(inPublic);
+
+        if (rval)
+            return rval;
 
         rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
                                             ctx->maxCmdSize,

--- a/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
+++ b/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
@@ -48,6 +48,10 @@ TSS2_RC Tss2_Sys_LoadExternal_Prepare(
                                       &ctx->nextData);
 
     } else {
+        rval = ValidatePublicTemplate(inPublic);
+
+        if (rval)
+            return rval;
 
         rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
                                             ctx->maxCmdSize,

--- a/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
@@ -20,6 +20,10 @@ TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    rval = ValidateNV_Public(publicInfo);
+    if (rval)
+        return rval;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_NV_DefineSpace);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Allocate.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Allocate.c
@@ -19,6 +19,10 @@ TSS2_RC Tss2_Sys_PCR_Allocate_Prepare(
     if (!ctx || !pcrAllocation)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    rval = ValidateTPML_PCR_SELECTION(pcrAllocation);
+    if (rval)
+        return rval;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Allocate);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -21,6 +21,9 @@ TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_SetAuthPolicy);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_PolicyPCR.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyPCR.c
@@ -20,6 +20,10 @@ TSS2_RC Tss2_Sys_PolicyPCR_Prepare(
     if (!ctx || !pcrs)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    rval = ValidateTPML_PCR_SELECTION(pcrs);
+    if (rval)
+        return rval;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyPCR);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_Quote.c
+++ b/src/tss2-sys/api/Tss2_Sys_Quote.c
@@ -21,6 +21,10 @@ TSS2_RC Tss2_Sys_Quote_Prepare(
     if (!ctx || !inScheme || !PCRselect)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    rval = ValidateTPML_PCR_SELECTION(PCRselect);
+    if (rval)
+        return rval;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_Quote);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -21,6 +21,9 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     if (!ctx || !setList  || !clearList)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(auditAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_SetCommandCodeAuditStatus);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
@@ -20,6 +20,9 @@ TSS2_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(hashAlg, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_SetPrimaryPolicy);
     if (rval)
         return rval;

--- a/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
+++ b/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
@@ -24,6 +24,9 @@ TSS2_RC Tss2_Sys_StartAuthSession_Prepare(
     if (!ctx || !symmetric)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
+    if (IsAlgorithmWeak(authHash, 0))
+        return TSS2_SYS_RC_BAD_VALUE;
+
     rval = CommonPreparePrologue(ctx, TPM2_CC_StartAuthSession);
     if (rval)
         return rval;

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -9,6 +9,7 @@
 #ifndef _WIN32
 #include <config.h>
 #endif
+#include <stdbool.h>
 
 #include "tss2_tpm2_types.h"
 #include "tss2_tcti.h"
@@ -108,6 +109,10 @@ TSS2_RC CommonPreparePrologue(
 TSS2_RC CommonPrepareEpilogue(_TSS2_SYS_CONTEXT_BLOB *ctx);
 int GetNumCommandHandles(TPM2_CC commandCode);
 int GetNumResponseHandles(TPM2_CC commandCode);
+bool IsAlgorithmWeak(TPM2_ALG_ID algorith, TPM2_KEY_SIZE key_size);
+TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *public);
+TSS2_RC ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info);
+TSS2_RC ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection);
 
 TSS2_SYS_CONTEXT *InitSysContext(
     UINT16 maxCommandSize,


### PR DESCRIPTION
Core Infrastructure best practices require usage only strong
cryptographic algorithms. To comply with this requirement we
need to have a way to disable usage of algorithms that are
considered weak. The diable mechanism will validate
the TPM2_PUBLIC template of an object and will not allow
to create or load object which the public template will
contain references to the not allowed algorithms.
Additionally it will validate the nameAlg of inPublic and
NV_PUBLIC, hashAlg of the different signing schemes, and
hashAlg of PCR selection for relevant commands.

Algorithms that will be disabled by this are as follows:
 - RSA with key size < 2048 bits
 - Symmetric ciphers with key size < 128 bits
 - SHA1

The new configure flag is called --disable-weakcrypto