### PR TITLE
esys: add a new function to retrieve sys context from esys

### DIFF
--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -23,6 +23,8 @@ Both the synchronous and asynchronous API are exposed through a single library: 
  \fn TSS2_RC Esys_GetTcti(ESYS_CONTEXT * esys_context, TSS2_TCTI_CONTEXT ** tcti)
  \fn TSS2_RC Esys_GetPollHandles(ESYS_CONTEXT * esys_context, TSS2_TCTI_POLL_HANDLE ** handles, size_t * count)
  \fn TSS2_RC Esys_SetTimeout(ESYS_CONTEXT *esys_context, int32_t timeout)
+ \fn TSS2_RC Esys_GetSysContext(ESYS_CONTEXT *esys_context, TSS2_SYS_CONTEXT **sys_context)
+ \fn void Esys_Free(void *__ptr)
  \}
 */
 

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -3228,6 +3228,11 @@ void
 Esys_Free(
     void *__ptr);
 
+TSS2_RC
+Esys_GetSysContext(
+    ESYS_CONTEXT *esys_context,
+    TSS2_SYS_CONTEXT **sys_context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -112,6 +112,7 @@ EXPORTS
     Esys_GetTime
     Esys_GetTime_Async
     Esys_GetTime_Finish
+    Esys_GetSysContext
     Esys_HMAC
     Esys_HMAC_Async
     Esys_HMAC_Finish

--- a/lib/tss2-esys.map
+++ b/lib/tss2-esys.map
@@ -110,6 +110,7 @@
         Esys_GetTime;
         Esys_GetTime_Async;
         Esys_GetTime_Finish;
+        Esys_GetSysContext;
         Esys_Hash;
         Esys_Hash_Async;
         Esys_Hash_Finish;

--- a/src/tss2-esys/esys_context.c
+++ b/src/tss2-esys/esys_context.c
@@ -219,3 +219,22 @@ Esys_SetTimeout(ESYS_CONTEXT * esys_context, int32_t timeout)
     esys_context->timeout = timeout;
     return TSS2_RC_SUCCESS;
 }
+
+/** Helper function that returns sys contest from the give esys context.
+ *
+ * Function returns sys contest from the give esys context.
+ * @param esys_context [in] ESYS context.
+ * @param sys_context [out] SYS context.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE if esys_context of sys_context are NULL.
+ */
+TSS2_RC
+Esys_GetSysContext(ESYS_CONTEXT *esys_context, TSS2_SYS_CONTEXT **sys_context)
+{
+    if (esys_context == NULL || sys_context == NULL)
+        return TSS2_ESYS_RC_BAD_REFERENCE;
+
+    *sys_context = esys_context->sys;
+
+    return TSS2_RC_SUCCESS;
+}

--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -250,7 +250,30 @@ check_free(void **state)
     Esys_Free(buffer);
 }
 
+static void
+check_get_sys_context(void **state)
+{
+    ESYS_CONTEXT *ctx;
+    TSS2_TCTI_CONTEXT_COMMON_V1 tcti = {0};
+    TSS2_SYS_CONTEXT *sys_ctx = NULL;
+    TSS2_RC rc;
 
+    rc = Esys_GetSysContext(NULL, NULL);
+    assert_int_equal(rc, TSS2_ESYS_RC_BAD_REFERENCE);
+
+    tcti.version = 1;
+    tcti.transmit = (void*) 0xdeadbeef;
+    tcti.receive = (void*) 0xdeadbeef;
+
+    rc = Esys_Initialize(&ctx, (TSS2_TCTI_CONTEXT *) &tcti, NULL);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    rc = Esys_GetSysContext(ctx, &sys_ctx);
+    assert_ptr_not_equal(sys_ctx, NULL);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    Esys_Finalize(&ctx);
+}
 
 int
 main(int argc, char *argv[])
@@ -262,6 +285,7 @@ main(int argc, char *argv[])
         cmocka_unit_test(check_pk_encrypt),
         cmocka_unit_test(check_aes_encrypt),
         cmocka_unit_test(check_free),
+        cmocka_unit_test(check_get_sys_context),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
In some cases it can be necessary to call the underlining
sys function before invoking esys function. One example
would be to retrieve cpHash buffer of a command that needs
to be fed to Esys_PolicySigned or Esys_PolicySecret calls.
This can be done by using the Tss2_Sys_GetCpBuffer()
sys call as long as the user can access the sys context.
That's one possible (and simple) solution.
See issue: #1533

