### PR TITLE
Makefile.am: remove nodist_ before pkgconfig_DATA

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,8 +182,8 @@ CLEANFILES += AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
 pkgconfigdir          = $(libdir)/pkgconfig
-nodist_pkgconfig_DATA =
-CLEANFILES += $(nodist_pkgconfig_DATA)
+pkgconfig_DATA =
+CLEANFILES += $(pkgconfig_DATA)
 
 %.pc : %.pc.in
 	$(AM_V_GEN)$(call make_parent_dir,$@) && \
@@ -207,7 +207,7 @@ libutil_la_SOURCES = $(UTIL_SRC)
 libtss2_mu = src/tss2-mu/libtss2-mu.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_mu.h
 lib_LTLIBRARIES += $(libtss2_mu)
-nodist_pkgconfig_DATA += lib/tss2-mu.pc
+pkgconfig_DATA += lib/tss2-mu.pc
 EXTRA_DIST += lib/tss2-mu.map lib/tss2-mu.pc.in
 
 if HAVE_LD_VERSION_SCRIPT
@@ -222,7 +222,7 @@ if ENABLE_TCTI_DEVICE
 libtss2_tcti_device = src/tss2-tcti/libtss2-tcti-device.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_device.h
 lib_LTLIBRARIES += $(libtss2_tcti_device)
-nodist_pkgconfig_DATA += lib/tss2-tcti-device.pc
+pkgconfig_DATA += lib/tss2-tcti-device.pc
 EXTRA_DIST += lib/tss2-tcti-device.map lib/tss2-tcti-device.pc.in
 
 if HAVE_LD_VERSION_SCRIPT
@@ -239,7 +239,7 @@ if ENABLE_TCTI_MSSIM
 libtss2_tcti_mssim = src/tss2-tcti/libtss2-tcti-mssim.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_mssim.h
 lib_LTLIBRARIES += $(libtss2_tcti_mssim)
-nodist_pkgconfig_DATA += lib/tss2-tcti-mssim.pc
+pkgconfig_DATA += lib/tss2-tcti-mssim.pc
 EXTRA_DIST += lib/tss2-tcti-mssim.map lib/tss2-tcti-mssim.pc.in
 
 if HAVE_LD_VERSION_SCRIPT
@@ -255,7 +255,7 @@ endif # ENABLE_TCTI_MSSIM
 libtss2_sys = src/tss2-sys/libtss2-sys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_sys.h
 lib_LTLIBRARIES += $(libtss2_sys)
-nodist_pkgconfig_DATA += lib/tss2-sys.pc
+pkgconfig_DATA += lib/tss2-sys.pc
 EXTRA_DIST += lib/tss2-sys.pc.in
 
 src_tss2_sys_libtss2_sys_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/tss2-sys
@@ -268,7 +268,7 @@ if ESAPI
 libtss2_esys = src/tss2-esys/libtss2-esys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_esys.h
 lib_LTLIBRARIES += $(libtss2_esys)
-nodist_pkgconfig_DATA += lib/tss2-esys.pc
+pkgconfig_DATA += lib/tss2-esys.pc
 EXTRA_DIST += lib/tss2-esys.pc.in
 
 


### PR DESCRIPTION
From the Automake manual: “Files listed with the ‘_DATA’ primary are not automatically part of the tarball built with ‘make dist’”.
