### PR TITLE
build: Add required tctildr headers to libtss2-tctildr _SOURCE.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -257,7 +257,7 @@ test_unit_tctildr_dl_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_tctildr_dl_LDFLAGS = -Wl,--wrap=dlopen,--wrap=dlclose,--wrap=dlsym \
     -Wl,--wrap=tcti_from_init,--wrap=tcti_from_info
 test_unit_tctildr_dl_SOURCES = test/unit/tctildr-dl.c \
-        src/tss2-tcti/tctildr-dl.c src/tss2-tcti/tctildr-interface.h
+        src/tss2-tcti/tctildr-dl.c
 
 test_unit_tctildr_nodl_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) \
         -UESYS_TCTI_DEFAULT_MODULE -UESYS_TCTI_DEFAUT_CONFIG
@@ -265,7 +265,7 @@ test_unit_tctildr_nodl_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_tctildr_nodl_LDFLAGS = -Wl,--wrap=Tss2_Tcti_Device_Init \
         -Wl,--wrap=Tss2_Tcti_Mssim_Init,--wrap=tcti_from_init
 test_unit_tctildr_nodl_SOURCES = test/unit/tctildr-nodl.c \
-        src/tss2-tcti/tctildr-nodl.c src/tss2-tcti/tctildr-interface.h
+        src/tss2-tcti/tctildr-nodl.c
 
 test_unit_io_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_io_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)

--- a/Makefile.am
+++ b/Makefile.am
@@ -330,7 +330,7 @@ if HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC) $(TSS2_ESYS_SRC_CRYPTO) \
-    src/tss2-tcti/tctildr.c
+    src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h
 if NO_DL
 src_tss2_esys_libtss2_esys_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim)
 src_tss2_esys_libtss2_esys_la_SOURCES += src/tss2-tcti/tctildr-nodl.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -330,7 +330,8 @@ if HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
 endif # HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC) $(TSS2_ESYS_SRC_CRYPTO) \
-    src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h
+    src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h \
+    src/tss2-tcti/tctildr-interface.h
 if NO_DL
 src_tss2_esys_libtss2_esys_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim)
 src_tss2_esys_libtss2_esys_la_SOURCES += src/tss2-tcti/tctildr-nodl.c


### PR DESCRIPTION
This header will not be shipped in a dist tarball otherwise causing
breakage for dist targets and generated source tarballs.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>