### PR TITLE
test: consistently set size of complex TPM2B to zero

### DIFF
--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -55,7 +55,7 @@ test_esys_audit(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -40,7 +40,7 @@ test_esys_certify_creation(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -40,7 +40,7 @@ test_esys_certify(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -57,7 +57,7 @@ test_esys_commit(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -44,7 +44,7 @@ test_esys_create_fail(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -48,7 +48,7 @@ test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -183,7 +183,7 @@ test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -199,7 +199,7 @@ test_esys_create_password_auth(ESYS_CONTEXT * esys_context)
     inSensitive2.sensitive.userAuth = authKey2;
 
     TPM2B_SENSITIVE_CREATE inSensitive3 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -47,7 +47,7 @@ test_esys_create_primary_hmac(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -58,7 +58,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -279,7 +279,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -295,7 +295,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     inSensitive2.sensitive.userAuth = authKey2;
 
     TPM2B_SENSITIVE_CREATE inSensitive3 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-createloaded.int.c
+++ b/test/integration/esys-createloaded.int.c
@@ -105,7 +105,7 @@ test_esys_createloaded(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValuePrimary,
             .data = {
@@ -153,7 +153,7 @@ test_esys_createloaded(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitiveObject = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValueObject,
             .data = {

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -107,7 +107,7 @@ test_esys_duplicate(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -209,7 +209,7 @@ test_esys_duplicate(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-ecdh-keygen.int.c
+++ b/test/integration/esys-ecdh-keygen.int.c
@@ -53,7 +53,7 @@ test_esys_ecdh_keygen(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -55,7 +55,7 @@ test_esys_ecdh_zgen(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -48,7 +48,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -134,7 +134,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-evict-control-serialization.int.c
+++ b/test/integration/esys-evict-control-serialization.int.c
@@ -46,7 +46,7 @@ test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -159,7 +159,7 @@ test_esys_evict_control_serialization(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -44,7 +44,7 @@ test_esys_get_time(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -60,7 +60,7 @@ test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: HierarchyControl", error);
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -59,7 +59,7 @@ test_esys_hierarchychangeauth(ESYS_CONTEXT * esys_context)
     auth_changed = true;
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-hmac.int.c
+++ b/test/integration/esys-hmac.int.c
@@ -42,7 +42,7 @@ test_esys_hmac(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -68,7 +68,7 @@ test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -104,7 +104,7 @@ test_esys_import(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -206,7 +206,7 @@ test_esys_import(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -103,7 +103,7 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -197,7 +197,7 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -47,7 +47,7 @@ test_esys_nv_certify(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -75,7 +75,7 @@ test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValuePrimary,
             .data = {
@@ -123,7 +123,7 @@ test_esys_object_changeauth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-policy-authorize.int.c
+++ b/test/integration/esys-policy-authorize.int.c
@@ -46,7 +46,7 @@ test_esys_policy_authorize(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValuePrimary,
             .data = {

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -122,7 +122,7 @@ test_esys_policy_password(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -200,7 +200,7 @@ test_esys_policy_password(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = authKey2,
             .data = {

--- a/test/integration/esys-policy-ticket.int.c
+++ b/test/integration/esys-policy-ticket.int.c
@@ -58,7 +58,7 @@ test_esys_policy_ticket(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValuePrimary,
             .data = {

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -41,7 +41,7 @@ test_esys_quote(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -43,7 +43,7 @@ test_esys_rsa_encrypt_decrypt(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -51,7 +51,7 @@ test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -185,7 +185,7 @@ test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -201,7 +201,7 @@ test_esys_save_and_load_context(ESYS_CONTEXT * esys_context)
     inSensitive2.sensitive.userAuth = authKey2;
 
     TPM2B_SENSITIVE_CREATE inSensitive3 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-session-attributes.int.c
+++ b/test/integration/esys-session-attributes.int.c
@@ -15,7 +15,7 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-extern TSS2_RC 
+extern TSS2_RC
 (*transmit_hook) (const uint8_t *command_buffer, size_t command_size);
 
 size_t handles;
@@ -44,7 +44,7 @@ test_esys_session_attributes(ESYS_CONTEXT * esys_context)
                               .mode = {.aes = TPM2_ALG_CFB}};
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,
@@ -153,21 +153,21 @@ test_esys_session_attributes(ESYS_CONTEXT * esys_context)
     session1_attributes = TPMA_SESSION_CONTINUESESSION | TPMA_SESSION_ENCRYPT;
     transmit_hook = hookcheck_session1;
 
-    r = Esys_GetRandom(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE, 
+    r = Esys_GetRandom(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE,
                        10, &rdata);
     transmit_hook = NULL;
     goto_if_error(r, "Error esapi create primary", error);
 
     transmit_hook = hookcheck_session1;
 
-    r = Esys_GetRandom(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE, 
+    r = Esys_GetRandom(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE,
                        10, &rdata);
     transmit_hook = NULL;
     goto_if_error(r, "Error esapi create primary", error);
 
     LOGBLOB_INFO(&rdata->buffer[0], rdata->size, "rdata");
 
-    /* Cleanup */   
+    /* Cleanup */
     r = Esys_FlushContext(esys_context, session);
     goto_if_error(r, "Flushing context", error);
 

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -44,7 +44,7 @@ test_esys_tr_fromTpmPublic_key(ESYS_CONTEXT * ectx)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -59,7 +59,7 @@ test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                 .size = 0,
@@ -157,7 +157,7 @@ test_esys_unseal_password_auth(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
-        .size = 1,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                 .size = 0,

--- a/test/integration/esys-verify-signature.int.c
+++ b/test/integration/esys-verify-signature.int.c
@@ -44,7 +44,7 @@ test_esys_verify_signature(ESYS_CONTEXT * esys_context)
     };
 
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = authValuePrimary,
             .data = {

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -15,7 +15,7 @@
 #include "util/aux_util.h"
 
 /** This test is intended to test Esys_ECDH_ZGen.
- * 
+ *
  * The test is based on an ECC key created with Esys_CreatePrimary
  * and data produced by the command Esys_EC_Ephemeral.
  *
@@ -62,7 +62,7 @@ test_esys_zgen_2phase(ESYS_CONTEXT * esys_context)
     goto_if_error(r, "Error: During initialization of session", error);
 
     TPM2B_SENSITIVE_CREATE inSensitive = {
-        .size = 4,
+        .size = 0,
         .sensitive = {
             .userAuth = {
                  .size = 0,

--- a/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
@@ -32,7 +32,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
     TSS2_RC rc;
     TPM2B_SENSITIVE_CREATE  in_sensitive;
-    TPM2B_PUBLIC            in_public;
+    TPM2B_PUBLIC            in_public = {0};
     TPM2B_DATA              outside_info = {0,};
     TPML_PCR_SELECTION      creation_pcr;
     TPM2B_NAME name = {sizeof(TPM2B_NAME)-2,};
@@ -56,7 +56,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
             .nonce={.size=0},
             .hmac={.size=0}}}};
 
-    in_sensitive.size =0;
+    in_sensitive.size = 0;
     in_sensitive.sensitive.userAuth.size = 0;
     in_sensitive.sensitive.data.size = 0;
 

--- a/test/integration/sapi-param-encrypt-decrypt.int.c
+++ b/test/integration/sapi-param-encrypt-decrypt.int.c
@@ -61,11 +61,10 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         return rc;
     }
 
+    nv_public.size = 0;
     nv_public.nvPublic.attributes = nv_attribs;
     CopySizedByteBuffer((TPM2B *)&nv_public.nvPublic.authPolicy, (TPM2B *)&policy_auth);
     nv_public.nvPublic.dataSize = TEST_DATA_LEN;
-    nv_public.size = sizeof(TPMI_RH_NV_INDEX) + sizeof(TPMI_ALG_HASH) +
-                     sizeof(TPMA_NV) + sizeof(UINT16) + sizeof(UINT16);
     nv_public.nvPublic.nvIndex = nv_index;
     nv_public.nvPublic.nameAlg = TPM2_ALG_SHA256;
 

--- a/test/integration/sapi-policy-authorizeNV.int.c
+++ b/test/integration/sapi-policy-authorizeNV.int.c
@@ -74,9 +74,6 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     };
     TPMI_RH_NV_INDEX nv_index = TPM2_HR_NV_INDEX | 0x01;
 
-    nv_public.size = sizeof(TPMI_RH_NV_INDEX) +
-        sizeof(TPMI_ALG_HASH) + sizeof(TPMA_NV) + sizeof(UINT16) +
-        sizeof(UINT16);
     nv_public.nvPublic.nvIndex = nv_index;
     nv_public.nvPublic.nameAlg = TPM2_ALG_SHA256;
     nv_public.nvPublic.attributes = TPMA_NV_PPREAD;

--- a/test/integration/sapi-util.c
+++ b/test/integration/sapi-util.c
@@ -102,6 +102,7 @@ create_aes_128_cfb (
     TPM2B_SENSITIVE_CREATE  in_sensitive    = { 0 };
     /* template defining key type */
     TPM2B_PUBLIC            in_public       = {
+            .size = 0,
             .publicArea.type = TPM2_ALG_SYMCIPHER,
             .publicArea.nameAlg = TPM2_ALG_SHA256,
             .publicArea.objectAttributes = TPMA_OBJECT_DECRYPT |
@@ -174,6 +175,7 @@ create_keyedhash_key (
     TPM2B_SENSITIVE_CREATE  in_sensitive    = { 0 };
     /* template defining key type */
     TPM2B_PUBLIC            in_public       = {
+            .size = 0,
             .publicArea.type = TPM2_ALG_KEYEDHASH,
             .publicArea.nameAlg = TPM2_ALG_SHA256,
             .publicArea.objectAttributes = TPMA_OBJECT_RESTRICTED |

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -671,9 +671,7 @@ static void TestNV()
         nvAuth.buffer[i] = (UINT8)i;
     }
 
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-        sizeof( UINT16 );
+    publicInfo.size = 0;
     publicInfo.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
@@ -811,9 +809,7 @@ static void TestHierarchyControl()
         nvAuth.buffer[i] = i;
     }
 
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-        sizeof( UINT16 );
+    publicInfo.size = 0;
     publicInfo.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
@@ -888,12 +884,10 @@ static TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION
     attributes |= TPMA_NV_ORDERLY;
 
     /* Init public info structure. */
+    publicInfo.size = 0;
     publicInfo.nvPublic.attributes = attributes;
     CopySizedByteBuffer((TPM2B *)&publicInfo.nvPublic.authPolicy, (TPM2B *)authPolicy);
     publicInfo.nvPublic.dataSize = size;
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
     publicInfo.nvPublic.nvIndex = nvIndex;
     publicInfo.nvPublic.nameAlg = nameAlg;
 
@@ -1106,9 +1100,11 @@ static TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySes
         .nonce = {.size = 0},
         .hmac = {.size = 0}}}};
 
+    inSensitive.size = 0;
     inSensitive.sensitive.userAuth.size = 0;
     inSensitive.sensitive.data.size = 0;
 
+    inPublic.size = 0;
     inPublic.publicArea.type = TPM2_ALG_RSA;
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
     *(UINT32 *)&( inPublic.publicArea.objectAttributes) = 0;
@@ -1512,9 +1508,7 @@ static void ProvisionOtherIndices()
     /* init nvAuth */
     nvAuth.size = 0;
 
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
+    publicInfo.size = 0;
     publicInfo.nvPublic.nvIndex = INDEX_LCP_SUP;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
@@ -1606,9 +1600,7 @@ static void ProvisionNvAux()
     /* init nvAuth */
     nvAuth.size = 0;
 
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
+    publicInfo.size = 0;
     publicInfo.nvPublic.nvIndex = INDEX_AUX;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
@@ -1882,11 +1874,13 @@ static void TestUnseal()
 
     LOG_INFO("UNSEAL TEST  :" );
 
+    inSensitive.size = 0;
     inSensitive.sensitive.userAuth.size = sizeof( authStr ) - 1;
     memcpy( &( inSensitive.sensitive.userAuth.buffer[0] ), authStr, sizeof( authStr ) - 1 );
     inSensitive.sensitive.data.size = sizeof( sensitiveData ) - 1;
     memcpy( &( inSensitive.sensitive.data.buffer[0] ), sensitiveData, sizeof( sensitiveData ) - 1 );
 
+    inPublic.size = 0;
     inPublic.publicArea.authPolicy.size = 0;
 
     inPublic.publicArea.unique.keyedHash.size = 0;
@@ -1968,9 +1962,7 @@ static void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
         nvAuth.buffer[i] = password[i];
     }
 
-    publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
-        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-        sizeof( UINT16 );
+    publicInfo.size = 0;
     publicInfo.nvPublic.nvIndex = nvIndex;
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 

--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -18,7 +18,7 @@
 static void
 tpm2b_marshal_success(void **state) {
     TPM2B_DIGEST dgst = {4, {0}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     uint8_t buffer[sizeof(dgst) + sizeof(point)] = {0};
     size_t  buffer_size = sizeof(buffer);
     uint16_t *size_ptr = (uint16_t *) buffer;
@@ -64,7 +64,7 @@ tpm2b_marshal_success(void **state) {
 static void
 tpm2b_marshal_success_offset(void **state) {
     TPM2B_DIGEST dgst = {4, {0}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     size_t offset = 10;
     uint8_t buffer[sizeof(dgst) + sizeof(point) + 10] = {0};
     size_t  buffer_size = sizeof(buffer);
@@ -117,7 +117,7 @@ static void
 tpm2b_marshal_buffer_null_with_offset(void **state)
 {
     TPM2B_DIGEST dgst = {4, {0}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     size_t offset = 10;
     size_t  buffer_size = sizeof(dgst) + sizeof(point) + 10;
     uint32_t value = 0xdeadbeef;
@@ -169,7 +169,7 @@ static void
 tpm2b_marshal_buffer_null_offset_null(void **state)
 {
     TPM2B_DIGEST dgst = {4, {0}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     size_t buffer_size = 1024;
     TSS2_RC rc;
 
@@ -186,7 +186,7 @@ tpm2b_marshal_buffer_null_offset_null(void **state)
 static void
 tpm2b_marshal_buffer_size_lt_data_nad_lt_offset(void **state) {
     TPM2B_DIGEST dgst = {4, {0}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     size_t offset = 10;
     uint8_t buffer[sizeof(dgst) + sizeof(point)] = {0};
     size_t  buffer_size = sizeof(buffer);
@@ -362,7 +362,7 @@ static void
 tpm2b_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
 {
     TPM2B_DIGEST dgst = {4, {0x00, 0x01, 0x02, 0x03}};
-    TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
+    TPM2B_ECC_POINT point = {0};
     uint8_t buffer[sizeof(dgst) + sizeof(point)] = { 0 };
     size_t offset = sizeof(dgst) - 5;
     TSS2_RC rc;


### PR DESCRIPTION
The complex TPM2B types TPM2B_SENSITIVE_CREATE, TPM2B_ECC_POINT, TPM2B_PUBLIC,
TPM2B_SENSITIVE, TPM2B_NV_PUBLIC, and TPM2B_CREATION_DATA have their size field
set automatically by the marshaling implementation.  This commit consistently
sets the size field to zero prior to marshaling.

Signed-off-by: Jeffrey Ferreira <jeffpferreira@gmail.com>