### PR TITLE
Makefile-fuzz.am: add to DISTCLEANFILES

### DIFF
--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -44,7 +44,7 @@ TESTS += $(TESTS_FUZZ)
 fuzz_PROGRAMS = $(TESTS_FUZZ)
 FUZZ = $(check_PROGRAMS)
 
-DISTCLEANFILES = Makefile-fuzz-generated.am
+DISTCLEANFILES += Makefile-fuzz-generated.am
 
 include Makefile-fuzz-generated.am
 endif # ENABLE_FUZZING


### PR DESCRIPTION
DISTCLEANFILES is declared in Makefile.am, therefore Makefile-fuzz.am cannot declare it once again, it can only add to it.

Regression introduced in 64b08028dc331a, fixes #1385.
