### PR TITLE
Add missing free on handles returned by Esys_GetPollHandles

### DIFF
--- a/test/unit/esys-getpollhandles.c
+++ b/test/unit/esys-getpollhandles.c
@@ -123,6 +123,7 @@ test_GetPollHandles(void **state)
 
     assert_int_equal(count, 2);
     assert_memory_equal((void*)&handles[0], (void*)&rev[0], sizeof(rev));
+    free(handles);
 }
 
 int


### PR DESCRIPTION
Esys_GetPollHandles returns callee-allocated handles in *handles which must be freed on exit.
Even if this is only in a test case, we should free it as someone might use it as a reference code.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>