### PR TITLE
Revert "build: add install-exec-hook"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -416,14 +416,7 @@ uninstall-local:
 	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
 endif
 
-install-exec-hook:
-	cd $(DESTDIR)$(libdir) && \
-		$(LN_S) -f libtss2-tcti-device.so libtss2-tcti-default.so
-
 uninstall-hook:
-	cd $(DESTDIR)$(libdir) && \
-		[ -L libtss2-tcti-default.so ] && \
-			rm -f libtss2-tcti-default.so || true
 	cd $(DESTDIR)$(man3dir) && \
 		[ -L Tss2_TctiLdr_Initialize_Ex.3 ] && \
 			rm -f Tss2_TctiLdr_Initialize_Ex.3 || true


### PR DESCRIPTION
As suggested in #1525, remove `libtss2-tcti-default.so` from the default installation.