### PR TITLE
Fixed Dockerfile environment in fuzzing section.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Fuzzing
 FROM base AS fuzzing
-RUN GEN_FUZZ=1 ./bootstrap \
+ENV GEN_FUZZ 1
+RUN ./bootstrap \
   && ./configure \
      CC=clang \
      CXX=clang++ \


### PR DESCRIPTION
Fixes environment variable problem (GEN_FUZZ=1) in Dockerfile.
Please backport to 2.2.2.

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>