### PR TITLE
esys_iutil.c: Update session attribute in cmdauths structure for policy sessions

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1299,11 +1299,12 @@ iesys_gen_auths(ESYS_CONTEXT * esys_context,
                 auths->auths[auths->count].sessionHandle = session->rsrc.handle;
                 if (objects[session_idx] == NULL) {
                     auths->auths[auths->count].hmac.size = 0;
-                    auths->count += 1;
                 } else {
                     auths->auths[auths->count].hmac = objects[session_idx]->auth;
-                    auths->count += 1;
                 }
+                auths->auths[auths->count].sessionAttributes =
+                    session->rsrc.misc.rsrc_session.sessionAttributes;
+                auths->count += 1;
                 continue;
             }
         }

--- a/test/integration/esys-policy-password.int.c
+++ b/test/integration/esys-policy-password.int.c
@@ -280,6 +280,9 @@ test_esys_policy_password(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, sessionTrial);
     goto_if_error(r, "Flushing context", error);
 
+    r = Esys_FlushContext(esys_context, policySession);
+    goto_if_error(r, "Flushing context", error);
+
     return EXIT_SUCCESS;
 
  error:


### PR DESCRIPTION
TPM commands like tpm2_encryptdecrypt can clear the continuesession flag in the
sessionAttributes. However, when it is intended to continue the policy session
inorder to be able to flush the session at a later time in order to:
1. Chain further TPM operations that are intended to modify policy digest
2. Run additional TPM commands using the session with satisfied policy

Signed-off-by: Imran Desai <imran.desai@intel.com>