### PR TITLE
test: Remove use of 'sysapi_util.h' from integration tests.

### DIFF
--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -12,7 +12,6 @@
 #include <stdint.h>
 
 #include <tss2_esys.h>
-#include "tss2-sys/sysapi_util.h"
 
 #include "test.h"
 #include "esys_types.h"

--- a/test/integration/sapi-entity-util.c
+++ b/test/integration/sapi-entity-util.c
@@ -5,7 +5,6 @@
  * All rights reserved.
  ***********************************************************************/
 #include "tss2_tpm2_types.h"
-#include "sysapi_util.h"
 #include "sapi-util.h"
 #include "session-util.h"
 

--- a/test/integration/sapi-pcr-extension.int.c
+++ b/test/integration/sapi-pcr-extension.int.c
@@ -13,7 +13,6 @@
 #define LOGMODULE test
 #include "util/log.h"
 #include "test.h"
-#include "sysapi_util.h"
 #include "sapi-util.h"
 #define PCR_8   8
 /**

--- a/test/integration/sapi-sys-initialize.int.c
+++ b/test/integration/sapi-sys-initialize.int.c
@@ -9,8 +9,6 @@
 
 #include "tss2_sys.h"
 
-#include "tss2-sys/sysapi_util.h"
-
 #define LOGMODULE test
 #include "util/log.h"
 #include "test.h"
@@ -50,7 +48,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)1;
     TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)0;
 
-    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
+    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, Tss2_Sys_GetContextSize (0), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
         LOG_ERROR("Sys_Initialize FAILED! Response Code : %x", rc);
         exit(1);
@@ -60,7 +58,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TSS2_TCTI_RECEIVE (&tctiContext) = (TSS2_TCTI_RECEIVE_FCN)0;
     TSS2_TCTI_TRANSMIT (&tctiContext) = (TSS2_TCTI_TRANSMIT_FCN)1;
 
-    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, sizeof( _TSS2_SYS_CONTEXT_BLOB ), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
+    rc = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, Tss2_Sys_GetContextSize (0), (TSS2_TCTI_CONTEXT *)&tctiContext, (TSS2_ABI_VERSION *)1 );
     if( rc != TSS2_SYS_RC_BAD_TCTI_STRUCTURE ) {
         LOG_ERROR("Sys_Initialize FAILED! Response Code : %x", rc);
         exit(1);

--- a/test/integration/sapi-tpm-properties.int.c
+++ b/test/integration/sapi-tpm-properties.int.c
@@ -12,7 +12,6 @@
 #define LOGMODULE test
 #include "util/log.h"
 #include "test.h"
-#include "sysapi_util.h"
 
 int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)


### PR DESCRIPTION
These tests don't test any of the code from the sysapi_util module. The
only use was to get the size of a structure defined there but this is
exposed through the tss2-sys API directly. Inclusion of this header is
largely an artifact of this code having been liberated from the legacy
`tpmclient` test.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>