### PR TITLE
esys: use GetEncryptParam funct to get the param to decrypt

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1398,10 +1398,17 @@ iesys_check_response(ESYS_CONTEXT * esys_context)
                                  rpHashNum);
         return_if_error(r, "Error: response hmac check");
 
-        if (esys_context->encryptNonce != NULL) {
-            r = iesys_decrypt_param(esys_context, rpBuffer, rpBuffer_size);
-            return_if_error(r, "Error: while decrypting parameter.");
-        }
+        r = Tss2_Sys_GetEncryptParam(esys_context->sys, &rpBuffer_size,
+			             &rpBuffer);
+
+	if (r == TSS2_SYS_RC_NO_ENCRYPT_PARAM ||
+            esys_context->encryptNonce == NULL)
+	    return TSS2_RC_SUCCESS;
+
+        return_if_error(r, "Error: GetEncryptParam");
+
+        r = iesys_decrypt_param(esys_context, rpBuffer, rpBuffer_size);
+        return_if_error(r, "Error: while decrypting parameter.");
     }
     return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
Use the Tss2_Sys_GetEncryptParam() function to get the parameter
to decrypt. Using Tss2_Sys_GetRpBuffer() is not correct as it
returns the buffer even for commands with TPM2_ST_NO_SESSIONS.