### PR TITLE
ESYS: add Esys_TR_GetTPMHandle

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -182,6 +182,8 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-tr-fromTpmPublic-nv.int \
     test/integration/esys-tr-fromTpmPublic-session.int \
     test/integration/esys-tr-getName-hierarchy.int \
+    test/integration/esys-tr-getTpmHandle-key.int \
+    test/integration/esys-tr-getTpmHandle-nv.int \
     test/integration/esys-unseal-password-auth.int \
     test/integration/esys-verify-signature.int \
     test/integration/esys-ecdh-keygen.int \
@@ -1135,6 +1137,20 @@ test_integration_esys_tr_getName_hierarchy_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_tr_getName_hierarchy_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_tr_getName_hierarchy_int_SOURCES = \
     test/integration/esys-tr-getName-hierarchy.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
+test_integration_esys_tr_getTpmHandle_key_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_tr_getTpmHandle_key_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_tr_getTpmHandle_key_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_tr_getTpmHandle_key_int_SOURCES = \
+    test/integration/esys-tr-getTpmHandle-key.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
+test_integration_esys_tr_getTpmHandle_nv_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_tr_getTpmHandle_nv_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_tr_getTpmHandle_nv_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_tr_getTpmHandle_nv_int_SOURCES = \
+    test/integration/esys-tr-getTpmHandle-nv.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 test_integration_esys_unseal_password_auth_int_CFLAGS  = $(TESTS_CFLAGS) $(TSS2_ESYS_CFLAGS_CRYPTO)

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -167,6 +167,12 @@ Esys_TRSess_GetNonceTPM(
     ESYS_TR session,
     TPM2B_NONCE **nonceTPM);
 
+TSS2_RC
+Esys_TR_GetTpmHandle(
+    ESYS_CONTEXT *esys_context,
+    ESYS_TR esys_handle,
+    TPM2_HANDLE *tpm_handle);
+
 /* Table 5 - TPM2_Startup Command */
 
 TSS2_RC

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -342,6 +342,7 @@ EXPORTS
     Esys_TR_GetName
     Esys_TR_Serialize
     Esys_TR_SetAuth
+    Esys_TR_GetTpmHandle;
     Esys_TestParms
     Esys_TestParms_Async
     Esys_TestParms_Finish

--- a/lib/tss2-esys.map
+++ b/lib/tss2-esys.map
@@ -342,6 +342,7 @@
         Esys_TR_GetName;
         Esys_TR_Serialize;
         Esys_TR_SetAuth;
+        Esys_TR_GetTpmHandle;
         Esys_Unseal;
         Esys_Unseal_Async;
         Esys_Unseal_Finish;

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -558,3 +558,42 @@ Esys_TRSess_GetNonceTPM(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     SAFE_FREE(*nonceTPM);
     return r;
 }
+
+/** Retrieves the associated TPM2_HANDLE from an ESYS_TR object.
+ *
+ * Retrieves the TPM2_HANDLE for an associated ESYS_TR object for use with the
+ * SAPI API or comparisons against raw TPM2_HANDLES from commands like
+ * TPM2_GetCapability or use of various handle bitwise comparisons. For example
+ * the mask TPM2_HR_NV_INDEX.
+ *
+ * @param esys_context [in,out] The ESYS_CONTEXT.
+ * @param esys_handle [in] The ESYS_TR object to retrieve the TPM2_HANDLE from.
+ * @param tpm_handle [out] The TPM2_HANDLE retrieved from the ESYS_TR object.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_ESYS_RC_BAD_TR if the ESYS_TR object is unknown to the
+ *         ESYS_CONTEXT or is ESYS_TR_NONE.
+ * @retval TSS2_ESYS_RC_BAD_VALUE if an unknown handle < ESYS_TR_MIN_OBJECT is
+ *         passed.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE For invalid ESYS_CONTEXT.
+ */
+TSS2_RC
+Esys_TR_GetTpmHandle(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
+                  TPM2_HANDLE * tpm_handle)
+{
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    RSRC_NODE_T *esys_object;
+
+    _ESYS_ASSERT_NON_NULL(esys_context);
+    _ESYS_ASSERT_NON_NULL(tpm_handle);
+
+    if (esys_handle == ESYS_TR_NONE) {
+        return TSS2_ESYS_RC_BAD_TR;
+    }
+
+    r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
+    return_if_error(r, "Get resource object");
+
+    *tpm_handle = esys_object->rsrc.handle;
+
+    return TSS2_RC_SUCCESS;
+};

--- a/test/integration/esys-tr-getTpmHandle-key.int.c
+++ b/test/integration/esys-tr-getTpmHandle-key.int.c
@@ -1,0 +1,160 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+/** This tests the Esys_TR_ToTPMPublic function by
+ *  creating a Primary Object Key and then attempting to retrieve
+ *  the TPM2_HANDLE for it and validating that the handle is correct for the
+ *  expected object type.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_CreatePrimary() (M)
+ *  - Esys_EvictControl() (M)
+ *  - Esys_FlushContext() (M)
+ *  - Esys_TR_ToTPMPublic() (M)
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_tr_toTpmPublic_key(ESYS_CONTEXT * ectx)
+{
+    int rc = EXIT_FAILURE;
+
+    TSS2_RC r;
+    ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR keyHandle = ESYS_TR_NONE;
+
+    TPM2B_AUTH authValuePrimary = {
+        .size = 5,
+        .buffer = {1, 2, 3, 4, 5}
+    };
+
+    TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
+        .size = 0,
+        .sensitive = {
+            .userAuth = {
+                 .size = 0,
+                 .buffer = {0 },
+             },
+            .data = {
+                 .size = 0,
+                 .buffer = {0},
+             },
+        },
+    };
+
+    inSensitivePrimary.sensitive.userAuth = authValuePrimary;
+
+    TPM2B_PUBLIC inPublic = {
+        .size = 0,
+        .publicArea = {
+            .type = TPM2_ALG_RSA,
+            .nameAlg = TPM2_ALG_SHA256,
+            .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                                 TPMA_OBJECT_RESTRICTED |
+                                 TPMA_OBJECT_DECRYPT |
+                                 TPMA_OBJECT_FIXEDTPM |
+                                 TPMA_OBJECT_FIXEDPARENT |
+                                 TPMA_OBJECT_SENSITIVEDATAORIGIN),
+            .authPolicy = {
+                 .size = 0,
+             },
+            .parameters.rsaDetail = {
+                 .symmetric = {
+                     .algorithm = TPM2_ALG_AES,
+                     .keyBits.aes = 128,
+                     .mode.aes = TPM2_ALG_CFB},
+                 .scheme = {
+                      .scheme = TPM2_ALG_NULL
+                  },
+                 .keyBits = 2048,
+                 .exponent = 0,
+             },
+            .unique.rsa = {
+                 .size = 0,
+                 .buffer = {},
+             },
+        },
+    };
+    LOG_INFO("\nRSA key will be created.");
+
+    TPM2B_DATA outsideInfo = {
+        .size = 0,
+        .buffer = {},
+    };
+
+    TPML_PCR_SELECTION creationPCR = {
+        .count = 0,
+    };
+
+    /* create a key */
+    r = Esys_CreatePrimary(ectx, ESYS_TR_RH_OWNER,
+                           ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                           &inSensitivePrimary, &inPublic, &outsideInfo,
+                           &creationPCR,
+                           &primaryHandle, NULL, NULL, NULL, NULL);
+    goto_if_error(r, "Create primary", out);
+
+    /* the handle should be transient */
+    TPM2_HANDLE tpmHandle = ESYS_TR_NONE;
+    r = Esys_TR_GetTpmHandle(ectx, primaryHandle, &tpmHandle);
+    goto_if_error(r, "Esys_TR_ToTPMPublic", error);
+
+    if (!(tpmHandle & TPM2_HR_TRANSIENT)) {
+        LOG_ERROR("Retrieved handle should be transient, got: 0x%x", tpmHandle);
+        goto error;
+    }
+
+    /* make it persistent */
+    r = Esys_EvictControl(ectx, ESYS_TR_RH_OWNER, primaryHandle,
+                          ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                          TPM2_PERSISTENT_FIRST, &keyHandle);
+    goto_if_error(r, "EvictControl make persistent", error);
+
+    /* handle should be persistent */
+    r = Esys_TR_GetTpmHandle(ectx, keyHandle, &tpmHandle);
+    goto_if_error(r, "Esys_TR_ToTPMPublic", error);
+
+    if (!(tpmHandle & TPM2_HR_PERSISTENT)) {
+        LOG_ERROR("Retrieved handle should be transient, got: 0x%x", tpmHandle);
+        goto error;
+    }
+
+    rc = EXIT_SUCCESS;
+
+error:
+    r = Esys_FlushContext(ectx, primaryHandle);
+    if (r != TSS2_RC_SUCCESS) {
+        rc = EXIT_FAILURE;
+        LOG_ERROR("TR close on key object");
+    }
+
+    r = Esys_EvictControl(ectx, ESYS_TR_RH_OWNER, keyHandle,
+                          ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                          TPM2_PERSISTENT_FIRST, &keyHandle);
+    if (r != TSS2_RC_SUCCESS) {
+        rc = EXIT_FAILURE;
+        LOG_ERROR("Esys_EvictControl");
+    }
+
+out:
+    return rc;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_toTpmPublic_key(esys_context);
+}

--- a/test/integration/esys-tr-getTpmHandle-nv.int.c
+++ b/test/integration/esys-tr-getTpmHandle-nv.int.c
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+/** This tests the Esys_TR_ToTPMPublic function by
+ *  creating an NV index object and then attempting to retrieve
+ *  the TPM2_HANDLE for it and validating that the handle is correct for the
+ *  expected object type.
+ *
+ * Tested ESAPI commands:
+ *  - Esys_NV_DefineSpace() (M)
+ *  - Esys_NV_UndefineSpace() (M)
+ *  - Esys_TR_ToTPMPublic() (M)
+ *
+ * @param[in,out] ectx The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_tr_toTpmPublic_nv(ESYS_CONTEXT * ectx)
+{
+    int rc = EXIT_FAILURE;
+
+    TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+
+    TPM2B_AUTH auth = {.size = 20,
+                       .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
+
+    TPM2B_NV_PUBLIC publicInfo = {
+        .size = 0,
+        .nvPublic = {
+            .nvIndex =TPM2_NV_INDEX_FIRST,
+            .nameAlg = TPM2_ALG_SHA1,
+            .attributes = TPMA_NV_AUTHWRITE | TPMA_NV_AUTHREAD,
+            .authPolicy = {
+                 .size = 0,
+                 .buffer = {},
+             },
+            .dataSize = 1,
+        }
+    };
+
+    r = Esys_NV_DefineSpace(ectx, ESYS_TR_RH_OWNER,
+                            ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                            &auth, &publicInfo, &nvHandle);
+    goto_if_error(r, "NV define space", out);
+
+    /* the handle should be NV */
+    TPM2_HANDLE tpmHandle = ESYS_TR_NONE;
+    r = Esys_TR_GetTpmHandle(ectx, nvHandle, &tpmHandle);
+    goto_if_error(r, "Esys_TR_ToTPMPublic", error);
+
+    if (!(tpmHandle & TPM2_HR_NV_INDEX)) {
+        LOG_ERROR("Retrieved handle should be NV, got: 0x%x", tpmHandle);
+        goto error;
+    }
+
+    rc = EXIT_SUCCESS;
+
+error:
+    r = Esys_NV_UndefineSpace(ectx, ESYS_TR_RH_OWNER, nvHandle,
+                              ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_ERROR("NV UndefineSpace");
+        rc = EXIT_FAILURE;
+    }
+out:
+    return rc;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_tr_toTpmPublic_nv(esys_context);
+}


### PR DESCRIPTION
Add routine Esys_TR_GetTpmHandle() which given an ESYS_TR retrieves the
TPM2_HANDLE which can be used with SAPI or for direct access to
handle values for comparisons or handle masks. Also, add tests.

Signed-off-by: William Roberts <william.c.roberts@intel.com>