### PR TITLE
build: remove fake config.h

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,1 +1,0 @@
-/* Empty config.h. for windows build */

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -9,8 +9,9 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include <string.h>
+#ifndef _WIN32
 #include <config.h>
-
+#endif
 #include "tss2_esys.h"
 
 #include "esys_int.h"

--- a/src/tss2-mu/base-types.c
+++ b/src/tss2-mu/base-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpma-types.c
+++ b/src/tss2-mu/tpma-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpml-types.c
+++ b/src/tss2-mu/tpml-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpmt-types.c
+++ b/src/tss2-mu/tpmt-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -7,7 +7,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <config.h>
 
 #include "tss2_mu.h"
 

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -6,8 +6,9 @@
 
 #ifndef TSS2_SYSAPI_UTIL_H
 #define TSS2_SYSAPI_UTIL_H
-
+#ifndef _WIN32
 #include <config.h>
+#endif
 
 #include "tss2_tpm2_types.h"
 #include "tss2_tcti.h"

--- a/src/tss2-tcti/tcti-common.h
+++ b/src/tss2-tcti/tcti-common.h
@@ -8,7 +8,9 @@
 
 #include <errno.h>
 #include <stdbool.h>
+#ifndef _WIN32
 #include <config.h>
+#endif
 
 #include "tss2_tcti.h"
 

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#ifndef _WIN32
 #include <config.h>
+#endif
 
 #ifndef LOGMODULE
 #error "LOGMODULE must be set before including log/log.h"


### PR DESCRIPTION
When ac config header was introduced and the C files included
config.h header it created a problem for windows build, where
the config.h file was never generated. To solve this windows
build problem an empty file was added to satisfy the
#include <config.h> on windows.
This created a different problem though. The problem is solely
git related. When configure generates the header with different
configuration values then git status treats this auto-generated
updates as legitimate code changes and "git commit -a ..." will
add the changes to the commit.
It can be worked around locally by
git update-index --assume-unchanged config.h or
git update-index --skip-worktree config.h but there is no good
way to enforce this on remote repo and propagate it to clones.
To avoid that we remove the header from tracked files and only
include this file on systems different than windows.