### PR TITLE
ESYS: Fix computation of session name in Esys_StartAuthSession.

### DIFF
--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -478,6 +478,14 @@ Esys_StartAuthSession_Finish(
 
         sessionHandleNode->rsrc.misc.rsrc_session.sessionKey.size = authHash_size;
     }
+    size_t offset = 0;
+    r = Tss2_MU_TPM2_HANDLE_Marshal(sessionHandleNode->rsrc.handle,
+                                    &sessionHandleNode->rsrc.name.name[0],
+                                    sizeof(sessionHandleNode->rsrc.name.name),
+                                    &offset);
+    goto_if_error(r, "Marshal session name", error_cleanup);
+
+    sessionHandleNode->rsrc.name.size = offset;
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -44,6 +44,7 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
     ESYS_TR nvHandle = ESYS_TR_NONE;
     ESYS_TR policySession = ESYS_TR_NONE;
+    ESYS_TR session = ESYS_TR_NONE;
     int failure_return = EXIT_FAILURE;
     /*
      * First the policy value for NV_UndefineSpaceSpecial has to be
@@ -146,6 +147,20 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
                    21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
     };
 
+    /* Create HMAC session to test HMAC with session name for policy sessions */
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              &policyNonceCaller,
+                              TPM2_SE_HMAC, &policySymmetric, TPM2_ALG_SHA1,
+                              &session);
+    goto_if_error(r, "Error: During initialization of session", error);
+
+    TPMA_SESSION sessionAttributes = TPMA_SESSION_AUDIT |
+                                     TPMA_SESSION_CONTINUESESSION;
+
+    r = Esys_TRSess_SetAttributes(esys_context, session, sessionAttributes, 0xFF);
+    goto_if_error(r, "Error: During SetAttributes", error);
+
     r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
                               ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                               &policyNonceCaller,
@@ -155,7 +170,7 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
 
     r = Esys_PolicyAuthValue(esys_context,
                              policySession,
-                             ESYS_TR_NONE,
+                             session,
                              ESYS_TR_NONE,
                              ESYS_TR_NONE
                              );
@@ -163,7 +178,7 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
 
     r = Esys_PolicyCommandCode(esys_context,
                                policySession,
-                               ESYS_TR_NONE,
+                               session,
                                ESYS_TR_NONE,
                                ESYS_TR_NONE,
                                TPM2_CC_NV_UndefineSpaceSpecial
@@ -190,6 +205,9 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
     r = Esys_FlushContext(esys_context, sessionTrial);
     goto_if_error(r, "Flushing context", error);
 
+    r = Esys_FlushContext(esys_context, session);
+    goto_if_error(r, "Flushing context", error);
+
     r = Esys_FlushContext(esys_context, policySession);
     goto_if_error(r, "Flushing context", error);
 
@@ -200,6 +218,12 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
     if (sessionTrial != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, sessionTrial) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup policySession failed.");
+        }
+    }
+
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
         }
     }
 


### PR DESCRIPTION
* The session name was no added to meta data in StartAuthSession.
* This caused an error in HMAC computation for policy sessions.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>