### PR TITLE
Disable optimizations for tctildr unit test (Fixes: #1547)

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -253,7 +253,7 @@ test_unit_tctildr_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tctildr_LDADD = $(CMOCKA_LIBS) $(libutil)
 test_unit_tctildr_LDFLAGS = -Wl,--wrap=calloc,--wrap=free \
     -Wl,--wrap=tctildr_finalize_data,--wrap=tctildr_get_tcti \
-    -Wl,--wrap=tctildr_get_info,--wrap=strlen,--wrap=strchr,--wrap=strcpy
+    -Wl,--wrap=tctildr_get_info
 test_unit_tctildr_SOURCES = test/unit/tctildr.c \
     src/tss2-tcti/tctildr.c
 

--- a/test/unit/tctildr.c
+++ b/test/unit/tctildr.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <setjmp.h>
 #include <cmocka.h>
@@ -171,38 +172,15 @@ test_conf_parse_null (void **state)
     TSS2_RC rc = tctildr_conf_parse (NULL, NULL, NULL);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
-#define NAME_CONF_STR (char*)0xf100d
-size_t __real_strlen (const char *s);
-size_t
-__wrap_strlen (const char *s)
-{
-    if (s != NAME_CONF_STR)
-        return __real_strlen (s);
-    return mock_type (size_t);
-}
-char* __real_strchr (const char *s, int c);
-char*
-__wrap_strchr (const char *s, int c)
-{
-    if (s != NAME_CONF_STR)
-        return __real_strchr (s, c);
-    return mock_type (char*);
-}
-char* __real_strcpy(char *dest, const char *src);
-char*
-__wrap_strcpy(char *dest, const char *src)
-{
-    if (src != NAME_CONF_STR)
-        return __real_strcpy (dest, src);
-    return mock_type (char*);
-}
 
 void
 test_conf_parse_bad_length (void **state)
 {
     char name_buf[0], conf_buf[0];
-    will_return (__wrap_strlen, PATH_MAX);
-    TSS2_RC rc = tctildr_conf_parse (NAME_CONF_STR, name_buf, conf_buf);
+    char name[PATH_MAX+1];
+    memset(&name[0], 'a', sizeof(name));
+    name[PATH_MAX] = '\0';
+    TSS2_RC rc = tctildr_conf_parse (name, name_buf, conf_buf);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 void
@@ -257,9 +235,10 @@ static void
 tctildr_init_conf_fail_test (void **state)
 {
     TSS2_RC rc;
-
-    will_return (__wrap_strlen, PATH_MAX);
-    rc = Tss2_TctiLdr_Initialize (NAME_CONF_STR, NULL);
+    char name[PATH_MAX+1];
+    memset(&name[0], 'a', sizeof(name));
+    name[PATH_MAX] = '\0';
+    rc = Tss2_TctiLdr_Initialize (name, NULL);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 static void


### PR DESCRIPTION
Optimizations on this unit test cause segmentation faults on s390x.
The problem is only caught on "releases" though because of policy
selected in `configure.ac`.

Ideally after (or something similar) this is merged, it should backport to `2.3.x` branch as well.