### PR TITLE
Improvements to Travis CI jobs configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   matrix:
   - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_0_2-stable
   - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_1_0-stable
-  - WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_1_0-stable GEN_FUZZ=1 CXX=clang++ CC=clang
   - WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE
   - WITH_TCTI_ASYNC=yes WITH_TCTI_PARTIAL=yes WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE
   - WITH_TCTI_ASYNC=yes WITH_TCTI_PARTIAL=no WITH_CRYPTO=gcrypt OPENSSL_BRANCH=NONE
@@ -115,17 +114,18 @@ script:
     else
       make -j$(nproc) check
     fi
-# check fuzz targets
-  - |
-    if [ "$CC" == "clang" ] && [ "x$GEN_FUZZ" == "x1" ]; then
-      ../configure --with-fuzzing=libfuzzer --enable-tcti-fuzzing --disable-tcti-device --disable-tcti-mssim --disable-shared --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
-      make -j$(nproc) check
-    fi
-  - |
-  - popd
 
 after_success:
   - |
     if [ "$CC" == "gcc" ]; then
         bash <(curl -s https://codecov.io/bash)
     fi
+
+# check fuzz targets
+matrix:
+  include:
+  - env: WITH_CRYPTO=ossl OPENSSL_BRANCH=OpenSSL_1_1_0-stable GEN_FUZZ=1 CXX=clang++ CC=clang
+    compiler: clang
+    script:
+    - ./configure --with-fuzzing=libfuzzer --enable-tcti-fuzzing --disable-tcti-device --disable-tcti-mssim --disable-shared --with-crypto=$WITH_CRYPTO CFLAGS=-I${PWD}/osslinstall/usr/local/include LDFLAGS=-L${PWD}/osslinstall/usr/local/lib
+    - make -j$(nproc) check

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
 # build with no tests enabled
   - mkdir ./build-no-tests
   - pushd ./build-no-tests
-  - ../configure CFLAGS=-I${PWD}/../osslinstall/usr/local/include --with-crypto=$WITH_CRYPTO LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
+  - ../configure --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --with-crypto=$WITH_CRYPTO CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
   - make -j$(nproc)
   - popd
 # build with all tests enabled


### PR DESCRIPTION
- tpm2-tss is built first without tests enabled in order to prevent test-specific code from causing errors if disabled (#913). Improve this test to respect `WITH_TCTI_PARTIAL` and `WITH_TCTI_ASYNC` for better configuration options coverage.
- The fuzz target is tested using a [separate build matrix entry](https://github.com/tpm2-software/tpm2-tss/blob/0e778bf959b20d8f38b5c4f440cfd6c6d55c48b7/.travis.yml#L14). This is redundant because it starts a job for both GCC and Clang (and fuzzing can be used only with Clang) and runs the integration tests already included in [another job](https://github.com/tpm2-software/tpm2-tss/blob/0e778bf959b20d8f38b5c4f440cfd6c6d55c48b7/.travis.yml#L13) before doing the fuzz target test. Move this test to a separate job in `matrix.include` instead.