### PR TITLE
Add the enable-asan configure option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
     elif [ "$CC" == "clang" ]; then
       ../configure --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
     else
-      ../configure --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
+      ../configure --with-sanitizer=undefined --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS CFLAGS=-I${PWD}/../osslinstall/usr/local/include LDFLAGS=-L${PWD}/../osslinstall/usr/local/lib
     fi
   - |
     if [ "$SCANBUILD" == "yes" ]; then

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,9 @@
 ### Initialize global variables used throughout the file ###
 INCLUDE_DIRS    = -I$(srcdir)/src -I$(srcdir)/include/tss2
 ACLOCAL_AMFLAGS = -I m4 --install
-AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS)
-AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
+AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
+				  $(SANITIZER_CFLAGS)
+AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(SANITIZER_LDFLAGS)
 
 # Initialize empty variables to be extended throughout
 lib_LTLIBRARIES =

--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,29 @@ AS_IF([test "x$enable_integration" = "xyes"],
        AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 #
+# sanitizer compiler flags
+#
+AC_ARG_WITH([sanitizer],
+            [AS_HELP_STRING([--with-sanitizer={none,address,undefined}],
+                            [build with the given sanitizer])],,
+            [with_sanitizer=none])
+AS_CASE(["x$with_sanitizer"],
+        ["xnone"],
+        [],
+        ["xaddress"],
+        [
+            SANITIZER_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+            SANITIZER_LDFLAGS="-lasan"
+        ],
+        ["xundefined"],
+        [
+            SANITIZER_CFLAGS="-fsanitize=undefined"
+            SANITIZER_LDFLAGS="-lubsan"
+        ],
+        [AC_MSG_ERROR([Bad value for --with-sanitizer])])
+AC_SUBST([SANITIZER_CFLAGS])
+AC_SUBST([SANITIZER_LDFLAGS])
+#
 # fuzz testing
 #
 AC_ARG_WITH([fuzzing],

--- a/test/unit/tctildr-tcti.c
+++ b/test/unit/tctildr-tcti.c
@@ -132,6 +132,8 @@ tctildr_teardown (void **state)
 
     tctildr_finalize (context);
 
+    free (context);
+
     return 0;
 }
 static void


### PR DESCRIPTION
Add the `enable-asan` configure option to allow building with `-fsanitize=address`.
I also fixed a simple leak in the unit tests detected by `LeakSanitizer`. There were a
few more memory errors that were detected with `enable-asan`, but I'd need a bit
more time to figure out the cause of them.

Comments and critiques are welcomed! :smile: