### PR TITLE
tcti: fix issues found by coverity scan

### DIFF
--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -146,7 +146,7 @@ tctildr_conf_parse (const char *name_conf,
         name [name_length] = '\0';
         LOG_DEBUG ("TCTI name: \"%s\"", name);
     }
-    if (conf != NULL && split [1] != '\0') {
+    if (conf != NULL && split && split [1] != '\0') {
         /* conf is more than empty string */
         strcpy (conf, &split [1]);
         LOG_DEBUG ("TCTI conf: \"%s\"", conf);
@@ -361,6 +361,7 @@ Tss2_TctiLdr_GetInfo (const char *name,
     rc = copy_info (info_lib, info_tmp);
     if (rc != TSS2_RC_SUCCESS) {
         free (info_tmp);
+        info_tmp = NULL;
         goto out;
     }
     info_tmp->init = NULL;


### PR DESCRIPTION
Fix two issues found by coverity scan:

** CID 1484591:  Null pointer dereferences  (NULL_RETURNS)
/src/tss2-tcti/tctildr.c: 149 in tctildr_conf_parse()

** CID 1484590:  Memory - illegal accesses  (USE_AFTER_FREE)
/src/tss2-tcti/tctildr.c: 369 in Tss2_TctiLdr_GetInfo()