### PR TITLE
ci: replace check with distcheck for Clang, remove separate distcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ script:
     fi
   - |
     if [ "$CC" == "clang" ]; then
-      scan-build --status-bugs make -j$(nproc) check
+      scan-build --status-bugs make -j$(nproc) distcheck
     else
       make -j$(nproc) check
     fi
@@ -120,12 +120,6 @@ script:
       make -j$(nproc) check
     fi
   - |
-  - popd
-# make distcheck
-  - mkdir ./distcheck_build
-  - pushd ./distcheck_build
-  - ../configure --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
-  - make -j$(nproc) distcheck
   - popd
 
 after_success:


### PR DESCRIPTION
Following the discussion in #1348, I suggest removing the separate `make distcheck` in Travis CI and instead replace the `check` by a `distcheck` target for Clang. The reasons are as follows:

- Doing this saves time, since the integration tests don't have to be run twice.
- Possible errors with files missing for specific configuration options are spotted more easily: currently `make distcheck` [only takes into account the value of `WITH_CRYPTO`](https://github.com/tpm2-software/tpm2-tss/blob/9f7cc086e9802d1ed3682e8f5b036bd33dc5aa21/.travis.yml#L127), while `WITH_TCTI_ASYNC` and `WITH_TCTI_PARTIAL` aren't considered.

The reason why we can't replace `check` by `distcheck` for GCC as well is that we want to [test code coverage for GCC](https://github.com/tpm2-software/tpm2-tss/blob/9f7cc086e9802d1ed3682e8f5b036bd33dc5aa21/.travis.yml#L101), which gets [automatically disabled](https://github.com/autoconf-archive/autoconf-archive/blob/92aa35374c4925056289515997d14af100280348/m4/ax_code_coverage.m4#L178) during distchecks.