### PR TITLE
Makefile*am: split between TESTS and programs compiled during “make check”

### DIFF
--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -10,7 +10,7 @@ TESTS_LIBADD = $(lib_LTLIBRARIES) $(libtss2_mu) $(libtss2_sys) $(libutil)
 # tcti library used for fuzzing
 if ENABLE_TCTI_FUZZING
 libtss2_tcti_fuzzing = test/fuzz/tcti/libtss2-tcti-fuzzing.la
-noinst_LTLIBRARIES += $(libtss2_tcti_fuzzing)
+check_LTLIBRARIES += $(libtss2_tcti_fuzzing)
 
 test_fuzz_tcti_libtss2_tcti_fuzzing_la_LIBADD   = $(TESTS_LIBADD)
 test_fuzz_tcti_libtss2_tcti_fuzzing_la_SOURCES  = \
@@ -23,7 +23,7 @@ FUZZ_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
 FUZZ_CPPFLAGS = $(INCLUDE_DIRS) -I$(srcdir)/test/integration $(LIB_FUZZING_ENGINE)
 
 libtss2_utils_fuzzing = test/fuzz/libfuzz_utils.la
-noinst_LTLIBRARIES += $(libtss2_utils_fuzzing)
+check_LTLIBRARIES += $(libtss2_utils_fuzzing)
 test_fuzz_libfuzz_utils_la_LDFLAGS = $(TESTS_LDFLAGS)
 test_fuzz_libfuzz_utils_la_LIBADD = $(TESTS_LIBADD)
 test_fuzz_libfuzz_utils_la_CFLAGS = $(AM_CFLAGS) $(FUZZ_CFLAGS)
@@ -38,6 +38,7 @@ fuzzdir = $(srcdir)
 fuzz-targets: $(fuzz_PROGRAMS)
 
 check_PROGRAMS += $(TESTS_FUZZ)
+TESTS += $(TESTS_FUZZ)
 fuzz_PROGRAMS = $(TESTS_FUZZ)
 FUZZ = $(check_PROGRAMS)
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -6,9 +6,10 @@
 TESTS_CFLAGS = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/src/tss2-mu \
     -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys \
     -Wno-unused-parameter -Wno-missing-field-initializers
-TESTS_LDADD = $(check_LTLIBRARIES) $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) \
+TESTS_LDADD = $(check_LTLIBRARIES) $(lib_LTLIBRARIES) \
     $(LIBCRYPTO_LIBS) $(libutil)
 
+check_LTLIBRARIES =
 # test harness configuration
 TEST_EXTENSIONS = .int
 if TESTPTPM
@@ -23,7 +24,7 @@ AM_TESTS_ENVIRONMENT = PATH="$(PATH)"
 check-programs: $(check_PROGRAMS)
 
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
-TESTS = $(check_PROGRAMS)
+TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 
 if ENABLE_INTEGRATION
 check_PROGRAMS += test/helper/tpm_startup
@@ -85,7 +86,7 @@ endif ESAPI
 endif #UNIT
 
 if ENABLE_INTEGRATION
-check_LTLIBRARIES = test/integration/libtest_utils.la
+check_LTLIBRARIES += test/integration/libtest_utils.la
 
 TESTS_INTEGRATION =
 if !TESTPTPM


### PR DESCRIPTION
TESTS are the tests, executed by $(make check), and for running $(make check) some further utility programs and libraries need to be compiled, that do not belong to TESTS.  The latter are not supposed to be compiled during $(make all), hence the split.

Makefile-test.am:
* Libraries build during $(make check) are no more called noinst_LTLIBRARIES, but check_LTLIBRARIES.  Add check_LTLIBRARIES to TESTS_LDADD, so that these libraries are considered when linking tests.

*  Remove noinst_LTLIBRARIES from TESTS_LDADD, because its value is libutil.la and the latter is included explicitly.

Follow up of https://github.com/tpm2-software/tpm2-tss/pull/1339.