### PR TITLE
esys: don't stringify ESYS_TCTI_DEFAULT_CONFIG

### DIFF
--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -23,9 +23,6 @@
 #define LOGMODULE esys
 #include "util/log.h"
 
-#define _STR(A) #A
-#define _XSTR(A) _STR(A)
-
 #define ARRAY_SIZE(X) (sizeof(X)/sizeof(X[0]))
 
 struct {
@@ -174,7 +171,7 @@ get_tcti_default(TSS2_TCTI_CONTEXT ** tcticontext, void **dlhandle)
 #ifdef ESYS_TCTI_DEFAULT_MODULE
 
 #ifdef ESYS_TCTI_DEFAULT_CONFIG
-    const char *config = _XSTR(ESYS_TCTI_DEFAULT_CONFIG);
+    const char *config = ESYS_TCTI_DEFAULT_CONFIG;
 #else /* ESYS_TCTI_DEFAULT_CONFIG */
     const char *config = NULL;
 #endif /* ESYS_TCTI_DEFAULT_CONFIG */


### PR DESCRIPTION
The macro is already quoted, so using stringification will lead to a configuration string like `"/dev/tpmrm0"`, including the double quotes. Just use the macro directly instead like `ESYS_TCTI_DEFAULT_MODULE`.

An alternative solution would be to keep the stringification and remove the double quotes from the [definition of `ESYS_TCTI_DEFAULT_MODULE` in `configure.ac`](https://github.com/tpm2-software/tpm2-tss/blob/2f3bff12ad2527668c84a684711b8ae478442adc/configure.ac#L110). However this wouldn't be consistent with the other strings in `config.h` (including the ones automatically defined by Autoconf) which all have quotes.