### PR TITLE
test/integration: move TPM simulator from ibmswtpm2 to ms-tpm-20-ref

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -13,7 +13,7 @@ source $TRAVIS_BUILD_DIR/.ci/download-deps.sh
 get_deps "$WORKSPACE"
 
 export LD_LIBRARY_PATH=/usr/local/lib/
-export PATH=/root/.local/bin/:/ibmtpm974/src:$PATH
+export PATH=/root/.local/bin/:$PATH
 
 echo "echo changing to $TRAVIS_BUILD_DIR"
 # Change to the the travis build dir

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 function get_deps() {
-
-    echo "no deps"
+    git clone https://github.com/microsoft/ms-tpm-20-ref.git
+    cd ms-tpm-20-ref/TPMCmd
+    ./bootstrap
+    # Work around a bug in ms-tpm-20-ref until the fix in
+    # https://github.com/microsoft/ms-tpm-20-ref/pull/39 is merged upstream
+    ./configure CPPFLAGS='-DTABLE_DRIVEN_MARSHAL=NO'
+    make
+    make install
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ The following are dependencies only required when building test suites.
     - uthash development libraries and header files
     - ps executable (usually in the procps package)
     - ss executable (usually in the iproute2 package)
-    - tpm_server executable (from https://sourceforge.net/projects/ibmswtpm2/)
+    - tpm2-simulator executable (from https://github.com/microsoft/ms-tpm-20-ref)
 * Unit test suite (see ./configure option --enable-unit):
     - cmocka unit test framework, version >= 1.0
 * Code coverage analysis:

--- a/README.md
+++ b/README.md
@@ -57,14 +57,10 @@ You have been warned.
 ## Simulator
 The TPM library specification contains reference code sufficient to construct a software TPM 2.0 simulator.
 This code was provided by Microsoft and they provide a binary download for Windows [here](https://www.microsoft.com/en-us/download/details.aspx?id=52507).
-IBM has repackaged this code with a few Makefiles so that the Microsoft code can be built and run on Linux systems.
-The Linux version of the Microsoft TPM 2.0 simulator can be obtained [here](https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz).
+The Linux version of the Microsoft TPM 2.0 simulator can be obtained [here](https://github.com/microsoft/ms-tpm-20-ref).
 Once you've downloaded and successfully built and execute the simulator it will, by default, be accepting connections on the localhost, TCP ports 2321 and 2322.
 
-Issues building or running the simulator should be reported to the IBM software TPM2 project.
-
-NOTE: The Intel TCG TSS is currently tested against version 974 of the simulator.
-Compatibility with later versions has not yet been tested.
+Issues building or running the simulator should be reported to the ms-tpm-20-ref GitHub project.
 
 ## Testing
 To test the various TCTI, SAPI and ESAPI api calls, unit and integration tests can

--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,7 @@ AC_ARG_ENABLE([integration],
         [build and execute integration tests])],,
     [enable_integration=no])
 AS_IF([test "x$enable_integration" = "xyes"],
-      [ERROR_IF_NO_PROG([tpm_server])
+      [ERROR_IF_NO_PROG([tpm2-simulator])
        ERROR_IF_NO_PROG([ss])
        ERROR_IF_NO_PROG([ps])
        ERROR_IF_NO_PROG([echo])

--- a/m4/misc.m4
+++ b/m4/misc.m4
@@ -3,8 +3,10 @@ dnl   A quick / dirty macro to ensure that a required program / executable
 dnl   is on PATH. If it is not we display an error message using AC_MSG_ERROR.
 dnl $1: program name
 AC_DEFUN([ERROR_IF_NO_PROG],[
-    AC_CHECK_PROG([result_$1], [$1], [yes], [no])
-    AS_IF([test "x$result_$1" != "xyes"], [
+    AC_CHECK_PROG(AS_TR_SH([result_$1]), [$1], [yes], [no])
+    AS_VAR_PUSHDEF([result], [result_$1])
+    AS_IF([test "x$result" != "xyes"], [
         AC_MSG_ERROR([Missing required program '$1': ensure it is installed and on PATH.])
     ])
+    AS_VAR_POPDEF([result])
 ])

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -66,8 +66,8 @@ sanity_test ()
         exit 1
     fi
 
-    if [ -z "$(which tpm_server)" ]; then
-        echo "tpm_server not on PATH; exiting"
+    if [ -z "$(which tpm2-simulator)" ]; then
+        echo "tpm2-simulator not on PATH; exiting"
         exit 1
     fi
 
@@ -136,7 +136,7 @@ simulator_start ()
     # simulator port is a random port between 1024 and 65535
 
     cd ${sim_tmp_dir}
-    daemon_start "${sim_bin}" "-port ${sim_port}" "${sim_log_file}" \
+    daemon_start "${sim_bin}" "${sim_port}" "${sim_log_file}" \
         "${sim_pid_file}" ""
     local ret=$?
     cd -
@@ -181,7 +181,7 @@ TEST_NAME=$(basename "${TEST_BIN}")
 # start an instance of the simulator for the test, have it use a random port
 SIM_LOG_FILE=${TEST_BIN}_simulator.log
 SIM_PID_FILE=${TEST_BIN}_simulator.pid
-SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm_server_XXXXXX)
+SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm2-simulator_XXXXXX)
 PORT_MIN=1024
 PORT_MAX=65534
 BACKOFF_FACTOR=2
@@ -194,7 +194,7 @@ for i in $(seq ${BACKOFF_MAX}); do
     fi
     SIM_PORT_CMD=$((${SIM_PORT_DATA}+1))
     echo "Starting simulator on port ${SIM_PORT_DATA}"
-    simulator_start tpm_server ${SIM_PORT_DATA} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
+    simulator_start tpm2-simulator ${SIM_PORT_DATA} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
     sleep 1 # give daemon time to bind to ports
     if [ ! -s ${SIM_PID_FILE} ] ; then
         echo "Simulator PID file is empty or missing. Giving up."


### PR DESCRIPTION
To continue the discussion from https://github.com/tpm2-software/tpm2-tss/pull/1542#issuecomment-548825653, here are the necessary changes to use [ms-tpm-20-ref](https://github.com/microsoft/ms-tpm-20-ref) instead of [ibmswtpm2](https://sourceforge.net/projects/ibmswtpm2/) for the TPM simulator. If we decide to move forward with this approach, the first commit should be moved to the Dockerfile in [tpm2-software-container](https://github.com/tpm2-software/tpm2-software-container) instead of building the simulator in each tpm2-tss CI run.