### PR TITLE
esys: change the hierarchy type according to the spec

### DIFF
--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -421,7 +421,7 @@ Esys_LoadExternal(
     ESYS_TR shandle3,
     const TPM2B_SENSITIVE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
-    TPMI_RH_HIERARCHY hierarchy,
+    ESYS_TR hierarchy,
     ESYS_TR *objectHandle);
 
 TSS2_RC
@@ -432,7 +432,7 @@ Esys_LoadExternal_Async(
     ESYS_TR shandle3,
     const TPM2B_SENSITIVE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
-    TPMI_RH_HIERARCHY hierarchy);
+    ESYS_TR hierarchy);
 
 TSS2_RC
 Esys_LoadExternal_Finish(
@@ -961,7 +961,7 @@ Esys_Hash(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *data,
     TPMI_ALG_HASH hashAlg,
-    TPMI_RH_HIERARCHY hierarchy,
+    ESYS_TR hierarchy,
     TPM2B_DIGEST **outHash,
     TPMT_TK_HASHCHECK **validation);
 
@@ -973,7 +973,7 @@ Esys_Hash_Async(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *data,
     TPMI_ALG_HASH hashAlg,
-    TPMI_RH_HIERARCHY hierarchy);
+    ESYS_TR hierarchy);
 
 TSS2_RC
 Esys_Hash_Finish(
@@ -1143,7 +1143,7 @@ Esys_SequenceComplete(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *buffer,
-    TPMI_RH_HIERARCHY hierarchy,
+    ESYS_TR hierarchy,
     TPM2B_DIGEST **result,
     TPMT_TK_HASHCHECK **validation);
 
@@ -1155,7 +1155,7 @@ Esys_SequenceComplete_Async(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *buffer,
-    TPMI_RH_HIERARCHY hierarchy);
+    ESYS_TR hierarchy);
 
 TSS2_RC
 Esys_SequenceComplete_Finish(
@@ -2304,7 +2304,7 @@ Esys_HierarchyControl(
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_RH_ENABLES enable,
+    ESYS_TR enable,
     TPMI_YES_NO state);
 
 TSS2_RC
@@ -2314,7 +2314,7 @@ Esys_HierarchyControl_Async(
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_RH_ENABLES enable,
+    ESYS_TR enable,
     TPMI_YES_NO state);
 
 TSS2_RC

--- a/src/tss2-esys/api/Esys_HierarchyControl.c
+++ b/src/tss2-esys/api/Esys_HierarchyControl.c
@@ -71,7 +71,7 @@ Esys_HierarchyControl(
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_RH_ENABLES enable,
+    ESYS_TR enable,
     TPMI_YES_NO state)
 {
     TSS2_RC r;
@@ -151,7 +151,7 @@ Esys_HierarchyControl_Async(
     ESYS_TR shandle1,
     ESYS_TR shandle2,
     ESYS_TR shandle3,
-    TPMI_RH_ENABLES enable,
+    ESYS_TR enable,
     TPMI_YES_NO state)
 {
     TSS2_RC r;
@@ -160,12 +160,18 @@ Esys_HierarchyControl_Async(
               esysContext, authHandle, enable, state);
     TSS2L_SYS_AUTH_COMMAND auths;
     RSRC_NODE_T *authHandleNode;
+    TPMI_RH_ENABLES tpm_enable;
 
     /* Check context, sequence correctness and set state to error for now */
     if (esysContext == NULL) {
         LOG_ERROR("esyscontext is NULL.");
         return TSS2_ESYS_RC_BAD_REFERENCE;
     }
+
+    r = iesys_handle_to_tpm_handle(enable, &tpm_enable);
+    if (r != TSS2_RC_SUCCESS)
+        return r;
+
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)
         return r;
@@ -182,8 +188,8 @@ Esys_HierarchyControl_Async(
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_HierarchyControl_Prepare(esysContext->sys,
                                           (authHandleNode == NULL) ? TPM2_RH_NULL
-                                           : authHandleNode->rsrc.handle, enable,
-                                          state);
+                                           : authHandleNode->rsrc.handle,
+                                           tpm_enable, state);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 
     /* Calculate the cpHash Values */

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -76,7 +76,7 @@ Esys_LoadExternal(
     ESYS_TR shandle3,
     const TPM2B_SENSITIVE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
-    TPMI_RH_HIERARCHY hierarchy, ESYS_TR *objectHandle)
+    ESYS_TR hierarchy, ESYS_TR *objectHandle)
 {
     TSS2_RC r;
 
@@ -145,19 +145,25 @@ Esys_LoadExternal_Async(
     ESYS_TR shandle3,
     const TPM2B_SENSITIVE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
-    TPMI_RH_HIERARCHY hierarchy)
+    ESYS_TR hierarchy)
 {
     TSS2_RC r;
     LOG_TRACE("context=%p, inPrivate=%p, inPublic=%p,"
               "hierarchy=%"PRIx32 "",
               esysContext, inPrivate, inPublic, hierarchy);
     TSS2L_SYS_AUTH_COMMAND auths;
+    TPMI_RH_HIERARCHY tpm_hierarchy;
 
     /* Check context, sequence correctness and set state to error for now */
     if (esysContext == NULL) {
         LOG_ERROR("esyscontext is NULL.");
         return TSS2_ESYS_RC_BAD_REFERENCE;
     }
+
+    r = iesys_handle_to_tpm_handle(hierarchy, &tpm_hierarchy);
+    if (r != TSS2_RC_SUCCESS)
+        return r;
+
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)
         return r;
@@ -170,7 +176,7 @@ Esys_LoadExternal_Async(
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_LoadExternal_Prepare(esysContext->sys, inPrivate, inPublic,
-                                      hierarchy);
+                                      tpm_hierarchy);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 
     /* Calculate the cpHash Values */

--- a/src/tss2-esys/api/Esys_SequenceComplete.c
+++ b/src/tss2-esys/api/Esys_SequenceComplete.c
@@ -77,7 +77,7 @@ Esys_SequenceComplete(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *buffer,
-    TPMI_RH_HIERARCHY hierarchy,
+    ESYS_TR hierarchy,
     TPM2B_DIGEST **result,
     TPMT_TK_HASHCHECK **validation)
 {
@@ -151,7 +151,7 @@ Esys_SequenceComplete_Async(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *buffer,
-    TPMI_RH_HIERARCHY hierarchy)
+    ESYS_TR hierarchy)
 {
     TSS2_RC r;
     LOG_TRACE("context=%p, sequenceHandle=%"PRIx32 ", buffer=%p,"
@@ -159,12 +159,18 @@ Esys_SequenceComplete_Async(
               esysContext, sequenceHandle, buffer, hierarchy);
     TSS2L_SYS_AUTH_COMMAND auths;
     RSRC_NODE_T *sequenceHandleNode;
+    TPMI_RH_HIERARCHY tpm_hierarchy;
 
     /* Check context, sequence correctness and set state to error for now */
     if (esysContext == NULL) {
         LOG_ERROR("esyscontext is NULL.");
         return TSS2_ESYS_RC_BAD_REFERENCE;
     }
+
+    r = iesys_handle_to_tpm_handle(hierarchy, &tpm_hierarchy);
+    if (r != TSS2_RC_SUCCESS)
+        return r;
+
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)
         return r;
@@ -184,7 +190,7 @@ Esys_SequenceComplete_Async(
                                           (sequenceHandleNode == NULL)
                                            ? TPM2_RH_NULL
                                            : sequenceHandleNode->rsrc.handle,
-                                          buffer, hierarchy);
+                                          buffer, tpm_hierarchy);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 
     /* Calculate the cpHash Values */

--- a/src/tss2-fapi/api/Fapi_ExportKey.c
+++ b/src/tss2-fapi/api/Fapi_ExportKey.c
@@ -357,7 +357,7 @@ Fapi_ExportKey_Finish(
             r = Esys_LoadExternal_Async(context->esys,
                                         ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                                         NULL,   &command->public_parent,
-                                        TPM2_RH_OWNER);
+                                        ESYS_TR_RH_OWNER);
             goto_if_error(r, "LoadExternal_Async", cleanup);
 
             fallthrough;

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -461,7 +461,7 @@ execute_policy_signed(
         /* Prepare the loading of the external public key, user for verificaton. */
         r = Esys_LoadExternal_Async(esys_ctx,
                                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-                                    NULL, &inPublic, TPM2_RH_OWNER);
+                                    NULL, &inPublic, ESYS_TR_RH_OWNER);
         goto_if_error(r, "LoadExternal_Async", cleanup);
         fallthrough;
 
@@ -584,7 +584,7 @@ execute_policy_authorize(
         public2b.publicArea = policy->keyPublic;
         r = Esys_LoadExternal_Async(esys_ctx,
                                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-                                    NULL,  &public2b, TPM2_RH_OWNER);
+                                    NULL,  &public2b, ESYS_TR_RH_OWNER);
         goto_if_error(r, "LoadExternal_Async", cleanup);
         fallthrough;
 

--- a/test/integration/esys-hash.int.c
+++ b/test/integration/esys-hash.int.c
@@ -37,7 +37,7 @@ test_esys_hash(ESYS_CONTEXT * esys_context)
                               .buffer={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
                                        1, 2, 3, 4, 5, 6, 7, 8, 9}};
     TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *outHash = NULL;
     TPMT_TK_HASHCHECK *validation = NULL;
 

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -112,7 +112,7 @@ test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
                               &buffer,
-                              TPM2_RH_OWNER,
+                              ESYS_TR_RH_OWNER,
                               &result,
                               &validation
                               );

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -41,7 +41,7 @@ test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
 
     ESYS_TR authHandle_handle = ESYS_TR_RH_PLATFORM;
-    TPMI_RH_ENABLES enable = TPM2_RH_OWNER;
+    ESYS_TR enable = ESYS_TR_RH_OWNER;
     TPMI_YES_NO state = TPM2_NO;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
     int failure_return = EXIT_FAILURE;

--- a/test/integration/esys-hmacsequencestart.int.c
+++ b/test/integration/esys-hmacsequencestart.int.c
@@ -172,7 +172,7 @@ test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
                               &buffer,
-                              TPM2_RH_OWNER,
+                              ESYS_TR_RH_OWNER,
                               &result,
                               &validation
                               );
@@ -236,7 +236,7 @@ test_esys_hmacsequencestart(ESYS_CONTEXT * esys_context)
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
                               &buffer,
-                              TPM2_RH_OWNER,
+                              ESYS_TR_RH_OWNER,
                               &result,
                               &validation
                               );

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -298,7 +298,7 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
                           ESYS_TR_NONE,
                           NULL,
                           outPublic2,
-                          TPM2_RH_OWNER,
+                          ESYS_TR_RH_OWNER,
                           &loadedKeyHandle);
     goto_if_error(r, "Error esys load external", error);
 

--- a/test/integration/esys-policy-ticket.int.c
+++ b/test/integration/esys-policy-ticket.int.c
@@ -231,7 +231,7 @@ test_esys_policy_ticket(ESYS_CONTEXT * esys_context)
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
                               (const TPM2B_MAX_BUFFER *)&expiration2b,
-                              TPM2_RH_OWNER,
+                              ESYS_TR_RH_OWNER,
                               &signed_digest,
                               &validation
                               );

--- a/test/unit/esys-resubmissions.c
+++ b/test/unit/esys-resubmissions.c
@@ -559,7 +559,7 @@ test_LoadExternal(void **state)
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
-                          NULL, &inPublic, TPM2_RH_OWNER, &objectHandle_handle);
+                          NULL, &inPublic, ESYS_TR_RH_OWNER, &objectHandle_handle);
 
     assert_int_equal(r, TPM2_RC_YIELDED);
     assert_int_equal(tcti_yielder->count, 5 /* _ESYS_MAX_SUBMISSIONS */ );
@@ -972,7 +972,7 @@ test_Hash(void **state)
 
     TPM2B_MAX_BUFFER data = DUMMY_2B_DATA(.buffer);
     TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *outHash;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_Hash(esys_context,
@@ -1120,7 +1120,7 @@ test_SequenceComplete(void **state)
 
     ESYS_TR sequenceHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *result;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_SequenceComplete(esys_context,
@@ -2093,7 +2093,7 @@ test_HierarchyControl(void **state)
     TSS2_TCTI_CONTEXT_YIELDER *tcti_yielder = tcti_yielder_cast(tcti);
 
     ESYS_TR authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_RH_ENABLES enable = TPM2_RH_OWNER;
+    ESYS_TR enable = ESYS_TR_RH_OWNER;
     TPMI_YES_NO state2 = 0;
     r = Esys_HierarchyControl(esys_context,
                               authHandle_handle,

--- a/test/unit/esys-tcti-rcs.c
+++ b/test/unit/esys-tcti-rcs.c
@@ -540,7 +540,7 @@ test_LoadExternal(void **state)
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
-                          NULL, &inPublic, TPM2_RH_OWNER, &objectHandle_handle);
+                          NULL, &inPublic, ESYS_TR_RH_OWNER, &objectHandle_handle);
 
     assert_int_equal(r, TSS2_TCTI_RC_NO_CONNECTION);
 }
@@ -919,7 +919,7 @@ test_Hash(void **state)
 
     TPM2B_MAX_BUFFER data = DUMMY_2B_DATA(.buffer);
     TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *outHash;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_Hash(esys_context,
@@ -1053,7 +1053,7 @@ test_SequenceComplete(void **state)
 
     ESYS_TR sequenceHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *result;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_SequenceComplete(esys_context,
@@ -1941,7 +1941,7 @@ test_HierarchyControl(void **state)
     Esys_GetTcti(esys_context, &tcti);
 
     ESYS_TR authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_RH_ENABLES enable = TPM2_RH_OWNER;
+    ESYS_TR enable = ESYS_TR_RH_OWNER;
     TPMI_YES_NO state2 = 0;
     r = Esys_HierarchyControl(esys_context,
                               authHandle_handle,

--- a/test/unit/esys-tpm-rcs.c
+++ b/test/unit/esys-tpm-rcs.c
@@ -520,7 +520,7 @@ test_LoadExternal(void **state)
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
-                          NULL, &inPublic, TPM2_RH_OWNER, &objectHandle_handle);
+                          NULL, &inPublic, ESYS_TR_RH_OWNER, &objectHandle_handle);
 
     assert_int_equal(r, 0x0FFF);
 }
@@ -899,7 +899,7 @@ test_Hash(void **state)
 
     TPM2B_MAX_BUFFER data = DUMMY_2B_DATA(.buffer);
     TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *outHash;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_Hash(esys_context,
@@ -1033,7 +1033,7 @@ test_SequenceComplete(void **state)
 
     ESYS_TR sequenceHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_RH_HIERARCHY hierarchy = TPM2_RH_OWNER;
+    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *result;
     TPMT_TK_HASHCHECK *validation;
     r = Esys_SequenceComplete(esys_context,
@@ -1921,7 +1921,7 @@ test_HierarchyControl(void **state)
     Esys_GetTcti(esys_context, &tcti);
 
     ESYS_TR authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_RH_ENABLES enable = TPM2_RH_OWNER;
+    ESYS_TR enable = ESYS_TR_RH_OWNER;
     TPMI_YES_NO state2 = 0;
     r = Esys_HierarchyControl(esys_context,
                               authHandle_handle,


### PR DESCRIPTION
There is a discrepancy between ESYS specification v0.90 rev4 and the
ESYS implementation, where the specification defines hierarchy
as ESYS_TR type and the implementation uses TPMI_RH_HIERARCHY type.
The affected functions include: Esys_Hash(), Esys_HierarchyControl(),
Esys_LoadExternal(), and Esys_SequenceComplete() plus their _Async()
version. This change makes the spec and the implementation consistent.