### PR TITLE
Add C++ linkage to tss2_rc.h

### DIFF
--- a/include/tss2/tss2_rc.h
+++ b/include/tss2/tss2_rc.h
@@ -7,10 +7,18 @@
 
 #include "tss2_tpm2_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef const char *(*TSS2_RC_HANDLER)(TSS2_RC rc);
 
 const char *Tss2_RC_Decode(TSS2_RC rc);
 
 TSS2_RC_HANDLER Tss2_RC_SetHandler(uint8_t layer, const char *name, TSS2_RC_HANDLER handler);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Without the change, using Tss2_RC_Decode() or Tss2_RC_SetHandler() from
C++ code results in undefined reference error during linkage.