### PR TITLE
Add valgrind for integration and unit tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,9 @@ else
 @CODE_COVERAGE_RULES@
 endif
 
+# ax_valgrind_check
+@VALGRIND_CHECK_RULES@
+
 # ax_doxygen
 @DX_RULES@
 MOSTLYCLEANFILES += $(DX_CLEANFILES)

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,8 @@ AS_IF([test "x$enable_integration" = "xyes"],
        AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 
+AX_VALGRIND_CHECK
+
 gl_LD_VERSION_SCRIPT
 
 AC_ARG_WITH([maxloglevel],


### PR DESCRIPTION
By adding these two autoconf-archive macros we can easily enable
valgrind checks for our unit and integration tests.

If valgrind is installed on the system during configure, a few new make
targets are added automatically

make check-valgrind
make check-valgrind-<toolname>

Normal testflow is not altered by these new targets.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>