### PR TITLE
tpm2b-types.c: fix maybe-uninitialized error

### DIFF
--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -150,7 +150,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
                                  size_t buffer_size, size_t *offset) \
 { \
     size_t local_offset = 0; \
-    UINT8 *ptr; \
+    UINT8 *ptr = NULL; \
     TSS2_RC rc; \
 \
     if (src == NULL) { \


### PR DESCRIPTION
src/tss2-mu/tpm2b-types.c: In function 'Tss2_MU_TPM2B_ECC_POINT_Marshal':
src/tss2-mu/tpm2b-types.c:201:24: error: 'ptr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         *(UINT16 *)ptr = HOST_TO_BE_16(buffer + local_offset - ptr - 2); \
                        ^
src/tss2-mu/tpm2b-types.c:152:12: note: 'ptr' was declared here
     UINT8 *ptr; \

Fixes:
 - http://autobuild.buildroot.org/results/8d7b6dad6602fe67338abc696bc4752dda8e9717

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>