### PR TITLE
script/gen_fuzz.py: don’t include test/fuzz/*.fuzz.cpp files on “make dist”

### DIFF
--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -7,6 +7,7 @@ FUZZ_LOG_COMPILER = $(srcdir)/script/fuzz-log-compiler.sh
 INCLUDE_DIRS += -I$(srcdir)/test/fuzz/tcti
 TESTS_LIBADD = $(lib_LTLIBRARIES) $(libtss2_mu) $(libtss2_sys) $(libutil)
 
+EXTRA_DIST += test/fuzz/main-sapi.cpp
 # tcti library used for fuzzing
 if ENABLE_TCTI_FUZZING
 libtss2_tcti_fuzzing = test/fuzz/tcti/libtss2-tcti-fuzzing.la
@@ -15,7 +16,8 @@ check_LTLIBRARIES += $(libtss2_tcti_fuzzing)
 test_fuzz_tcti_libtss2_tcti_fuzzing_la_LIBADD   = $(TESTS_LIBADD)
 test_fuzz_tcti_libtss2_tcti_fuzzing_la_SOURCES  = \
     src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
-    test/fuzz/tcti/tcti-fuzzing.c test/fuzz/tcti/tcti-fuzzing.h
+    test/fuzz/tcti/tcti-fuzzing.c test/fuzz/tcti/tcti-fuzzing.h \
+    test/fuzz/tcti/tss2_tcti_fuzzing.h
 endif # ENABLE_TCTI_FUZZING
 
 if ENABLE_FUZZING

--- a/script/gen_fuzz.py
+++ b/script/gen_fuzz.py
@@ -19,7 +19,7 @@ MAKEFILE_FUZZ_TARGET = '''
 noinst_PROGRAMS += test/fuzz/%s.fuzz
 test_fuzz_%s_fuzz_CPPFLAGS = $(FUZZ_CPPFLAGS)
 test_fuzz_%s_fuzz_LDADD    = $(FUZZ_LDADD)
-test_fuzz_%s_fuzz_SOURCES  = test/fuzz/main-sapi.cpp \\
+nodist_test_fuzz_%s_fuzz_SOURCES  = test/fuzz/main-sapi.cpp \\
         test/fuzz/%s.fuzz.cpp
 
 DISTCLEANFILES += test/fuzz/%s.fuzz.cpp'''


### PR DESCRIPTION
Before this change, when `GEN_FUZZ=1 ./bootstrap` has filled Makefile-fuzz-generated.am, the aforementioned files were genetared, and included on “make dist”.

Likewise, test/fuzz/main-sapi.cpp was sometimes considered by “make dist” and test/fuzz/tcti/tss2_tcti_fuzzing.h was always forgotten.