### PR TITLE
Tests: Fix valgrind errors

### DIFF
--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -295,7 +295,7 @@ tpm2b_unmarshal_buffer_null (void **state)
     TPM2B_DIGEST dgst = {0};
     TPM2B_ECC_POINT point = {0};
     TSS2_RC rc;
-    size_t offset;
+    size_t offset = 0;
 
     rc = Tss2_MU_TPM2B_DIGEST_Unmarshal (NULL, 1, NULL, NULL);
     assert_int_equal (rc, TSS2_MU_RC_BAD_REFERENCE);

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -46,7 +46,10 @@ __wrap_read (int fd, void *buffer, size_t count)
 {
     LOG_DEBUG ("%s: reading %zu bytes from fd: %d to buffer at 0x%" PRIxPTR,
                __func__, count, fd, (uintptr_t)buffer);
-    return mock_type (ssize_t);
+    int r = mock_type (ssize_t);
+    if (r > 0)
+        memset(buffer, 0x66, r);
+    return r;
 }
 
 ssize_t


### PR DESCRIPTION
Fix memcheckd error on reading unitialized memory during make check-valgrind.