### PR TITLE
sys: fix wrong enc flag in EncryptDecrypt

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
@@ -74,7 +74,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
     if (rval)
         return rval;
 
-    ctx->decryptAllowed = 1;
+    ctx->decryptAllowed = 0;
     ctx->encryptAllowed = 1;
     ctx->authAllowed = 1;
 


### PR DESCRIPTION
EncryptDecrypt cmd does not allow param encryption because
the first param is not a TPM2B type.
