### PR TITLE
Revert "Makefile.am: compile test utilities only on “make test”"

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -6,8 +6,7 @@
 TESTS_CFLAGS = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/src/tss2-mu \
     -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys \
     -Wno-unused-parameter -Wno-missing-field-initializers
-TESTS_LDADD = $(check_LTLIBRARIES) $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) \
-    $(LIBCRYPTO_LIBS) $(libutil)
+TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(LIBCRYPTO_LIBS) $(libutil)
 
 # test harness configuration
 TEST_EXTENSIONS = .int
@@ -26,12 +25,12 @@ check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(check_PROGRAMS)
 
 if ENABLE_INTEGRATION
-check_PROGRAMS += test/helper/tpm_startup
+noinst_PROGRAMS += test/helper/tpm_startup
 test_helper_tpm_startup_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
 test_helper_tpm_startup_LDFLAGS = $(TESTS_LDFLAGS)
 test_helper_tpm_startup_LDADD = $(TESTS_LDADD)
 
-check_PROGRAMS += test/helper/tpm_transientempty
+noinst_PROGRAMS += test/helper/tpm_transientempty
 test_helper_tpm_transientempty_CFLAGS = $(TESTS_CFLAGS) -I$(srcdir)/test/integration
 test_helper_tpm_transientempty_LDFLAGS = $(TESTS_LDFLAGS)
 test_helper_tpm_transientempty_LDADD = $(TESTS_LDADD)
@@ -85,7 +84,7 @@ endif ESAPI
 endif #UNIT
 
 if ENABLE_INTEGRATION
-check_LTLIBRARIES = test/integration/libtest_utils.la
+noinst_LTLIBRARIES += test/integration/libtest_utils.la
 
 TESTS_INTEGRATION =
 if !TESTPTPM


### PR DESCRIPTION
Reverts tpm2-software/tpm2-tss#1339 since it makes the build to fail, because startup becomes a test instead of helper for tests