### PR TITLE
ESAPI: Fix tests using platform hierarchy.

### DIFF
--- a/test/integration/esys-clear-control.int.c
+++ b/test/integration/esys-clear-control.int.c
@@ -50,7 +50,8 @@ test_esys_clear_control(ESYS_CONTEXT * esys_context)
         ESYS_TR_NONE,
         disable);
 
-    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH ||
+        (r & ~TPM2_RC_N_MASK) == TPM2_RC_HIERARCHY) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return =  EXIT_SKIP;

--- a/test/integration/esys-clockset.int.c
+++ b/test/integration/esys-clockset.int.c
@@ -39,7 +39,7 @@ test_esys_clockset(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
     int failure_return = EXIT_FAILURE;
 
-    ESYS_TR auth_handle = ESYS_TR_RH_PLATFORM;
+    ESYS_TR auth_handle = ESYS_TR_RH_OWNER;
     TPMS_TIME_INFO *currentTime;
 
     r = Esys_ReadClock(esys_context,

--- a/test/integration/esys-policy-nv-undefine-special.int.c
+++ b/test/integration/esys-policy-nv-undefine-special.int.c
@@ -132,7 +132,8 @@ test_esys_policy_nv_undefine_special(ESYS_CONTEXT * esys_context)
                             &publicInfo,
                             &nvHandle);
 
-    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH) {
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH  ||
+        (r & ~TPM2_RC_N_MASK) == TPM2_RC_HIERARCHY) {
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return = EXIT_SKIP;


### PR DESCRIPTION
* Fixes: #1479
* Some integration tests did use platform hierarchy. These tests did not check
  the error code TPM2_RC_HIERARCHY if platform hierarchy is disabled. The check was added.
* The clock set tests did also use platform hierarchy. Here owner hierarchy can be
  used.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>