### PR TITLE
types: add CMAC algorithm

### DIFF
--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -100,6 +100,7 @@ typedef UINT16 TPM2_ALG_ID;
 #define TPM2_ALG_ECC                 ((TPM2_ALG_ID) 0x0023)
 #define TPM2_ALG_SYMCIPHER           ((TPM2_ALG_ID) 0x0025)
 #define TPM2_ALG_CAMELLIA            ((TPM2_ALG_ID) 0x0026)
+#define TPM2_ALG_CMAC                ((TPM2_ALG_ID) 0x003F)
 #define TPM2_ALG_CTR                 ((TPM2_ALG_ID) 0x0040)
 #define TPM2_ALG_SHA3_256            ((TPM2_ALG_ID) 0x0027)
 #define TPM2_ALG_SHA3_384            ((TPM2_ALG_ID) 0x0028)


### PR DESCRIPTION
The algorithm was added in [revision 1.27 of the TCG Algorithm Registry](https://trustedcomputinggroup.org/wp-content/uploads/TCG-_Algorithm_Registry_Rev_1.27_FinalPublication.pdf). Please advise if there are more places in tpm2-tss where it needs to be added.

Fixes: #1436