### PR TITLE
doc: fix doxygen's index.html

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -942,7 +942,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             =
+IMAGE_PATH             = @top_srcdir@/doc/
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ SAPI library, TAB/RM, and Test Code Block Diagram:
 ![Architecture Block Diagram](doc/TSS_block_diagram.png)
 
 # Project Layout
+```
 ├── doc     : various bits of documentation\
 ├── include : header files installed in $(includedir)\
 │   └── tss2      : all public headers for this project\
@@ -191,3 +192,4 @@ SAPI library, TAB/RM, and Test Code Block Diagram:
     ├── integration : integration test harness and test cases\
     ├── tpmclient   : monolithic, legacy test application\
     └── unit        : unit tests
+```


### PR DESCRIPTION
The main page of the doxygen documentation index.html is broken both on readthedocs.io and after being built locally.

Changes:
1. adds the architecture image to the doxygen build in `Doxygen.in`
1. moves the *project layout* section into a code block to preserve the newlines

Fixes #1524 