### PR TITLE
pkg-config files: use AC_CONFIG_FILES and define variables

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -186,12 +186,6 @@ pkgconfigdir          = $(libdir)/pkgconfig
 pkgconfig_DATA =
 CLEANFILES += $(pkgconfig_DATA)
 
-%.pc : %.pc.in
-	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
-	        s,[@]libdir[@],$(libdir),g; \
-	        s,[@]includedir[@],$(includedir),g;" $^ > $@
-
 # Base TSS2 headers
 tss2dir = $(includedir)/tss2
 tss2_HEADERS = \
@@ -209,7 +203,7 @@ libtss2_mu = src/tss2-mu/libtss2-mu.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_mu.h
 lib_LTLIBRARIES += $(libtss2_mu)
 pkgconfig_DATA += lib/tss2-mu.pc
-EXTRA_DIST += lib/tss2-mu.map lib/tss2-mu.pc.in
+EXTRA_DIST += lib/tss2-mu.map
 
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_mu_libtss2_mu_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/tss2-mu.map
@@ -224,7 +218,7 @@ libtss2_tcti_device = src/tss2-tcti/libtss2-tcti-device.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_device.h
 lib_LTLIBRARIES += $(libtss2_tcti_device)
 pkgconfig_DATA += lib/tss2-tcti-device.pc
-EXTRA_DIST += lib/tss2-tcti-device.map lib/tss2-tcti-device.pc.in
+EXTRA_DIST += lib/tss2-tcti-device.map
 
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-device.map
@@ -241,7 +235,7 @@ libtss2_tcti_mssim = src/tss2-tcti/libtss2-tcti-mssim.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_mssim.h
 lib_LTLIBRARIES += $(libtss2_tcti_mssim)
 pkgconfig_DATA += lib/tss2-tcti-mssim.pc
-EXTRA_DIST += lib/tss2-tcti-mssim.map lib/tss2-tcti-mssim.pc.in
+EXTRA_DIST += lib/tss2-tcti-mssim.map
 
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_mssim_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-mssim.map
@@ -257,7 +251,6 @@ libtss2_sys = src/tss2-sys/libtss2-sys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_sys.h
 lib_LTLIBRARIES += $(libtss2_sys)
 pkgconfig_DATA += lib/tss2-sys.pc
-EXTRA_DIST += lib/tss2-sys.pc.in
 
 src_tss2_sys_libtss2_sys_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/tss2-sys
 src_tss2_sys_libtss2_sys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBSOCKET_LDFLAGS)
@@ -270,7 +263,6 @@ libtss2_esys = src/tss2-esys/libtss2-esys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_esys.h
 lib_LTLIBRARIES += $(libtss2_esys)
 pkgconfig_DATA += lib/tss2-esys.pc
-EXTRA_DIST += lib/tss2-esys.pc.in
 
 
 src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])

--- a/lib/tss2-esys.pc.in
+++ b/lib/tss2-esys.pc.in
@@ -1,7 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-esys
 Description: TPM2 Enhanced System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires: tss2-mu tss2-sys
-Cflags: -I@includedir@
-Libs: -ltss2-esys -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-esys -L${libdir}

--- a/lib/tss2-mu.pc.in
+++ b/lib/tss2-mu.pc.in
@@ -1,6 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-mu
 Description: TPM2 type marshaling and unmarshaling library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Cflags: -I@includedir@
-Libs: -ltss2-mu -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-mu -L${libdir}

--- a/lib/tss2-sys.pc.in
+++ b/lib/tss2-sys.pc.in
@@ -1,7 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-sys
 Description: TPM2 System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires: tss2-mu
-Cflags: -I@includedir@
-Libs: -ltss2-sys -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-sys -L${libdir}

--- a/lib/tss2-tcti-device.pc.in
+++ b/lib/tss2-tcti-device.pc.in
@@ -1,7 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-tcti-device
 Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires: tss2-mu
-Cflags: -I@includedir@
-Libs: -ltss2-tcti-device -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-tcti-device -L${libdir}

--- a/lib/tss2-tcti-mssim.pc.in
+++ b/lib/tss2-tcti-mssim.pc.in
@@ -1,7 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-tcti-mssim
 Description: TCTI library for communicating with the Microsoft TPM2 simulator.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires: tss2-mu
-Cflags: -I@includedir@
-Libs: -ltss2-tcti-mssim -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-tcti-mssim -L${libdir}


### PR DESCRIPTION
- Properly use `AC_CONFIG_FILES` instead of doing manual search-and-replace to generate the pkg-config files.
- Define variables for `libdir` and `includedir` in pkg-config files. This is [standard practice](https://people.freedesktop.org/~dbn/pkg-config-guide.html#using) and allows the user to figure out where the files have been installed, which is e.g. required in [tpm2-tools](https://github.com/tpm2-software/tpm2-tools/pull/1401#discussion_r273539639).