### PR TITLE
sphinx: remove unused imports from conf.py

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -13,8 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
 import subprocess
 
 # Create (unused) root file


### PR DESCRIPTION
The file is autogenerated from a template and includes these imports for an [option that is commented out](https://github.com/tpm2-software/tpm2-tss/blob/c42450a294c4267998aa16a477e9218ee5953aa9/sphinx/conf.py#L41). Remove the imports to make [LGTM](https://lgtm.com/projects/g/tpm2-software/tpm2-tss/snapshot/359631ab0822728ff1c16b578f1519afc4fa36d1/files/sphinx/conf.py) happy.