### PR TITLE
build: Limit code coverage metrics collection to $(top_builddir)/src.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ distclean-local: code-coverage-dist-clean
 else
 @CODE_COVERAGE_RULES@
 endif
+CODE_COVERAGE_DIRECTORY = $(top_builddir)/src
 
 # ax_valgrind_check
 @VALGRIND_CHECK_RULES@


### PR DESCRIPTION
We don't care how much of our test code gets executed when the test
harness is run. Including this data in our metrics causes the LOC count
to be off by a full 1% while the coverage of functions is over reported
by nearly 10%.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>