### PR TITLE
Session flags

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -684,15 +684,16 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
             uint8_t symKey[key_len];
             size_t paramSize = 0;
             const uint8_t *paramBuffer;
+
+             if (!iesys_update_session_flags(esys_context, rsrc_session))
+                  return TSS2_RC_SUCCESS;
+
             r = Tss2_Sys_GetDecryptParam(esys_context->sys, &paramSize,
                                          &paramBuffer);
             return_if_error(r, "Encryption not possible");
 
             if (paramSize == 0)
                 continue;
-
-            if (!iesys_update_session_flags(esys_context, rsrc_session))
-                return TSS2_RC_SUCCESS;
 
             BYTE encrypt_buffer[paramSize];
             memcpy(&encrypt_buffer[0], paramBuffer, paramSize);

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1400,11 +1400,11 @@ iesys_check_response(ESYS_CONTEXT * esys_context)
         return_if_error(r, "Error: response hmac check");
 
         r = Tss2_Sys_GetEncryptParam(esys_context->sys, &rpBuffer_size,
-			             &rpBuffer);
+                                     &rpBuffer);
 
-	if (r == TSS2_SYS_RC_NO_ENCRYPT_PARAM ||
+        if (r == TSS2_SYS_RC_NO_ENCRYPT_PARAM ||
             esys_context->encryptNonce == NULL)
-	    return TSS2_RC_SUCCESS;
+            return TSS2_RC_SUCCESS;
 
         return_if_error(r, "Error: GetEncryptParam");
 


### PR DESCRIPTION
 The enc flag needs to be check earlier, before bailing out on TSS2_SYS_RC_NO_ENCRYPT_PARAM error.
