### PR TITLE
tss2-esys: Support sessions in Esys_TR_FromTPMPublic

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -177,6 +177,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-tpm-tests.int \
     test/integration/esys-tr-fromTpmPublic-key.int \
     test/integration/esys-tr-fromTpmPublic-nv.int \
+    test/integration/esys-tr-fromTpmPublic-session.int \
     test/integration/esys-tr-getName-hierarchy.int \
     test/integration/esys-unseal-password-auth.int \
     test/integration/esys-verify-signature.int \
@@ -1071,6 +1072,13 @@ test_integration_esys_tr_fromTpmPublic_nv_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_tr_fromTpmPublic_nv_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tr_fromTpmPublic_nv_int_SOURCES = \
     test/integration/esys-tr-fromTpmPublic-nv.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
+test_integration_esys_tr_fromTpmPublic_session_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_tr_fromTpmPublic_session_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_tr_fromTpmPublic_session_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_tr_fromTpmPublic_session_int_SOURCES = \
+    test/integration/esys-tr-fromTpmPublic-session.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_tr_getName_hierarchy_int_CFLAGS  = $(TESTS_CFLAGS)

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -138,7 +138,13 @@ init_session_tab(ESYS_CONTEXT *esys_context,
             r = esys_GetResourceObject(esys_context, handle_tab[i],
                                        &esys_context->session_tab[i]);
             return_if_error(r, "Unknown resource.");
+
+            if (esys_context->session_tab[i]->rsrc.rsrcType != IESYSC_SESSION_RSRC) {
+                LOG_ERROR("Error: ESYS_TR is not a session resource.");
+                return TSS2_ESYS_RC_BAD_TR;
+            }
         }
+
     }
     return r;
 }

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -141,6 +141,10 @@ Esys_TR_FromTPMPublic_Async(ESYS_CONTEXT * esys_context,
                                      shandle2, shandle3);
         goto_if_error(r, "Error NV_ReadPublic", error_cleanup);
 
+    } else if(tpm_handle >> TPM2_HR_SHIFT == TPM2_HT_LOADED_SESSION
+            || tpm_handle >> TPM2_HR_SHIFT == TPM2_HT_SAVED_SESSION) {
+        // no readpublic call for loaded or saved sessions.
+        r = TSS2_RC_SUCCESS;
     } else {
         r = Esys_ReadPublic_Async(esys_context, esys_handle, shandle1, shandle2,
                                   shandle3);
@@ -203,6 +207,9 @@ Esys_TR_FromTPMPublic_Finish(ESYS_CONTEXT * esys_context, ESYS_TR * object)
         objectHandleNode->rsrc.misc.rsrc_nv_pub = *nvPublic;
         SAFE_FREE(nvPublic);
         SAFE_FREE(nvName);
+    } else if(objectHandleNode->rsrc.handle >> TPM2_HR_SHIFT == TPM2_HT_LOADED_SESSION
+            || objectHandleNode->rsrc.handle >> TPM2_HR_SHIFT == TPM2_HT_SAVED_SESSION) {
+        objectHandleNode->rsrc.rsrcType = IESYSC_DEGRADED_SESSION_RSRC;
     } else {
         TPM2B_PUBLIC *public;
         TPM2B_NAME *name = NULL;

--- a/src/tss2-esys/esys_types.h
+++ b/src/tss2-esys/esys_types.h
@@ -23,6 +23,7 @@ typedef UINT32 IESYSC_RESOURCE_TYPE_CONSTANT;
 #define IESYSC_KEY_RSRC                1    /**< Tag for key resource */
 #define IESYSC_NV_RSRC                 2    /**< Tag for NV Ram resource */
 #define IESYSC_SESSION_RSRC            3    /**< Tag for session resources */
+#define IESYSC_DEGRADED_SESSION_RSRC   4    /**< Tag for degraded session resources */
 #define IESYSC_WITHOUT_MISC_RSRC       0    /**< Tag for other resources, e.g. PCR register, hierarchies */
 
 /** Type to indicate parameter encryption (by TPM)

--- a/test/integration/esys-tr-fromTpmPublic-session.int.c
+++ b/test/integration/esys-tr-fromTpmPublic-session.int.c
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+/** This tests the ability to create an ESYS_TR object via Esys_TR_FromTPMPublic
+ *  given a TPM2_HANDLE representing a session handle.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_StartAuthSession() (M)
+ *  - Esys_GetCapability() (M)
+ *  - Esys_FlushContext() (M)
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_tr_fromTpmPublic_session(ESYS_CONTEXT * ectx)
+{
+    int rc = EXIT_FAILURE;
+
+    ESYS_TR session = ESYS_TR_NONE;
+    TPMT_SYM_DEF symmetric = {
+        .algorithm = TPM2_ALG_XOR,
+        .keyBits = { .exclusiveOr = TPM2_ALG_SHA1 }
+    };
+
+    TPMS_CAPABILITY_DATA *cap_data = NULL;
+
+    TSS2_RC r = Esys_StartAuthSession(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              NULL,
+                              TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA1,
+                              &session);
+    goto_if_error(r, "Error: During initialization of session", out);
+
+    TPMI_YES_NO more_data;
+    r = Esys_GetCapability(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 TPM2_CAP_HANDLES,
+                                 TPM2_LOADED_SESSION_FIRST,
+                                 TPM2_MAX_CAP_HANDLES,
+                                 &more_data,
+                                 &cap_data);
+    goto_if_error(r, "Error: getting capability for loaded sessions", out);
+
+    if (cap_data->data.handles.count != 1) {
+        LOG_ERROR("Expected 1 loaded session handle, got: %"PRIu32,
+                  cap_data->data.handles.count);
+        goto out;
+    }
+
+    TPM2_HANDLE tpm2_handle = cap_data->data.handles.handle[0];
+
+    ESYS_TR new_handle = ESYS_TR_NONE;
+    r = Esys_TR_FromTPMPublic(
+            ectx,
+            tpm2_handle,
+            ESYS_TR_NONE,
+            ESYS_TR_NONE,
+            ESYS_TR_NONE,
+            &new_handle);
+    goto_if_error(r, "Error: converting TPM2_HANDLE to ESYS_TR object", out);
+
+    r = Esys_TRSess_SetAttributes(ectx, new_handle,
+          TPMA_SESSION_DECRYPT|TPMA_SESSION_ENCRYPT,
+          0xFF);
+    if (r != TSS2_ESYS_RC_BAD_TR) {
+        LOG_ERROR("Error: Expected GetCapability call to fail with "
+                "TSS2_ESYS_RC_BAD_TR, got: "TPM2_ERROR_FORMAT,
+                TPM2_ERROR_TEXT(r));
+        goto out;
+    }
+
+    free(cap_data);
+    cap_data = NULL;
+
+    r = Esys_GetCapability(ectx, new_handle, ESYS_TR_NONE, ESYS_TR_NONE,
+                           TPM2_CAP_HANDLES,
+                           TPM2_LOADED_SESSION_FIRST,
+                           TPM2_MAX_CAP_HANDLES,
+                           &more_data,
+                           &cap_data);
+    if (r != TSS2_ESYS_RC_BAD_TR) {
+        LOG_ERROR("Error: Expected GetCapability call to fail with "
+                "TSS2_ESYS_RC_BAD_TR, got: "TPM2_ERROR_FORMAT,
+                TPM2_ERROR_TEXT(r));
+        goto out;
+    }
+
+    /* ensure you can flush the frompublic session handle */
+    session = new_handle;
+
+    rc = EXIT_SUCCESS;
+out:
+    free(cap_data);
+
+    if (session != ESYS_TR_NONE) {
+        r = Esys_FlushContext(ectx, session);
+        if (r != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Error: FlushContext " TPM2_ERROR_FORMAT, TPM2_ERROR_TEXT(r));
+            rc = EXIT_FAILURE;
+        }
+    }
+
+    return rc;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_fromTpmPublic_session(esys_context);
+}


### PR DESCRIPTION
The getcap command can return a TPM2_HANDLE for the loaded or saved
session however, ESAPI has no way to flush this from the TPM. Modify
Esys_TR_FromTPMPublic() to accept a TPM2_HANDLE representing a session
and create a resource object tagged with IESYSC_SESSION_RSRC.

TODO:
  - [x] add tests
  - [x] add issue tracker

Fixes: https://github.com/tpm2-software/tpm2-tss/issues/1443

Signed-off-by: William Roberts <william.c.roberts@intel.com>