### PR TITLE
tctildr: initialise rc in get_info_default to avoid compiler warning 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,8 @@ AC_ARG_ENABLE([defaultflags],
 AS_IF([test "x$enable_defaultflags" = "xyes"],
       [
       AS_IF([test "x$enable_debug" = "xno"],
-            [AX_ADD_FORTIFY_SOURCE])
+            [ADD_COMPILER_FLAG([-O2])
+             AX_ADD_FORTIFY_SOURCE])
       ADD_COMPILER_FLAG([-std=c99])
       ADD_COMPILER_FLAG([-Wall])
       ADD_COMPILER_FLAG([-Wextra])

--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -166,7 +166,7 @@ get_info_default(const TSS2_TCTI_INFO **info,
     void *handle = NULL;
     const TSS2_TCTI_INFO *info_src;
     char *name = NULL;
-    TSS2_RC rc;
+    TSS2_RC rc = TSS2_TCTI_RC_GENERAL_FAILURE;
 
     LOG_DEBUG("%s", __func__);
     if (info == NULL || dlhandle == NULL) {


### PR DESCRIPTION
When compiling with `CFLAGS='-O2'` and GCC 9.1.0, compilation fails with
```
src/tss2-tcti/tctildr-dl.c: In function ‘get_info_default’:
src/tss2-tcti/tctildr-dl.c:210:12: error: ‘rc’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  210 |     return rc;
      |            ^~
cc1: all warnings being treated as errors
```
This is a false positive because if `ESYS_TCTI_DEFAULT_MODULE` is not defined and the (constant) `tctis` array does not have any elements, `info_from_handle` will return `NULL` and `rc` will be initialised, but initialising `rc` with a failure value does not hurt.

Also take the opportunity to add `-O2` to the compilation flags if fortification is enabled, otherwise compilation fails with
```
/usr/include/features.h:382:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  382 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```
(see https://github.com/tpm2-software/tpm2-tools/pull/1590).