### PR TITLE
ESYS: Fix usage of bad auth values.

### DIFF
--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -374,11 +374,14 @@ Esys_TR_SetAuth(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     if (r != TPM2_RC_SUCCESS)
         return r;
 
-    if (authValue == NULL)
+    if (authValue == NULL) {
         esys_object->auth.size = 0;
-    else
+    } else {
+        if (authValue->size > sizeof(TPMU_HA)) {
+            return_error(TSS2_ESYS_RC_BAD_SIZE, "Bad size for auth value.");
+        }
         esys_object->auth = *authValue;
-
+    }
     return TSS2_RC_SUCCESS;
 }
 


### PR DESCRIPTION
* The size of auth value is not checked in Esys_TR_SetAuth, but the size is used for memcpy.
* memcpy caused an out-of-bound overwrite if size > sizeof(TPMU_HA).

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>