### PR TITLE
sys: rename public to pub in ValidatePublicTemplate declaration

### DIFF
--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -334,9 +334,9 @@ bool IsAlgorithmWeak(TPM2_ALG_ID algorithm, TPM2_KEY_SIZE key_size)
     return false;
 }
 
-TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *public)
+TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *pub)
 {
-    const TPMT_PUBLIC *tmpl = &public->publicArea;
+    const TPMT_PUBLIC *tmpl = &pub->publicArea;
 
     switch (tmpl->type) {
         case TPM2_ALG_RSA:
@@ -410,9 +410,9 @@ TSS2_RC ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info)
     return TSS2_RC_SUCCESS;
 }
 
-TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *public)
+TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *pub)
 {
-    (void) public;
+    (void) pub;
 
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -110,7 +110,7 @@ TSS2_RC CommonPrepareEpilogue(_TSS2_SYS_CONTEXT_BLOB *ctx);
 int GetNumCommandHandles(TPM2_CC commandCode);
 int GetNumResponseHandles(TPM2_CC commandCode);
 bool IsAlgorithmWeak(TPM2_ALG_ID algorith, TPM2_KEY_SIZE key_size);
-TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *public);
+TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *pub);
 TSS2_RC ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info);
 TSS2_RC ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection);
 


### PR DESCRIPTION
The "public" is a C++ keyword and since the sysapi_utils.h in
included by fuzz/main-sapi.cpp it needs to be renamed.