### PR TITLE
doc/fuzzing.md: relax requirements

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -19,7 +19,6 @@ Build the fuzz tests by setting `--with-fuzzing=libfuzzer` and statically
 linking to the fuzzing TCTI.
 
 ```console
-export LD_LIBRARY_PATH=/usr/local/bin
 export GEN_FUZZ=1
 
 ./bootstrap


### PR DESCRIPTION
As communicated with John Andersen, the line
  `export LD_LIBRARY_PATH=/usr/local/bin`
was supposed to be copied from the Dockerfile, but it was not.  In the latter the variable is set to /usr/local/lib and the purpose is likely to find the libtss2-tcti-*.so files.  Summa summarum, the line removed herein does nothing.