### PR TITLE
configure.ac: check for libcrypto/libssl with PKG_CHECK_MODULES

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -39,8 +39,8 @@ test_helper_tpm_transientempty_LDADD = $(TESTS_LDADD)
 endif #ENABLE_INTEGRATION
 
 if ESYS_OSSL
-esyscryCFLAGS = -DOSSL
-esyscryLDFLAGS = -lssl -lcrypto -ldl
+esyscryCFLAGS = -DOSSL $(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
+esyscryLDFLAGS = $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS) -ldl
 else
 if ESYS_GCRYPT
 esyscryCFLAGS =

--- a/Makefile.am
+++ b/Makefile.am
@@ -278,8 +278,10 @@ src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \
 
 if ESYS_OSSL
 TSS2_ESYS_SRC += src/tss2-esys/esys_crypto_ossl.h src/tss2-esys/esys_crypto_ossl.c
-src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys -DOSSL
-src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBDL_LDFLAGS) $(LIBSOCKET_LDFLAGS) -lssl -lcrypto
+src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys -DOSSL \
+    $(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
+src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBDL_LDFLAGS) $(LIBSOCKET_LDFLAGS) \
+    $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
 else
 if ESYS_GCRYPT
 TSS2_ESYS_SRC += src/tss2-esys/esys_crypto_gcrypt.h src/tss2-esys/esys_crypto_gcrypt.c

--- a/configure.ac
+++ b/configure.ac
@@ -85,28 +85,17 @@ AC_ARG_WITH([crypto],
 AM_CONDITIONAL(ESYS_OSSL, test "x$with_crypto" = "xossl")
 AM_CONDITIONAL(ESYS_GCRYPT, test "x$with_crypto" = "xgcrypt")
 
-AS_IF([test "x$with_crypto" != xgcrypt -a "x$with_crypto" != xossl],
-          AC_MSG_ERROR([Bad value for --with-crypto $with_crypto]))
-
-AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = xgcrypt],
-      [AC_CHECK_HEADER([gcrypt.h],
-                       [],
-                       [AC_MSG_ERROR([Missing required header: gcrypt.h.])])
-       AC_CHECK_LIB([gcrypt],
-                    [gcry_mac_open],
-                    [],
-                    [AC_MSG_ERROR([Missing required library: gcrypt.])])])
-
-AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = "xossl"],
-      [AC_CHECK_HEADER([openssl/ssl.h],
-                       [],
-                       [AC_MSG_ERROR([Missing required header: openssl/ssl.h.])])])
-
-AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = "xossl"],
-    AC_CHECK_LIB(ssl, OPENSSL_init_ssl, [FOUND_SSL_LIB="yes"]))
-
-AS_IF([test "x$enable_esapi" != xno -a "x$with_crypto" = "xossl"],
-    AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])]))
+AS_IF([test "x$enable_esapi" = xyes],
+      [AS_IF([test "x$with_crypto" = xgcrypt], [
+           AC_CHECK_HEADER([gcrypt.h],,
+               [AC_MSG_ERROR([Missing required header: gcrypt.h.])])
+           AC_CHECK_LIB([gcrypt],
+               [gcry_mac_open],,
+               [AC_MSG_ERROR([Missing required library: gcrypt.])])
+       ], [test "x$with_crypto" = xossl], [
+           PKG_CHECK_MODULES([LIBSSL], [libssl])
+           PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto])
+       ], AC_MSG_ERROR([Bad value for --with-crypto $with_crypto]))])
 
 AC_ARG_WITH([tctidefaultmodule],
             [AS_HELP_STRING([--with-tctidefaultmodule],
@@ -185,7 +174,8 @@ AS_IF([test "x$enable_integration" = "xyes"],
        ERROR_IF_NO_PROG([grep])
        ERROR_IF_NO_PROG([env])
        ERROR_IF_NO_PROG([rm])
-       PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])
+       AS_IF([test "x$with_crypto" != xossl -o "x$enable_esapi" != xyes],
+           PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto]))
        AC_CHECK_HEADER(uthash.h, [], [AC_MSG_ERROR([Can not find uthash.h. Please install uthash-dev])])
        AS_IF([test "x$enable_tcti_mssim" = xno],
               AC_MSG_ERROR([Integration tests can not be enabled without the TCTI_MSSIM module]))


### PR DESCRIPTION
* Makefile.am: instead of linking libtss2-esys with -lssl -lcrypto, link with $(LIBCRYPTO_LIBS) $(LIBSSL_LIBS).  Use $(LIBSSL_CFLAGS) and $(LIBCRYPTO_CFLAGS) as CFLAGS for the library.

* Makefile-test.am:
  - likewise for the ESYS unit tests.
  - N.B.: test/unit/esys_context_null uses $(esyscryLDFLAGS) but not $(esyscryCFLAGS); test/integration/esys_policy_ticket.int uses $(esyscryCFLAGS) but not $(esysLDFLAGS).

* Discontinue linking libtss2-sys.so, libtss2-mu.so, libtss2-tcti-mssim.so and libtss2-tcti-device.so with -lcrypto, but on --with-crypto=gcrypt continue linking them with -lgcrypt.

* configure.ac: When --with-crypto=ossl --enable-esapi --enable-integration is used, don't check a second time for libcrypto.