### PR TITLE
configure.ac: preserve default behaviour of CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ AC_INIT([tpm2-tss],
         [],
         [https://github.com/tpm2-software/tpm2-tss])
 AC_CONFIG_MACRO_DIR([m4])
-: ${CFLAGS=""}
 AC_PROG_CXX([clang++ g++])
 AC_PROG_CC([clang gcc])
 LT_INIT()
@@ -276,7 +275,6 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
             [
             ADD_PREPROC_FLAG([-U_FORTIFY_SOURCE])
             ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])
-            ADD_COMPILER_FLAG([-g -O2])
             ])
       ADD_COMPILER_FLAG([-std=c99])
       ADD_COMPILER_FLAG([-Wall])


### PR DESCRIPTION
In all Autoconf projects is expected that:

• calling “./configure” implies passing -O2 -g to the compiler, while
• calling “CFLAGS=–flto ./configure” implies passing -flto to the compiler
but omiting “-O2 -g”.

This patch restores the expected behaviour.