### PR TITLE
esys: tr: Esys_TR_FromTPMPublic_Finish null check fix

### DIFF
--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -187,10 +187,13 @@ TSS2_RC
 Esys_TR_FromTPMPublic_Finish(ESYS_CONTEXT * esys_context, ESYS_TR * object)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    ESYS_TR objectHandle = esys_context->esys_handle;
+    ESYS_TR objectHandle = ESYS_TR_NONE;
     RSRC_NODE_T *objectHandleNode;
 
     _ESYS_ASSERT_NON_NULL(esys_context);
+
+    objectHandle = esys_context->esys_handle;
+
     r = esys_GetResourceObject(esys_context, objectHandle, &objectHandleNode);
     goto_if_error(r, "get resource", error_cleanup);
 


### PR DESCRIPTION
* In Esys_TR_FromTPMPublic_Finish esys_handle within esys_context was
  accessed prior to a _ESYS_ASSERT_NON_NULL check. This patch fixes this.

Fixes: #1458

Signed-off-by: John Andersen <john.s.andersen@intel.com>