### PR TITLE
Fix a segfault in the tests, a bug with ecc key sizes and a typo

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -14,7 +14,7 @@ Possible levels are: NONE, ERROR, WARNING, INFO, DEBUG, TRACE
 The level can be set for all module using the `all` module name or individually
 per module. The environment variable is evaluated left to right.
 
-Example: `TSS2_LOG=all+ERROR,marshal+TRACE,tcti+DEBUG
+Example: `TSS2_LOG=all+ERROR,marshal+TRACE,tcti+DEBUG`
 
 # Implementation
 

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -804,7 +804,7 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC *key,
         break;
     case TPM2_ECC_NIST_P224:
         curveId = NID_secp224r1;
-        key_size = 38;
+        key_size = 28;
         break;
     case TPM2_ECC_NIST_P256:
         curveId = NID_X9_62_prime256v1;

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -117,7 +117,6 @@ tctildr_conf_parse (const char *name_conf,
     char *split;
     size_t combined_length;
 
-    LOG_DEBUG ("name_conf: \"%s\"", name_conf);
     if (name_conf == NULL) {
         LOG_ERROR ("'name_conf' param may NOT be NULL");
         return TSS2_TCTI_RC_BAD_REFERENCE;
@@ -127,6 +126,8 @@ tctildr_conf_parse (const char *name_conf,
         LOG_ERROR ("combined conf length must be between 0 and PATH_MAX");
         return TSS2_TCTI_RC_BAD_VALUE;
     }
+
+    LOG_DEBUG ("name_conf: \"%s\"", name_conf);
     if (combined_length == 0)
         return TSS2_RC_SUCCESS;
     split = strchr (name_conf, ':');


### PR DESCRIPTION
This are three pretty straightforward issues I wanted to fix:

- if `TSS2_LOG="all+ERROR,tcti+DEBUG" make check`, the test `test/unit/tctildr` will run into a segfault since `LOG_DEBUG()` wants to print an (for test purposes) enormous string. Therefore, `LOG_DEBUG()` needs to be moved further down (after a length check).
- in `esys_crypto_ossl.c`, a wrong key size is chosen for the ECC curve `TPM2_ECC_NISTP224 `.
- in `logging.md`, there is an unterminated inline code block