### PR TITLE
TCTI: Fix the default locality value of tcti-mssim.

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -489,7 +489,7 @@ tcti_mssim_init_context_data (
     TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_mssim_set_locality;
     TSS2_TCTI_MAKE_STICKY (tcti_common) = tcti_make_sticky_not_implemented;
     tcti_common->state = TCTI_STATE_TRANSMIT;
-    tcti_common->locality = 3;
+    tcti_common->locality = 0;
     memset (&tcti_common->header, 0, sizeof (tcti_common->header));
 }
 /*


### PR DESCRIPTION
* The default value should be 0 instead of 3.
* The integration tests relying on locality 3 (extend pcr 17, pcr event pcr 18) were adapted.
* The locality is reset to 0 at the end of the locality integration test.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>