### PR TITLE
esys: simplify resubmit path

### DIFF
--- a/src/tss2-esys/api/Esys_Certify.c
+++ b/src/tss2-esys/api/Esys_Certify.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR objectHandle,
-    ESYS_TR signHandle,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme)
-{
-    esysContext->in.Certify.objectHandle = objectHandle;
-    esysContext->in.Certify.signHandle = signHandle;
-    if (qualifyingData == NULL) {
-        esysContext->in.Certify.qualifyingData = NULL;
-    } else {
-        esysContext->in.Certify.qualifyingDataData = *qualifyingData;
-        esysContext->in.Certify.qualifyingData =
-            &esysContext->in.Certify.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.Certify.inScheme = NULL;
-    } else {
-        esysContext->in.Certify.inSchemeData = *inScheme;
-        esysContext->in.Certify.inScheme =
-            &esysContext->in.Certify.inSchemeData;
-    }
-}
-
 /** One-Call function for TPM2_Certify
  *
  * This function invokes the TPM2_Certify command in a one-call
@@ -193,11 +167,9 @@ Esys_Certify_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, objectHandle, signHandle, qualifyingData,
-                           inScheme);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, objectHandle, &objectHandleNode);
@@ -292,7 +264,8 @@ Esys_Certify_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -324,19 +297,13 @@ Esys_Certify_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Certify_Async(esysContext, esysContext->in.Certify.objectHandle,
-                               esysContext->in.Certify.signHandle,
-                               esysContext->session_type[0],
-                               esysContext->session_type[1],
-                               esysContext->session_type[2],
-                               esysContext->in.Certify.qualifyingData,
-                               esysContext->in.Certify.inScheme);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ChangeEPS.c
+++ b/src/tss2-esys/api/Esys_ChangeEPS.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle)
-{
-    esysContext->in.ChangeEPS.authHandle = authHandle;
-}
-
 /** One-Call function for TPM2_ChangeEPS
  *
  * This function invokes the TPM2_ChangeEPS command in a one-call
@@ -162,10 +154,9 @@ Esys_ChangeEPS_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -247,7 +238,8 @@ Esys_ChangeEPS_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +257,13 @@ Esys_ChangeEPS_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ChangeEPS_Async(esysContext,
-                                 esysContext->in.ChangeEPS.authHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ChangePPS.c
+++ b/src/tss2-esys/api/Esys_ChangePPS.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle)
-{
-    esysContext->in.ChangePPS.authHandle = authHandle;
-}
-
 /** One-Call function for TPM2_ChangePPS
  *
  * This function invokes the TPM2_ChangePPS command in a one-call
@@ -162,10 +154,9 @@ Esys_ChangePPS_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -247,7 +238,8 @@ Esys_ChangePPS_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +257,13 @@ Esys_ChangePPS_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ChangePPS_Async(esysContext,
-                                 esysContext->in.ChangePPS.authHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Clear.c
+++ b/src/tss2-esys/api/Esys_Clear.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle)
-{
-    esysContext->in.Clear.authHandle = authHandle;
-}
-
 /** One-Call function for TPM2_Clear
  *
  * This function invokes the TPM2_Clear command in a one-call
@@ -161,10 +153,9 @@ Esys_Clear_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -246,7 +237,8 @@ Esys_Clear_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -264,16 +256,13 @@ Esys_Clear_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Clear_Async(esysContext, esysContext->in.Clear.authHandle,
-                             esysContext->session_type[0],
-                             esysContext->session_type[1],
-                             esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ClearControl.c
+++ b/src/tss2-esys/api/Esys_ClearControl.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR auth,
-    TPMI_YES_NO disable)
-{
-    esysContext->in.ClearControl.auth = auth;
-    esysContext->in.ClearControl.disable = disable;
-}
-
 /** One-Call function for TPM2_ClearControl
  *
  * This function invokes the TPM2_ClearControl command in a one-call
@@ -170,10 +160,9 @@ Esys_ClearControl_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, disable);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, auth, &authNode);
@@ -255,7 +244,8 @@ Esys_ClearControl_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -273,18 +263,13 @@ Esys_ClearControl_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ClearControl_Async(esysContext,
-                                    esysContext->in.ClearControl.auth,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.ClearControl.disable);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ClockRateAdjust.c
+++ b/src/tss2-esys/api/Esys_ClockRateAdjust.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR auth,
-    TPM2_CLOCK_ADJUST rateAdjust)
-{
-    esysContext->in.ClockRateAdjust.auth = auth;
-    esysContext->in.ClockRateAdjust.rateAdjust = rateAdjust;
-}
-
 /** One-Call function for TPM2_ClockRateAdjust
  *
  * This function invokes the TPM2_ClockRateAdjust command in a one-call
@@ -168,10 +158,9 @@ Esys_ClockRateAdjust_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, rateAdjust);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, auth, &authNode);
@@ -253,7 +242,8 @@ Esys_ClockRateAdjust_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -271,18 +261,13 @@ Esys_ClockRateAdjust_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ClockRateAdjust_Async(esysContext,
-                                       esysContext->in.ClockRateAdjust.auth,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.ClockRateAdjust.rateAdjust);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ClockSet.c
+++ b/src/tss2-esys/api/Esys_ClockSet.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR auth,
-    UINT64 newTime)
-{
-    esysContext->in.ClockSet.auth = auth;
-    esysContext->in.ClockSet.newTime = newTime;
-}
-
 /** One-Call function for TPM2_ClockSet
  *
  * This function invokes the TPM2_ClockSet command in a one-call
@@ -168,10 +158,9 @@ Esys_ClockSet_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, newTime);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, auth, &authNode);
@@ -253,7 +242,8 @@ Esys_ClockSet_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -271,17 +261,13 @@ Esys_ClockSet_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ClockSet_Async(esysContext, esysContext->in.ClockSet.auth,
-                                esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.ClockSet.newTime);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ContextLoad.c
+++ b/src/tss2-esys/api/Esys_ContextLoad.c
@@ -214,7 +214,8 @@ Esys_ContextLoad_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -252,14 +253,13 @@ Esys_ContextLoad_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ContextLoad_Async(esysContext,
-                                   esysContext->in.ContextLoad.context);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ContextSave.c
+++ b/src/tss2-esys/api/Esys_ContextSave.c
@@ -196,7 +196,8 @@ Esys_ContextSave_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -220,14 +221,13 @@ Esys_ContextSave_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ContextSave_Async(esysContext,
-                                   esysContext->in.ContextSave.saveHandle);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Create.c
+++ b/src/tss2-esys/api/Esys_Create.c
@@ -15,46 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR parentHandle,
-    const TPM2B_SENSITIVE_CREATE *inSensitive,
-    const TPM2B_PUBLIC *inPublic,
-    const TPM2B_DATA *outsideInfo,
-    const TPML_PCR_SELECTION *creationPCR)
-{
-    esysContext->in.Create.parentHandle = parentHandle;
-    if (inSensitive == NULL) {
-        esysContext->in.Create.inSensitive = NULL;
-    } else {
-        esysContext->in.Create.inSensitiveData = *inSensitive;
-        esysContext->in.Create.inSensitive =
-            &esysContext->in.Create.inSensitiveData;
-    }
-    if (inPublic == NULL) {
-        esysContext->in.Create.inPublic = NULL;
-    } else {
-        esysContext->in.Create.inPublicData = *inPublic;
-        esysContext->in.Create.inPublic =
-            &esysContext->in.Create.inPublicData;
-    }
-    if (outsideInfo == NULL) {
-        esysContext->in.Create.outsideInfo = NULL;
-    } else {
-        esysContext->in.Create.outsideInfoData = *outsideInfo;
-        esysContext->in.Create.outsideInfo =
-            &esysContext->in.Create.outsideInfoData;
-    }
-    if (creationPCR == NULL) {
-        esysContext->in.Create.creationPCR = NULL;
-    } else {
-        esysContext->in.Create.creationPCRData = *creationPCR;
-        esysContext->in.Create.creationPCR =
-            &esysContext->in.Create.creationPCRData;
-    }
-}
-
 /** One-Call function for TPM2_Create
  *
  * This function invokes the TPM2_Create command in a one-call
@@ -222,11 +182,9 @@ Esys_Create_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, parentHandle, inSensitive, inPublic,
-                           outsideInfo, creationPCR);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, parentHandle, &parentHandleNode);
@@ -327,7 +285,8 @@ Esys_Create_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -385,20 +344,13 @@ Esys_Create_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Create_Async(esysContext, esysContext->in.Create.parentHandle,
-                              esysContext->session_type[0],
-                              esysContext->session_type[1],
-                              esysContext->session_type[2],
-                              esysContext->in.Create.inSensitive,
-                              esysContext->in.Create.inPublic,
-                              esysContext->in.Create.outsideInfo,
-                              esysContext->in.Create.creationPCR);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR parentHandle,
     const TPM2B_SENSITIVE_CREATE *inSensitive,
     const TPM2B_TEMPLATE *inPublic)
 {
-    esysContext->in.CreateLoaded.parentHandle = parentHandle;
     if (inSensitive == NULL) {
         esysContext->in.CreateLoaded.inSensitive = NULL;
     } else {
@@ -189,10 +187,10 @@ Esys_CreateLoaded_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, parentHandle, inSensitive, inPublic);
+    store_input_parameters(esysContext, inSensitive, inPublic);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, parentHandle, &parentHandleNode);
@@ -285,7 +283,8 @@ Esys_CreateLoaded_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -334,19 +333,13 @@ Esys_CreateLoaded_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_CreateLoaded_Async(esysContext,
-                                    esysContext->in.CreateLoaded.parentHandle,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.CreateLoaded.inSensitive,
-                                    esysContext->in.CreateLoaded.inPublic);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR lockHandle)
-{
-    esysContext->in.DictionaryAttackLockReset.lockHandle = lockHandle;
-}
-
 /** One-Call function for TPM2_DictionaryAttackLockReset
  *
  * This function invokes the TPM2_DictionaryAttackLockReset command in a one-call
@@ -162,10 +154,9 @@ Esys_DictionaryAttackLockReset_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, lockHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, lockHandle, &lockHandleNode);
@@ -248,7 +239,8 @@ Esys_DictionaryAttackLockReset_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -266,17 +258,13 @@ Esys_DictionaryAttackLockReset_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_DictionaryAttackLockReset_Async(esysContext,
-                                                 esysContext->in.DictionaryAttackLockReset.lockHandle,
-                                                 esysContext->session_type[0],
-                                                 esysContext->session_type[1],
-                                                 esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR lockHandle,
-    UINT32 newMaxTries,
-    UINT32 newRecoveryTime,
-    UINT32 lockoutRecovery)
-{
-    esysContext->in.DictionaryAttackParameters.lockHandle = lockHandle;
-    esysContext->in.DictionaryAttackParameters.newMaxTries = newMaxTries;
-    esysContext->in.DictionaryAttackParameters.newRecoveryTime = newRecoveryTime;
-    esysContext->in.DictionaryAttackParameters.lockoutRecovery = lockoutRecovery;
-}
-
 /** One-Call function for TPM2_DictionaryAttackParameters
  *
  * This function invokes the TPM2_DictionaryAttackParameters command in a one-call
@@ -188,11 +174,9 @@ Esys_DictionaryAttackParameters_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, lockHandle, newMaxTries, newRecoveryTime,
-                           lockoutRecovery);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, lockHandle, &lockHandleNode);
@@ -277,7 +261,8 @@ Esys_DictionaryAttackParameters_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -295,20 +280,13 @@ Esys_DictionaryAttackParameters_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_DictionaryAttackParameters_Async(esysContext,
-                                                  esysContext->in.DictionaryAttackParameters.lockHandle,
-                                                  esysContext->session_type[0],
-                                                  esysContext->session_type[1],
-                                                  esysContext->session_type[2],
-                                                  esysContext->in.DictionaryAttackParameters.newMaxTries,
-                                                  esysContext->in.DictionaryAttackParameters.newRecoveryTime,
-                                                  esysContext->in.DictionaryAttackParameters.lockoutRecovery);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Duplicate.c
+++ b/src/tss2-esys/api/Esys_Duplicate.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR objectHandle,
-    ESYS_TR newParentHandle,
-    const TPM2B_DATA *encryptionKeyIn,
-    const TPMT_SYM_DEF_OBJECT *symmetricAlg)
-{
-    esysContext->in.Duplicate.objectHandle = objectHandle;
-    esysContext->in.Duplicate.newParentHandle = newParentHandle;
-    if (encryptionKeyIn == NULL) {
-        esysContext->in.Duplicate.encryptionKeyIn = NULL;
-    } else {
-        esysContext->in.Duplicate.encryptionKeyInData = *encryptionKeyIn;
-        esysContext->in.Duplicate.encryptionKeyIn =
-            &esysContext->in.Duplicate.encryptionKeyInData;
-    }
-    if (symmetricAlg == NULL) {
-        esysContext->in.Duplicate.symmetricAlg = NULL;
-    } else {
-        esysContext->in.Duplicate.symmetricAlgData = *symmetricAlg;
-        esysContext->in.Duplicate.symmetricAlg =
-            &esysContext->in.Duplicate.symmetricAlgData;
-    }
-}
-
 /** One-Call function for TPM2_Duplicate
  *
  * This function invokes the TPM2_Duplicate command in a one-call
@@ -202,11 +176,9 @@ Esys_Duplicate_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, objectHandle, newParentHandle,
-                           encryptionKeyIn, symmetricAlg);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, objectHandle, &objectHandleNode);
@@ -309,7 +281,8 @@ Esys_Duplicate_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -351,20 +324,13 @@ Esys_Duplicate_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Duplicate_Async(esysContext,
-                                 esysContext->in.Duplicate.objectHandle,
-                                 esysContext->in.Duplicate.newParentHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.Duplicate.encryptionKeyIn,
-                                 esysContext->in.Duplicate.symmetricAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ECC_Parameters.c
+++ b/src/tss2-esys/api/Esys_ECC_Parameters.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPMI_ECC_CURVE curveID)
-{
-    esysContext->in.ECC_Parameters.curveID = curveID;
-}
-
 /** One-Call function for TPM2_ECC_Parameters
  *
  * This function invokes the TPM2_ECC_Parameters command in a one-call
@@ -158,10 +150,9 @@ Esys_ECC_Parameters_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, curveID);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_ECC_Parameters_Prepare(esysContext->sys, curveID);
@@ -239,7 +230,8 @@ Esys_ECC_Parameters_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,16 +257,13 @@ Esys_ECC_Parameters_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ECC_Parameters_Async(esysContext, esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.ECC_Parameters.curveID);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ECDH_KeyGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_KeyGen.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle)
-{
-    esysContext->in.ECDH_KeyGen.keyHandle = keyHandle;
-}
-
 /** One-Call function for TPM2_ECDH_KeyGen
  *
  * This function invokes the TPM2_ECDH_KeyGen command in a one-call
@@ -162,10 +154,9 @@ Esys_ECDH_KeyGen_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -252,7 +243,8 @@ Esys_ECDH_KeyGen_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -284,17 +276,13 @@ Esys_ECDH_KeyGen_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ECDH_KeyGen_Async(esysContext,
-                                   esysContext->in.ECDH_KeyGen.keyHandle,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ECDH_ZGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_ZGen.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_ECC_POINT *inPoint)
-{
-    esysContext->in.ECDH_ZGen.keyHandle = keyHandle;
-    if (inPoint == NULL) {
-        esysContext->in.ECDH_ZGen.inPoint = NULL;
-    } else {
-        esysContext->in.ECDH_ZGen.inPointData = *inPoint;
-        esysContext->in.ECDH_ZGen.inPoint =
-            &esysContext->in.ECDH_ZGen.inPointData;
-    }
-}
-
 /** One-Call function for TPM2_ECDH_ZGen
  *
  * This function invokes the TPM2_ECDH_ZGen command in a one-call
@@ -166,10 +150,9 @@ Esys_ECDH_ZGen_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, inPoint);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -255,7 +238,8 @@ Esys_ECDH_ZGen_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -281,18 +265,13 @@ Esys_ECDH_ZGen_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ECDH_ZGen_Async(esysContext,
-                                 esysContext->in.ECDH_ZGen.keyHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.ECDH_ZGen.inPoint);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_EC_Ephemeral.c
+++ b/src/tss2-esys/api/Esys_EC_Ephemeral.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPMI_ECC_CURVE curveID)
-{
-    esysContext->in.EC_Ephemeral.curveID = curveID;
-}
-
 /** One-Call function for TPM2_EC_Ephemeral
  *
  * This function invokes the TPM2_EC_Ephemeral command in a one-call
@@ -155,10 +147,9 @@ Esys_EC_Ephemeral_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, curveID);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_EC_Ephemeral_Prepare(esysContext->sys, curveID);
@@ -239,7 +230,8 @@ Esys_EC_Ephemeral_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,16 +257,13 @@ Esys_EC_Ephemeral_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_EC_Ephemeral_Async(esysContext, esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.EC_Ephemeral.curveID);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_EncryptDecrypt.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt.c
@@ -15,34 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
-    const TPM2B_IV *ivIn,
-    const TPM2B_MAX_BUFFER *inData)
-{
-    esysContext->in.EncryptDecrypt.keyHandle = keyHandle;
-    esysContext->in.EncryptDecrypt.decrypt = decrypt;
-    esysContext->in.EncryptDecrypt.mode = mode;
-    if (ivIn == NULL) {
-        esysContext->in.EncryptDecrypt.ivIn = NULL;
-    } else {
-        esysContext->in.EncryptDecrypt.ivInData = *ivIn;
-        esysContext->in.EncryptDecrypt.ivIn =
-            &esysContext->in.EncryptDecrypt.ivInData;
-    }
-    if (inData == NULL) {
-        esysContext->in.EncryptDecrypt.inData = NULL;
-    } else {
-        esysContext->in.EncryptDecrypt.inDataData = *inData;
-        esysContext->in.EncryptDecrypt.inData =
-            &esysContext->in.EncryptDecrypt.inDataData;
-    }
-}
-
 /** One-Call function for TPM2_EncryptDecrypt
  *
  * This function invokes the TPM2_EncryptDecrypt command in a one-call
@@ -202,10 +174,9 @@ Esys_EncryptDecrypt_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, decrypt, mode, ivIn, inData);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -294,7 +265,8 @@ Esys_EncryptDecrypt_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -326,21 +298,13 @@ Esys_EncryptDecrypt_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_EncryptDecrypt_Async(esysContext,
-                                      esysContext->in.EncryptDecrypt.keyHandle,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.EncryptDecrypt.decrypt,
-                                      esysContext->in.EncryptDecrypt.mode,
-                                      esysContext->in.EncryptDecrypt.ivIn,
-                                      esysContext->in.EncryptDecrypt.inData);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_EncryptDecrypt2.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt2.c
@@ -15,34 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_MAX_BUFFER *inData,
-    TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
-    const TPM2B_IV *ivIn)
-{
-    esysContext->in.EncryptDecrypt2.keyHandle = keyHandle;
-    esysContext->in.EncryptDecrypt2.decrypt = decrypt;
-    esysContext->in.EncryptDecrypt2.mode = mode;
-    if (inData == NULL) {
-        esysContext->in.EncryptDecrypt2.inData = NULL;
-    } else {
-        esysContext->in.EncryptDecrypt2.inDataData = *inData;
-        esysContext->in.EncryptDecrypt2.inData =
-            &esysContext->in.EncryptDecrypt2.inDataData;
-    }
-    if (ivIn == NULL) {
-        esysContext->in.EncryptDecrypt2.ivIn = NULL;
-    } else {
-        esysContext->in.EncryptDecrypt2.ivInData = *ivIn;
-        esysContext->in.EncryptDecrypt2.ivIn =
-            &esysContext->in.EncryptDecrypt2.ivInData;
-    }
-}
-
 /** One-Call function for TPM2_EncryptDecrypt2
  *
  * This function invokes the TPM2_EncryptDecrypt2 command in a one-call
@@ -196,10 +168,9 @@ Esys_EncryptDecrypt2_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, inData, decrypt, mode, ivIn);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -288,7 +259,8 @@ Esys_EncryptDecrypt2_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -320,21 +292,13 @@ Esys_EncryptDecrypt2_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_EncryptDecrypt2_Async(esysContext,
-                                       esysContext->in.EncryptDecrypt2.keyHandle,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.EncryptDecrypt2.inData,
-                                       esysContext->in.EncryptDecrypt2.decrypt,
-                                       esysContext->in.EncryptDecrypt2.mode,
-                                       esysContext->in.EncryptDecrypt2.ivIn);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_EventSequenceComplete.c
+++ b/src/tss2-esys/api/Esys_EventSequenceComplete.c
@@ -15,24 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR pcrHandle,
-    ESYS_TR sequenceHandle,
-    const TPM2B_MAX_BUFFER *buffer)
-{
-    esysContext->in.EventSequenceComplete.pcrHandle = pcrHandle;
-    esysContext->in.EventSequenceComplete.sequenceHandle = sequenceHandle;
-    if (buffer == NULL) {
-        esysContext->in.EventSequenceComplete.buffer = NULL;
-    } else {
-        esysContext->in.EventSequenceComplete.bufferData = *buffer;
-        esysContext->in.EventSequenceComplete.buffer =
-            &esysContext->in.EventSequenceComplete.bufferData;
-    }
-}
-
 /** One-Call function for TPM2_EventSequenceComplete
  *
  * This function invokes the TPM2_EventSequenceComplete command in a one-call
@@ -179,10 +161,9 @@ Esys_EventSequenceComplete_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrHandle, sequenceHandle, buffer);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
@@ -276,7 +257,8 @@ Esys_EventSequenceComplete_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -302,19 +284,13 @@ Esys_EventSequenceComplete_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_EventSequenceComplete_Async(esysContext,
-                                             esysContext->in.EventSequenceComplete.pcrHandle,
-                                             esysContext->in.EventSequenceComplete.sequenceHandle,
-                                             esysContext->session_type[0],
-                                             esysContext->session_type[1],
-                                             esysContext->session_type[2],
-                                             esysContext->in.EventSequenceComplete.buffer);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_FieldUpgradeData.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeData.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_MAX_BUFFER *fuData)
-{
-    if (fuData == NULL) {
-        esysContext->in.FieldUpgradeData.fuData = NULL;
-    } else {
-        esysContext->in.FieldUpgradeData.fuDataData = *fuData;
-        esysContext->in.FieldUpgradeData.fuData =
-            &esysContext->in.FieldUpgradeData.fuDataData;
-    }
-}
-
 /** One-Call function for TPM2_FieldUpgradeData
  *
  * This function invokes the TPM2_FieldUpgradeData command in a one-call
@@ -161,10 +147,9 @@ Esys_FieldUpgradeData_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, fuData);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_FieldUpgradeData_Prepare(esysContext->sys, fuData);
@@ -245,7 +230,8 @@ Esys_FieldUpgradeData_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -277,17 +263,13 @@ Esys_FieldUpgradeData_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_FieldUpgradeData_Async(esysContext,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.FieldUpgradeData.fuData);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_FieldUpgradeStart.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeStart.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authorization,
-    ESYS_TR keyHandle,
-    const TPM2B_DIGEST *fuDigest,
-    const TPMT_SIGNATURE *manifestSignature)
-{
-    esysContext->in.FieldUpgradeStart.authorization = authorization;
-    esysContext->in.FieldUpgradeStart.keyHandle = keyHandle;
-    if (fuDigest == NULL) {
-        esysContext->in.FieldUpgradeStart.fuDigest = NULL;
-    } else {
-        esysContext->in.FieldUpgradeStart.fuDigestData = *fuDigest;
-        esysContext->in.FieldUpgradeStart.fuDigest =
-            &esysContext->in.FieldUpgradeStart.fuDigestData;
-    }
-    if (manifestSignature == NULL) {
-        esysContext->in.FieldUpgradeStart.manifestSignature = NULL;
-    } else {
-        esysContext->in.FieldUpgradeStart.manifestSignatureData = *manifestSignature;
-        esysContext->in.FieldUpgradeStart.manifestSignature =
-            &esysContext->in.FieldUpgradeStart.manifestSignatureData;
-    }
-}
-
 /** One-Call function for TPM2_FieldUpgradeStart
  *
  * This function invokes the TPM2_FieldUpgradeStart command in a one-call
@@ -195,11 +169,9 @@ Esys_FieldUpgradeStart_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authorization, keyHandle, fuDigest,
-                           manifestSignature);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authorization, &authorizationNode);
@@ -287,7 +259,8 @@ Esys_FieldUpgradeStart_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -305,20 +278,13 @@ Esys_FieldUpgradeStart_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_FieldUpgradeStart_Async(esysContext,
-                                         esysContext->in.FieldUpgradeStart.authorization,
-                                         esysContext->in.FieldUpgradeStart.keyHandle,
-                                         esysContext->session_type[0],
-                                         esysContext->session_type[1],
-                                         esysContext->session_type[2],
-                                         esysContext->in.FieldUpgradeStart.fuDigest,
-                                         esysContext->in.FieldUpgradeStart.manifestSignature);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_FirmwareRead.c
+++ b/src/tss2-esys/api/Esys_FirmwareRead.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    UINT32 sequenceNumber)
-{
-    esysContext->in.FirmwareRead.sequenceNumber = sequenceNumber;
-}
-
 /** One-Call function for TPM2_FirmwareRead
  *
  * This function invokes the TPM2_FirmwareRead command in a one-call
@@ -154,10 +146,9 @@ Esys_FirmwareRead_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, sequenceNumber);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_FirmwareRead_Prepare(esysContext->sys, sequenceNumber);
@@ -235,7 +226,8 @@ Esys_FirmwareRead_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -261,16 +253,13 @@ Esys_FirmwareRead_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_FirmwareRead_Async(esysContext, esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.FirmwareRead.sequenceNumber);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetCapability.c
+++ b/src/tss2-esys/api/Esys_GetCapability.c
@@ -15,18 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPM2_CAP capability,
-    UINT32 property,
-    UINT32 propertyCount)
-{
-    esysContext->in.GetCapability.capability = capability;
-    esysContext->in.GetCapability.property = property;
-    esysContext->in.GetCapability.propertyCount = propertyCount;
-}
-
 /** One-Call function for TPM2_GetCapability
  *
  * This function invokes the TPM2_GetCapability command in a one-call
@@ -178,10 +166,9 @@ Esys_GetCapability_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, capability, property, propertyCount);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_GetCapability_Prepare(esysContext->sys, capability, property,
@@ -263,7 +250,8 @@ Esys_GetCapability_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -289,18 +277,13 @@ Esys_GetCapability_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetCapability_Async(esysContext, esysContext->session_type[0],
-                                     esysContext->session_type[1],
-                                     esysContext->session_type[2],
-                                     esysContext->in.GetCapability.capability,
-                                     esysContext->in.GetCapability.property,
-                                     esysContext->in.GetCapability.propertyCount);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR privacyHandle,
-    ESYS_TR signHandle,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme)
-{
-    esysContext->in.GetCommandAuditDigest.privacyHandle = privacyHandle;
-    esysContext->in.GetCommandAuditDigest.signHandle = signHandle;
-    if (qualifyingData == NULL) {
-        esysContext->in.GetCommandAuditDigest.qualifyingData = NULL;
-    } else {
-        esysContext->in.GetCommandAuditDigest.qualifyingDataData = *qualifyingData;
-        esysContext->in.GetCommandAuditDigest.qualifyingData =
-            &esysContext->in.GetCommandAuditDigest.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.GetCommandAuditDigest.inScheme = NULL;
-    } else {
-        esysContext->in.GetCommandAuditDigest.inSchemeData = *inScheme;
-        esysContext->in.GetCommandAuditDigest.inScheme =
-            &esysContext->in.GetCommandAuditDigest.inSchemeData;
-    }
-}
-
 /** One-Call function for TPM2_GetCommandAuditDigest
  *
  * This function invokes the TPM2_GetCommandAuditDigest command in a one-call
@@ -194,11 +168,9 @@ Esys_GetCommandAuditDigest_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, privacyHandle, signHandle,
-                           qualifyingData, inScheme);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, privacyHandle, &privacyHandleNode);
@@ -294,7 +266,8 @@ Esys_GetCommandAuditDigest_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -326,20 +299,13 @@ Esys_GetCommandAuditDigest_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetCommandAuditDigest_Async(esysContext,
-                                             esysContext->in.GetCommandAuditDigest.privacyHandle,
-                                             esysContext->in.GetCommandAuditDigest.signHandle,
-                                             esysContext->session_type[0],
-                                             esysContext->session_type[1],
-                                             esysContext->session_type[2],
-                                             esysContext->in.GetCommandAuditDigest.qualifyingData,
-                                             esysContext->in.GetCommandAuditDigest.inScheme);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetRandom.c
+++ b/src/tss2-esys/api/Esys_GetRandom.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    UINT16 bytesRequested)
-{
-    esysContext->in.GetRandom.bytesRequested = bytesRequested;
-}
-
 /** One-Call function for TPM2_GetRandom
  *
  * This function invokes the TPM2_GetRandom command in a one-call
@@ -152,10 +144,9 @@ Esys_GetRandom_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, bytesRequested);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_GetRandom_Prepare(esysContext->sys, bytesRequested);
@@ -233,7 +224,8 @@ Esys_GetRandom_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -259,16 +251,13 @@ Esys_GetRandom_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetRandom_Async(esysContext, esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.GetRandom.bytesRequested);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
@@ -15,34 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR privacyAdminHandle,
-    ESYS_TR signHandle,
-    ESYS_TR sessionHandle,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme)
-{
-    esysContext->in.GetSessionAuditDigest.privacyAdminHandle = privacyAdminHandle;
-    esysContext->in.GetSessionAuditDigest.signHandle = signHandle;
-    esysContext->in.GetSessionAuditDigest.sessionHandle = sessionHandle;
-    if (qualifyingData == NULL) {
-        esysContext->in.GetSessionAuditDigest.qualifyingData = NULL;
-    } else {
-        esysContext->in.GetSessionAuditDigest.qualifyingDataData = *qualifyingData;
-        esysContext->in.GetSessionAuditDigest.qualifyingData =
-            &esysContext->in.GetSessionAuditDigest.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.GetSessionAuditDigest.inScheme = NULL;
-    } else {
-        esysContext->in.GetSessionAuditDigest.inSchemeData = *inScheme;
-        esysContext->in.GetSessionAuditDigest.inScheme =
-            &esysContext->in.GetSessionAuditDigest.inSchemeData;
-    }
-}
-
 /** One-Call function for TPM2_GetSessionAuditDigest
  *
  * This function invokes the TPM2_GetSessionAuditDigest command in a one-call
@@ -205,11 +177,9 @@ Esys_GetSessionAuditDigest_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, privacyAdminHandle, signHandle,
-                           sessionHandle, qualifyingData, inScheme);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, privacyAdminHandle, &privacyAdminHandleNode);
@@ -310,7 +280,8 @@ Esys_GetSessionAuditDigest_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -342,21 +313,13 @@ Esys_GetSessionAuditDigest_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetSessionAuditDigest_Async(esysContext,
-                                             esysContext->in.GetSessionAuditDigest.privacyAdminHandle,
-                                             esysContext->in.GetSessionAuditDigest.signHandle,
-                                             esysContext->in.GetSessionAuditDigest.sessionHandle,
-                                             esysContext->session_type[0],
-                                             esysContext->session_type[1],
-                                             esysContext->session_type[2],
-                                             esysContext->in.GetSessionAuditDigest.qualifyingData,
-                                             esysContext->in.GetSessionAuditDigest.inScheme);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetTestResult.c
+++ b/src/tss2-esys/api/Esys_GetTestResult.c
@@ -15,7 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 /** One-Call function for TPM2_GetTestResult
  *
  * This function invokes the TPM2_GetTestResult command in a one-call
@@ -143,7 +142,7 @@ Esys_GetTestResult_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
 
@@ -226,7 +225,8 @@ Esys_GetTestResult_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -252,15 +252,13 @@ Esys_GetTestResult_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetTestResult_Async(esysContext, esysContext->session_type[0],
-                                     esysContext->session_type[1],
-                                     esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_GetTime.c
+++ b/src/tss2-esys/api/Esys_GetTime.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR privacyAdminHandle,
-    ESYS_TR signHandle,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme)
-{
-    esysContext->in.GetTime.privacyAdminHandle = privacyAdminHandle;
-    esysContext->in.GetTime.signHandle = signHandle;
-    if (qualifyingData == NULL) {
-        esysContext->in.GetTime.qualifyingData = NULL;
-    } else {
-        esysContext->in.GetTime.qualifyingDataData = *qualifyingData;
-        esysContext->in.GetTime.qualifyingData =
-            &esysContext->in.GetTime.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.GetTime.inScheme = NULL;
-    } else {
-        esysContext->in.GetTime.inSchemeData = *inScheme;
-        esysContext->in.GetTime.inScheme =
-            &esysContext->in.GetTime.inSchemeData;
-    }
-}
-
 /** One-Call function for TPM2_GetTime
  *
  * This function invokes the TPM2_GetTime command in a one-call
@@ -194,11 +168,9 @@ Esys_GetTime_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, privacyAdminHandle, signHandle,
-                           qualifyingData, inScheme);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, privacyAdminHandle, &privacyAdminHandleNode);
@@ -292,7 +264,8 @@ Esys_GetTime_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -324,20 +297,13 @@ Esys_GetTime_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_GetTime_Async(esysContext,
-                               esysContext->in.GetTime.privacyAdminHandle,
-                               esysContext->in.GetTime.signHandle,
-                               esysContext->session_type[0],
-                               esysContext->session_type[1],
-                               esysContext->session_type[2],
-                               esysContext->in.GetTime.qualifyingData,
-                               esysContext->in.GetTime.inScheme);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_HMAC.c
+++ b/src/tss2-esys/api/Esys_HMAC.c
@@ -15,24 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR handle,
-    const TPM2B_MAX_BUFFER *buffer,
-    TPMI_ALG_HASH hashAlg)
-{
-    esysContext->in.HMAC.handle = handle;
-    esysContext->in.HMAC.hashAlg = hashAlg;
-    if (buffer == NULL) {
-        esysContext->in.HMAC.buffer = NULL;
-    } else {
-        esysContext->in.HMAC.bufferData = *buffer;
-        esysContext->in.HMAC.buffer =
-            &esysContext->in.HMAC.bufferData;
-    }
-}
-
 /** One-Call function for TPM2_HMAC
  *
  * This function invokes the TPM2_HMAC command in a one-call
@@ -174,10 +156,9 @@ Esys_HMAC_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, handle, buffer, hashAlg);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, handle, &handleNode);
@@ -262,7 +243,8 @@ Esys_HMAC_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -288,18 +270,13 @@ Esys_HMAC_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_HMAC_Async(esysContext, esysContext->in.HMAC.handle,
-                            esysContext->session_type[0],
-                            esysContext->session_type[1],
-                            esysContext->session_type[2],
-                            esysContext->in.HMAC.buffer,
-                            esysContext->in.HMAC.hashAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_HMAC_Start.c
+++ b/src/tss2-esys/api/Esys_HMAC_Start.c
@@ -18,12 +18,8 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR handle,
-    const TPM2B_AUTH *auth,
-    TPMI_ALG_HASH hashAlg)
+    const TPM2B_AUTH *auth)
 {
-    esysContext->in.HMAC_Start.handle = handle;
-    esysContext->in.HMAC_Start.hashAlg = hashAlg;
     if (auth == NULL) {
         esysContext->in.HMAC_Start.auth = NULL;
     } else {
@@ -176,10 +172,10 @@ Esys_HMAC_Start_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, handle, auth, hashAlg);
+    store_input_parameters(esysContext, auth);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, handle, &handleNode);
@@ -262,7 +258,8 @@ Esys_HMAC_Start_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -292,18 +289,13 @@ Esys_HMAC_Start_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_HMAC_Start_Async(esysContext, esysContext->in.HMAC_Start.handle,
-                                  esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2],
-                                  esysContext->in.HMAC_Start.auth,
-                                  esysContext->in.HMAC_Start.hashAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Hash.c
+++ b/src/tss2-esys/api/Esys_Hash.c
@@ -15,24 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_MAX_BUFFER *data,
-    TPMI_ALG_HASH hashAlg,
-    TPMI_RH_HIERARCHY hierarchy)
-{
-    esysContext->in.Hash.hashAlg = hashAlg;
-    esysContext->in.Hash.hierarchy = hierarchy;
-    if (data == NULL) {
-        esysContext->in.Hash.data = NULL;
-    } else {
-        esysContext->in.Hash.dataData = *data;
-        esysContext->in.Hash.data =
-            &esysContext->in.Hash.dataData;
-    }
-}
-
 /** One-Call function for TPM2_Hash
  *
  * This function invokes the TPM2_Hash command in a one-call
@@ -171,10 +153,9 @@ Esys_Hash_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, data, hashAlg, hierarchy);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_Hash_Prepare(esysContext->sys, data, hashAlg, hierarchy);
@@ -256,7 +237,8 @@ Esys_Hash_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -288,18 +270,13 @@ Esys_Hash_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Hash_Async(esysContext, esysContext->session_type[0],
-                            esysContext->session_type[1],
-                            esysContext->session_type[2],
-                            esysContext->in.Hash.data,
-                            esysContext->in.Hash.hashAlg,
-                            esysContext->in.Hash.hierarchy);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_HashSequenceStart.c
+++ b/src/tss2-esys/api/Esys_HashSequenceStart.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_AUTH *auth,
-    TPMI_ALG_HASH hashAlg)
-{
-    esysContext->in.HashSequenceStart.hashAlg = hashAlg;
-    if (auth == NULL) {
-        esysContext->in.HashSequenceStart.auth = NULL;
-    } else {
-        esysContext->in.HashSequenceStart.authData = *auth;
-        esysContext->in.HashSequenceStart.auth =
-            &esysContext->in.HashSequenceStart.authData;
-    }
-}
-
 /** One-Call function for TPM2_HashSequenceStart
  *
  * This function invokes the TPM2_HashSequenceStart command in a one-call
@@ -162,10 +146,9 @@ Esys_HashSequenceStart_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, hashAlg);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_HashSequenceStart_Prepare(esysContext->sys, auth, hashAlg);
@@ -241,7 +224,8 @@ Esys_HashSequenceStart_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -271,18 +255,13 @@ Esys_HashSequenceStart_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_HashSequenceStart_Async(esysContext,
-                                         esysContext->session_type[0],
-                                         esysContext->session_type[1],
-                                         esysContext->session_type[2],
-                                         esysContext->in.HashSequenceStart.auth,
-                                         esysContext->in.HashSequenceStart.hashAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
+++ b/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
@@ -170,7 +170,7 @@ Esys_HierarchyChangeAuth_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, authHandle, newAuth);
@@ -260,7 +260,8 @@ Esys_HierarchyChangeAuth_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +279,13 @@ Esys_HierarchyChangeAuth_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_HierarchyChangeAuth_Async(esysContext,
-                                           esysContext->in.HierarchyChangeAuth.authHandle,
-                                           esysContext->session_type[0],
-                                           esysContext->session_type[1],
-                                           esysContext->session_type[2],
-                                           esysContext->in.HierarchyChangeAuth.newAuth);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_HierarchyControl.c
+++ b/src/tss2-esys/api/Esys_HierarchyControl.c
@@ -15,18 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    TPMI_RH_ENABLES enable,
-    TPMI_YES_NO state)
-{
-    esysContext->in.HierarchyControl.authHandle = authHandle;
-    esysContext->in.HierarchyControl.enable = enable;
-    esysContext->in.HierarchyControl.state = state;
-}
-
 /** One-Call function for TPM2_HierarchyControl
  *
  * This function invokes the TPM2_HierarchyControl command in a one-call
@@ -179,10 +167,9 @@ Esys_HierarchyControl_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, enable, state);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -265,7 +252,8 @@ Esys_HierarchyControl_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -283,19 +271,13 @@ Esys_HierarchyControl_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_HierarchyControl_Async(esysContext,
-                                        esysContext->in.HierarchyControl.authHandle,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.HierarchyControl.enable,
-                                        esysContext->in.HierarchyControl.state);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Import.c
+++ b/src/tss2-esys/api/Esys_Import.c
@@ -15,54 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR parentHandle,
-    const TPM2B_DATA *encryptionKey,
-    const TPM2B_PUBLIC *objectPublic,
-    const TPM2B_PRIVATE *duplicate,
-    const TPM2B_ENCRYPTED_SECRET *inSymSeed,
-    const TPMT_SYM_DEF_OBJECT *symmetricAlg)
-{
-    esysContext->in.Import.parentHandle = parentHandle;
-    if (encryptionKey == NULL) {
-        esysContext->in.Import.encryptionKey = NULL;
-    } else {
-        esysContext->in.Import.encryptionKeyData = *encryptionKey;
-        esysContext->in.Import.encryptionKey =
-            &esysContext->in.Import.encryptionKeyData;
-    }
-    if (objectPublic == NULL) {
-        esysContext->in.Import.objectPublic = NULL;
-    } else {
-        esysContext->in.Import.objectPublicData = *objectPublic;
-        esysContext->in.Import.objectPublic =
-            &esysContext->in.Import.objectPublicData;
-    }
-    if (duplicate == NULL) {
-        esysContext->in.Import.duplicate = NULL;
-    } else {
-        esysContext->in.Import.duplicateData = *duplicate;
-        esysContext->in.Import.duplicate =
-            &esysContext->in.Import.duplicateData;
-    }
-    if (inSymSeed == NULL) {
-        esysContext->in.Import.inSymSeed = NULL;
-    } else {
-        esysContext->in.Import.inSymSeedData = *inSymSeed;
-        esysContext->in.Import.inSymSeed =
-            &esysContext->in.Import.inSymSeedData;
-    }
-    if (symmetricAlg == NULL) {
-        esysContext->in.Import.symmetricAlg = NULL;
-    } else {
-        esysContext->in.Import.symmetricAlgData = *symmetricAlg;
-        esysContext->in.Import.symmetricAlg =
-            &esysContext->in.Import.symmetricAlgData;
-    }
-}
-
 /** One-Call function for TPM2_Import
  *
  * This function invokes the TPM2_Import command in a one-call
@@ -224,11 +176,9 @@ Esys_Import_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, parentHandle, encryptionKey,
-                           objectPublic, duplicate, inSymSeed, symmetricAlg);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, parentHandle, &parentHandleNode);
@@ -316,7 +266,8 @@ Esys_Import_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -342,21 +293,13 @@ Esys_Import_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Import_Async(esysContext, esysContext->in.Import.parentHandle,
-                              esysContext->session_type[0],
-                              esysContext->session_type[1],
-                              esysContext->session_type[2],
-                              esysContext->in.Import.encryptionKey,
-                              esysContext->in.Import.objectPublic,
-                              esysContext->in.Import.duplicate,
-                              esysContext->in.Import.inSymSeed,
-                              esysContext->in.Import.symmetricAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_IncrementalSelfTest.c
+++ b/src/tss2-esys/api/Esys_IncrementalSelfTest.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPML_ALG *toTest)
-{
-    if (toTest == NULL) {
-        esysContext->in.IncrementalSelfTest.toTest = NULL;
-    } else {
-        esysContext->in.IncrementalSelfTest.toTestData = *toTest;
-        esysContext->in.IncrementalSelfTest.toTest =
-            &esysContext->in.IncrementalSelfTest.toTestData;
-    }
-}
-
 /** One-Call function for TPM2_IncrementalSelfTest
  *
  * This function invokes the TPM2_IncrementalSelfTest command in a one-call
@@ -164,10 +150,9 @@ Esys_IncrementalSelfTest_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, toTest);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_IncrementalSelfTest_Prepare(esysContext->sys, toTest);
@@ -245,7 +230,8 @@ Esys_IncrementalSelfTest_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -271,17 +257,13 @@ Esys_IncrementalSelfTest_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_IncrementalSelfTest_Async(esysContext,
-                                           esysContext->session_type[0],
-                                           esysContext->session_type[1],
-                                           esysContext->session_type[2],
-                                           esysContext->in.IncrementalSelfTest.toTest);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Load.c
+++ b/src/tss2-esys/api/Esys_Load.c
@@ -18,18 +18,8 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR parentHandle,
-    const TPM2B_PRIVATE *inPrivate,
     const TPM2B_PUBLIC *inPublic)
 {
-    esysContext->in.Load.parentHandle = parentHandle;
-    if (inPrivate == NULL) {
-        esysContext->in.Load.inPrivate = NULL;
-    } else {
-        esysContext->in.Load.inPrivateData = *inPrivate;
-        esysContext->in.Load.inPrivate =
-            &esysContext->in.Load.inPrivateData;
-    }
     if (inPublic == NULL) {
         esysContext->in.Load.inPublic = NULL;
     } else {
@@ -178,10 +168,10 @@ Esys_Load_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, parentHandle, inPrivate, inPublic);
+    store_input_parameters(esysContext, inPublic);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, parentHandle, &parentHandleNode);
@@ -265,7 +255,8 @@ Esys_Load_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -303,18 +294,13 @@ Esys_Load_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Load_Async(esysContext, esysContext->in.Load.parentHandle,
-                            esysContext->session_type[0],
-                            esysContext->session_type[1],
-                            esysContext->session_type[2],
-                            esysContext->in.Load.inPrivate,
-                            esysContext->in.Load.inPublic);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -18,18 +18,8 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    const TPM2B_SENSITIVE *inPrivate,
-    const TPM2B_PUBLIC *inPublic,
-    TPMI_RH_HIERARCHY hierarchy)
+    const TPM2B_PUBLIC *inPublic)
 {
-    esysContext->in.LoadExternal.hierarchy = hierarchy;
-    if (inPrivate == NULL) {
-        esysContext->in.LoadExternal.inPrivate = NULL;
-    } else {
-        esysContext->in.LoadExternal.inPrivateData = *inPrivate;
-        esysContext->in.LoadExternal.inPrivate =
-            &esysContext->in.LoadExternal.inPrivateData;
-    }
     if (inPublic == NULL) {
         esysContext->in.LoadExternal.inPublic = NULL;
     } else {
@@ -169,10 +159,10 @@ Esys_LoadExternal_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, inPrivate, inPublic, hierarchy);
+    store_input_parameters(esysContext, inPublic);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_LoadExternal_Prepare(esysContext->sys, inPrivate, inPublic,
@@ -249,7 +239,8 @@ Esys_LoadExternal_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -287,18 +278,13 @@ Esys_LoadExternal_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_LoadExternal_Async(esysContext, esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.LoadExternal.inPrivate,
-                                    esysContext->in.LoadExternal.inPublic,
-                                    esysContext->in.LoadExternal.hierarchy);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_MakeCredential.c
+++ b/src/tss2-esys/api/Esys_MakeCredential.c
@@ -15,30 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR handle,
-    const TPM2B_DIGEST *credential,
-    const TPM2B_NAME *objectName)
-{
-    esysContext->in.MakeCredential.handle = handle;
-    if (credential == NULL) {
-        esysContext->in.MakeCredential.credential = NULL;
-    } else {
-        esysContext->in.MakeCredential.credentialData = *credential;
-        esysContext->in.MakeCredential.credential =
-            &esysContext->in.MakeCredential.credentialData;
-    }
-    if (objectName == NULL) {
-        esysContext->in.MakeCredential.objectName = NULL;
-    } else {
-        esysContext->in.MakeCredential.objectNameData = *objectName;
-        esysContext->in.MakeCredential.objectName =
-            &esysContext->in.MakeCredential.objectNameData;
-    }
-}
-
 /** One-Call function for TPM2_MakeCredential
  *
  * This function invokes the TPM2_MakeCredential command in a one-call
@@ -184,10 +160,9 @@ Esys_MakeCredential_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, handle, credential, objectName);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, handle, &handleNode);
@@ -276,7 +251,8 @@ Esys_MakeCredential_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -308,19 +284,13 @@ Esys_MakeCredential_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_MakeCredential_Async(esysContext,
-                                      esysContext->in.MakeCredential.handle,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.MakeCredential.credential,
-                                      esysContext->in.MakeCredential.objectName);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_NV_Certify.c
+++ b/src/tss2-esys/api/Esys_NV_Certify.c
@@ -15,38 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR signHandle,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme,
-    UINT16 size,
-    UINT16 offset)
-{
-    esysContext->in.NV_Certify.signHandle = signHandle;
-    esysContext->in.NV_Certify.authHandle = authHandle;
-    esysContext->in.NV_Certify.nvIndex = nvIndex;
-    esysContext->in.NV_Certify.size = size;
-    esysContext->in.NV_Certify.offset = offset;
-    if (qualifyingData == NULL) {
-        esysContext->in.NV_Certify.qualifyingData = NULL;
-    } else {
-        esysContext->in.NV_Certify.qualifyingDataData = *qualifyingData;
-        esysContext->in.NV_Certify.qualifyingData =
-            &esysContext->in.NV_Certify.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.NV_Certify.inScheme = NULL;
-    } else {
-        esysContext->in.NV_Certify.inSchemeData = *inScheme;
-        esysContext->in.NV_Certify.inScheme =
-            &esysContext->in.NV_Certify.inSchemeData;
-    }
-}
-
 /** One-Call function for TPM2_NV_Certify
  *
  * This function invokes the TPM2_NV_Certify command in a one-call
@@ -217,11 +185,9 @@ Esys_NV_Certify_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, signHandle, authHandle, nvIndex,
-                           qualifyingData, inScheme, size, offset);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, signHandle, &signHandleNode);
@@ -320,7 +286,8 @@ Esys_NV_Certify_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -352,23 +319,13 @@ Esys_NV_Certify_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_Certify_Async(esysContext,
-                                  esysContext->in.NV_Certify.signHandle,
-                                  esysContext->in.NV_Certify.authHandle,
-                                  esysContext->in.NV_Certify.nvIndex,
-                                  esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2],
-                                  esysContext->in.NV_Certify.qualifyingData,
-                                  esysContext->in.NV_Certify.inScheme,
-                                  esysContext->in.NV_Certify.size,
-                                  esysContext->in.NV_Certify.offset);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_NV_Extend.c
+++ b/src/tss2-esys/api/Esys_NV_Extend.c
@@ -18,19 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    const TPM2B_MAX_NV_BUFFER *data)
+    ESYS_TR nvIndex)
 {
-    esysContext->in.NV_Extend.authHandle = authHandle;
-    esysContext->in.NV_Extend.nvIndex = nvIndex;
-    if (data == NULL) {
-        esysContext->in.NV_Extend.data = NULL;
-    } else {
-        esysContext->in.NV_Extend.dataData = *data;
-        esysContext->in.NV_Extend.data =
-            &esysContext->in.NV_Extend.dataData;
-    }
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_Extend
@@ -178,10 +168,10 @@ Esys_NV_Extend_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, data);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -267,7 +257,8 @@ Esys_NV_Extend_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -285,19 +276,13 @@ Esys_NV_Extend_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_Extend_Async(esysContext,
-                                 esysContext->in.NV_Extend.authHandle,
-                                 esysContext->in.NV_Extend.nvIndex,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.NV_Extend.data);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -335,7 +320,7 @@ Esys_NV_Extend_Finish(
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR,
                           "Received error from SAPI unmarshaling" );
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
     RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle)
-{
-    esysContext->in.NV_GlobalWriteLock.authHandle = authHandle;
-}
-
 /** One-Call function for TPM2_NV_GlobalWriteLock
  *
  * This function invokes the TPM2_NV_GlobalWriteLock command in a one-call
@@ -162,10 +154,9 @@ Esys_NV_GlobalWriteLock_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -248,7 +239,8 @@ Esys_NV_GlobalWriteLock_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -266,17 +258,13 @@ Esys_NV_GlobalWriteLock_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_GlobalWriteLock_Async(esysContext,
-                                          esysContext->in.NV_GlobalWriteLock.authHandle,
-                                          esysContext->session_type[0],
-                                          esysContext->session_type[1],
-                                          esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_NV_Increment.c
+++ b/src/tss2-esys/api/Esys_NV_Increment.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
     ESYS_TR nvIndex)
 {
-    esysContext->in.NV_Increment.authHandle = authHandle;
-    esysContext->in.NV_Increment.nvIndex = nvIndex;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_Increment
@@ -171,10 +169,10 @@ Esys_NV_Increment_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -260,7 +258,8 @@ Esys_NV_Increment_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +277,13 @@ Esys_NV_Increment_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_Increment_Async(esysContext,
-                                    esysContext->in.NV_Increment.authHandle,
-                                    esysContext->in.NV_Increment.nvIndex,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -328,7 +322,7 @@ Esys_NV_Increment_Finish(
                           "Received error from SAPI unmarshaling" );
 
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
         RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_NV_Read.c
+++ b/src/tss2-esys/api/Esys_NV_Read.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    UINT16 size,
-    UINT16 offset)
-{
-    esysContext->in.NV_Read.authHandle = authHandle;
-    esysContext->in.NV_Read.nvIndex = nvIndex;
-    esysContext->in.NV_Read.size = size;
-    esysContext->in.NV_Read.offset = offset;
-}
-
 /** One-Call function for TPM2_NV_Read
  *
  * This function invokes the TPM2_NV_Read command in a one-call
@@ -181,10 +167,9 @@ Esys_NV_Read_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, size, offset);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -273,7 +258,8 @@ Esys_NV_Read_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -299,19 +285,13 @@ Esys_NV_Read_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_Read_Async(esysContext, esysContext->in.NV_Read.authHandle,
-                               esysContext->in.NV_Read.nvIndex,
-                               esysContext->session_type[0],
-                               esysContext->session_type[1],
-                               esysContext->session_type[2],
-                               esysContext->in.NV_Read.size,
-                               esysContext->in.NV_Read.offset);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_NV_ReadLock.c
+++ b/src/tss2-esys/api/Esys_NV_ReadLock.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
     ESYS_TR nvIndex)
 {
-    esysContext->in.NV_ReadLock.authHandle = authHandle;
-    esysContext->in.NV_ReadLock.nvIndex = nvIndex;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_ReadLock
@@ -171,10 +169,10 @@ Esys_NV_ReadLock_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -260,7 +258,8 @@ Esys_NV_ReadLock_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +277,13 @@ Esys_NV_ReadLock_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_ReadLock_Async(esysContext,
-                                   esysContext->in.NV_ReadLock.authHandle,
-                                   esysContext->in.NV_ReadLock.nvIndex,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -328,7 +322,7 @@ Esys_NV_ReadLock_Finish(
                           "Received error from SAPI unmarshaling" );
 
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
         RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_NV_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_NV_ReadPublic.c
@@ -20,7 +20,7 @@ static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
     ESYS_TR nvIndex)
 {
-    esysContext->in.NV_ReadPublic.nvIndex = nvIndex;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_ReadPublic
@@ -162,7 +162,7 @@ Esys_NV_ReadPublic_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, nvIndex);
@@ -254,7 +254,8 @@ Esys_NV_ReadPublic_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -282,17 +283,13 @@ Esys_NV_ReadPublic_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_ReadPublic_Async(esysContext,
-                                     esysContext->in.NV_ReadPublic.nvIndex,
-                                     esysContext->session_type[0],
-                                     esysContext->session_type[1],
-                                     esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -333,7 +330,7 @@ Esys_NV_ReadPublic_Finish(
 
 
     /* Update the meta data of the ESYS_TR object */
-    ESYS_TR nvIndex = esysContext->in.NV_ReadPublic.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
     RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     goto_if_error(r, "get resource", error_cleanup);

--- a/src/tss2-esys/api/Esys_NV_SetBits.c
+++ b/src/tss2-esys/api/Esys_NV_SetBits.c
@@ -18,13 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    UINT64 bits)
+    ESYS_TR nvIndex)
 {
-    esysContext->in.NV_SetBits.authHandle = authHandle;
-    esysContext->in.NV_SetBits.nvIndex = nvIndex;
-    esysContext->in.NV_SetBits.bits = bits;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_SetBits
@@ -178,10 +174,10 @@ Esys_NV_SetBits_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, bits);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -267,7 +263,8 @@ Esys_NV_SetBits_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -285,19 +282,13 @@ Esys_NV_SetBits_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_SetBits_Async(esysContext,
-                                  esysContext->in.NV_SetBits.authHandle,
-                                  esysContext->in.NV_SetBits.nvIndex,
-                                  esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2],
-                                  esysContext->in.NV_SetBits.bits);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -336,7 +327,7 @@ Esys_NV_SetBits_Finish(
                           "Received error from SAPI unmarshaling" );
 
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
         RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_NV_UndefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpace.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
     ESYS_TR nvIndex)
 {
-    esysContext->in.NV_UndefineSpace.authHandle = authHandle;
-    esysContext->in.NV_UndefineSpace.nvIndex = nvIndex;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_UndefineSpace
@@ -169,10 +167,10 @@ Esys_NV_UndefineSpace_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -258,7 +256,8 @@ Esys_NV_UndefineSpace_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -276,18 +275,13 @@ Esys_NV_UndefineSpace_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_UndefineSpace_Async(esysContext,
-                                        esysContext->in.NV_UndefineSpace.authHandle,
-                                        esysContext->in.NV_UndefineSpace.nvIndex,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -326,7 +320,7 @@ Esys_NV_UndefineSpace_Finish(
                           "Received error from SAPI unmarshaling" );
 
     /* The ESYS_TR object (nvIndex) has to be invalidated */
-    r = Esys_TR_Close(esysContext, &esysContext->in.NV_UndefineSpace.nvIndex);
+    r = Esys_TR_Close(esysContext, &esysContext->in.NV.nvIndex);
     return_if_error(r, "invalidate object");
 
     esysContext->state = _ESYS_STATE_INIT;

--- a/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR nvIndex,
-    ESYS_TR platform)
+    ESYS_TR nvIndex)
 {
-    esysContext->in.NV_UndefineSpaceSpecial.nvIndex = nvIndex;
-    esysContext->in.NV_UndefineSpaceSpecial.platform = platform;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_UndefineSpaceSpecial
@@ -169,10 +167,10 @@ Esys_NV_UndefineSpaceSpecial_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, nvIndex, platform);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
@@ -264,7 +262,8 @@ Esys_NV_UndefineSpaceSpecial_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -282,18 +281,13 @@ Esys_NV_UndefineSpaceSpecial_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_UndefineSpaceSpecial_Async(esysContext,
-                                               esysContext->in.NV_UndefineSpaceSpecial.nvIndex,
-                                               esysContext->in.NV_UndefineSpaceSpecial.platform,
-                                               esysContext->session_type[0],
-                                               esysContext->session_type[1],
-                                               esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -319,7 +313,7 @@ Esys_NV_UndefineSpaceSpecial_Finish(
      * correct computation of HMAC. The size of the session value is
      * decreased because the auth value is not used for the response HMAC.
      */
-    nvIndex = esysContext->in.NV_UndefineSpaceSpecial.nvIndex;
+    nvIndex = esysContext->in.NV.nvIndex;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");
 
@@ -329,8 +323,7 @@ Esys_NV_UndefineSpaceSpecial_Finish(
     session->rsrc.misc.rsrc_session.sizeHmacValue -= nvIndexNode->auth.size;
 
     /* The ESYS_TR object (nvIndex) has to be invalidated */
-    r = Esys_TR_Close(esysContext,
-                      &esysContext->in.NV_UndefineSpaceSpecial.nvIndex);
+    r = Esys_TR_Close(esysContext, &esysContext->in.NV.nvIndex);
     return_if_error(r, "TR_Close");
 
     /*

--- a/src/tss2-esys/api/Esys_NV_Write.c
+++ b/src/tss2-esys/api/Esys_NV_Write.c
@@ -18,21 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    const TPM2B_MAX_NV_BUFFER *data,
-    UINT16 offset)
+    ESYS_TR nvIndex)
 {
-    esysContext->in.NV_Write.authHandle = authHandle;
-    esysContext->in.NV_Write.nvIndex = nvIndex;
-    esysContext->in.NV_Write.offset = offset;
-    if (data == NULL) {
-        esysContext->in.NV_Write.data = NULL;
-    } else {
-        esysContext->in.NV_Write.dataData = *data;
-        esysContext->in.NV_Write.data =
-            &esysContext->in.NV_Write.dataData;
-    }
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_Write
@@ -184,10 +172,10 @@ Esys_NV_Write_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, data, offset);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -273,7 +261,8 @@ Esys_NV_Write_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -291,19 +280,13 @@ Esys_NV_Write_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_Write_Async(esysContext, esysContext->in.NV_Write.authHandle,
-                                esysContext->in.NV_Write.nvIndex,
-                                esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.NV_Write.data,
-                                esysContext->in.NV_Write.offset);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -342,7 +325,7 @@ Esys_NV_Write_Finish(
                           "Received error from SAPI unmarshaling" );
 
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
     RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_NV_WriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_WriteLock.c
@@ -18,11 +18,9 @@
 /** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
     ESYS_TR nvIndex)
 {
-    esysContext->in.NV_WriteLock.authHandle = authHandle;
-    esysContext->in.NV_WriteLock.nvIndex = nvIndex;
+    esysContext->in.NV.nvIndex = nvIndex;
 }
 
 /** One-Call function for TPM2_NV_WriteLock
@@ -171,10 +169,10 @@ Esys_NV_WriteLock_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex);
+    store_input_parameters(esysContext, nvIndex);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -260,7 +258,8 @@ Esys_NV_WriteLock_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +277,13 @@ Esys_NV_WriteLock_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_NV_WriteLock_Async(esysContext,
-                                    esysContext->in.NV_WriteLock.authHandle,
-                                    esysContext->in.NV_WriteLock.nvIndex,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -328,7 +322,7 @@ Esys_NV_WriteLock_Finish(
                           "Received error from SAPI unmarshaling" );
 
 
-    ESYS_TR nvIndex = esysContext->in.NV_Write.nvIndex;
+    ESYS_TR nvIndex = esysContext->in.NV.nvIndex;
         RSRC_NODE_T *nvIndexNode;
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_ObjectChangeAuth.c
+++ b/src/tss2-esys/api/Esys_ObjectChangeAuth.c
@@ -15,24 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR objectHandle,
-    ESYS_TR parentHandle,
-    const TPM2B_AUTH *newAuth)
-{
-    esysContext->in.ObjectChangeAuth.objectHandle = objectHandle;
-    esysContext->in.ObjectChangeAuth.parentHandle = parentHandle;
-    if (newAuth == NULL) {
-        esysContext->in.ObjectChangeAuth.newAuth = NULL;
-    } else {
-        esysContext->in.ObjectChangeAuth.newAuthData = *newAuth;
-        esysContext->in.ObjectChangeAuth.newAuth =
-            &esysContext->in.ObjectChangeAuth.newAuthData;
-    }
-}
-
 /** One-Call function for TPM2_ObjectChangeAuth
  *
  * This function invokes the TPM2_ObjectChangeAuth command in a one-call
@@ -173,10 +155,9 @@ Esys_ObjectChangeAuth_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, objectHandle, parentHandle, newAuth);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, objectHandle, &objectHandleNode);
@@ -268,7 +249,8 @@ Esys_ObjectChangeAuth_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -294,19 +276,13 @@ Esys_ObjectChangeAuth_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ObjectChangeAuth_Async(esysContext,
-                                        esysContext->in.ObjectChangeAuth.objectHandle,
-                                        esysContext->in.ObjectChangeAuth.parentHandle,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.ObjectChangeAuth.newAuth);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_Allocate.c
+++ b/src/tss2-esys/api/Esys_PCR_Allocate.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    const TPML_PCR_SELECTION *pcrAllocation)
-{
-    esysContext->in.PCR_Allocate.authHandle = authHandle;
-    if (pcrAllocation == NULL) {
-        esysContext->in.PCR_Allocate.pcrAllocation = NULL;
-    } else {
-        esysContext->in.PCR_Allocate.pcrAllocationData = *pcrAllocation;
-        esysContext->in.PCR_Allocate.pcrAllocation =
-            &esysContext->in.PCR_Allocate.pcrAllocationData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_Allocate
  *
  * This function invokes the TPM2_PCR_Allocate command in a one-call
@@ -188,10 +172,9 @@ Esys_PCR_Allocate_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, pcrAllocation);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -289,7 +272,8 @@ Esys_PCR_Allocate_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -307,18 +291,13 @@ Esys_PCR_Allocate_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_Allocate_Async(esysContext,
-                                    esysContext->in.PCR_Allocate.authHandle,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.PCR_Allocate.pcrAllocation);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_Event.c
+++ b/src/tss2-esys/api/Esys_PCR_Event.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR pcrHandle,
-    const TPM2B_EVENT *eventData)
-{
-    esysContext->in.PCR_Event.pcrHandle = pcrHandle;
-    if (eventData == NULL) {
-        esysContext->in.PCR_Event.eventData = NULL;
-    } else {
-        esysContext->in.PCR_Event.eventDataData = *eventData;
-        esysContext->in.PCR_Event.eventData =
-            &esysContext->in.PCR_Event.eventDataData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_Event
  *
  * This function invokes the TPM2_PCR_Event command in a one-call
@@ -171,10 +155,9 @@ Esys_PCR_Event_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrHandle, eventData);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
@@ -259,7 +242,8 @@ Esys_PCR_Event_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -285,18 +269,13 @@ Esys_PCR_Event_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_Event_Async(esysContext,
-                                 esysContext->in.PCR_Event.pcrHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.PCR_Event.eventData);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_Extend.c
+++ b/src/tss2-esys/api/Esys_PCR_Extend.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR pcrHandle,
-    const TPML_DIGEST_VALUES *digests)
-{
-    esysContext->in.PCR_Extend.pcrHandle = pcrHandle;
-    if (digests == NULL) {
-        esysContext->in.PCR_Extend.digests = NULL;
-    } else {
-        esysContext->in.PCR_Extend.digestsData = *digests;
-        esysContext->in.PCR_Extend.digests =
-            &esysContext->in.PCR_Extend.digestsData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_Extend
  *
  * This function invokes the TPM2_PCR_Extend command in a one-call
@@ -174,10 +158,9 @@ Esys_PCR_Extend_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrHandle, digests);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
@@ -259,7 +242,8 @@ Esys_PCR_Extend_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -277,18 +261,13 @@ Esys_PCR_Extend_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_Extend_Async(esysContext,
-                                  esysContext->in.PCR_Extend.pcrHandle,
-                                  esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2],
-                                  esysContext->in.PCR_Extend.digests);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_Read.c
+++ b/src/tss2-esys/api/Esys_PCR_Read.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPML_PCR_SELECTION *pcrSelectionIn)
-{
-    if (pcrSelectionIn == NULL) {
-        esysContext->in.PCR_Read.pcrSelectionIn = NULL;
-    } else {
-        esysContext->in.PCR_Read.pcrSelectionInData = *pcrSelectionIn;
-        esysContext->in.PCR_Read.pcrSelectionIn =
-            &esysContext->in.PCR_Read.pcrSelectionInData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_Read
  *
  * This function invokes the TPM2_PCR_Read command in a one-call
@@ -172,10 +158,9 @@ Esys_PCR_Read_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrSelectionIn);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_PCR_Read_Prepare(esysContext->sys, pcrSelectionIn);
@@ -262,7 +247,8 @@ Esys_PCR_Read_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -294,16 +280,13 @@ Esys_PCR_Read_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_Read_Async(esysContext, esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.PCR_Read.pcrSelectionIn);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_Reset.c
+++ b/src/tss2-esys/api/Esys_PCR_Reset.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR pcrHandle)
-{
-    esysContext->in.PCR_Reset.pcrHandle = pcrHandle;
-}
-
 /** One-Call function for TPM2_PCR_Reset
  *
  * This function invokes the TPM2_PCR_Reset command in a one-call
@@ -162,10 +154,9 @@ Esys_PCR_Reset_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
@@ -247,7 +238,8 @@ Esys_PCR_Reset_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +257,13 @@ Esys_PCR_Reset_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_Reset_Async(esysContext,
-                                 esysContext->in.PCR_Reset.pcrHandle,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
@@ -15,26 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    const TPM2B_DIGEST *authPolicy,
-    TPMI_ALG_HASH hashAlg,
-    TPMI_DH_PCR pcrNum)
-{
-    esysContext->in.PCR_SetAuthPolicy.authHandle = authHandle;
-    esysContext->in.PCR_SetAuthPolicy.hashAlg = hashAlg;
-    esysContext->in.PCR_SetAuthPolicy.pcrNum = pcrNum;
-    if (authPolicy == NULL) {
-        esysContext->in.PCR_SetAuthPolicy.authPolicy = NULL;
-    } else {
-        esysContext->in.PCR_SetAuthPolicy.authPolicyData = *authPolicy;
-        esysContext->in.PCR_SetAuthPolicy.authPolicy =
-            &esysContext->in.PCR_SetAuthPolicy.authPolicyData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_SetAuthPolicy
  *
  * This function invokes the TPM2_PCR_SetAuthPolicy command in a one-call
@@ -181,11 +161,9 @@ Esys_PCR_SetAuthPolicy_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, authPolicy, hashAlg,
-                           pcrNum);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -269,7 +247,8 @@ Esys_PCR_SetAuthPolicy_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -287,20 +266,13 @@ Esys_PCR_SetAuthPolicy_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_SetAuthPolicy_Async(esysContext,
-                                         esysContext->in.PCR_SetAuthPolicy.authHandle,
-                                         esysContext->session_type[0],
-                                         esysContext->session_type[1],
-                                         esysContext->session_type[2],
-                                         esysContext->in.PCR_SetAuthPolicy.authPolicy,
-                                         esysContext->in.PCR_SetAuthPolicy.hashAlg,
-                                         esysContext->in.PCR_SetAuthPolicy.pcrNum);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR pcrHandle,
-    const TPM2B_DIGEST *auth)
-{
-    esysContext->in.PCR_SetAuthValue.pcrHandle = pcrHandle;
-    if (auth == NULL) {
-        esysContext->in.PCR_SetAuthValue.auth = NULL;
-    } else {
-        esysContext->in.PCR_SetAuthValue.authData = *auth;
-        esysContext->in.PCR_SetAuthValue.auth =
-            &esysContext->in.PCR_SetAuthValue.authData;
-    }
-}
-
 /** One-Call function for TPM2_PCR_SetAuthValue
  *
  * This function invokes the TPM2_PCR_SetAuthValue command in a one-call
@@ -170,10 +154,9 @@ Esys_PCR_SetAuthValue_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, pcrHandle, auth);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
@@ -255,7 +238,8 @@ Esys_PCR_SetAuthValue_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -273,18 +257,13 @@ Esys_PCR_SetAuthValue_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PCR_SetAuthValue_Async(esysContext,
-                                        esysContext->in.PCR_SetAuthValue.pcrHandle,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.PCR_SetAuthValue.auth);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PP_Commands.c
+++ b/src/tss2-esys/api/Esys_PP_Commands.c
@@ -15,30 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR auth,
-    const TPML_CC *setList,
-    const TPML_CC *clearList)
-{
-    esysContext->in.PP_Commands.auth = auth;
-    if (setList == NULL) {
-        esysContext->in.PP_Commands.setList = NULL;
-    } else {
-        esysContext->in.PP_Commands.setListData = *setList;
-        esysContext->in.PP_Commands.setList =
-            &esysContext->in.PP_Commands.setListData;
-    }
-    if (clearList == NULL) {
-        esysContext->in.PP_Commands.clearList = NULL;
-    } else {
-        esysContext->in.PP_Commands.clearListData = *clearList;
-        esysContext->in.PP_Commands.clearList =
-            &esysContext->in.PP_Commands.clearListData;
-    }
-}
-
 /** One-Call function for TPM2_PP_Commands
  *
  * This function invokes the TPM2_PP_Commands command in a one-call
@@ -191,10 +167,9 @@ Esys_PP_Commands_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, setList, clearList);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, auth, &authNode);
@@ -277,7 +252,8 @@ Esys_PP_Commands_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -295,18 +271,13 @@ Esys_PP_Commands_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PP_Commands_Async(esysContext, esysContext->in.PP_Commands.auth,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2],
-                                   esysContext->in.PP_Commands.setList,
-                                   esysContext->in.PP_Commands.clearList);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyAuthValue.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthValue.c
@@ -20,7 +20,7 @@ static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
     ESYS_TR policySession)
 {
-    esysContext->in.PolicyAuthValue.policySession = policySession;
+    esysContext->in.Policy.policySession = policySession;
 }
 
 /** One-Call function for TPM2_PolicyAuthValue
@@ -162,7 +162,7 @@ Esys_PolicyAuthValue_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
@@ -247,7 +247,8 @@ Esys_PolicyAuthValue_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +266,13 @@ Esys_PolicyAuthValue_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyAuthValue_Async(esysContext,
-                                       esysContext->in.PolicyAuthValue.policySession,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -313,7 +310,7 @@ Esys_PolicyAuthValue_Finish(
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR,
                           "Received error from SAPI unmarshaling" );
 
-    ESYS_TR policySession = esysContext->in.PolicyAuthValue.policySession;
+    ESYS_TR policySession = esysContext->in.Policy.policySession;
     RSRC_NODE_T *policySessionNode;
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
@@ -15,18 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    ESYS_TR policySession)
-{
-    esysContext->in.PolicyAuthorizeNV.authHandle = authHandle;
-    esysContext->in.PolicyAuthorizeNV.nvIndex = nvIndex;
-    esysContext->in.PolicyAuthorizeNV.policySession = policySession;
-}
-
 /** One-Call function for TPM2_PolicyAuthorizeNV
  *
  * This function invokes the TPM2_PolicyAuthorizeNV command in a one-call
@@ -180,10 +168,9 @@ Esys_PolicyAuthorizeNV_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, policySession);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -275,7 +262,8 @@ Esys_PolicyAuthorizeNV_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -293,19 +281,13 @@ Esys_PolicyAuthorizeNV_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyAuthorizeNV_Async(esysContext,
-                                         esysContext->in.PolicyAuthorizeNV.authHandle,
-                                         esysContext->in.PolicyAuthorizeNV.nvIndex,
-                                         esysContext->in.PolicyAuthorizeNV.policySession,
-                                         esysContext->session_type[0],
-                                         esysContext->session_type[1],
-                                         esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyCommandCode.c
+++ b/src/tss2-esys/api/Esys_PolicyCommandCode.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    TPM2_CC code)
-{
-    esysContext->in.PolicyCommandCode.policySession = policySession;
-    esysContext->in.PolicyCommandCode.code = code;
-}
-
 /** One-Call function for TPM2_PolicyCommandCode
  *
  * This function invokes the TPM2_PolicyCommandCode command in a one-call
@@ -168,10 +158,9 @@ Esys_PolicyCommandCode_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, code);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -254,7 +243,8 @@ Esys_PolicyCommandCode_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -272,18 +262,13 @@ Esys_PolicyCommandCode_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyCommandCode_Async(esysContext,
-                                         esysContext->in.PolicyCommandCode.policySession,
-                                         esysContext->session_type[0],
-                                         esysContext->session_type[1],
-                                         esysContext->session_type[2],
-                                         esysContext->in.PolicyCommandCode.code);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyCounterTimer.c
+++ b/src/tss2-esys/api/Esys_PolicyCounterTimer.c
@@ -15,26 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_OPERAND *operandB,
-    UINT16 offset,
-    TPM2_EO operation)
-{
-    esysContext->in.PolicyCounterTimer.policySession = policySession;
-    esysContext->in.PolicyCounterTimer.offset = offset;
-    esysContext->in.PolicyCounterTimer.operation = operation;
-    if (operandB == NULL) {
-        esysContext->in.PolicyCounterTimer.operandB = NULL;
-    } else {
-        esysContext->in.PolicyCounterTimer.operandBData = *operandB;
-        esysContext->in.PolicyCounterTimer.operandB =
-            &esysContext->in.PolicyCounterTimer.operandBData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyCounterTimer
  *
  * This function invokes the TPM2_PolicyCounterTimer command in a one-call
@@ -184,11 +164,9 @@ Esys_PolicyCounterTimer_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, operandB, offset,
-                           operation);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -271,7 +249,8 @@ Esys_PolicyCounterTimer_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -289,20 +268,13 @@ Esys_PolicyCounterTimer_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyCounterTimer_Async(esysContext,
-                                          esysContext->in.PolicyCounterTimer.policySession,
-                                          esysContext->session_type[0],
-                                          esysContext->session_type[1],
-                                          esysContext->session_type[2],
-                                          esysContext->in.PolicyCounterTimer.operandB,
-                                          esysContext->in.PolicyCounterTimer.offset,
-                                          esysContext->in.PolicyCounterTimer.operation);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyCpHash.c
+++ b/src/tss2-esys/api/Esys_PolicyCpHash.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_DIGEST *cpHashA)
-{
-    esysContext->in.PolicyCpHash.policySession = policySession;
-    if (cpHashA == NULL) {
-        esysContext->in.PolicyCpHash.cpHashA = NULL;
-    } else {
-        esysContext->in.PolicyCpHash.cpHashAData = *cpHashA;
-        esysContext->in.PolicyCpHash.cpHashA =
-            &esysContext->in.PolicyCpHash.cpHashAData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyCpHash
  *
  * This function invokes the TPM2_PolicyCpHash command in a one-call
@@ -174,10 +158,9 @@ Esys_PolicyCpHash_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, cpHashA);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -259,7 +242,8 @@ Esys_PolicyCpHash_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -277,18 +261,13 @@ Esys_PolicyCpHash_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyCpHash_Async(esysContext,
-                                    esysContext->in.PolicyCpHash.policySession,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.PolicyCpHash.cpHashA);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
+++ b/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_NAME *objectName,
-    const TPM2B_NAME *newParentName,
-    TPMI_YES_NO includeObject)
-{
-    esysContext->in.PolicyDuplicationSelect.policySession = policySession;
-    esysContext->in.PolicyDuplicationSelect.includeObject = includeObject;
-    if (objectName == NULL) {
-        esysContext->in.PolicyDuplicationSelect.objectName = NULL;
-    } else {
-        esysContext->in.PolicyDuplicationSelect.objectNameData = *objectName;
-        esysContext->in.PolicyDuplicationSelect.objectName =
-            &esysContext->in.PolicyDuplicationSelect.objectNameData;
-    }
-    if (newParentName == NULL) {
-        esysContext->in.PolicyDuplicationSelect.newParentName = NULL;
-    } else {
-        esysContext->in.PolicyDuplicationSelect.newParentNameData = *newParentName;
-        esysContext->in.PolicyDuplicationSelect.newParentName =
-            &esysContext->in.PolicyDuplicationSelect.newParentNameData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyDuplicationSelect
  *
  * This function invokes the TPM2_PolicyDuplicationSelect command in a one-call
@@ -196,11 +170,9 @@ Esys_PolicyDuplicationSelect_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, objectName, newParentName,
-                           includeObject);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -284,7 +256,8 @@ Esys_PolicyDuplicationSelect_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -302,20 +275,13 @@ Esys_PolicyDuplicationSelect_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyDuplicationSelect_Async(esysContext,
-                                               esysContext->in.PolicyDuplicationSelect.policySession,
-                                               esysContext->session_type[0],
-                                               esysContext->session_type[1],
-                                               esysContext->session_type[2],
-                                               esysContext->in.PolicyDuplicationSelect.objectName,
-                                               esysContext->in.PolicyDuplicationSelect.newParentName,
-                                               esysContext->in.PolicyDuplicationSelect.includeObject);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyGetDigest.c
+++ b/src/tss2-esys/api/Esys_PolicyGetDigest.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession)
-{
-    esysContext->in.PolicyGetDigest.policySession = policySession;
-}
-
 /** One-Call function for TPM2_PolicyGetDigest
  *
  * This function invokes the TPM2_PolicyGetDigest command in a one-call
@@ -160,10 +152,9 @@ Esys_PolicyGetDigest_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -249,7 +240,8 @@ Esys_PolicyGetDigest_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -275,17 +267,13 @@ Esys_PolicyGetDigest_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyGetDigest_Async(esysContext,
-                                       esysContext->in.PolicyGetDigest.policySession,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyLocality.c
+++ b/src/tss2-esys/api/Esys_PolicyLocality.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    TPMA_LOCALITY locality)
-{
-    esysContext->in.PolicyLocality.policySession = policySession;
-    esysContext->in.PolicyLocality.locality = locality;
-}
-
 /** One-Call function for TPM2_PolicyLocality
  *
  * This function invokes the TPM2_PolicyLocality command in a one-call
@@ -168,10 +158,9 @@ Esys_PolicyLocality_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, locality);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -254,7 +243,8 @@ Esys_PolicyLocality_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -272,18 +262,13 @@ Esys_PolicyLocality_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyLocality_Async(esysContext,
-                                      esysContext->in.PolicyLocality.policySession,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.PolicyLocality.locality);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyNV.c
+++ b/src/tss2-esys/api/Esys_PolicyNV.c
@@ -15,30 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR nvIndex,
-    ESYS_TR policySession,
-    const TPM2B_OPERAND *operandB,
-    UINT16 offset,
-    TPM2_EO operation)
-{
-    esysContext->in.PolicyNV.authHandle = authHandle;
-    esysContext->in.PolicyNV.nvIndex = nvIndex;
-    esysContext->in.PolicyNV.policySession = policySession;
-    esysContext->in.PolicyNV.offset = offset;
-    esysContext->in.PolicyNV.operation = operation;
-    if (operandB == NULL) {
-        esysContext->in.PolicyNV.operandB = NULL;
-    } else {
-        esysContext->in.PolicyNV.operandBData = *operandB;
-        esysContext->in.PolicyNV.operandB =
-            &esysContext->in.PolicyNV.operandBData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyNV
  *
  * This function invokes the TPM2_PolicyNV command in a one-call
@@ -200,11 +176,9 @@ Esys_PolicyNV_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, nvIndex, policySession,
-                           operandB, offset, operation);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -295,7 +269,8 @@ Esys_PolicyNV_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -313,21 +288,13 @@ Esys_PolicyNV_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyNV_Async(esysContext, esysContext->in.PolicyNV.authHandle,
-                                esysContext->in.PolicyNV.nvIndex,
-                                esysContext->in.PolicyNV.policySession,
-                                esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.PolicyNV.operandB,
-                                esysContext->in.PolicyNV.offset,
-                                esysContext->in.PolicyNV.operation);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyNameHash.c
+++ b/src/tss2-esys/api/Esys_PolicyNameHash.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_DIGEST *nameHash)
-{
-    esysContext->in.PolicyNameHash.policySession = policySession;
-    if (nameHash == NULL) {
-        esysContext->in.PolicyNameHash.nameHash = NULL;
-    } else {
-        esysContext->in.PolicyNameHash.nameHashData = *nameHash;
-        esysContext->in.PolicyNameHash.nameHash =
-            &esysContext->in.PolicyNameHash.nameHashData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyNameHash
  *
  * This function invokes the TPM2_PolicyNameHash command in a one-call
@@ -174,10 +158,9 @@ Esys_PolicyNameHash_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, nameHash);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -260,7 +243,8 @@ Esys_PolicyNameHash_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +262,13 @@ Esys_PolicyNameHash_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyNameHash_Async(esysContext,
-                                      esysContext->in.PolicyNameHash.policySession,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.PolicyNameHash.nameHash);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyNvWritten.c
+++ b/src/tss2-esys/api/Esys_PolicyNvWritten.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    TPMI_YES_NO writtenSet)
-{
-    esysContext->in.PolicyNvWritten.policySession = policySession;
-    esysContext->in.PolicyNvWritten.writtenSet = writtenSet;
-}
-
 /** One-Call function for TPM2_PolicyNvWritten
  *
  * This function invokes the TPM2_PolicyNvWritten command in a one-call
@@ -168,10 +158,9 @@ Esys_PolicyNvWritten_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, writtenSet);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -254,7 +243,8 @@ Esys_PolicyNvWritten_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -272,18 +262,13 @@ Esys_PolicyNvWritten_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyNvWritten_Async(esysContext,
-                                       esysContext->in.PolicyNvWritten.policySession,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.PolicyNvWritten.writtenSet);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyOR.c
+++ b/src/tss2-esys/api/Esys_PolicyOR.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPML_DIGEST *pHashList)
-{
-    esysContext->in.PolicyOR.policySession = policySession;
-    if (pHashList == NULL) {
-        esysContext->in.PolicyOR.pHashList = NULL;
-    } else {
-        esysContext->in.PolicyOR.pHashListData = *pHashList;
-        esysContext->in.PolicyOR.pHashList =
-            &esysContext->in.PolicyOR.pHashListData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyOR
  *
  * This function invokes the TPM2_PolicyOR command in a one-call
@@ -174,10 +158,9 @@ Esys_PolicyOR_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, pHashList);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -258,7 +241,8 @@ Esys_PolicyOR_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -276,18 +260,13 @@ Esys_PolicyOR_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyOR_Async(esysContext,
-                                esysContext->in.PolicyOR.policySession,
-                                esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.PolicyOR.pHashList);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyPCR.c
+++ b/src/tss2-esys/api/Esys_PolicyPCR.c
@@ -15,30 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_DIGEST *pcrDigest,
-    const TPML_PCR_SELECTION *pcrs)
-{
-    esysContext->in.PolicyPCR.policySession = policySession;
-    if (pcrDigest == NULL) {
-        esysContext->in.PolicyPCR.pcrDigest = NULL;
-    } else {
-        esysContext->in.PolicyPCR.pcrDigestData = *pcrDigest;
-        esysContext->in.PolicyPCR.pcrDigest =
-            &esysContext->in.PolicyPCR.pcrDigestData;
-    }
-    if (pcrs == NULL) {
-        esysContext->in.PolicyPCR.pcrs = NULL;
-    } else {
-        esysContext->in.PolicyPCR.pcrsData = *pcrs;
-        esysContext->in.PolicyPCR.pcrs =
-            &esysContext->in.PolicyPCR.pcrsData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyPCR
  *
  * This function invokes the TPM2_PolicyPCR command in a one-call
@@ -183,10 +159,9 @@ Esys_PolicyPCR_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, pcrDigest, pcrs);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -268,7 +243,8 @@ Esys_PolicyPCR_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -286,19 +262,13 @@ Esys_PolicyPCR_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyPCR_Async(esysContext,
-                                 esysContext->in.PolicyPCR.policySession,
-                                 esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.PolicyPCR.pcrDigest,
-                                 esysContext->in.PolicyPCR.pcrs);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyPassword.c
+++ b/src/tss2-esys/api/Esys_PolicyPassword.c
@@ -20,7 +20,7 @@ static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
     ESYS_TR policySession)
 {
-    esysContext->in.PolicyPassword.policySession = policySession;
+    esysContext->in.Policy.policySession = policySession;
 }
 
 /** One-Call function for TPM2_PolicyPassword
@@ -162,7 +162,7 @@ Esys_PolicyPassword_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, policySession);
@@ -247,7 +247,8 @@ Esys_PolicyPassword_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +266,13 @@ Esys_PolicyPassword_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyPassword_Async(esysContext,
-                                      esysContext->in.PolicyPassword.policySession,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent
@@ -313,7 +310,7 @@ Esys_PolicyPassword_Finish(
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR,
                           "Received error from SAPI unmarshaling" );
 
-    ESYS_TR policySession = esysContext->in.PolicyPassword.policySession;
+    ESYS_TR policySession = esysContext->in.Policy.policySession;
     RSRC_NODE_T *policySessionNode;
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
     return_if_error(r, "get resource");

--- a/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
+++ b/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession)
-{
-    esysContext->in.PolicyPhysicalPresence.policySession = policySession;
-}
-
 /** One-Call function for TPM2_PolicyPhysicalPresence
  *
  * This function invokes the TPM2_PolicyPhysicalPresence command in a one-call
@@ -162,10 +154,9 @@ Esys_PolicyPhysicalPresence_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -247,7 +238,8 @@ Esys_PolicyPhysicalPresence_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -265,17 +257,13 @@ Esys_PolicyPhysicalPresence_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyPhysicalPresence_Async(esysContext,
-                                              esysContext->in.PolicyPhysicalPresence.policySession,
-                                              esysContext->session_type[0],
-                                              esysContext->session_type[1],
-                                              esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyRestart.c
+++ b/src/tss2-esys/api/Esys_PolicyRestart.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR sessionHandle)
-{
-    esysContext->in.PolicyRestart.sessionHandle = sessionHandle;
-}
-
 /** One-Call function for TPM2_PolicyRestart
  *
  * This function invokes the TPM2_PolicyRestart command in a one-call
@@ -162,10 +154,9 @@ Esys_PolicyRestart_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, sessionHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, sessionHandle, &sessionHandleNode);
@@ -246,7 +237,8 @@ Esys_PolicyRestart_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -264,17 +256,13 @@ Esys_PolicyRestart_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyRestart_Async(esysContext,
-                                     esysContext->in.PolicyRestart.sessionHandle,
-                                     esysContext->session_type[0],
-                                     esysContext->session_type[1],
-                                     esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicySecret.c
+++ b/src/tss2-esys/api/Esys_PolicySecret.c
@@ -15,42 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    ESYS_TR policySession,
-    const TPM2B_NONCE *nonceTPM,
-    const TPM2B_DIGEST *cpHashA,
-    const TPM2B_NONCE *policyRef,
-    INT32 expiration)
-{
-    esysContext->in.PolicySecret.authHandle = authHandle;
-    esysContext->in.PolicySecret.policySession = policySession;
-    esysContext->in.PolicySecret.expiration = expiration;
-    if (nonceTPM == NULL) {
-        esysContext->in.PolicySecret.nonceTPM = NULL;
-    } else {
-        esysContext->in.PolicySecret.nonceTPMData = *nonceTPM;
-        esysContext->in.PolicySecret.nonceTPM =
-            &esysContext->in.PolicySecret.nonceTPMData;
-    }
-    if (cpHashA == NULL) {
-        esysContext->in.PolicySecret.cpHashA = NULL;
-    } else {
-        esysContext->in.PolicySecret.cpHashAData = *cpHashA;
-        esysContext->in.PolicySecret.cpHashA =
-            &esysContext->in.PolicySecret.cpHashAData;
-    }
-    if (policyRef == NULL) {
-        esysContext->in.PolicySecret.policyRef = NULL;
-    } else {
-        esysContext->in.PolicySecret.policyRefData = *policyRef;
-        esysContext->in.PolicySecret.policyRef =
-            &esysContext->in.PolicySecret.policyRefData;
-    }
-}
-
 /** One-Call function for TPM2_PolicySecret
  *
  * This function invokes the TPM2_PolicySecret command in a one-call
@@ -218,11 +182,9 @@ Esys_PolicySecret_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, policySession, nonceTPM,
-                           cpHashA, policyRef, expiration);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -318,7 +280,8 @@ Esys_PolicySecret_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -350,22 +313,13 @@ Esys_PolicySecret_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicySecret_Async(esysContext,
-                                    esysContext->in.PolicySecret.authHandle,
-                                    esysContext->in.PolicySecret.policySession,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.PolicySecret.nonceTPM,
-                                    esysContext->in.PolicySecret.cpHashA,
-                                    esysContext->in.PolicySecret.policyRef,
-                                    esysContext->in.PolicySecret.expiration);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyTemplate.c
+++ b/src/tss2-esys/api/Esys_PolicyTemplate.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_DIGEST *templateHash)
-{
-    esysContext->in.PolicyTemplate.policySession = policySession;
-    if (templateHash == NULL) {
-        esysContext->in.PolicyTemplate.templateHash = NULL;
-    } else {
-        esysContext->in.PolicyTemplate.templateHashData = *templateHash;
-        esysContext->in.PolicyTemplate.templateHash =
-            &esysContext->in.PolicyTemplate.templateHashData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyTemplate
  *
  * This function invokes the TPM2_PolicyTemplate command in a one-call
@@ -174,10 +158,9 @@ Esys_PolicyTemplate_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, templateHash);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -260,7 +243,8 @@ Esys_PolicyTemplate_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -278,18 +262,13 @@ Esys_PolicyTemplate_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyTemplate_Async(esysContext,
-                                      esysContext->in.PolicyTemplate.policySession,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.PolicyTemplate.templateHash);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_PolicyTicket.c
+++ b/src/tss2-esys/api/Esys_PolicyTicket.c
@@ -15,54 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR policySession,
-    const TPM2B_TIMEOUT *timeout,
-    const TPM2B_DIGEST *cpHashA,
-    const TPM2B_NONCE *policyRef,
-    const TPM2B_NAME *authName,
-    const TPMT_TK_AUTH *ticket)
-{
-    esysContext->in.PolicyTicket.policySession = policySession;
-    if (timeout == NULL) {
-        esysContext->in.PolicyTicket.timeout = NULL;
-    } else {
-        esysContext->in.PolicyTicket.timeoutData = *timeout;
-        esysContext->in.PolicyTicket.timeout =
-            &esysContext->in.PolicyTicket.timeoutData;
-    }
-    if (cpHashA == NULL) {
-        esysContext->in.PolicyTicket.cpHashA = NULL;
-    } else {
-        esysContext->in.PolicyTicket.cpHashAData = *cpHashA;
-        esysContext->in.PolicyTicket.cpHashA =
-            &esysContext->in.PolicyTicket.cpHashAData;
-    }
-    if (policyRef == NULL) {
-        esysContext->in.PolicyTicket.policyRef = NULL;
-    } else {
-        esysContext->in.PolicyTicket.policyRefData = *policyRef;
-        esysContext->in.PolicyTicket.policyRef =
-            &esysContext->in.PolicyTicket.policyRefData;
-    }
-    if (authName == NULL) {
-        esysContext->in.PolicyTicket.authName = NULL;
-    } else {
-        esysContext->in.PolicyTicket.authNameData = *authName;
-        esysContext->in.PolicyTicket.authName =
-            &esysContext->in.PolicyTicket.authNameData;
-    }
-    if (ticket == NULL) {
-        esysContext->in.PolicyTicket.ticket = NULL;
-    } else {
-        esysContext->in.PolicyTicket.ticketData = *ticket;
-        esysContext->in.PolicyTicket.ticket =
-            &esysContext->in.PolicyTicket.ticketData;
-    }
-}
-
 /** One-Call function for TPM2_PolicyTicket
  *
  * This function invokes the TPM2_PolicyTicket command in a one-call
@@ -226,11 +178,9 @@ Esys_PolicyTicket_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, policySession, timeout, cpHashA,
-                           policyRef, authName, ticket);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, policySession, &policySessionNode);
@@ -312,7 +262,8 @@ Esys_PolicyTicket_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -330,22 +281,13 @@ Esys_PolicyTicket_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_PolicyTicket_Async(esysContext,
-                                    esysContext->in.PolicyTicket.policySession,
-                                    esysContext->session_type[0],
-                                    esysContext->session_type[1],
-                                    esysContext->session_type[2],
-                                    esysContext->in.PolicyTicket.timeout,
-                                    esysContext->in.PolicyTicket.cpHashA,
-                                    esysContext->in.PolicyTicket.policyRef,
-                                    esysContext->in.PolicyTicket.authName,
-                                    esysContext->in.PolicyTicket.ticket);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Quote.c
+++ b/src/tss2-esys/api/Esys_Quote.c
@@ -15,38 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR signHandle,
-    const TPM2B_DATA *qualifyingData,
-    const TPMT_SIG_SCHEME *inScheme,
-    const TPML_PCR_SELECTION *PCRselect)
-{
-    esysContext->in.Quote.signHandle = signHandle;
-    if (qualifyingData == NULL) {
-        esysContext->in.Quote.qualifyingData = NULL;
-    } else {
-        esysContext->in.Quote.qualifyingDataData = *qualifyingData;
-        esysContext->in.Quote.qualifyingData =
-            &esysContext->in.Quote.qualifyingDataData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.Quote.inScheme = NULL;
-    } else {
-        esysContext->in.Quote.inSchemeData = *inScheme;
-        esysContext->in.Quote.inScheme =
-            &esysContext->in.Quote.inSchemeData;
-    }
-    if (PCRselect == NULL) {
-        esysContext->in.Quote.PCRselect = NULL;
-    } else {
-        esysContext->in.Quote.PCRselectData = *PCRselect;
-        esysContext->in.Quote.PCRselect =
-            &esysContext->in.Quote.PCRselectData;
-    }
-}
-
 /** One-Call function for TPM2_Quote
  *
  * This function invokes the TPM2_Quote command in a one-call
@@ -195,11 +163,9 @@ Esys_Quote_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, signHandle, qualifyingData, inScheme,
-                           PCRselect);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, signHandle, &signHandleNode);
@@ -288,7 +254,8 @@ Esys_Quote_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -320,19 +287,13 @@ Esys_Quote_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Quote_Async(esysContext, esysContext->in.Quote.signHandle,
-                             esysContext->session_type[0],
-                             esysContext->session_type[1],
-                             esysContext->session_type[2],
-                             esysContext->in.Quote.qualifyingData,
-                             esysContext->in.Quote.inScheme,
-                             esysContext->in.Quote.PCRselect);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_RSA_Decrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Decrypt.c
@@ -15,38 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_PUBLIC_KEY_RSA *cipherText,
-    const TPMT_RSA_DECRYPT *inScheme,
-    const TPM2B_DATA *label)
-{
-    esysContext->in.RSA_Decrypt.keyHandle = keyHandle;
-    if (cipherText == NULL) {
-        esysContext->in.RSA_Decrypt.cipherText = NULL;
-    } else {
-        esysContext->in.RSA_Decrypt.cipherTextData = *cipherText;
-        esysContext->in.RSA_Decrypt.cipherText =
-            &esysContext->in.RSA_Decrypt.cipherTextData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.RSA_Decrypt.inScheme = NULL;
-    } else {
-        esysContext->in.RSA_Decrypt.inSchemeData = *inScheme;
-        esysContext->in.RSA_Decrypt.inScheme =
-            &esysContext->in.RSA_Decrypt.inSchemeData;
-    }
-    if (label == NULL) {
-        esysContext->in.RSA_Decrypt.label = NULL;
-    } else {
-        esysContext->in.RSA_Decrypt.labelData = *label;
-        esysContext->in.RSA_Decrypt.label =
-            &esysContext->in.RSA_Decrypt.labelData;
-    }
-}
-
 /** One-Call function for TPM2_RSA_Decrypt
  *
  * This function invokes the TPM2_RSA_Decrypt command in a one-call
@@ -192,10 +160,9 @@ Esys_RSA_Decrypt_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, cipherText, inScheme, label);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -281,7 +248,8 @@ Esys_RSA_Decrypt_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -307,20 +275,13 @@ Esys_RSA_Decrypt_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_RSA_Decrypt_Async(esysContext,
-                                   esysContext->in.RSA_Decrypt.keyHandle,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2],
-                                   esysContext->in.RSA_Decrypt.cipherText,
-                                   esysContext->in.RSA_Decrypt.inScheme,
-                                   esysContext->in.RSA_Decrypt.label);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_RSA_Encrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Encrypt.c
@@ -15,38 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_PUBLIC_KEY_RSA *message,
-    const TPMT_RSA_DECRYPT *inScheme,
-    const TPM2B_DATA *label)
-{
-    esysContext->in.RSA_Encrypt.keyHandle = keyHandle;
-    if (message == NULL) {
-        esysContext->in.RSA_Encrypt.message = NULL;
-    } else {
-        esysContext->in.RSA_Encrypt.messageData = *message;
-        esysContext->in.RSA_Encrypt.message =
-            &esysContext->in.RSA_Encrypt.messageData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.RSA_Encrypt.inScheme = NULL;
-    } else {
-        esysContext->in.RSA_Encrypt.inSchemeData = *inScheme;
-        esysContext->in.RSA_Encrypt.inScheme =
-            &esysContext->in.RSA_Encrypt.inSchemeData;
-    }
-    if (label == NULL) {
-        esysContext->in.RSA_Encrypt.label = NULL;
-    } else {
-        esysContext->in.RSA_Encrypt.labelData = *label;
-        esysContext->in.RSA_Encrypt.label =
-            &esysContext->in.RSA_Encrypt.labelData;
-    }
-}
-
 /** One-Call function for TPM2_RSA_Encrypt
  *
  * This function invokes the TPM2_RSA_Encrypt command in a one-call
@@ -194,10 +162,9 @@ Esys_RSA_Encrypt_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, message, inScheme, label);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -282,7 +249,8 @@ Esys_RSA_Encrypt_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -308,20 +276,13 @@ Esys_RSA_Encrypt_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_RSA_Encrypt_Async(esysContext,
-                                   esysContext->in.RSA_Encrypt.keyHandle,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2],
-                                   esysContext->in.RSA_Encrypt.message,
-                                   esysContext->in.RSA_Encrypt.inScheme,
-                                   esysContext->in.RSA_Encrypt.label);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ReadClock.c
+++ b/src/tss2-esys/api/Esys_ReadClock.c
@@ -15,7 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
 /** One-Call function for TPM2_ReadClock
  *
  * This function invokes the TPM2_ReadClock command in a one-call
@@ -146,7 +145,7 @@ Esys_ReadClock_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
 
@@ -226,7 +225,8 @@ Esys_ReadClock_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -252,15 +252,13 @@ Esys_ReadClock_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ReadClock_Async(esysContext, esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_ReadPublic.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR objectHandle)
-{
-    esysContext->in.ReadPublic.objectHandle = objectHandle;
-}
-
 /** One-Call function for TPM2_ReadPublic
  *
  * This function invokes the TPM2_ReadPublic command in a one-call
@@ -165,10 +157,9 @@ Esys_ReadPublic_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, objectHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, objectHandle, &objectHandleNode);
@@ -260,7 +251,8 @@ Esys_ReadPublic_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -302,17 +294,13 @@ Esys_ReadPublic_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ReadPublic_Async(esysContext,
-                                  esysContext->in.ReadPublic.objectHandle,
-                                  esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Rewrap.c
+++ b/src/tss2-esys/api/Esys_Rewrap.c
@@ -15,40 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR oldParent,
-    ESYS_TR newParent,
-    const TPM2B_PRIVATE *inDuplicate,
-    const TPM2B_NAME *name,
-    const TPM2B_ENCRYPTED_SECRET *inSymSeed)
-{
-    esysContext->in.Rewrap.oldParent = oldParent;
-    esysContext->in.Rewrap.newParent = newParent;
-    if (inDuplicate == NULL) {
-        esysContext->in.Rewrap.inDuplicate = NULL;
-    } else {
-        esysContext->in.Rewrap.inDuplicateData = *inDuplicate;
-        esysContext->in.Rewrap.inDuplicate =
-            &esysContext->in.Rewrap.inDuplicateData;
-    }
-    if (name == NULL) {
-        esysContext->in.Rewrap.name = NULL;
-    } else {
-        esysContext->in.Rewrap.nameData = *name;
-        esysContext->in.Rewrap.name =
-            &esysContext->in.Rewrap.nameData;
-    }
-    if (inSymSeed == NULL) {
-        esysContext->in.Rewrap.inSymSeed = NULL;
-    } else {
-        esysContext->in.Rewrap.inSymSeedData = *inSymSeed;
-        esysContext->in.Rewrap.inSymSeed =
-            &esysContext->in.Rewrap.inSymSeedData;
-    }
-}
-
 /** One-Call function for TPM2_Rewrap
  *
  * This function invokes the TPM2_Rewrap command in a one-call
@@ -205,11 +171,9 @@ Esys_Rewrap_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, oldParent, newParent, inDuplicate, name,
-                           inSymSeed);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, oldParent, &oldParentNode);
@@ -304,7 +268,8 @@ Esys_Rewrap_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -336,20 +301,13 @@ Esys_Rewrap_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Rewrap_Async(esysContext, esysContext->in.Rewrap.oldParent,
-                              esysContext->in.Rewrap.newParent,
-                              esysContext->session_type[0],
-                              esysContext->session_type[1],
-                              esysContext->session_type[2],
-                              esysContext->in.Rewrap.inDuplicate,
-                              esysContext->in.Rewrap.name,
-                              esysContext->in.Rewrap.inSymSeed);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_SelfTest.c
+++ b/src/tss2-esys/api/Esys_SelfTest.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPMI_YES_NO fullTest)
-{
-    esysContext->in.SelfTest.fullTest = fullTest;
-}
-
 /** One-Call function for TPM2_SelfTest
  *
  * This function invokes the TPM2_SelfTest command in a one-call
@@ -155,10 +147,9 @@ Esys_SelfTest_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, fullTest);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_SelfTest_Prepare(esysContext->sys, fullTest);
@@ -233,7 +224,8 @@ Esys_SelfTest_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -251,16 +243,13 @@ Esys_SelfTest_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_SelfTest_Async(esysContext, esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.SelfTest.fullTest);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_SequenceUpdate.c
+++ b/src/tss2-esys/api/Esys_SequenceUpdate.c
@@ -15,22 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR sequenceHandle,
-    const TPM2B_MAX_BUFFER *buffer)
-{
-    esysContext->in.SequenceUpdate.sequenceHandle = sequenceHandle;
-    if (buffer == NULL) {
-        esysContext->in.SequenceUpdate.buffer = NULL;
-    } else {
-        esysContext->in.SequenceUpdate.bufferData = *buffer;
-        esysContext->in.SequenceUpdate.buffer =
-            &esysContext->in.SequenceUpdate.bufferData;
-    }
-}
-
 /** One-Call function for TPM2_SequenceUpdate
  *
  * This function invokes the TPM2_SequenceUpdate command in a one-call
@@ -168,10 +152,9 @@ Esys_SequenceUpdate_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, sequenceHandle, buffer);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, sequenceHandle, &sequenceHandleNode);
@@ -256,7 +239,8 @@ Esys_SequenceUpdate_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -274,18 +258,13 @@ Esys_SequenceUpdate_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_SequenceUpdate_Async(esysContext,
-                                      esysContext->in.SequenceUpdate.sequenceHandle,
-                                      esysContext->session_type[0],
-                                      esysContext->session_type[1],
-                                      esysContext->session_type[2],
-                                      esysContext->in.SequenceUpdate.buffer);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_SetAlgorithmSet.c
+++ b/src/tss2-esys/api/Esys_SetAlgorithmSet.c
@@ -15,16 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    UINT32 algorithmSet)
-{
-    esysContext->in.SetAlgorithmSet.authHandle = authHandle;
-    esysContext->in.SetAlgorithmSet.algorithmSet = algorithmSet;
-}
-
 /** One-Call function for TPM2_SetAlgorithmSet
  *
  * This function invokes the TPM2_SetAlgorithmSet command in a one-call
@@ -170,10 +160,9 @@ Esys_SetAlgorithmSet_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, algorithmSet);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -256,7 +245,8 @@ Esys_SetAlgorithmSet_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -274,18 +264,13 @@ Esys_SetAlgorithmSet_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_SetAlgorithmSet_Async(esysContext,
-                                       esysContext->in.SetAlgorithmSet.authHandle,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.SetAlgorithmSet.algorithmSet);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
@@ -15,32 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR auth,
-    TPMI_ALG_HASH auditAlg,
-    const TPML_CC *setList,
-    const TPML_CC *clearList)
-{
-    esysContext->in.SetCommandCodeAuditStatus.auth = auth;
-    esysContext->in.SetCommandCodeAuditStatus.auditAlg = auditAlg;
-    if (setList == NULL) {
-        esysContext->in.SetCommandCodeAuditStatus.setList = NULL;
-    } else {
-        esysContext->in.SetCommandCodeAuditStatus.setListData = *setList;
-        esysContext->in.SetCommandCodeAuditStatus.setList =
-            &esysContext->in.SetCommandCodeAuditStatus.setListData;
-    }
-    if (clearList == NULL) {
-        esysContext->in.SetCommandCodeAuditStatus.clearList = NULL;
-    } else {
-        esysContext->in.SetCommandCodeAuditStatus.clearListData = *clearList;
-        esysContext->in.SetCommandCodeAuditStatus.clearList =
-            &esysContext->in.SetCommandCodeAuditStatus.clearListData;
-    }
-}
-
 /** One-Call function for TPM2_SetCommandCodeAuditStatus
  *
  * This function invokes the TPM2_SetCommandCodeAuditStatus command in a one-call
@@ -198,10 +172,9 @@ Esys_SetCommandCodeAuditStatus_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, auth, auditAlg, setList, clearList);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, auth, &authNode);
@@ -286,7 +259,8 @@ Esys_SetCommandCodeAuditStatus_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -304,20 +278,13 @@ Esys_SetCommandCodeAuditStatus_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_SetCommandCodeAuditStatus_Async(esysContext,
-                                                 esysContext->in.SetCommandCodeAuditStatus.auth,
-                                                 esysContext->session_type[0],
-                                                 esysContext->session_type[1],
-                                                 esysContext->session_type[2],
-                                                 esysContext->in.SetCommandCodeAuditStatus.auditAlg,
-                                                 esysContext->in.SetCommandCodeAuditStatus.setList,
-                                                 esysContext->in.SetCommandCodeAuditStatus.clearList);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
+++ b/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
@@ -15,24 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR authHandle,
-    const TPM2B_DIGEST *authPolicy,
-    TPMI_ALG_HASH hashAlg)
-{
-    esysContext->in.SetPrimaryPolicy.authHandle = authHandle;
-    esysContext->in.SetPrimaryPolicy.hashAlg = hashAlg;
-    if (authPolicy == NULL) {
-        esysContext->in.SetPrimaryPolicy.authPolicy = NULL;
-    } else {
-        esysContext->in.SetPrimaryPolicy.authPolicyData = *authPolicy;
-        esysContext->in.SetPrimaryPolicy.authPolicy =
-            &esysContext->in.SetPrimaryPolicy.authPolicyData;
-    }
-}
-
 /** One-Call function for TPM2_SetPrimaryPolicy
  *
  * This function invokes the TPM2_SetPrimaryPolicy command in a one-call
@@ -179,10 +161,9 @@ Esys_SetPrimaryPolicy_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, authHandle, authPolicy, hashAlg);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -265,7 +246,8 @@ Esys_SetPrimaryPolicy_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -283,19 +265,13 @@ Esys_SetPrimaryPolicy_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_SetPrimaryPolicy_Async(esysContext,
-                                        esysContext->in.SetPrimaryPolicy.authHandle,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.SetPrimaryPolicy.authPolicy,
-                                        esysContext->in.SetPrimaryPolicy.hashAlg);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Shutdown.c
+++ b/src/tss2-esys/api/Esys_Shutdown.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPM2_SU shutdownType)
-{
-    esysContext->in.Shutdown.shutdownType = shutdownType;
-}
-
 /** One-Call function for TPM2_Shutdown
  *
  * This function invokes the TPM2_Shutdown command in a one-call
@@ -155,10 +147,9 @@ Esys_Shutdown_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, shutdownType);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_Shutdown_Prepare(esysContext->sys, shutdownType);
@@ -233,7 +224,8 @@ Esys_Shutdown_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -251,16 +243,13 @@ Esys_Shutdown_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Shutdown_Async(esysContext, esysContext->session_type[0],
-                                esysContext->session_type[1],
-                                esysContext->session_type[2],
-                                esysContext->in.Shutdown.shutdownType);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Sign.c
+++ b/src/tss2-esys/api/Esys_Sign.c
@@ -15,38 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_DIGEST *digest,
-    const TPMT_SIG_SCHEME *inScheme,
-    const TPMT_TK_HASHCHECK *validation)
-{
-    esysContext->in.Sign.keyHandle = keyHandle;
-    if (digest == NULL) {
-        esysContext->in.Sign.digest = NULL;
-    } else {
-        esysContext->in.Sign.digestData = *digest;
-        esysContext->in.Sign.digest =
-            &esysContext->in.Sign.digestData;
-    }
-    if (inScheme == NULL) {
-        esysContext->in.Sign.inScheme = NULL;
-    } else {
-        esysContext->in.Sign.inSchemeData = *inScheme;
-        esysContext->in.Sign.inScheme =
-            &esysContext->in.Sign.inSchemeData;
-    }
-    if (validation == NULL) {
-        esysContext->in.Sign.validation = NULL;
-    } else {
-        esysContext->in.Sign.validationData = *validation;
-        esysContext->in.Sign.validation =
-            &esysContext->in.Sign.validationData;
-    }
-}
-
 /** One-Call function for TPM2_Sign
  *
  * This function invokes the TPM2_Sign command in a one-call
@@ -198,11 +166,9 @@ Esys_Sign_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, digest, inScheme,
-                           validation);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -288,7 +254,8 @@ Esys_Sign_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -314,19 +281,13 @@ Esys_Sign_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Sign_Async(esysContext, esysContext->in.Sign.keyHandle,
-                            esysContext->session_type[0],
-                            esysContext->session_type[1],
-                            esysContext->session_type[2],
-                            esysContext->in.Sign.digest,
-                            esysContext->in.Sign.inScheme,
-                            esysContext->in.Sign.validation);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -204,7 +204,7 @@ Esys_StartAuthSession_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters(esysContext, tpmKey, bind, nonceCaller, sessionType,
@@ -319,7 +319,8 @@ Esys_StartAuthSession_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -338,18 +339,13 @@ Esys_StartAuthSession_Finish(
 
     IESYS_RESOURCE *rsrc = &sessionHandleNode->rsrc;
     rsrc->handle = ESYS_TR_NONE;
-    rsrc->misc.rsrc_session.sessionAttributes =
-        TPMA_SESSION_CONTINUESESSION;
-    rsrc->misc.rsrc_session.sessionType =
-        esysContext->in.StartAuthSession.sessionType;
-    rsrc->misc.rsrc_session.authHash =
-        esysContext->in.StartAuthSession.authHash;
-    rsrc->misc.rsrc_session.symmetric =
-        *esysContext->in.StartAuthSession.symmetric;
-    rsrc->misc.rsrc_session.nonceCaller =
-        esysContext->in.StartAuthSession.nonceCallerData;
+    rsrc->misc.rsrc_session.sessionAttributes = TPMA_SESSION_CONTINUESESSION;
+    rsrc->misc.rsrc_session.sessionType = esysContext->in.StartAuthSession.sessionType;
+    rsrc->misc.rsrc_session.authHash = esysContext->in.StartAuthSession.authHash;
+    rsrc->misc.rsrc_session.symmetric = *esysContext->in.StartAuthSession.symmetric;
+    rsrc->misc.rsrc_session.nonceCaller = esysContext->in.StartAuthSession.nonceCallerData;
 
-    /*Receive the TPM response and handle resubmissions if necessary. */
+    /* Receive the TPM response and handle resubmissions if necessary. */
     r = Tss2_Sys_ExecuteFinish(esysContext->sys, esysContext->timeout);
     if ((r & ~TSS2_RC_LAYER_MASK) == TSS2_BASE_RC_TRY_AGAIN) {
         LOG_DEBUG("A layer below returned TRY_AGAIN: %" PRIx32, r);
@@ -361,22 +357,13 @@ Esys_StartAuthSession_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_StartAuthSession_Async(esysContext,
-                                        esysContext->in.StartAuthSession.tpmKey,
-                                        esysContext->in.StartAuthSession.bind,
-                                        esysContext->session_type[0],
-                                        esysContext->session_type[1],
-                                        esysContext->session_type[2],
-                                        esysContext->in.StartAuthSession.nonceCaller,
-                                        esysContext->in.StartAuthSession.sessionType,
-                                        esysContext->in.StartAuthSession.symmetric,
-                                        esysContext->in.StartAuthSession.authHash);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Startup.c
+++ b/src/tss2-esys/api/Esys_Startup.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    TPM2_SU startupType)
-{
-    esysContext->in.Startup.startupType = startupType;
-}
-
 /** One-Call function for TPM2_Startup
  *
  * This function invokes the TPM2_Startup command in a one-call
@@ -120,7 +112,6 @@ Esys_Startup_Async(
     if (r != TSS2_RC_SUCCESS)
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
-    store_input_parameters(esysContext, startupType);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_Startup_Prepare(esysContext->sys, startupType);
@@ -176,7 +167,8 @@ Esys_Startup_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -194,14 +186,13 @@ Esys_Startup_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
-        esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Startup_Async(esysContext,
-                               esysContext->in.Startup.startupType);
+        esysContext->state = _ESYS_STATE_SENT;
+	r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_StirRandom.c
+++ b/src/tss2-esys/api/Esys_StirRandom.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_SENSITIVE_DATA *inData)
-{
-    if (inData == NULL) {
-        esysContext->in.StirRandom.inData = NULL;
-    } else {
-        esysContext->in.StirRandom.inDataData = *inData;
-        esysContext->in.StirRandom.inData =
-            &esysContext->in.StirRandom.inDataData;
-    }
-}
-
 /** One-Call function for TPM2_StirRandom
  *
  * This function invokes the TPM2_StirRandom command in a one-call
@@ -155,10 +141,9 @@ Esys_StirRandom_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, inData);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_StirRandom_Prepare(esysContext->sys, inData);
@@ -233,7 +218,8 @@ Esys_StirRandom_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -251,16 +237,13 @@ Esys_StirRandom_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_StirRandom_Async(esysContext, esysContext->session_type[0],
-                                  esysContext->session_type[1],
-                                  esysContext->session_type[2],
-                                  esysContext->in.StirRandom.inData);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_TestParms.c
+++ b/src/tss2-esys/api/Esys_TestParms.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPMT_PUBLIC_PARMS *parameters)
-{
-    if (parameters == NULL) {
-        esysContext->in.TestParms.parameters = NULL;
-    } else {
-        esysContext->in.TestParms.parametersData = *parameters;
-        esysContext->in.TestParms.parameters =
-            &esysContext->in.TestParms.parametersData;
-    }
-}
-
 /** One-Call function for TPM2_TestParms
  *
  * This function invokes the TPM2_TestParms command in a one-call
@@ -161,10 +147,9 @@ Esys_TestParms_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, parameters);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_TestParms_Prepare(esysContext->sys, parameters);
@@ -239,7 +224,8 @@ Esys_TestParms_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -257,16 +243,13 @@ Esys_TestParms_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             return r;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_TestParms_Async(esysContext, esysContext->session_type[0],
-                                 esysContext->session_type[1],
-                                 esysContext->session_type[2],
-                                 esysContext->in.TestParms.parameters);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Unseal.c
+++ b/src/tss2-esys/api/Esys_Unseal.c
@@ -15,14 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR itemHandle)
-{
-    esysContext->in.Unseal.itemHandle = itemHandle;
-}
-
 /** One-Call function for TPM2_Unseal
  *
  * This function invokes the TPM2_Unseal command in a one-call
@@ -159,10 +151,9 @@ Esys_Unseal_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, itemHandle);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, itemHandle, &itemHandleNode);
@@ -247,7 +238,8 @@ Esys_Unseal_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -273,16 +265,13 @@ Esys_Unseal_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Unseal_Async(esysContext, esysContext->in.Unseal.itemHandle,
-                              esysContext->session_type[0],
-                              esysContext->session_type[1],
-                              esysContext->session_type[2]);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
+++ b/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
@@ -15,20 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_DATA *inputData)
-{
-    if (inputData == NULL) {
-        esysContext->in.Vendor_TCG_Test.inputData = NULL;
-    } else {
-        esysContext->in.Vendor_TCG_Test.inputDataData = *inputData;
-        esysContext->in.Vendor_TCG_Test.inputData =
-            &esysContext->in.Vendor_TCG_Test.inputDataData;
-    }
-}
-
 /** One-Call function for TPM2_Vendor_TCG_Test
  *
  * This function invokes the TPM2_Vendor_TCG_Test command in a one-call
@@ -152,10 +138,9 @@ Esys_Vendor_TCG_Test_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, inputData);
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_Vendor_TCG_Test_Prepare(esysContext->sys, inputData);
@@ -233,7 +218,8 @@ Esys_Vendor_TCG_Test_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -259,16 +245,13 @@ Esys_Vendor_TCG_Test_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_Vendor_TCG_Test_Async(esysContext, esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.Vendor_TCG_Test.inputData);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_VerifySignature.c
+++ b/src/tss2-esys/api/Esys_VerifySignature.c
@@ -15,30 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyHandle,
-    const TPM2B_DIGEST *digest,
-    const TPMT_SIGNATURE *signature)
-{
-    esysContext->in.VerifySignature.keyHandle = keyHandle;
-    if (digest == NULL) {
-        esysContext->in.VerifySignature.digest = NULL;
-    } else {
-        esysContext->in.VerifySignature.digestData = *digest;
-        esysContext->in.VerifySignature.digest =
-            &esysContext->in.VerifySignature.digestData;
-    }
-    if (signature == NULL) {
-        esysContext->in.VerifySignature.signature = NULL;
-    } else {
-        esysContext->in.VerifySignature.signatureData = *signature;
-        esysContext->in.VerifySignature.signature =
-            &esysContext->in.VerifySignature.signatureData;
-    }
-}
-
 /** One-Call function for TPM2_VerifySignature
  *
  * This function invokes the TPM2_VerifySignature command in a one-call
@@ -186,10 +162,9 @@ Esys_VerifySignature_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 0);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyHandle, digest, signature);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyHandle, &keyHandleNode);
@@ -274,7 +249,8 @@ Esys_VerifySignature_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -300,19 +276,13 @@ Esys_VerifySignature_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_VerifySignature_Async(esysContext,
-                                       esysContext->in.VerifySignature.keyHandle,
-                                       esysContext->session_type[0],
-                                       esysContext->session_type[1],
-                                       esysContext->session_type[2],
-                                       esysContext->in.VerifySignature.digest,
-                                       esysContext->in.VerifySignature.signature);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/api/Esys_ZGen_2Phase.c
+++ b/src/tss2-esys/api/Esys_ZGen_2Phase.c
@@ -15,34 +15,6 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
-static void store_input_parameters (
-    ESYS_CONTEXT *esysContext,
-    ESYS_TR keyA,
-    const TPM2B_ECC_POINT *inQsB,
-    const TPM2B_ECC_POINT *inQeB,
-    TPMI_ECC_KEY_EXCHANGE inScheme,
-    UINT16 counter)
-{
-    esysContext->in.ZGen_2Phase.keyA = keyA;
-    esysContext->in.ZGen_2Phase.inScheme = inScheme;
-    esysContext->in.ZGen_2Phase.counter = counter;
-    if (inQsB == NULL) {
-        esysContext->in.ZGen_2Phase.inQsB = NULL;
-    } else {
-        esysContext->in.ZGen_2Phase.inQsBData = *inQsB;
-        esysContext->in.ZGen_2Phase.inQsB =
-            &esysContext->in.ZGen_2Phase.inQsBData;
-    }
-    if (inQeB == NULL) {
-        esysContext->in.ZGen_2Phase.inQeB = NULL;
-    } else {
-        esysContext->in.ZGen_2Phase.inQeBData = *inQeB;
-        esysContext->in.ZGen_2Phase.inQeB =
-            &esysContext->in.ZGen_2Phase.inQeBData;
-    }
-}
-
 /** One-Call function for TPM2_ZGen_2Phase
  *
  * This function invokes the TPM2_ZGen_2Phase command in a one-call
@@ -196,10 +168,9 @@ Esys_ZGen_2Phase_Async(
         return r;
     esysContext->state = _ESYS_STATE_INTERNALERROR;
 
-    /* Check and store input parameters */
+    /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
-    store_input_parameters(esysContext, keyA, inQsB, inQeB, inScheme, counter);
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, keyA, &keyANode);
@@ -290,7 +261,8 @@ Esys_ZGen_2Phase_Finish(
     }
 
     /* Check for correct sequence and set sequence to irregular for now */
-    if (esysContext->state != _ESYS_STATE_SENT) {
+    if (esysContext->state != _ESYS_STATE_SENT &&
+        esysContext->state != _ESYS_STATE_RESUBMISSION) {
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
@@ -322,20 +294,13 @@ Esys_ZGen_2Phase_Finish(
     if (r == TPM2_RC_RETRY || r == TPM2_RC_TESTING || r == TPM2_RC_YIELDED) {
         LOG_DEBUG("TPM returned RETRY, TESTING or YIELDED, which triggers a "
             "resubmission: %" PRIx32, r);
-        if (esysContext->submissionCount >= _ESYS_MAX_SUBMISSIONS) {
+        if (esysContext->submissionCount++ >= _ESYS_MAX_SUBMISSIONS) {
             LOG_WARNING("Maximum number of (re)submissions has been reached.");
             esysContext->state = _ESYS_STATE_INIT;
             goto error_cleanup;
         }
         esysContext->state = _ESYS_STATE_RESUBMISSION;
-        r = Esys_ZGen_2Phase_Async(esysContext, esysContext->in.ZGen_2Phase.keyA,
-                                   esysContext->session_type[0],
-                                   esysContext->session_type[1],
-                                   esysContext->session_type[2],
-                                   esysContext->in.ZGen_2Phase.inQsB,
-                                   esysContext->in.ZGen_2Phase.inQeB,
-                                   esysContext->in.ZGen_2Phase.inScheme,
-                                   esysContext->in.ZGen_2Phase.counter);
+        r = Tss2_Sys_ExecuteAsync(esysContext->sys);
         if (r != TSS2_RC_SUCCESS) {
             LOG_WARNING("Error attempting to resubmit");
             /* We do not set esysContext->state here but inherit the most recent

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -26,26 +26,6 @@ typedef struct RSRC_NODE_T {
     struct RSRC_NODE_T * next;  /**< The next object in the linked list. */
 } RSRC_NODE_T;
 
-
-typedef struct {
-    TPM2_SU startupType;
-} Startup_IN;
-
-typedef struct {
-    TPM2_SU shutdownType;
-} Shutdown_IN;
-
-typedef struct {
-    TPMI_YES_NO fullTest;
-} SelfTest_IN;
-
-typedef struct {
-    TPML_ALG *toTest;
-    TPML_ALG toTestData;
-} IncrementalSelfTest_IN;
-
-typedef TPMS_EMPTY  GetTestResult_IN;
-
 typedef struct {
     ESYS_TR tpmKey;
     ESYS_TR bind;
@@ -58,610 +38,9 @@ typedef struct {
 } StartAuthSession_IN;
 
 typedef struct {
-    ESYS_TR sessionHandle;
-} PolicyRestart_IN;
-
-typedef struct {
-    ESYS_TR parentHandle;
     TPM2B_SENSITIVE_CREATE *inSensitive;
     TPM2B_SENSITIVE_CREATE inSensitiveData;
-    TPM2B_PUBLIC *inPublic;
-    TPM2B_PUBLIC inPublicData;
-    TPM2B_DATA *outsideInfo;
-    TPM2B_DATA outsideInfoData;
-    TPML_PCR_SELECTION *creationPCR;
-    TPML_PCR_SELECTION creationPCRData;
-} Create_IN;
-
-typedef struct {
-    ESYS_TR parentHandle;
-    TPM2B_PRIVATE *inPrivate;
-    TPM2B_PRIVATE inPrivateData;
-    TPM2B_PUBLIC *inPublic;
-    TPM2B_PUBLIC inPublicData;
-} Load_IN;
-
-typedef struct {
-    TPMI_RH_HIERARCHY hierarchy;
-    TPM2B_SENSITIVE *inPrivate;
-    TPM2B_SENSITIVE inPrivateData;
-    TPM2B_PUBLIC *inPublic;
-    TPM2B_PUBLIC inPublicData;
-} LoadExternal_IN;
-
-typedef struct {
-    ESYS_TR objectHandle;
-} ReadPublic_IN;
-
-typedef struct {
-    ESYS_TR activateHandle;
-    ESYS_TR keyHandle;
-    TPM2B_ID_OBJECT *credentialBlob;
-    TPM2B_ID_OBJECT credentialBlobData;
-    TPM2B_ENCRYPTED_SECRET *secret;
-    TPM2B_ENCRYPTED_SECRET secretData;
-} ActivateCredential_IN;
-
-typedef struct {
-    ESYS_TR handle;
-    TPM2B_DIGEST *credential;
-    TPM2B_DIGEST credentialData;
-    TPM2B_NAME *objectName;
-    TPM2B_NAME objectNameData;
-} MakeCredential_IN;
-
-typedef struct {
-    ESYS_TR itemHandle;
-} Unseal_IN;
-
-typedef struct {
-    ESYS_TR objectHandle;
-    ESYS_TR parentHandle;
-    TPM2B_AUTH *newAuth;
-    TPM2B_AUTH newAuthData;
-} ObjectChangeAuth_IN;
-
-typedef struct {
-    ESYS_TR parentHandle;
-    TPM2B_SENSITIVE_CREATE *inSensitive;
-    TPM2B_SENSITIVE_CREATE inSensitiveData;
-    TPM2B_TEMPLATE *inPublic;
-    TPM2B_TEMPLATE inPublicData;
-} CreateLoaded_IN;
-
-typedef struct {
-    ESYS_TR objectHandle;
-    ESYS_TR newParentHandle;
-    TPM2B_DATA *encryptionKeyIn;
-    TPM2B_DATA encryptionKeyInData;
-    TPMT_SYM_DEF_OBJECT *symmetricAlg;
-    TPMT_SYM_DEF_OBJECT symmetricAlgData;
-} Duplicate_IN;
-
-typedef struct {
-    ESYS_TR oldParent;
-    ESYS_TR newParent;
-    TPM2B_PRIVATE *inDuplicate;
-    TPM2B_PRIVATE inDuplicateData;
-    TPM2B_NAME *name;
-    TPM2B_NAME nameData;
-    TPM2B_ENCRYPTED_SECRET *inSymSeed;
-    TPM2B_ENCRYPTED_SECRET inSymSeedData;
-} Rewrap_IN;
-
-typedef struct {
-    ESYS_TR parentHandle;
-    TPM2B_DATA *encryptionKey;
-    TPM2B_DATA encryptionKeyData;
-    TPM2B_PUBLIC *objectPublic;
-    TPM2B_PUBLIC objectPublicData;
-    TPM2B_PRIVATE *duplicate;
-    TPM2B_PRIVATE duplicateData;
-    TPM2B_ENCRYPTED_SECRET *inSymSeed;
-    TPM2B_ENCRYPTED_SECRET inSymSeedData;
-    TPMT_SYM_DEF_OBJECT *symmetricAlg;
-    TPMT_SYM_DEF_OBJECT symmetricAlgData;
-} Import_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPM2B_PUBLIC_KEY_RSA *message;
-    TPM2B_PUBLIC_KEY_RSA messageData;
-    TPMT_RSA_DECRYPT *inScheme;
-    TPMT_RSA_DECRYPT inSchemeData;
-    TPM2B_DATA *label;
-    TPM2B_DATA labelData;
-} RSA_Encrypt_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPM2B_PUBLIC_KEY_RSA *cipherText;
-    TPM2B_PUBLIC_KEY_RSA cipherTextData;
-    TPMT_RSA_DECRYPT *inScheme;
-    TPMT_RSA_DECRYPT inSchemeData;
-    TPM2B_DATA *label;
-    TPM2B_DATA labelData;
-} RSA_Decrypt_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-} ECDH_KeyGen_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPM2B_ECC_POINT *inPoint;
-    TPM2B_ECC_POINT inPointData;
-} ECDH_ZGen_IN;
-
-typedef struct {
-    TPMI_ECC_CURVE curveID;
-} ECC_Parameters_IN;
-
-typedef struct {
-    ESYS_TR keyA;
-    TPMI_ECC_KEY_EXCHANGE inScheme;
-    UINT16 counter;
-    TPM2B_ECC_POINT *inQsB;
-    TPM2B_ECC_POINT inQsBData;
-    TPM2B_ECC_POINT *inQeB;
-    TPM2B_ECC_POINT inQeBData;
-} ZGen_2Phase_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPMI_YES_NO decrypt;
-    TPMI_ALG_SYM_MODE mode;
-    TPM2B_IV *ivIn;
-    TPM2B_IV ivInData;
-    TPM2B_MAX_BUFFER *inData;
-    TPM2B_MAX_BUFFER inDataData;
-} EncryptDecrypt_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPMI_YES_NO decrypt;
-    TPMI_ALG_SYM_MODE mode;
-    TPM2B_MAX_BUFFER *inData;
-    TPM2B_MAX_BUFFER inDataData;
-    TPM2B_IV *ivIn;
-    TPM2B_IV ivInData;
-} EncryptDecrypt2_IN;
-
-typedef struct {
-    TPMI_ALG_HASH hashAlg;
-    TPMI_RH_HIERARCHY hierarchy;
-    TPM2B_MAX_BUFFER *data;
-    TPM2B_MAX_BUFFER dataData;
-} Hash_IN;
-
-typedef struct {
-    ESYS_TR handle;
-    TPMI_ALG_HASH hashAlg;
-    TPM2B_MAX_BUFFER *buffer;
-    TPM2B_MAX_BUFFER bufferData;
-} HMAC_IN;
-
-typedef struct {
-    UINT16 bytesRequested;
-} GetRandom_IN;
-
-typedef struct {
-    TPM2B_SENSITIVE_DATA *inData;
-    TPM2B_SENSITIVE_DATA inDataData;
-} StirRandom_IN;
-
-typedef struct {
-    ESYS_TR handle;
-    TPMI_ALG_HASH hashAlg;
-    TPM2B_AUTH *auth;
-    TPM2B_AUTH authData;
-} HMAC_Start_IN;
-
-typedef struct {
-    TPMI_ALG_HASH hashAlg;
-    TPM2B_AUTH *auth;
-    TPM2B_AUTH authData;
-} HashSequenceStart_IN;
-
-typedef struct {
-    ESYS_TR sequenceHandle;
-    TPM2B_MAX_BUFFER *buffer;
-    TPM2B_MAX_BUFFER bufferData;
-} SequenceUpdate_IN;
-
-typedef struct {
-    ESYS_TR sequenceHandle;
-    TPMI_RH_HIERARCHY hierarchy;
-    TPM2B_MAX_BUFFER *buffer;
-    TPM2B_MAX_BUFFER bufferData;
-} SequenceComplete_IN;
-
-typedef struct {
-    ESYS_TR pcrHandle;
-    ESYS_TR sequenceHandle;
-    TPM2B_MAX_BUFFER *buffer;
-    TPM2B_MAX_BUFFER bufferData;
-} EventSequenceComplete_IN;
-
-typedef struct {
-    ESYS_TR objectHandle;
-    ESYS_TR signHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-} Certify_IN;
-
-typedef struct {
-    ESYS_TR signHandle;
-    ESYS_TR objectHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPM2B_DIGEST *creationHash;
-    TPM2B_DIGEST creationHashData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-    TPMT_TK_CREATION *creationTicket;
-    TPMT_TK_CREATION creationTicketData;
-} CertifyCreation_IN;
-
-typedef struct {
-    ESYS_TR signHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-    TPML_PCR_SELECTION *PCRselect;
-    TPML_PCR_SELECTION PCRselectData;
-} Quote_IN;
-
-typedef struct {
-    ESYS_TR privacyAdminHandle;
-    ESYS_TR signHandle;
-    ESYS_TR sessionHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-} GetSessionAuditDigest_IN;
-
-typedef struct {
-    ESYS_TR privacyHandle;
-    ESYS_TR signHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-} GetCommandAuditDigest_IN;
-
-typedef struct {
-    ESYS_TR privacyAdminHandle;
-    ESYS_TR signHandle;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-} GetTime_IN;
-
-typedef struct {
-    ESYS_TR signHandle;
-    TPM2B_ECC_POINT *P1;
-    TPM2B_ECC_POINT P1Data;
-    TPM2B_SENSITIVE_DATA *s2;
-    TPM2B_SENSITIVE_DATA s2Data;
-    TPM2B_ECC_PARAMETER *y2;
-    TPM2B_ECC_PARAMETER y2Data;
-} Commit_IN;
-
-typedef struct {
-    TPMI_ECC_CURVE curveID;
-} EC_Ephemeral_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPM2B_DIGEST *digest;
-    TPM2B_DIGEST digestData;
-    TPMT_SIGNATURE *signature;
-    TPMT_SIGNATURE signatureData;
-} VerifySignature_IN;
-
-typedef struct {
-    ESYS_TR keyHandle;
-    TPM2B_DIGEST *digest;
-    TPM2B_DIGEST digestData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-    TPMT_TK_HASHCHECK *validation;
-    TPMT_TK_HASHCHECK validationData;
-} Sign_IN;
-
-typedef struct {
-    ESYS_TR auth;
-    TPMI_ALG_HASH auditAlg;
-    TPML_CC *setList;
-    TPML_CC setListData;
-    TPML_CC *clearList;
-    TPML_CC clearListData;
-} SetCommandCodeAuditStatus_IN;
-
-typedef struct {
-    ESYS_TR pcrHandle;
-    TPML_DIGEST_VALUES *digests;
-    TPML_DIGEST_VALUES digestsData;
-} PCR_Extend_IN;
-
-typedef struct {
-    ESYS_TR pcrHandle;
-    TPM2B_EVENT *eventData;
-    TPM2B_EVENT eventDataData;
-} PCR_Event_IN;
-
-typedef struct {
-    TPML_PCR_SELECTION *pcrSelectionIn;
-    TPML_PCR_SELECTION pcrSelectionInData;
-} PCR_Read_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    TPML_PCR_SELECTION *pcrAllocation;
-    TPML_PCR_SELECTION pcrAllocationData;
-} PCR_Allocate_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    TPMI_ALG_HASH hashAlg;
-    TPMI_DH_PCR pcrNum;
-    TPM2B_DIGEST *authPolicy;
-    TPM2B_DIGEST authPolicyData;
-} PCR_SetAuthPolicy_IN;
-
-typedef struct {
-    ESYS_TR pcrHandle;
-    TPM2B_DIGEST *auth;
-    TPM2B_DIGEST authData;
-} PCR_SetAuthValue_IN;
-
-typedef struct {
-    ESYS_TR pcrHandle;
-} PCR_Reset_IN;
-
-typedef struct {
-    ESYS_TR authObject;
-    ESYS_TR policySession;
-    INT32 expiration;
-    TPM2B_NONCE *nonceTPM;
-    TPM2B_NONCE nonceTPMData;
-    TPM2B_DIGEST *cpHashA;
-    TPM2B_DIGEST cpHashAData;
-    TPM2B_NONCE *policyRef;
-    TPM2B_NONCE policyRefData;
-    TPMT_SIGNATURE *auth;
-    TPMT_SIGNATURE authData;
-} PolicySigned_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR policySession;
-    INT32 expiration;
-    TPM2B_NONCE *nonceTPM;
-    TPM2B_NONCE nonceTPMData;
-    TPM2B_DIGEST *cpHashA;
-    TPM2B_DIGEST cpHashAData;
-    TPM2B_NONCE *policyRef;
-    TPM2B_NONCE policyRefData;
-} PolicySecret_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_TIMEOUT *timeout;
-    TPM2B_TIMEOUT timeoutData;
-    TPM2B_DIGEST *cpHashA;
-    TPM2B_DIGEST cpHashAData;
-    TPM2B_NONCE *policyRef;
-    TPM2B_NONCE policyRefData;
-    TPM2B_NAME *authName;
-    TPM2B_NAME authNameData;
-    TPMT_TK_AUTH *ticket;
-    TPMT_TK_AUTH ticketData;
-} PolicyTicket_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPML_DIGEST *pHashList;
-    TPML_DIGEST pHashListData;
-} PolicyOR_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_DIGEST *pcrDigest;
-    TPM2B_DIGEST pcrDigestData;
-    TPML_PCR_SELECTION *pcrs;
-    TPML_PCR_SELECTION pcrsData;
-} PolicyPCR_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPMA_LOCALITY locality;
-} PolicyLocality_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    ESYS_TR policySession;
-    UINT16 offset;
-    TPM2_EO operation;
-    TPM2B_OPERAND *operandB;
-    TPM2B_OPERAND operandBData;
-} PolicyNV_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    UINT16 offset;
-    TPM2_EO operation;
-    TPM2B_OPERAND *operandB;
-    TPM2B_OPERAND operandBData;
-} PolicyCounterTimer_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2_CC code;
-} PolicyCommandCode_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-} PolicyPhysicalPresence_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_DIGEST *cpHashA;
-    TPM2B_DIGEST cpHashAData;
-} PolicyCpHash_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_DIGEST *nameHash;
-    TPM2B_DIGEST nameHashData;
-} PolicyNameHash_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPMI_YES_NO includeObject;
-    TPM2B_NAME *objectName;
-    TPM2B_NAME objectNameData;
-    TPM2B_NAME *newParentName;
-    TPM2B_NAME newParentNameData;
-} PolicyDuplicationSelect_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_DIGEST *approvedPolicy;
-    TPM2B_DIGEST approvedPolicyData;
-    TPM2B_NONCE *policyRef;
-    TPM2B_NONCE policyRefData;
-    TPM2B_NAME *keySign;
-    TPM2B_NAME keySignData;
-    TPMT_TK_VERIFIED *checkTicket;
-    TPMT_TK_VERIFIED checkTicketData;
-} PolicyAuthorize_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-} PolicyAuthValue_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-} PolicyPassword_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-} PolicyGetDigest_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPMI_YES_NO writtenSet;
-} PolicyNvWritten_IN;
-
-typedef struct {
-    ESYS_TR policySession;
-    TPM2B_DIGEST *templateHash;
-    TPM2B_DIGEST templateHashData;
-} PolicyTemplate_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    ESYS_TR policySession;
-} PolicyAuthorizeNV_IN;
-
-typedef struct {
-    ESYS_TR primaryHandle;
-    TPM2B_SENSITIVE_CREATE *inSensitive;
-    TPM2B_SENSITIVE_CREATE inSensitiveData;
-    TPM2B_PUBLIC *inPublic;
-    TPM2B_PUBLIC inPublicData;
-    TPM2B_DATA *outsideInfo;
-    TPM2B_DATA outsideInfoData;
-    TPML_PCR_SELECTION *creationPCR;
-    TPML_PCR_SELECTION creationPCRData;
 } CreatePrimary_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    TPMI_RH_ENABLES enable;
-    TPMI_YES_NO state;
-} HierarchyControl_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    TPMI_ALG_HASH hashAlg;
-    TPM2B_DIGEST *authPolicy;
-    TPM2B_DIGEST authPolicyData;
-} SetPrimaryPolicy_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-} ChangePPS_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-} ChangeEPS_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-} Clear_IN;
-
-typedef struct {
-    ESYS_TR auth;
-    TPMI_YES_NO disable;
-} ClearControl_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    TPM2B_AUTH *newAuth;
-    TPM2B_AUTH newAuthData;
-} HierarchyChangeAuth_IN;
-
-typedef struct {
-    ESYS_TR lockHandle;
-} DictionaryAttackLockReset_IN;
-
-typedef struct {
-    ESYS_TR lockHandle;
-    UINT32 newMaxTries;
-    UINT32 newRecoveryTime;
-    UINT32 lockoutRecovery;
-} DictionaryAttackParameters_IN;
-
-typedef struct {
-    ESYS_TR auth;
-    TPML_CC *setList;
-    TPML_CC setListData;
-    TPML_CC *clearList;
-    TPML_CC clearListData;
-} PP_Commands_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    UINT32 algorithmSet;
-} SetAlgorithmSet_IN;
-
-typedef struct {
-    ESYS_TR authorization;
-    ESYS_TR keyHandle;
-    TPM2B_DIGEST *fuDigest;
-    TPM2B_DIGEST fuDigestData;
-    TPMT_SIGNATURE *manifestSignature;
-    TPMT_SIGNATURE manifestSignatureData;
-} FieldUpgradeStart_IN;
-
-typedef struct {
-    TPM2B_MAX_BUFFER *fuData;
-    TPM2B_MAX_BUFFER fuDataData;
-} FieldUpgradeData_IN;
-
-typedef struct {
-    UINT32 sequenceNumber;
-} FirmwareRead_IN;
 
 typedef struct {
     ESYS_TR saveHandle;
@@ -673,250 +52,78 @@ typedef struct {
 } ContextLoad_IN;
 
 typedef struct {
-    ESYS_TR flushHandle;
-} FlushContext_IN;
+    TPM2B_PUBLIC *inPublic;
+    TPM2B_PUBLIC inPublicData;
+} Load_IN;
 
 typedef struct {
-    ESYS_TR auth;
+    TPM2B_PUBLIC *inPublic;
+    TPM2B_PUBLIC inPublicData;
+} LoadExternal_IN;
+
+typedef struct {
+    TPM2B_SENSITIVE_CREATE *inSensitive;
+    TPM2B_SENSITIVE_CREATE inSensitiveData;
+    TPM2B_TEMPLATE *inPublic;
+    TPM2B_TEMPLATE inPublicData;
+} CreateLoaded_IN;
+
+typedef struct {
     ESYS_TR objectHandle;
     TPMI_DH_PERSISTENT persistentHandle;
 } EvictControl_IN;
 
-typedef TPMS_EMPTY  ReadClock_IN;
-
 typedef struct {
-    ESYS_TR auth;
-    UINT64 newTime;
-} ClockSet_IN;
-
-typedef struct {
-    ESYS_TR auth;
-    TPM2_CLOCK_ADJUST rateAdjust;
-} ClockRateAdjust_IN;
-
-typedef struct {
-    TPM2_CAP capability;
-    UINT32 property;
-    UINT32 propertyCount;
-} GetCapability_IN;
-
-typedef struct {
-    TPMT_PUBLIC_PARMS *parameters;
-    TPMT_PUBLIC_PARMS parametersData;
-} TestParms_IN;
+    TPM2B_AUTH *auth;
+    TPM2B_AUTH authData;
+} HMAC_Start_IN;
 
 typedef struct {
     ESYS_TR authHandle;
+    TPM2B_AUTH *newAuth;
+    TPM2B_AUTH newAuthData;
+} HierarchyChangeAuth_IN;
+
+typedef struct {
+    ESYS_TR sequenceHandle;
+} SequenceComplete_IN;
+
+typedef struct {
+    ESYS_TR policySession;
+} Policy_IN;
+
+typedef struct {
+    ESYS_TR nvIndex;
     TPM2B_AUTH *auth;
     TPM2B_AUTH authData;
     TPM2B_NV_PUBLIC *publicInfo;
     TPM2B_NV_PUBLIC publicInfoData;
-} NV_DefineSpace_IN;
+} NV_IN;
 
 typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-} NV_UndefineSpace_IN;
+    ESYS_TR flushHandle;
+} FlushContext_IN;
 
-typedef struct {
-    ESYS_TR nvIndex;
-    ESYS_TR platform;
-} NV_UndefineSpaceSpecial_IN;
-
-typedef struct {
-    ESYS_TR nvIndex;
-} NV_ReadPublic_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    UINT16 offset;
-    TPM2B_MAX_NV_BUFFER *data;
-    TPM2B_MAX_NV_BUFFER dataData;
-} NV_Write_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-} NV_Increment_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    TPM2B_MAX_NV_BUFFER *data;
-    TPM2B_MAX_NV_BUFFER dataData;
-} NV_Extend_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    UINT64 bits;
-} NV_SetBits_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-} NV_WriteLock_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-} NV_GlobalWriteLock_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    UINT16 size;
-    UINT16 offset;
-} NV_Read_IN;
-
-typedef struct {
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-} NV_ReadLock_IN;
-
-typedef struct {
-    ESYS_TR nvIndex;
-    TPM2B_AUTH *newAuth;
-    TPM2B_AUTH newAuthData;
-} NV_ChangeAuth_IN;
-
-typedef struct {
-    ESYS_TR signHandle;
-    ESYS_TR authHandle;
-    ESYS_TR nvIndex;
-    UINT16 size;
-    UINT16 offset;
-    TPM2B_DATA *qualifyingData;
-    TPM2B_DATA qualifyingDataData;
-    TPMT_SIG_SCHEME *inScheme;
-    TPMT_SIG_SCHEME inSchemeData;
-} NV_Certify_IN;
-
-typedef struct {
-    TPM2B_DATA *inputData;
-    TPM2B_DATA inputDataData;
-} Vendor_TCG_Test_IN;
-
-/** Union for all input parameters.
+/** Union for input parameters.
  *
- * The input parameters of a command need to be stored in order to enable
- * resubmission. This type provides the corresponding facilities.
+ * The input parameters of a command need to be stored if they are needed
+ * in corresponding _Finish() function.
  */
 typedef union {
-
-    Startup_IN Startup;
-    Shutdown_IN Shutdown;
-    SelfTest_IN SelfTest;
-    IncrementalSelfTest_IN IncrementalSelfTest;
-    GetTestResult_IN GetTestResult;
     StartAuthSession_IN StartAuthSession;
-    PolicyRestart_IN PolicyRestart;
-    Create_IN Create;
-    Load_IN Load;
-    LoadExternal_IN LoadExternal;
-    ReadPublic_IN ReadPublic;
-    ActivateCredential_IN ActivateCredential;
-    MakeCredential_IN MakeCredential;
-    Unseal_IN Unseal;
-    ObjectChangeAuth_IN ObjectChangeAuth;
-    CreateLoaded_IN CreateLoaded;
-    Duplicate_IN Duplicate;
-    Rewrap_IN Rewrap;
-    Import_IN Import;
-    RSA_Encrypt_IN RSA_Encrypt;
-    RSA_Decrypt_IN RSA_Decrypt;
-    ECDH_KeyGen_IN ECDH_KeyGen;
-    ECDH_ZGen_IN ECDH_ZGen;
-    ECC_Parameters_IN ECC_Parameters;
-    ZGen_2Phase_IN ZGen_2Phase;
-    EncryptDecrypt_IN EncryptDecrypt;
-    EncryptDecrypt2_IN EncryptDecrypt2;
-    Hash_IN Hash;
-    HMAC_IN HMAC;
-    GetRandom_IN GetRandom;
-    StirRandom_IN StirRandom;
-    HMAC_Start_IN HMAC_Start;
-    HashSequenceStart_IN HashSequenceStart;
-    SequenceUpdate_IN SequenceUpdate;
-    SequenceComplete_IN SequenceComplete;
-    EventSequenceComplete_IN EventSequenceComplete;
-    Certify_IN Certify;
-    CertifyCreation_IN CertifyCreation;
-    Quote_IN Quote;
-    GetSessionAuditDigest_IN GetSessionAuditDigest;
-    GetCommandAuditDigest_IN GetCommandAuditDigest;
-    GetTime_IN GetTime;
-    Commit_IN Commit;
-    EC_Ephemeral_IN EC_Ephemeral;
-    VerifySignature_IN VerifySignature;
-    Sign_IN Sign;
-    SetCommandCodeAuditStatus_IN SetCommandCodeAuditStatus;
-    PCR_Extend_IN PCR_Extend;
-    PCR_Event_IN PCR_Event;
-    PCR_Read_IN PCR_Read;
-    PCR_Allocate_IN PCR_Allocate;
-    PCR_SetAuthPolicy_IN PCR_SetAuthPolicy;
-    PCR_SetAuthValue_IN PCR_SetAuthValue;
-    PCR_Reset_IN PCR_Reset;
-    PolicySigned_IN PolicySigned;
-    PolicySecret_IN PolicySecret;
-    PolicyTicket_IN PolicyTicket;
-    PolicyOR_IN PolicyOR;
-    PolicyPCR_IN PolicyPCR;
-    PolicyLocality_IN PolicyLocality;
-    PolicyNV_IN PolicyNV;
-    PolicyCounterTimer_IN PolicyCounterTimer;
-    PolicyCommandCode_IN PolicyCommandCode;
-    PolicyPhysicalPresence_IN PolicyPhysicalPresence;
-    PolicyCpHash_IN PolicyCpHash;
-    PolicyNameHash_IN PolicyNameHash;
-    PolicyDuplicationSelect_IN PolicyDuplicationSelect;
-    PolicyAuthorize_IN PolicyAuthorize;
-    PolicyAuthValue_IN PolicyAuthValue;
-    PolicyPassword_IN PolicyPassword;
-    PolicyGetDigest_IN PolicyGetDigest;
-    PolicyNvWritten_IN PolicyNvWritten;
-    PolicyTemplate_IN PolicyTemplate;
-    PolicyAuthorizeNV_IN PolicyAuthorizeNV;
     CreatePrimary_IN CreatePrimary;
-    HierarchyControl_IN HierarchyControl;
-    SetPrimaryPolicy_IN SetPrimaryPolicy;
-    ChangePPS_IN ChangePPS;
-    ChangeEPS_IN ChangeEPS;
-    Clear_IN Clear;
-    ClearControl_IN ClearControl;
-    HierarchyChangeAuth_IN HierarchyChangeAuth;
-    DictionaryAttackLockReset_IN DictionaryAttackLockReset;
-    DictionaryAttackParameters_IN DictionaryAttackParameters;
-    PP_Commands_IN PP_Commands;
-    SetAlgorithmSet_IN SetAlgorithmSet;
-    FieldUpgradeStart_IN FieldUpgradeStart;
-    FieldUpgradeData_IN FieldUpgradeData;
-    FirmwareRead_IN FirmwareRead;
     ContextSave_IN ContextSave;
     ContextLoad_IN ContextLoad;
-    FlushContext_IN FlushContext;
+    Load_IN Load;
+    LoadExternal_IN LoadExternal;
+    CreateLoaded_IN CreateLoaded;
     EvictControl_IN EvictControl;
-    ReadClock_IN ReadClock;
-    ClockSet_IN ClockSet;
-    ClockRateAdjust_IN ClockRateAdjust;
-    GetCapability_IN GetCapability;
-    TestParms_IN TestParms;
-    NV_DefineSpace_IN NV_DefineSpace;
-    NV_UndefineSpace_IN NV_UndefineSpace;
-    NV_UndefineSpaceSpecial_IN NV_UndefineSpaceSpecial;
-    NV_ReadPublic_IN NV_ReadPublic;
-    NV_Write_IN NV_Write;
-    NV_Increment_IN NV_Increment;
-    NV_Extend_IN NV_Extend;
-    NV_SetBits_IN NV_SetBits;
-    NV_WriteLock_IN NV_WriteLock;
-    NV_GlobalWriteLock_IN NV_GlobalWriteLock;
-    NV_Read_IN NV_Read;
-    NV_ReadLock_IN NV_ReadLock;
-    NV_ChangeAuth_IN NV_ChangeAuth;
-    NV_Certify_IN NV_Certify;
-    Vendor_TCG_Test_IN Vendor_TCG_Test;
+    HMAC_Start_IN HMAC_Start;
+    HierarchyChangeAuth_IN HierarchyChangeAuth;
+    SequenceComplete_IN SequenceComplete;
+    Policy_IN Policy;
+    NV_IN NV;
+    FlushContext_IN FlushContext;
 } IESYS_CMD_IN_PARAM;
 
 /** The states for the ESAPI's internal state machine */
@@ -958,11 +165,8 @@ struct ESYS_CONTEXT {
     int submissionCount;         /**< The current number of submissions of this
                                       command to the TPM. */
     TPM2B_DATA salt;             /**< The salt used during a StartAuthSession.*/
-    IESYS_CMD_IN_PARAM in;       /**< Temporary storage for Input parameters.
-                                      A union over all possible input parameters
-                                      for all Esys_*_async calls.
-                                      (Note that this field's type is not
-                                      included in the documentation.) */
+    IESYS_CMD_IN_PARAM in;       /**< Temporary storage for Input parameters
+                                      needed in corresponding _Finish function*/
     ESYS_TR esys_handle;         /**< Temporary storage for the object's TPM
                                       handle during Esys_TR_FromTPMPublic. */
     TSS2_TCTI_CONTEXT *tcti_app_param;/**< The TCTI context provided by the

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1125,15 +1125,7 @@ iesys_check_sequence_async(ESYS_CONTEXT * esys_context)
         LOG_ERROR("Esys called in bad sequence.");
         return TSS2_ESYS_RC_BAD_SEQUENCE;
     }
-    /* TODO: Check if RESUBMISSION BELONGS HERE OR RATHER INTO THE FINISH METHOD. */
-    if (esys_context->state == _ESYS_STATE_RESUBMISSION) {
-        iesys_restore_session_flags(esys_context);
-        esys_context->submissionCount++;
-        LOG_DEBUG("The command will be resubmitted for the %i time.",
-                  esys_context->submissionCount);
-    } else {
-        esys_context->submissionCount = 1;
-    }
+    esys_context->submissionCount = 1;
     return TSS2_RC_SUCCESS;
 }
 

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -137,13 +137,11 @@ Esys_TR_FromTPMPublic_Async(ESYS_CONTEXT * esys_context,
     esys_context->esys_handle = esys_handle;
 
     if (tpm_handle >= TPM2_NV_INDEX_FIRST && tpm_handle <= TPM2_NV_INDEX_LAST) {
-        esys_context->in.NV_ReadPublic.nvIndex = esys_handle;
         r = Esys_NV_ReadPublic_Async(esys_context, esys_handle, shandle1,
                                      shandle2, shandle3);
         goto_if_error(r, "Error NV_ReadPublic", error_cleanup);
 
     } else {
-        esys_context->in.ReadPublic.objectHandle = esys_handle;
         r = Esys_ReadPublic_Async(esys_context, esys_handle, shandle1, shandle2,
                                   shandle3);
         goto_if_error(r, "Error ReadPublic", error_cleanup);

--- a/test/unit/esys-sequence-finish.c
+++ b/test/unit/esys-sequence-finish.c
@@ -98,7 +98,6 @@ check_Startup(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -115,7 +114,6 @@ check_Shutdown(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -132,7 +130,6 @@ check_SelfTest(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -149,7 +146,6 @@ check_IncrementalSelfTest(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPML_ALG *toDoList;
@@ -167,7 +163,6 @@ check_GetTestResult(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_MAX_BUFFER *outData;
@@ -186,7 +181,6 @@ check_StartAuthSession(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR sessionHandle_handle;
@@ -205,7 +199,6 @@ check_PolicyRestart(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -222,7 +215,6 @@ check_Create(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PRIVATE *outPrivate;
@@ -247,7 +239,6 @@ check_Load(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR objectHandle_handle;
@@ -265,7 +256,6 @@ check_LoadExternal(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR objectHandle_handle;
@@ -283,7 +273,6 @@ check_ReadPublic(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PUBLIC *outPublic;
@@ -304,7 +293,6 @@ check_ActivateCredential(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *certInfo;
@@ -322,7 +310,6 @@ check_MakeCredential(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ID_OBJECT *credentialBlob;
@@ -341,7 +328,6 @@ check_Unseal(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_SENSITIVE_DATA *outData;
@@ -359,7 +345,6 @@ check_ObjectChangeAuth(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PRIVATE *outPrivate;
@@ -377,7 +362,6 @@ check_CreateLoaded(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR objectHandle_handle;
@@ -399,7 +383,6 @@ check_Duplicate(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DATA *encryptionKeyOut;
@@ -420,7 +403,6 @@ check_Rewrap(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PRIVATE *outDuplicate;
@@ -439,7 +421,6 @@ check_Import(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PRIVATE *outPrivate;
@@ -457,7 +438,6 @@ check_RSA_Encrypt(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PUBLIC_KEY_RSA *outData;
@@ -475,7 +455,6 @@ check_RSA_Decrypt(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_PUBLIC_KEY_RSA *message;
@@ -493,7 +472,6 @@ check_ECDH_KeyGen(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ECC_POINT *zPoint;
@@ -512,7 +490,6 @@ check_ECDH_ZGen(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ECC_POINT *outPoint;
@@ -530,7 +507,6 @@ check_ECC_Parameters(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMS_ALGORITHM_DETAIL_ECC *parameters;
@@ -548,7 +524,6 @@ check_ZGen_2Phase(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ECC_POINT *outZ1;
@@ -567,7 +542,6 @@ check_EncryptDecrypt(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_MAX_BUFFER *outData;
@@ -586,7 +560,6 @@ check_EncryptDecrypt2(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_MAX_BUFFER *outData;
@@ -605,7 +578,6 @@ check_Hash(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *outHash;
@@ -624,7 +596,6 @@ check_HMAC(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *outHMAC;
@@ -642,7 +613,6 @@ check_GetRandom(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *randomBytes;
@@ -660,7 +630,6 @@ check_StirRandom(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -677,7 +646,6 @@ check_HMAC_Start(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR sequenceHandle_handle;
@@ -695,7 +663,6 @@ check_HashSequenceStart(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR sequenceHandle_handle;
@@ -713,7 +680,6 @@ check_SequenceUpdate(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -730,7 +696,6 @@ check_SequenceComplete(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *result;
@@ -749,7 +714,6 @@ check_EventSequenceComplete(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPML_DIGEST_VALUES *results;
@@ -767,7 +731,6 @@ check_Certify(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *certifyInfo;
@@ -786,7 +749,6 @@ check_CertifyCreation(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *certifyInfo;
@@ -805,7 +767,6 @@ check_Quote(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *quoted;
@@ -824,7 +785,6 @@ check_GetSessionAuditDigest(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *auditInfo;
@@ -844,7 +804,6 @@ check_GetCommandAuditDigest(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *auditInfo;
@@ -864,7 +823,6 @@ check_GetTime(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *timeInfo;
@@ -883,7 +841,6 @@ check_Commit(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ECC_POINT *K;
@@ -904,7 +861,6 @@ check_EC_Ephemeral(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ECC_POINT *Q;
@@ -923,7 +879,6 @@ check_VerifySignature(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMT_TK_VERIFIED *validation;
@@ -941,7 +896,6 @@ check_Sign(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMT_SIGNATURE *signature;
@@ -959,7 +913,6 @@ check_SetCommandCodeAuditStatus(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -976,7 +929,6 @@ check_PCR_Extend(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -993,7 +945,6 @@ check_PCR_Event(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPML_DIGEST_VALUES *digests;
@@ -1011,7 +962,6 @@ check_PCR_Read(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPML_PCR_SELECTION *pcrSelectionOut;
@@ -1033,7 +983,6 @@ check_PCR_Allocate(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMI_YES_NO allocationSuccess;
@@ -1056,7 +1005,6 @@ check_PCR_SetAuthPolicy(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1073,7 +1021,6 @@ check_PCR_SetAuthValue(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1090,7 +1037,6 @@ check_PCR_Reset(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1107,7 +1053,6 @@ check_PolicySigned(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_TIMEOUT *timeout;
@@ -1126,7 +1071,6 @@ check_PolicySecret(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_TIMEOUT *timeout;
@@ -1145,7 +1089,6 @@ check_PolicyTicket(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1162,7 +1105,6 @@ check_PolicyOR(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1179,7 +1121,6 @@ check_PolicyPCR(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1196,7 +1137,6 @@ check_PolicyLocality(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1213,7 +1153,6 @@ check_PolicyNV(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1230,7 +1169,6 @@ check_PolicyCounterTimer(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1247,7 +1185,6 @@ check_PolicyCommandCode(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1264,7 +1201,6 @@ check_PolicyPhysicalPresence(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1281,7 +1217,6 @@ check_PolicyCpHash(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1298,7 +1233,6 @@ check_PolicyNameHash(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1315,7 +1249,6 @@ check_PolicyDuplicationSelect(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1332,7 +1265,6 @@ check_PolicyAuthorize(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1349,7 +1281,6 @@ check_PolicyAuthValue(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1366,7 +1297,6 @@ check_PolicyPassword(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1383,7 +1313,6 @@ check_PolicyGetDigest(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DIGEST *policyDigest;
@@ -1401,7 +1330,6 @@ check_PolicyNvWritten(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1418,7 +1346,6 @@ check_PolicyTemplate(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1435,7 +1362,6 @@ check_PolicyAuthorizeNV(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1452,7 +1378,6 @@ check_CreatePrimary(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR objectHandle_handle;
@@ -1478,7 +1403,6 @@ check_HierarchyControl(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1495,7 +1419,6 @@ check_SetPrimaryPolicy(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1512,7 +1435,6 @@ check_ChangePPS(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1529,7 +1451,6 @@ check_ChangeEPS(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1546,7 +1467,6 @@ check_Clear(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1563,7 +1483,6 @@ check_ClearControl(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1580,7 +1499,6 @@ check_HierarchyChangeAuth(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1597,7 +1515,6 @@ check_DictionaryAttackLockReset(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1614,7 +1531,6 @@ check_DictionaryAttackParameters(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1631,7 +1547,6 @@ check_PP_Commands(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1648,7 +1563,6 @@ check_SetAlgorithmSet(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1665,7 +1579,6 @@ check_FieldUpgradeStart(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1682,7 +1595,6 @@ check_FieldUpgradeData(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMT_HA *nextDigest;
@@ -1702,7 +1614,6 @@ check_FirmwareRead(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_MAX_BUFFER *fuData;
@@ -1720,7 +1631,6 @@ check_ContextSave(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMS_CONTEXT *context;
@@ -1738,7 +1648,6 @@ check_ContextLoad(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR loadedHandle_handle;
@@ -1756,7 +1665,6 @@ check_FlushContext(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1773,7 +1681,6 @@ check_EvictControl(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR newObjectHandle_handle;
@@ -1791,7 +1698,6 @@ check_ReadClock(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMS_TIME_INFO *currentTime;
@@ -1809,7 +1715,6 @@ check_ClockSet(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1826,7 +1731,6 @@ check_ClockRateAdjust(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1843,7 +1747,6 @@ check_GetCapability(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPMS_CAPABILITY_DATA *capabilityData;
@@ -1862,7 +1765,6 @@ check_TestParms(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1879,7 +1781,6 @@ check_NV_DefineSpace(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     ESYS_TR nvHandle_handle;
@@ -1897,7 +1798,6 @@ check_NV_UndefineSpace(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1914,7 +1814,6 @@ check_NV_UndefineSpaceSpecial(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1931,7 +1830,6 @@ check_NV_ReadPublic(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_NV_PUBLIC *nvPublic;
@@ -1950,7 +1848,6 @@ check_NV_Write(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1967,7 +1864,6 @@ check_NV_Increment(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -1984,7 +1880,6 @@ check_NV_Extend(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2001,7 +1896,6 @@ check_NV_SetBits(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2018,7 +1912,6 @@ check_NV_WriteLock(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2035,7 +1928,6 @@ check_NV_GlobalWriteLock(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2052,7 +1944,6 @@ check_NV_Read(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_MAX_NV_BUFFER *data;
@@ -2070,7 +1961,6 @@ check_NV_ReadLock(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2087,7 +1977,6 @@ check_NV_ChangeAuth(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     for (size_t i = 0; i < sizeof(esys_states) / sizeof(esys_states[0]); i++) {
@@ -2104,7 +1993,6 @@ check_NV_Certify(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_ATTEST *certifyInfo;
@@ -2123,7 +2011,6 @@ check_Vendor_TCG_Test(void **state)
     ESYS_CONTEXT *esys_context = (ESYS_CONTEXT *) * state;
     enum _ESYS_STATE esys_states[3] = {
         _ESYS_STATE_INIT,
-        _ESYS_STATE_RESUBMISSION,
         _ESYS_STATE_INTERNALERROR
     };
     TPM2B_DATA *outputData;


### PR DESCRIPTION
Recent System API spec (v1.1 rev 24) simplifies command
re-submission in case of TPM RC_RETRY, RC_TESTING or RC_YIELDED
by storing the command header and parameters at the SAPI layer
and allowing the ESAPI invoke TSS_Sys_ExecuteAsync multiple times.
Change the re-submission logic in ESAPI to leverage this new feature.
By doing that, many of the <TYPE>_IN data structures are no longer
needed and can be removed.
Only the input parameters that are used in _Finish() functions
for purposes other than re-submission need to be stored.