### PR TITLE
Public is not updated when CreateLoaded() completes

### DIFF
--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -392,6 +392,8 @@ Esys_CreateLoaded_Finish(
             "in Public name not equal name in response", error_cleanup);
 
     /* Update the meta data of the ESYS_TR object */
+    objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
+    objectHandleNode->rsrc.misc.rsrc_key_pub = *loutPublic;
     objectHandleNode->rsrc.name = name;
     objectHandleNode->auth = esysContext->in.CreateLoaded.inSensitive->sensitive.userAuth;
     if (outPublic != NULL)


### PR DESCRIPTION
This results in Esys_TR_GetName() returning the name of the template and not the actual public that was created.