### PR TITLE
esys: tr: Esys_TR_GetName SAFE_FREE correction

### DIFF
--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -443,7 +443,7 @@ Esys_TR_GetName(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     }
     return r;
  error_cleanup:
-    SAFE_FREE(name);
+    SAFE_FREE(*name);
     return r;
 }
 


### PR DESCRIPTION
* In Esys_TR_GetName the allocated TPM2B_NAME object is assigned to the
  value of the pointer to pointer to TPM2B_NAME. However, the call to
  SAFE_FREE passed the pointer to pointer to TPM2B_NAME rather than the
  pointer to TPM2B_NAME, as intended. This patch fixes that.

Fixes: #1432

Signed-off-by: John Andersen <john.s.andersen@intel.com>