### PR TITLE
deheader: remove double #include’d headers

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -22,7 +22,6 @@
 #define LOGMODULE esys_crypto
 #include "util/log.h"
 #include "util/aux_util.h"
-#include "esys_crypto_ossl.h"
 
 static ENGINE *engine = NULL;
 

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #ifndef _WIN32
 #include <sys/time.h>

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -181,7 +181,7 @@ test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
 
     /* Check HMAC_Start with auth equal NULL */
 
- #ifdef TEST_SESSION
+#ifdef TEST_SESSION
     r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
                               ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                               &nonceCaller,

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -10,7 +10,6 @@
 
 #include "esys_iutil.h"
 #include "test-esapi.h"
-#include "test-esapi.h"
 #define LOGMODULE test
 #include "util/log.h"
 #include "util/aux_util.h"


### PR DESCRIPTION
and fix unbalanced #ifdef .. #endif

Found by http://www.catb.org/~esr/deheader/ .