### PR TITLE
Fix tpm2-abrmd startup failure due to wrong permission of /dev/tpm0

### DIFF
--- a/dist/tpm-udev.rules
+++ b/dist/tpm-udev.rules
@@ -1,4 +1,4 @@
 # tpm devices can only be accessed by the tss user but the tss
 # group members can access tpmrm devices
-KERNEL=="tpm[0-9]*", MODE="0660", OWNER="tss"
+KERNEL=="tpm[0-9]*", MODE="0660", OWNER="tss", GROUP="tss"
 KERNEL=="tpmrm[0-9]*", MODE="0660", OWNER="tss", GROUP="tss"


### PR DESCRIPTION
The group permission should be also specified.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>