### PR TITLE
build: remove libssl

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -44,8 +44,8 @@ test_helper_tpm_dumpstate_LDADD = $(TESTS_LDADD)
 endif #ENABLE_INTEGRATION
 
 if ESYS_OSSL
-esyscryCFLAGS = -DOSSL $(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
-esyscryLDFLAGS = $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS) -ldl
+esyscryCFLAGS = -DOSSL $(LIBCRYPTO_CFLAGS)
+esyscryLDFLAGS = $(LIBCRYPTO_LIBS) -ldl
 esyscrySRC = src/tss2-esys/esys_crypto_ossl.c
 else
 if ESYS_GCRYPT

--- a/Makefile.am
+++ b/Makefile.am
@@ -310,9 +310,9 @@ src_tss2_esys_libtss2_esys_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) \
 if ESYS_OSSL
 TSS2_ESYS_SRC_CRYPTO = src/tss2-esys/esys_crypto_ossl.h src/tss2-esys/esys_crypto_ossl.c
 src_tss2_esys_libtss2_esys_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-esys -DOSSL \
-    $(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
+    $(LIBCRYPTO_CFLAGS)
 src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBDL_LDFLAGS) $(LIBSOCKET_LDFLAGS) \
-    $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS) -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
+    $(LIBCRYPTO_LIBS) -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
 else
 if ESYS_GCRYPT
 TSS2_ESYS_SRC_CRYPTO = src/tss2-esys/esys_crypto_gcrypt.h src/tss2-esys/esys_crypto_gcrypt.c

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,6 @@ AS_IF([test "x$enable_esapi" = xyes],
                [gcry_mac_open],,
                [AC_MSG_ERROR([Missing required library: gcrypt.])])
        ], [test "x$with_crypto" = xossl], [
-           PKG_CHECK_MODULES([LIBSSL], [libssl])
            PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto])
        ], AC_MSG_ERROR([Bad value for --with-crypto $with_crypto]))])
 


### PR DESCRIPTION
Linking against `libssl` doesn't appear to be necessary according to `ldd -u -r`, everything builds fine with `libcrypto` alone. This change is related to, but completely independent of #1417 and reduces overlinking.