### PR TITLE
build: allow programs with special characters in ERROR_IF_NO_PROG

### DIFF
--- a/m4/misc.m4
+++ b/m4/misc.m4
@@ -3,8 +3,10 @@ dnl   A quick / dirty macro to ensure that a required program / executable
 dnl   is on PATH. If it is not we display an error message using AC_MSG_ERROR.
 dnl $1: program name
 AC_DEFUN([ERROR_IF_NO_PROG],[
-    AC_CHECK_PROG([result_$1], [$1], [yes], [no])
-    AS_IF([test "x$result_$1" != "xyes"], [
+    AC_CHECK_PROG(AS_TR_SH([result_$1]), [$1], [yes], [no])
+    AS_VAR_PUSHDEF([result], [result_$1])
+    AS_IF([test "x$result" != "xyes"], [
         AC_MSG_ERROR([Missing required program '$1': ensure it is installed and on PATH.])
     ])
+    AS_VAR_POPDEF([result])
 ])


### PR DESCRIPTION
If the program name contains characters that are not allowed in a shell variable, defining `result_$1` fails with an error like
```
configure.ac:177: error: AC_SUBST: `result_tpm2-simulator' is not a valid shell variable name
```
Use `AS_TR_SH` to replace all invalid characters with underscores.