### PR TITLE
build: Update generated ignore rules to catch code coverage data

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -346,8 +346,6 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk $(top_srcdir)/configure.a
 			$(TEST_LOGS:.log=.trs) \
 			$(TEST_SUITE_LOG) \
 			$(TESTS:=.test) \
-			"*.gcda" \
-			"*.gcno" \
 			$(DISTCLEANFILES) \
 			$(am__CONFIG_DISTCLEAN_FILES) \
 			$(CONFIG_CLEAN_FILES) \
@@ -369,6 +367,8 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk $(top_srcdir)/configure.a
 			".dirstamp" \
 		; do echo "/$$x"; done; \
 		for x in \
+			"*.gcda" \
+			"*.gcno" \
 			"*.$(OBJEXT)" \
 			$(DEPDIR) \
 		; do echo "$$x"; done; \


### PR DESCRIPTION
The existing rules will only ignore gcda & gcno files in the root
directory. The code coverage macros generate these files in
subdirectories alongside the object files.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>