### PR TITLE
ci: don't limit the amount of parallel jobs for make (dist)check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,9 +113,9 @@ script:
     fi
   - |
     if [ "$CC" == "clang" ]; then
-      scan-build --status-bugs make -j$(nproc) distcheck
+      scan-build --status-bugs make -j distcheck
     else
-      make -j$(nproc) check
+      make -j check
     fi
 
 after_success:


### PR DESCRIPTION
Much of the CI time is spent on running the integration test suite, which is not CPU bound. This speeds up the CI from about [00:35 real-time/02:15 total](https://travis-ci.org/diabonas/tpm2-tss/builds/544156308) to about [00:25 real-time/01:30 total](https://travis-ci.org/diabonas/tpm2-tss/builds/544133369) (both measured with warm cache).