### PR TITLE
esys: fix null ptr dereference in Esys_Load and Esys_loadExternal

### DIFF
--- a/src/tss2-esys/api/Esys_Load.c
+++ b/src/tss2-esys/api/Esys_Load.c
@@ -281,10 +281,13 @@ Esys_Load_Finish(
     if (r != TSS2_RC_SUCCESS)
         return r;
 
-
-    /* Update the meta data of the ESYS_TR object */
-    objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
-    objectHandleNode->rsrc.misc.rsrc_key_pub = *esysContext->in.Load.inPublic;
+    if (esysContext->in.Load.inPublic) {
+        /* Update the meta data of the ESYS_TR object */
+        objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
+        objectHandleNode->rsrc.misc.rsrc_key_pub = *esysContext->in.Load.inPublic;
+    } else {
+        objectHandleNode->rsrc.misc.rsrc_key_pub.size = 0;
+    }
 
     /*Receive the TPM response and handle resubmissions if necessary. */
     r = Tss2_Sys_ExecuteFinish(esysContext->sys, esysContext->timeout);

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -265,8 +265,13 @@ Esys_LoadExternal_Finish(
     if (r != TSS2_RC_SUCCESS)
         return r;
 
-    objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
-    objectHandleNode->rsrc.misc.rsrc_key_pub = *esysContext->in.LoadExternal.inPublic;
+    if (esysContext->in.LoadExternal.inPublic) {
+        objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
+        objectHandleNode->rsrc.misc.rsrc_key_pub =
+                                        *esysContext->in.LoadExternal.inPublic;
+    } else {
+        objectHandleNode->rsrc.misc.rsrc_key_pub.size = 0;
+    }
 
     /*Receive the TPM response and handle resubmissions if necessary. */
     r = Tss2_Sys_ExecuteFinish(esysContext->sys, esysContext->timeout);


### PR DESCRIPTION
Both functions dereference inPublic param in their corresponding
_Finish functions so it needs to be checked if it is not null.