### PR TITLE
test: Restore output of Check* macros in tpmclient.

### DIFF
--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -109,10 +109,11 @@ static void InitSysContextFailure()
     Cleanup();
 }
 
+#define ERROR_STR_LEN 200
 #define CheckPassed(rval) {             \
-    char error_string[200];         \
+    char error_string[ERROR_STR_LEN];         \
     if ((rval) != TPM2_RC_SUCCESS) {      \
-      ErrorHandler((rval), error_string, strlen(error_string)); \
+      ErrorHandler((rval), error_string, ERROR_STR_LEN); \
       LOG_INFO("passing case: \tFAILED!  %s (%s@%u)",  \
                error_string, __FUNCTION__, __LINE__ ); \
       Cleanup(); \
@@ -123,9 +124,9 @@ static void InitSysContextFailure()
   }
 
 #define CheckFailed(rval, expected_rval) { \
-    char error_string[200];             \
+    char error_string[ERROR_STR_LEN];             \
     if ((rval) != (expected_rval)) {    \
-      ErrorHandler((rval), error_string, strlen(error_string)); \
+      ErrorHandler((rval), error_string, ERROR_STR_LEN); \
       LOG_INFO("\tfailing case: FAILED! %s  Ret code s/b: 0x%x, but was: 0x%x (%s@%u)", \
                error_string, (expected_rval), (rval), __FUNCTION__, __LINE__ ); \
       Cleanup(); \


### PR DESCRIPTION
Using strlen on an uninitialized character array means the old behavior
of this macro is undefined. "Most compilers" initialize this memory to
'\0' however and the behavior is as if the ErrorHandler function were
passed a character array with length 0. This causes the ErrorHandler to
write no data to the array and no output to be displayed.

The array size is constant and this patch moves its definition to a
macro.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>