### PR TITLE
test: fuzz: Remove compile time fuzzing flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,8 +226,7 @@ AS_CASE(["x$with_fuzzing"],
         [AC_MSG_ERROR([Bad value for --with-fuzzing])])
 AM_CONDITIONAL([ENABLE_FUZZING],[test "x$with_fuzzing" != "xnone"])
 AS_IF([test "x$with_fuzzing" != "xnone"],
-      [ADD_COMPILER_FLAG([-fsanitize=fuzzer-no-link], [required])
-       AS_IF([test "x$enable_tcti_fuzzng" = "xno"],
+      [AS_IF([test "x$enable_tcti_fuzzng" = "xno"],
              AC_MSG_ERROR([Fuzz tests can not be enabled without the TCTI_FUZZING module]))
        AS_IF([test "x$GEN_FUZZ" != "x1"],
              AC_MSG_ERROR([Fuzz tests can not be enabled without "GEN_FUZZ=1" variable]))])

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -20,7 +20,9 @@ linking to the fuzzing TCTI.
 
 ```console
 export LD_LIBRARY_PATH=/usr/local/bin
-GEN_FUZZ=1 ./bootstrap
+export GEN_FUZZ=1
+
+./bootstrap
 ./configure \
   CC=clang \
   CXX=clang++ \
@@ -31,6 +33,7 @@ GEN_FUZZ=1 ./bootstrap
   --enable-tcti-mssim=no \
   --with-maxloglevel=none \
   --disable-shared
+
 make -j $(nproc) check
 ```
 


### PR DESCRIPTION
* The flag -fsanitize=fuzzer-no-link is required per clang's
  documentation. However, the link stage -fsanitize=address (and others)
  seem to provide the same effect.
* The flag -fsanitize=fuzzer-no-link when combined with building under
  Google's OSS-Fuzz with AFL as the fuzzing engine, results in discarded
  .text sections, breaking the build during linking.
* Update fuzzing.md doc to reflect recent changes made to configure

Signed-off-by: John Andersen <john.s.andersen@intel.com>