### PR TITLE
pkg-config: remove TCTI loaders from ESYS dependencies

### DIFF
--- a/lib/tss2-esys.pc.in
+++ b/lib/tss2-esys.pc.in
@@ -7,7 +7,7 @@ Name: tss2-esys
 Description: TPM2 Enhanced System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires.private: tss2-mu tss2-sys tss2-tcti-device tss2-tcti-mssim
+Requires.private: tss2-mu tss2-sys
 Cflags: -I${includedir}
 Libs: -ltss2-esys -L${libdir}
 Libs.private: @LIBDL_LDFLAGS@ @LIBSOCKET_LDFLAGS@ @TSS2_ESYS_LDFLAGS_CRYPTO@


### PR DESCRIPTION
Since commit b258ab9618ded645777917a742b917a3ba72f107 the ESYS library is not linked to any TCTI libraries any more, they are dlopen()'ed if available instead. Removing them from the dependencies also fixes an error when using pkg-config to discover tss2-esys if tpm2-tss was built with `--disable-tcti-mssim`.

Fixes: https://github.com/tpm2-software/tpm2-tools/issues/1851