### PR TITLE
Make case_insensitive_strncmp more robust

### DIFF
--- a/src/util/log.c
+++ b/src/util/log.c
@@ -54,21 +54,21 @@ case_insensitive_strncmp(const char *string1,
 
     size_t string1_size = strlen (string1);
     size_t string2_size = strlen (string2);
-    unsigned char lower_string1 [string1_size + 1];
-    unsigned char lower_string2 [string2_size + 1];
+    char lower_string1 [string1_size + 1];
+    char lower_string2 [string2_size + 1];
     size_t i;
 
     for (i = 0; i < string1_size; i++)
-        lower_string1[i] = tolower(string1[i]);
+        lower_string1[i] = tolower((unsigned char) string1[i]);
 
     lower_string1[i] = '\0';
 
     for (i = 0; i < string2_size; i++)
-        lower_string2[i] = tolower(string2[i]);
+        lower_string2[i] = tolower((unsigned char) string2[i]);
 
     lower_string2[i] = '\0';
 
-    return memcmp (lower_string1, lower_string2, n);
+    return strncmp (lower_string1, lower_string2, n);
 }
 
 log_level


### PR DESCRIPTION
Valgrind complaints that "conditional jump or move depends on uninitialized value(s)” in memcmp of `case_insensitive_strncmp`,
 if `n` is larger than `strlen` of `string1` or `string2`. Although the result of memcmp will be correct, it still accesses unitialized memory in this case (which might even crash). Using strncmp fixes the problem, but operates on (regular) chars.

Moreover manpage of `tolower` indicates that its parameter should be casted to unsigned char (as char might be signed and thus create problem. Even though the return value is int, reference also assigns it to a regular char.

Signed-off-by:Peter Huewe <peter.huewe@infineon.com>