### PR TITLE
Automake: a .h file needs to be included only once in _SOURCES or _HEADERS for the whole project

### DIFF
--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -28,8 +28,8 @@ test_fuzz_libfuzz_utils_la_LDFLAGS = $(TESTS_LDFLAGS)
 test_fuzz_libfuzz_utils_la_LIBADD = $(TESTS_LIBADD)
 test_fuzz_libfuzz_utils_la_CFLAGS = $(AM_CFLAGS) $(FUZZ_CFLAGS)
 test_fuzz_libfuzz_utils_la_SOURCES = \
-    test/integration/sapi-context-util.c test/integration/context-util.h \
-    test/integration/sapi-test-options.c test/integration/test-options.h
+    test/integration/sapi-context-util.c \
+    test/integration/sapi-test-options.c
 
 TESTS_LDADD += $(libtss2_utils_fuzzing)
 FUZZ_LDADD = $(TESTS_LDADD) $(TESTS_LDFLAGS) $(FUZZ_LDFLAGS)

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -235,14 +235,14 @@ test_unit_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
 test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,--wrap=write, -Wl,--wrap=poll
 test_unit_tcti_device_SOURCES = test/unit/tcti-device.c \
-    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
 
 test_unit_tcti_mssim_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_mssim_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
 test_unit_tcti_mssim_LDFLAGS = -Wl,--wrap=connect,--wrap=read,--wrap=select,--wrap=write
 test_unit_tcti_mssim_SOURCES = test/unit/tcti-mssim.c \
-    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
+    src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-mssim.c src/tss2-tcti/tcti-mssim.h
 
 test_unit_io_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -230,8 +230,8 @@ src_tss2_tcti_libtss2_tcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/l
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_device_la_LIBADD   = $(libtss2_mu) $(libutil)
 src_tss2_tcti_libtss2_tcti_device_la_SOURCES  = \
-    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
-    src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-device.c
 endif # ENABLE_TCTI_DEVICE
 
 # tcti library for Microsoft TPM2 simulator
@@ -247,8 +247,8 @@ src_tss2_tcti_libtss2_tcti_mssim_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/li
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_mssim_la_LIBADD   = $(libtss2_mu) $(libutil)
 src_tss2_tcti_libtss2_tcti_mssim_la_SOURCES  = \
-    src/tss2-tcti/tcti-common.c src/tss2-tcti/tcti-common.h \
-    src/tss2-tcti/tcti-mssim.c src/tss2-tcti/tcti-mssim.h
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-mssim.c
 endif # ENABLE_TCTI_MSSIM
 
 ### TCG TSS SAPI spec library ###


### PR DESCRIPTION
The sole purpose of mentioning a .h file in Makefile*.am is either:
• for installing and distributing it, being in a _HEADERS primary, or
• only for distributing it, when it is in a _SOURCE primary.

The dependencies between .c and .h files (when a .h file is changed, recompile the .c file and relink) are anyway generated by $CC -M.