### PR TITLE
pkg-config: sort out dependencies

### DIFF
--- a/lib/tss2-esys.pc.in
+++ b/lib/tss2-esys.pc.in
@@ -7,6 +7,6 @@ Name: tss2-esys
 Description: TPM2 Enhanced System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires: tss2-mu tss2-sys
+Requires.private: tss2-mu tss2-sys
 Cflags: -I${includedir}
 Libs: -ltss2-esys -L${libdir}

--- a/lib/tss2-esys.pc.in
+++ b/lib/tss2-esys.pc.in
@@ -7,6 +7,7 @@ Name: tss2-esys
 Description: TPM2 Enhanced System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires.private: tss2-mu tss2-sys
+Requires.private: tss2-mu tss2-sys tss2-tcti-device tss2-tcti-mssim
 Cflags: -I${includedir}
 Libs: -ltss2-esys -L${libdir}
+Libs.private: @LIBDL_LDFLAGS@ @LIBSOCKET_LDFLAGS@ @TSS2_ESYS_LDFLAGS_CRYPTO@

--- a/lib/tss2-sys.pc.in
+++ b/lib/tss2-sys.pc.in
@@ -10,3 +10,4 @@ Version: @VERSION@
 Requires.private: tss2-mu
 Cflags: -I${includedir}
 Libs: -ltss2-sys -L${libdir}
+Libs.private: @LIBSOCKET_LDFLAGS@

--- a/lib/tss2-sys.pc.in
+++ b/lib/tss2-sys.pc.in
@@ -7,6 +7,6 @@ Name: tss2-sys
 Description: TPM2 System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires: tss2-mu
+Requires.private: tss2-mu
 Cflags: -I${includedir}
 Libs: -ltss2-sys -L${libdir}

--- a/lib/tss2-tcti-device.pc.in
+++ b/lib/tss2-tcti-device.pc.in
@@ -7,6 +7,6 @@ Name: tss2-tcti-device
 Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires: tss2-mu
+Requires.private: tss2-mu
 Cflags: -I${includedir}
 Libs: -ltss2-tcti-device -L${libdir}

--- a/lib/tss2-tcti-mssim.pc.in
+++ b/lib/tss2-tcti-mssim.pc.in
@@ -7,6 +7,6 @@ Name: tss2-tcti-mssim
 Description: TCTI library for communicating with the Microsoft TPM2 simulator.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires: tss2-mu
+Requires.private: tss2-mu
 Cflags: -I${includedir}
 Libs: -ltss2-tcti-mssim -L${libdir}


### PR DESCRIPTION
The pkg-config files should contain the modules required by the respective library according to the [following guidelines](https://people.freedesktop.org/~dbn/pkg-config-guide.html#writing):

> `Requires` and `Requires.private` define other modules needed by the library. It is usually preferred to use the private variant of `Requires` to avoid exposing unnecessary libraries to the program that is linking with your library. If the program will not be using the symbols of the required library, it should not be linking directly to that library. See the discussion of [overlinking](https://wiki.openmandriva.org/en/Overlinking_issues_in_packaging) for a more thorough explanation.
>
> Since `pkg-config` always exposes the link flags of the `Requires` libraries, these modules will become direct dependencies of the program. On the other hand, libraries from `Requires.private` will only be included when static linking. For this reason, it is usually only appropriate to add modules from the same package in `Requires`.
>
> The `Libs` field contains the link flags necessary to use that library. In addition, `Libs` and `Libs.private` contain link flags for other libraries not supported by `pkg-config`. Similar to the `Requires` field, it is preferred to add link flags for external libraries to the `Libs.private` field so programs do not acquire an additional direct dependency.

The currently specified dependencies in `Requires` are only used internally, so according to these guidelines, they should be in `Requires.private` instead. **Note that this will break downstream programs like tpm2-abrmd and tpm2-tools** because they currently use functions from tss2-mu without explicitly adding this dependency, relying on the dependencies specified in pkg-config. If it is decided that this PR is the right approach, I would open separate pull requests for these projects before merging this PR to add the missing libraries. If you are worried about breaking compatibility like this, it might also be ok to keep these dependencies in `Requires` according to
> For this reason, it is usually only appropriate to add modules from the same package in `Requires`.

above. However keep in mind that the current states lead to unnecessary overlinking for *all* binaries using tss2-sys or tss2-esys.

The other change in this PR is completely backwards-compatible: tss2-sys and tss2-esys are missing some internal dependencies, most notably the cryptographic for the ESAPI. These should be specified in `Requires.private`/`Libs.private` to allow static linking, see also #1398.

Fixes: #1174