### PR TITLE
build: Delete AUTHORS file in `maintainer-clean` make target.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,8 @@ MAINTAINERCLEANFILES = \
     m4/ax_prog_doxygen.m4 \
     m4/ax_valgrind_check.m4 \
     m4/pkg.m4 \
-    $(DIST_ARCHIVES)
+    $(DIST_ARCHIVES) \
+    AUTHORS
 
 ### Add ax_* rules ###
 # ax_code_coverage
@@ -217,7 +218,6 @@ AUTHORS :
 	$(AM_V_GEN)git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \
 	    uniq -c | sort -nr | sed 's/^\s*//' | cut -d" " -f2- > $@
 EXTRA_DIST += AUTHORS
-CLEANFILES += AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
 pkgconfig_DATA =


### PR DESCRIPTION
When building from a release tarball having `make clean` delete the
AUTHORS file isn't what the user expects. This file is only generated by
the `dist*` targets and it should only be removed on `maintainer-clean`.

This resolves #1402

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>