### PR TITLE
ESYS: Fix openssl building

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -34,7 +34,8 @@ ENGINE *get_engine()
     return engine;
 }
 
-int BN_bn2binpad(const BIGNUM *bn, unsigned char *bin, int bin_length)
+static int
+iesys_bn2binpad(const BIGNUM *bn, unsigned char *bin, int bin_length)
 {
     int len_bn = BN_num_bytes(bn);
     int offset = bin_length - len_bn;
@@ -888,12 +889,12 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC *key,
                    "Get affine x coordinate", cleanup);
     }
 
-    if (1 != BN_bn2binpad(bn_x, &Q->x.buffer[0], key_size)) {
+    if (1 != iesys_bn2binpad(bn_x, &Q->x.buffer[0], key_size)) {
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
                    "Write big num byte buffer", cleanup);
     }
 
-    if (1 != BN_bn2binpad(bn_y, &Q->y.buffer[0], key_size)) {
+    if (1 != iesys_bn2binpad(bn_y, &Q->y.buffer[0], key_size)) {
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
                    "Write big num byte buffer", cleanup);
     }
@@ -925,7 +926,7 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC *key,
                    "Get affine x coordinate", cleanup);
     }
 
-    if (1 != BN_bn2binpad(bn_x, &Z->buffer[0], key_size)) {
+    if (1 != iesys_bn2binpad(bn_x, &Z->buffer[0], key_size)) {
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
                    "Write big num byte buffer", cleanup);
     }


### PR DESCRIPTION
If OpenSSL was compiled without -Bsymbolic (which some packages patched out), then we had a symbolic naming conflict. Even though the functionality seems to be 100% equivalent. Moved the function in question to internal namespace and made it static.

Fixes: #1273