### PR TITLE
Makefile-test.am: remove target check-programs

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -21,8 +21,6 @@ endif
 EXTRA_DIST += $(srcdir)/script/int-log-compiler.sh $(srcdir)/script/int-log-compiler-ptpm.sh
 AM_TESTS_ENVIRONMENT = PATH="$(PATH)"
 
-check-programs: $(check_PROGRAMS)
-
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 


### PR DESCRIPTION
This reverts completely commit 24fb1306e, partially reverted with commit a4e8c0ce.

The initial motivation for introducing the check-programs target was, that parallel builds have not worked.  If Makefile is correct, then parallel builds will run rigth.
