### PR TITLE
esys: tr: Esys_TRSess_SetAttributes null check fix

### DIFF
--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -501,7 +501,7 @@ Esys_TRSess_SetAttributes(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     TSS2_RC r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
 
-    return_if_null(esys_context, "Object not found", TSS2_ESYS_RC_BAD_VALUE);
+    return_if_null(esys_object, "Object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     if (esys_object->rsrc.rsrcType != IESYSC_SESSION_RSRC)
         return_error(TSS2_ESYS_RC_BAD_TR, "Object is not a session object");


### PR DESCRIPTION
* In Esys_TRSess_SetAttributes a return_if_null checked the
  esys_context pointer instead of the esys_object pointer it was meant
  to check. This patch fixes this.

Fixes: #1471

Signed-off-by: John Andersen <john.s.andersen@intel.com>