### PR TITLE
Fix SPDX License Identifier

### DIFF
--- a/Makefile-fuzz.am
+++ b/Makefile-fuzz.am
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2019 Intel Corporation
 # All rights reserved.
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2015 - 2018 Intel Corporation
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2015 - 2018 Intel Corporation
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2015 - 2018 Intel Corporation
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.

--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015-2018, Intel Corporation
  *

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015-2018, Intel Corporation
  *

--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018, Intel Corporation
  *

--- a/include/tss2/tss2_tcti_device.h
+++ b/include/tss2/tss2_tcti_device.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/include/tss2/tss2_tcti_mssim.h
+++ b/include/tss2/tss2_tcti_mssim.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/include/tss2/tss2_tcti_tbs.h
+++ b/include/tss2/tss2_tcti_tbs.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/script/fuzz-log-compiler.sh
+++ b/script/fuzz-log-compiler.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2019, Intel Corporation
 set -exu
 

--- a/script/gen_fuzz.py
+++ b/script/gen_fuzz.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 import os
 import argparse
 import itertools
 
 # Makefile-fuzz-generated.am is created from this template.
-MAKEFILE_FUZZ = '''# SPDX-License-Identifier: BSD-2
+MAKEFILE_FUZZ = '''# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2018 Intel Corporation
 # All rights reserved.
 
@@ -24,7 +24,7 @@ nodist_test_fuzz_%s_fuzz_SOURCES  = test/fuzz/main-sapi.cpp \\
 
 DISTCLEANFILES += test/fuzz/%s.fuzz.cpp'''
 # Common include definitions needed for fuzzing an SAPI call
-SAPI_TEMPLATE_HEADER = '''/* SPDX-License-Identifier: BSD-2 */
+SAPI_TEMPLATE_HEADER = '''/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2018, Intel Corporation
  *

--- a/src/tss2-esys/api/Esys_ActivateCredential.c
+++ b/src/tss2-esys/api/Esys_ActivateCredential.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Certify.c
+++ b/src/tss2-esys/api/Esys_Certify.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_CertifyCreation.c
+++ b/src/tss2-esys/api/Esys_CertifyCreation.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ChangeEPS.c
+++ b/src/tss2-esys/api/Esys_ChangeEPS.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ChangePPS.c
+++ b/src/tss2-esys/api/Esys_ChangePPS.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Clear.c
+++ b/src/tss2-esys/api/Esys_Clear.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ClearControl.c
+++ b/src/tss2-esys/api/Esys_ClearControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ClockRateAdjust.c
+++ b/src/tss2-esys/api/Esys_ClockRateAdjust.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ClockSet.c
+++ b/src/tss2-esys/api/Esys_ClockSet.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Commit.c
+++ b/src/tss2-esys/api/Esys_Commit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ContextLoad.c
+++ b/src/tss2-esys/api/Esys_ContextLoad.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ContextSave.c
+++ b/src/tss2-esys/api/Esys_ContextSave.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Create.c
+++ b/src/tss2-esys/api/Esys_Create.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_CreatePrimary.c
+++ b/src/tss2-esys/api/Esys_CreatePrimary.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackLockReset.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
+++ b/src/tss2-esys/api/Esys_DictionaryAttackParameters.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Duplicate.c
+++ b/src/tss2-esys/api/Esys_Duplicate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ECC_Parameters.c
+++ b/src/tss2-esys/api/Esys_ECC_Parameters.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ECDH_KeyGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_KeyGen.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ECDH_ZGen.c
+++ b/src/tss2-esys/api/Esys_ECDH_ZGen.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_EC_Ephemeral.c
+++ b/src/tss2-esys/api/Esys_EC_Ephemeral.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_EncryptDecrypt.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_EncryptDecrypt2.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt2.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_EventSequenceComplete.c
+++ b/src/tss2-esys/api/Esys_EventSequenceComplete.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_EvictControl.c
+++ b/src/tss2-esys/api/Esys_EvictControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_FieldUpgradeData.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeData.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_FieldUpgradeStart.c
+++ b/src/tss2-esys/api/Esys_FieldUpgradeStart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_FirmwareRead.c
+++ b/src/tss2-esys/api/Esys_FirmwareRead.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_FlushContext.c
+++ b/src/tss2-esys/api/Esys_FlushContext.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetCapability.c
+++ b/src/tss2-esys/api/Esys_GetCapability.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetCommandAuditDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetRandom.c
+++ b/src/tss2-esys/api/Esys_GetRandom.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
+++ b/src/tss2-esys/api/Esys_GetSessionAuditDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetTestResult.c
+++ b/src/tss2-esys/api/Esys_GetTestResult.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_GetTime.c
+++ b/src/tss2-esys/api/Esys_GetTime.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_HMAC.c
+++ b/src/tss2-esys/api/Esys_HMAC.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_HMAC_Start.c
+++ b/src/tss2-esys/api/Esys_HMAC_Start.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Hash.c
+++ b/src/tss2-esys/api/Esys_Hash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_HashSequenceStart.c
+++ b/src/tss2-esys/api/Esys_HashSequenceStart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
+++ b/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_HierarchyControl.c
+++ b/src/tss2-esys/api/Esys_HierarchyControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Import.c
+++ b/src/tss2-esys/api/Esys_Import.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_IncrementalSelfTest.c
+++ b/src/tss2-esys/api/Esys_IncrementalSelfTest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Load.c
+++ b/src/tss2-esys/api/Esys_Load.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_MakeCredential.c
+++ b/src/tss2-esys/api/Esys_MakeCredential.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_Certify.c
+++ b/src/tss2-esys/api/Esys_NV_Certify.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_ChangeAuth.c
+++ b/src/tss2-esys/api/Esys_NV_ChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_DefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_DefineSpace.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_Extend.c
+++ b/src/tss2-esys/api/Esys_NV_Extend.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_GlobalWriteLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_Increment.c
+++ b/src/tss2-esys/api/Esys_NV_Increment.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_Read.c
+++ b/src/tss2-esys/api/Esys_NV_Read.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_ReadLock.c
+++ b/src/tss2-esys/api/Esys_NV_ReadLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_NV_ReadPublic.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_SetBits.c
+++ b/src/tss2-esys/api/Esys_NV_SetBits.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_UndefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpace.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
+++ b/src/tss2-esys/api/Esys_NV_UndefineSpaceSpecial.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_Write.c
+++ b/src/tss2-esys/api/Esys_NV_Write.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_NV_WriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_WriteLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ObjectChangeAuth.c
+++ b/src/tss2-esys/api/Esys_ObjectChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_Allocate.c
+++ b/src/tss2-esys/api/Esys_PCR_Allocate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_Event.c
+++ b/src/tss2-esys/api/Esys_PCR_Event.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_Extend.c
+++ b/src/tss2-esys/api/Esys_PCR_Extend.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_Read.c
+++ b/src/tss2-esys/api/Esys_PCR_Read.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_Reset.c
+++ b/src/tss2-esys/api/Esys_PCR_Reset.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthPolicy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PP_Commands.c
+++ b/src/tss2-esys/api/Esys_PP_Commands.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyAuthValue.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthValue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyAuthorize.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthorize.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
+++ b/src/tss2-esys/api/Esys_PolicyAuthorizeNV.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyCommandCode.c
+++ b/src/tss2-esys/api/Esys_PolicyCommandCode.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyCounterTimer.c
+++ b/src/tss2-esys/api/Esys_PolicyCounterTimer.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyCpHash.c
+++ b/src/tss2-esys/api/Esys_PolicyCpHash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
+++ b/src/tss2-esys/api/Esys_PolicyDuplicationSelect.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyGetDigest.c
+++ b/src/tss2-esys/api/Esys_PolicyGetDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyLocality.c
+++ b/src/tss2-esys/api/Esys_PolicyLocality.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyNV.c
+++ b/src/tss2-esys/api/Esys_PolicyNV.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyNameHash.c
+++ b/src/tss2-esys/api/Esys_PolicyNameHash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyNvWritten.c
+++ b/src/tss2-esys/api/Esys_PolicyNvWritten.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyOR.c
+++ b/src/tss2-esys/api/Esys_PolicyOR.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyPCR.c
+++ b/src/tss2-esys/api/Esys_PolicyPCR.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyPassword.c
+++ b/src/tss2-esys/api/Esys_PolicyPassword.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
+++ b/src/tss2-esys/api/Esys_PolicyPhysicalPresence.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyRestart.c
+++ b/src/tss2-esys/api/Esys_PolicyRestart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicySecret.c
+++ b/src/tss2-esys/api/Esys_PolicySecret.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicySigned.c
+++ b/src/tss2-esys/api/Esys_PolicySigned.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyTemplate.c
+++ b/src/tss2-esys/api/Esys_PolicyTemplate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_PolicyTicket.c
+++ b/src/tss2-esys/api/Esys_PolicyTicket.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Quote.c
+++ b/src/tss2-esys/api/Esys_Quote.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_RSA_Decrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Decrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_RSA_Encrypt.c
+++ b/src/tss2-esys/api/Esys_RSA_Encrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ReadClock.c
+++ b/src/tss2-esys/api/Esys_ReadClock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ReadPublic.c
+++ b/src/tss2-esys/api/Esys_ReadPublic.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Rewrap.c
+++ b/src/tss2-esys/api/Esys_Rewrap.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SelfTest.c
+++ b/src/tss2-esys/api/Esys_SelfTest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SequenceComplete.c
+++ b/src/tss2-esys/api/Esys_SequenceComplete.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SequenceUpdate.c
+++ b/src/tss2-esys/api/Esys_SequenceUpdate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SetAlgorithmSet.c
+++ b/src/tss2-esys/api/Esys_SetAlgorithmSet.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-esys/api/Esys_SetCommandCodeAuditStatus.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
+++ b/src/tss2-esys/api/Esys_SetPrimaryPolicy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Shutdown.c
+++ b/src/tss2-esys/api/Esys_Shutdown.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Sign.c
+++ b/src/tss2-esys/api/Esys_Sign.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Startup.c
+++ b/src/tss2-esys/api/Esys_Startup.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_StirRandom.c
+++ b/src/tss2-esys/api/Esys_StirRandom.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_TestParms.c
+++ b/src/tss2-esys/api/Esys_TestParms.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Unseal.c
+++ b/src/tss2-esys/api/Esys_Unseal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
+++ b/src/tss2-esys/api/Esys_Vendor_TCG_Test.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_VerifySignature.c
+++ b/src/tss2-esys/api/Esys_VerifySignature.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/api/Esys_ZGen_2Phase.c
+++ b/src/tss2-esys/api/Esys_ZGen_2Phase.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_context.c
+++ b/src/tss2-esys/esys_context.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto.h
+++ b/src/tss2-esys/esys_crypto.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto_gcrypt.c
+++ b/src/tss2-esys/esys_crypto_gcrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto_gcrypt.h
+++ b/src/tss2-esys/esys_crypto_gcrypt.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_crypto_ossl.h
+++ b/src/tss2-esys/esys_crypto_ossl.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_free.c
+++ b/src/tss2-esys/esys_free.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <stdlib.h>
 
 /*

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_mu.c
+++ b/src/tss2-esys/esys_mu.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_mu.h
+++ b/src/tss2-esys/esys_mu.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_tcti_default.h
+++ b/src/tss2-esys/esys_tcti_default.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-esys/esys_types.h
+++ b/src/tss2-esys/esys_types.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/tss2-mu/base-types.c
+++ b/src/tss2-mu/base-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpma-types.c
+++ b/src/tss2-mu/tpma-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpml-types.c
+++ b/src/tss2-mu/tpml-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpmt-types.c
+++ b/src/tss2-mu/tpmt-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/src/tss2-sys/api/Tss2_Sys_AC_GetCapability.c
+++ b/src/tss2-sys/api/Tss2_Sys_AC_GetCapability.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_AC_Send.c
+++ b/src/tss2-sys/api/Tss2_Sys_AC_Send.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ActivateCredential.c
+++ b/src/tss2-sys/api/Tss2_Sys_ActivateCredential.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Certify.c
+++ b/src/tss2-sys/api/Tss2_Sys_Certify.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_CertifyCreation.c
+++ b/src/tss2-sys/api/Tss2_Sys_CertifyCreation.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ChangeEPS.c
+++ b/src/tss2-sys/api/Tss2_Sys_ChangeEPS.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ChangePPS.c
+++ b/src/tss2-sys/api/Tss2_Sys_ChangePPS.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Clear.c
+++ b/src/tss2-sys/api/Tss2_Sys_Clear.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ClearControl.c
+++ b/src/tss2-sys/api/Tss2_Sys_ClearControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ClockRateAdjust.c
+++ b/src/tss2-sys/api/Tss2_Sys_ClockRateAdjust.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ClockSet.c
+++ b/src/tss2-sys/api/Tss2_Sys_ClockSet.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Commit.c
+++ b/src/tss2-sys/api/Tss2_Sys_Commit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ContextLoad.c
+++ b/src/tss2-sys/api/Tss2_Sys_ContextLoad.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ContextSave.c
+++ b/src/tss2-sys/api/Tss2_Sys_ContextSave.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Create.c
+++ b/src/tss2-sys/api/Tss2_Sys_Create.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_CreateLoaded.c
+++ b/src/tss2-sys/api/Tss2_Sys_CreateLoaded.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
+++ b/src/tss2-sys/api/Tss2_Sys_CreatePrimary.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/src/tss2-sys/api/Tss2_Sys_DictionaryAttackLockReset.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_DictionaryAttackParameters.c
+++ b/src/tss2-sys/api/Tss2_Sys_DictionaryAttackParameters.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Duplicate.c
+++ b/src/tss2-sys/api/Tss2_Sys_Duplicate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ECC_Parameters.c
+++ b/src/tss2-sys/api/Tss2_Sys_ECC_Parameters.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ECDH_KeyGen.c
+++ b/src/tss2-sys/api/Tss2_Sys_ECDH_KeyGen.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ECDH_ZGen.c
+++ b/src/tss2-sys/api/Tss2_Sys_ECDH_ZGen.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_EC_Ephemeral.c
+++ b/src/tss2-sys/api/Tss2_Sys_EC_Ephemeral.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_EventSequenceComplete.c
+++ b/src/tss2-sys/api/Tss2_Sys_EventSequenceComplete.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_EvictControl.c
+++ b/src/tss2-sys/api/Tss2_Sys_EvictControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Execute.c
+++ b/src/tss2-sys/api/Tss2_Sys_Execute.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_FieldUpgradeData.c
+++ b/src/tss2-sys/api/Tss2_Sys_FieldUpgradeData.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_FieldUpgradeStart.c
+++ b/src/tss2-sys/api/Tss2_Sys_FieldUpgradeStart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Finalize.c
+++ b/src/tss2-sys/api/Tss2_Sys_Finalize.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_FirmwareRead.c
+++ b/src/tss2-sys/api/Tss2_Sys_FirmwareRead.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_FlushContext.c
+++ b/src/tss2-sys/api/Tss2_Sys_FlushContext.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetCapability.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetCapability.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetCommandAuditDigest.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetCommandAuditDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetCommandCode.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetCommandCode.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetContextSize.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetContextSize.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetCpBuffer.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetCpBuffer.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetDecryptParam.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetDecryptParam.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetEncryptParam.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetEncryptParam.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetRandom.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRandom.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRpBuffer.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetRspAuths.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetRspAuths.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2018, Intel Corporation
  *

--- a/src/tss2-sys/api/Tss2_Sys_GetSessionAuditDigest.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetSessionAuditDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetTctiContext.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetTctiContext.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetTestResult.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetTestResult.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_GetTime.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetTime.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_HMAC.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Hash.c
+++ b/src/tss2-sys/api/Tss2_Sys_Hash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
+++ b/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_HierarchyChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_HierarchyChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_HierarchyControl.c
+++ b/src/tss2-sys/api/Tss2_Sys_HierarchyControl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Import.c
+++ b/src/tss2-sys/api/Tss2_Sys_Import.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_IncrementalSelfTest.c
+++ b/src/tss2-sys/api/Tss2_Sys_IncrementalSelfTest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Initialize.c
+++ b/src/tss2-sys/api/Tss2_Sys_Initialize.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015-2018, Intel Corporation
  *

--- a/src/tss2-sys/api/Tss2_Sys_Load.c
+++ b/src/tss2-sys/api/Tss2_Sys_Load.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
+++ b/src/tss2-sys/api/Tss2_Sys_LoadExternal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_MakeCredential.c
+++ b/src/tss2-sys/api/Tss2_Sys_MakeCredential.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_Certify.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Certify.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_ChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_ChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_DefineSpace.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_Extend.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Extend.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_GlobalWriteLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_Increment.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Increment.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_Read.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Read.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_ReadLock.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_ReadLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_ReadPublic.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_ReadPublic.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_SetBits.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_SetBits.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_UndefineSpace.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_UndefineSpace.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_Write.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_Write.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_NV_WriteLock.c
+++ b/src/tss2-sys/api/Tss2_Sys_NV_WriteLock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ObjectChangeAuth.c
+++ b/src/tss2-sys/api/Tss2_Sys_ObjectChangeAuth.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Allocate.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Allocate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Event.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Event.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Extend.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Extend.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Read.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Read.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_Reset.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_Reset.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthValue.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthValue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PP_Commands.c
+++ b/src/tss2-sys/api/Tss2_Sys_PP_Commands.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyAuthValue.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyAuthValue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyAuthorize.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyAuthorize.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyAuthorizeNV.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyAuthorizeNV.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyCommandCode.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyCommandCode.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyCounterTimer.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyCounterTimer.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyCpHash.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyCpHash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyDuplicationSelect.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyGetDigest.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyGetDigest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyLocality.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyLocality.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyNV.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyNV.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyNameHash.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyNameHash.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyNvWritten.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyNvWritten.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyOR.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyOR.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyPCR.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyPCR.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyPassword.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyPassword.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyPhysicalPresence.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyRestart.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyRestart.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicySecret.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicySecret.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicySigned.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicySigned.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyTemplate.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyTemplate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_PolicyTicket.c
+++ b/src/tss2-sys/api/Tss2_Sys_PolicyTicket.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Policy_AC_SendSelect.c
+++ b/src/tss2-sys/api/Tss2_Sys_Policy_AC_SendSelect.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Quote.c
+++ b/src/tss2-sys/api/Tss2_Sys_Quote.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_RSA_Decrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_RSA_Decrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_RSA_Encrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_RSA_Encrypt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ReadClock.c
+++ b/src/tss2-sys/api/Tss2_Sys_ReadClock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ReadPublic.c
+++ b/src/tss2-sys/api/Tss2_Sys_ReadPublic.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Rewrap.c
+++ b/src/tss2-sys/api/Tss2_Sys_Rewrap.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SelfTest.c
+++ b/src/tss2-sys/api/Tss2_Sys_SelfTest.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SequenceComplete.c
+++ b/src/tss2-sys/api/Tss2_Sys_SequenceComplete.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SequenceUpdate.c
+++ b/src/tss2-sys/api/Tss2_Sys_SequenceUpdate.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SetAlgorithmSet.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetAlgorithmSet.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2018, Intel Corporation
  *

--- a/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SetDecryptParam.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetDecryptParam.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SetEncryptParam.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetEncryptParam.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Shutdown.c
+++ b/src/tss2-sys/api/Tss2_Sys_Shutdown.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Sign.c
+++ b/src/tss2-sys/api/Tss2_Sys_Sign.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
+++ b/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Startup.c
+++ b/src/tss2-sys/api/Tss2_Sys_Startup.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_StirRandom.c
+++ b/src/tss2-sys/api/Tss2_Sys_StirRandom.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_TestParms.c
+++ b/src/tss2-sys/api/Tss2_Sys_TestParms.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Unseal.c
+++ b/src/tss2-sys/api/Tss2_Sys_Unseal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_Vendor_TCG_Test.c
+++ b/src/tss2-sys/api/Tss2_Sys_Vendor_TCG_Test.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_VerifySignature.c
+++ b/src/tss2-sys/api/Tss2_Sys_VerifySignature.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/api/Tss2_Sys_ZGen_2Phase.c
+++ b/src/tss2-sys/api/Tss2_Sys_ZGen_2Phase.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  * All rights reserved.

--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015-2018, Intel Corporation
  *

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-common.c
+++ b/src/tss2-tcti/tcti-common.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-common.h
+++ b/src/tss2-tcti/tcti-common.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-device.h
+++ b/src/tss2-tcti/tcti-device.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/src/tss2-tcti/tcti-tbs.h
+++ b/src/tss2-tcti/tcti-tbs.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/src/util/aux_util.h
+++ b/src/util/aux_util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/src/util/io.c
+++ b/src/util/io.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015 - 2018 Intel Corporation
  * All rights reserved.

--- a/src/util/key-value-parse.c
+++ b/src/util/key-value-parse.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/util/key-value-parse.h
+++ b/src/util/key-value-parse.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/util/tpm2b.h
+++ b/src/util/tpm2b.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/util/tss2_endian.h
+++ b/src/util/tss2_endian.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2017, Intel Corporation
  *

--- a/test/fuzz/main-sapi.cpp
+++ b/test/fuzz/main-sapi.cpp
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2018, Intel Corporation
  *

--- a/test/fuzz/tcti/tcti-fuzzing.c
+++ b/test/fuzz/tcti/tcti-fuzzing.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/test/fuzz/tcti/tcti-fuzzing.h
+++ b/test/fuzz/tcti/tcti-fuzzing.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.

--- a/test/fuzz/tcti/tss2_tcti_fuzzing.h
+++ b/test/fuzz/tcti/tss2_tcti_fuzzing.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/context-util.h
+++ b/test/integration/context-util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/esys-audit.int.c
+++ b/test/integration/esys-audit.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-auto-session-flags.int.c
+++ b/test/integration/esys-auto-session-flags.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2019, Intel Corporation
  * All rights reserved.

--- a/test/integration/esys-certify-creation.int.c
+++ b/test/integration/esys-certify-creation.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-certify.int.c
+++ b/test/integration/esys-certify.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-change-eps.int.c
+++ b/test/integration/esys-change-eps.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-clear.int.c
+++ b/test/integration/esys-clear.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-commit.int.c
+++ b/test/integration/esys-commit.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-create-fail.int.c
+++ b/test/integration/esys-create-fail.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-create-password-auth.int.c
+++ b/test/integration/esys-create-password-auth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-create-primary-hmac.int.c
+++ b/test/integration/esys-create-primary-hmac.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-createloaded.int.c
+++ b/test/integration/esys-createloaded.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-duplicate.int.c
+++ b/test/integration/esys-duplicate.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-ecc-parameters.int.c
+++ b/test/integration/esys-ecc-parameters.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-ecdh-keygen.int.c
+++ b/test/integration/esys-ecdh-keygen.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-ecdh-zgen.int.c
+++ b/test/integration/esys-ecdh-zgen.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-event-sequence-complete.int.c
+++ b/test/integration/esys-event-sequence-complete.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-evict-control-serialization.int.c
+++ b/test/integration/esys-evict-control-serialization.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-field-upgrade.int.c
+++ b/test/integration/esys-field-upgrade.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-firmware-read.int.c
+++ b/test/integration/esys-firmware-read.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-get-capability.int.c
+++ b/test/integration/esys-get-capability.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-get-random.int.c
+++ b/test/integration/esys-get-random.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-get-time.int.c
+++ b/test/integration/esys-get-time.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hash.int.c
+++ b/test/integration/esys-hash.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hierarchychangeauth.int.c
+++ b/test/integration/esys-hierarchychangeauth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hmac.int.c
+++ b/test/integration/esys-hmac.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-import.int.c
+++ b/test/integration/esys-import.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-lock.int.c
+++ b/test/integration/esys-lock.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-nv-certify.int.c
+++ b/test/integration/esys-nv-certify.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-nv-ram-extend-index.int.c
+++ b/test/integration/esys-nv-ram-extend-index.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-nv-ram-ordinary-index.int.c
+++ b/test/integration/esys-nv-ram-ordinary-index.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-nv-ram-set-bits.int.c
+++ b/test/integration/esys-nv-ram-set-bits.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-object-changeauth.int.c
+++ b/test/integration/esys-object-changeauth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-authorize-nv-opt.int.c
+++ b/test/integration/esys-policy-authorize-nv-opt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-authorize.int.c
+++ b/test/integration/esys-policy-authorize.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-nv-changeauth.int.c
+++ b/test/integration/esys-policy-nv-changeauth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-physical-presence-opt.int.c
+++ b/test/integration/esys-policy-physical-presence-opt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-regression.int.c
+++ b/test/integration/esys-policy-regression.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-template-opt.int.c
+++ b/test/integration/esys-policy-template-opt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-policy-ticket.int.c
+++ b/test/integration/esys-policy-ticket.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-quote.int.c
+++ b/test/integration/esys-quote.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-rsa-encrypt-decrypt.int.c
+++ b/test/integration/esys-rsa-encrypt-decrypt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-save-and-load-context.int.c
+++ b/test/integration/esys-save-and-load-context.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-session-attributes.int.c
+++ b/test/integration/esys-session-attributes.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-set-algorithm-set.int.c
+++ b/test/integration/esys-set-algorithm-set.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-stir-random.int.c
+++ b/test/integration/esys-stir-random.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-testparms.int.c
+++ b/test/integration/esys-testparms.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-tpm-tests.int.c
+++ b/test/integration/esys-tpm-tests.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-tr-fromTpmPublic-key.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-key.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-tr-fromTpmPublic-nv.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-nv.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-tr-getName-hierarchy.int.c
+++ b/test/integration/esys-tr-getName-hierarchy.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-unseal-password-auth.int.c
+++ b/test/integration/esys-unseal-password-auth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-verify-signature.int.c
+++ b/test/integration/esys-verify-signature.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/esys-zgen-2phase.int.c
+++ b/test/integration/esys-zgen-2phase.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/main-esapi.c
+++ b/test/integration/main-esapi.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/integration/main-sapi.c
+++ b/test/integration/main-sapi.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-abi-version.int.c
+++ b/test/integration/sapi-abi-version.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/sapi-asymmetric-encrypt-decrypt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-command-cancel.int.c
+++ b/test/integration/sapi-command-cancel.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-context-util.c
+++ b/test/integration/sapi-context-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-create-keyedhash-sha1-hmac.int.c
+++ b/test/integration/sapi-create-keyedhash-sha1-hmac.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-create-loaded.int.c
+++ b/test/integration/sapi-create-loaded.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-encrypt-decrypt-2.int.c
+++ b/test/integration/sapi-encrypt-decrypt-2.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-encrypt-decrypt.int.c
+++ b/test/integration/sapi-encrypt-decrypt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-entity-util.c
+++ b/test/integration/sapi-entity-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-evict-ctrl.int.c
+++ b/test/integration/sapi-evict-ctrl.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-get-random.int.c
+++ b/test/integration/sapi-get-random.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-hierarchy-change-auth.int.c
+++ b/test/integration/sapi-hierarchy-change-auth.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-nv-policy-locality.int.c
+++ b/test/integration/sapi-nv-policy-locality.int.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-2
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2019, Intel Corporation
  */
 

--- a/test/integration/sapi-nv-readwrite.int.c
+++ b/test/integration/sapi-nv-readwrite.int.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-2
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2019, Intel Corporation
  */
 

--- a/test/integration/sapi-param-encrypt-decrypt.int.c
+++ b/test/integration/sapi-param-encrypt-decrypt.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-pcr-extension.int.c
+++ b/test/integration/sapi-pcr-extension.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-policy-authorizeNV.int.c
+++ b/test/integration/sapi-policy-authorizeNV.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-policy-template.int.c
+++ b/test/integration/sapi-policy-template.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-primary-rsa-2K-aes128cfb.int.c
+++ b/test/integration/sapi-primary-rsa-2K-aes128cfb.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-self-test.int.c
+++ b/test/integration/sapi-self-test.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-session-util.c
+++ b/test/integration/sapi-session-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-start-auth-session.int.c
+++ b/test/integration/sapi-start-auth-session.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-stir-random.int.c
+++ b/test/integration/sapi-stir-random.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-sys-initialize.int.c
+++ b/test/integration/sapi-sys-initialize.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-system-api.int.c
+++ b/test/integration/sapi-system-api.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-test-options.c
+++ b/test/integration/sapi-test-options.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-tpm-properties.int.c
+++ b/test/integration/sapi-tpm-properties.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-util.c
+++ b/test/integration/sapi-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/sapi-util.h
+++ b/test/integration/sapi-util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/session-util.h
+++ b/test/integration/session-util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/test-esapi.h
+++ b/test/integration/test-esapi.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * Copyright (c) 2017-2018, Intel Corporation

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015, Intel Corporation
  * All rights reserved.

--- a/test/unit/CommonPreparePrologue.c
+++ b/test/unit/CommonPreparePrologue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/CopyCommandHeader.c
+++ b/test/unit/CopyCommandHeader.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPMA-marshal.c
+++ b/test/unit/TPMA-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPML-marshal.c
+++ b/test/unit/TPML-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPMS-marshal.c
+++ b/test/unit/TPMS-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPMT-marshal.c
+++ b/test/unit/TPMT-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/TPMU-marshal.c
+++ b/test/unit/TPMU-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/UINT16-marshal.c
+++ b/test/unit/UINT16-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/UINT32-marshal.c
+++ b/test/unit/UINT32-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/UINT64-marshal.c
+++ b/test/unit/UINT64-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/UINT8-marshal.c
+++ b/test/unit/UINT8-marshal.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/esys-context-null.c
+++ b/test/unit/esys-context-null.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/unit/esys-default-tcti.c
+++ b/test/unit/esys-default-tcti.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/unit/esys-getpollhandles.c
+++ b/test/unit/esys-getpollhandles.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
  * rights reserved.

--- a/test/unit/esys-nulltcti.c
+++ b/test/unit/esys-nulltcti.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/unit/esys-resubmissions.c
+++ b/test/unit/esys-resubmissions.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
  * rights reserved.

--- a/test/unit/esys-sequence-finish.c
+++ b/test/unit/esys-sequence-finish.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.

--- a/test/unit/esys-tcti-rcs.c
+++ b/test/unit/esys-tcti-rcs.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
  * rights reserved.

--- a/test/unit/esys-tpm-rcs.c
+++ b/test/unit/esys-tpm-rcs.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG All
  * rights reserved.

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/key-value-parse.c
+++ b/test/unit/key-value-parse.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/log.c
+++ b/test/unit/log.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2019, Infineon Technologies AG
  *

--- a/test/unit/sys-execute.c
+++ b/test/unit/sys-execute.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*******************************************************************************
  * Copyright 2019, Intel Corporation
  *

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************
  * Copyright (c) 2017-2018, Intel Corporation
  *

--- a/test/unit/tcti-mssim.c
+++ b/test/unit/tcti-mssim.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /***********************************************************************;
  * Copyright (c) 2015 - 2018, Intel Corporation
  * All rights reserved.


### PR DESCRIPTION
According to the latest SPDX Documentation
(https://spdx.org/licenses/BSD-2-Clause.html)
the correct SPDX Identifier for BSD 2 Clause is
`BSD-2-Clause` not `BSD-2`

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>