### PR TITLE
build: use PKG_INSTALLDIR to determine pkgconfigdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,7 +182,6 @@ EXTRA_DIST += AUTHORS
 CLEANFILES += AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
-pkgconfigdir          = $(libdir)/pkgconfig
 pkgconfig_DATA =
 CLEANFILES += $(pkgconfig_DATA)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
 EXTRA_DIST =
+DISTCLEANFILES =
 CLEANFILES =
 MOSTLYCLEANFILES =
 noinst_PROGRAMS =
@@ -183,7 +184,7 @@ CLEANFILES += AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
 pkgconfig_DATA =
-CLEANFILES += $(pkgconfig_DATA)
+DISTCLEANFILES += $(pkgconfig_DATA)
 
 # Base TSS2 headers
 tss2dir = $(includedir)/tss2

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CXX
 AC_PROG_CC
 LT_INIT()
+PKG_INSTALLDIR()
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setting of "silent-rules"


### PR DESCRIPTION
This allows configuring the pkg-config directory using
```
./configure --with-pkgconfigdir
```
Also use distclean instead of clean for `.pc` files, since they are generated by `configure` since 8ed533fba7dad438f4e8fcd99f108a75eddfff0f.