### PR TITLE
Configure: further tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,17 +85,14 @@ AC_ARG_WITH([crypto],
 AM_CONDITIONAL(ESYS_OSSL, test "x$with_crypto" = "xossl")
 AM_CONDITIONAL(ESYS_GCRYPT, test "x$with_crypto" = "xgcrypt")
 
-AS_IF([test "x$with_crypto" != "xgcrypt"],
-    AS_IF([test "x$with_crypto" != "xossl"],
-          AC_MSG_ERROR([Bad value for --with-crypto $with_crypto])))
+AS_IF([test "x$with_crypto" != xgcrypt -a "x$with_crypto" != xossl],
+          AC_MSG_ERROR([Bad value for --with-crypto $with_crypto]))
 
-AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = "xgcrypt"],
+AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = xgcrypt],
       [AC_CHECK_HEADER([gcrypt.h],
                        [],
-                       [AC_MSG_ERROR([Missing required header: gcrypt.h.])])])
-
-AS_IF([test "x$enable_esapi" != xno -a "x$with_cryptor" = "xgcrypt"],
-      [AC_CHECK_LIB([gcrypt],
+                       [AC_MSG_ERROR([Missing required header: gcrypt.h.])])
+       AC_CHECK_LIB([gcrypt],
                     [gcry_mac_open],
                     [],
                     [AC_MSG_ERROR([Missing required library: gcrypt.])])])

--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,8 @@ AC_ARG_WITH([tctidefaultmodule],
 [The default TCTI module for ESAPI. (Default: libtss2-tcti-default.so)])],
             [AC_DEFINE_UNQUOTED([ESYS_TCTI_DEFAULT_MODULE],
                                 ["$with_tctidefaultmodule"],
-                                ["The default TCTI library file"])])
+                                ["The default TCTI library file"])],
+	    [with_tctidefaultmodule=libtss2-tcti-default.so])
 
 AC_ARG_WITH([tctidefaultconfig],
             [AS_HELP_STRING([--with-tctidefaultconfig],


### PR DESCRIPTION
* print in the summary the default value for tctidefaultmodule, if --with-tctidefaultmodule was not supplied
* replace "x$with_cryptor" → "x$with_crypto"