### PR TITLE
test: cleanup hmac and hash contexts

### DIFF
--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -72,6 +72,9 @@ check_hash_functions(void **state)
 
     rc = iesys_crypto_hash_finish(&context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
+    
+    /* cleanup */
+    iesys_crypto_hmac_abort(&context);
 } 
 
 static void
@@ -126,6 +129,9 @@ check_hmac_functions(void **state)
 
     rc = iesys_crypto_hmac_finish(&context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
+    
+    /* cleanup */
+    iesys_crypto_hash_abort(&context);
 }
 
 static void


### PR DESCRIPTION
If we do not clean up the 'invalid' contexts valgrind complains about memory leaks - also tests often serve as reference code.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>