### PR TITLE
sys: match counter variable type for cmdAuthsArray->count

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c
@@ -20,7 +20,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
     const TSS2L_SYS_AUTH_COMMAND *cmdAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
-    uint8_t i;
+    uint16_t i;
     UINT32 authSize = 0;
     UINT32 newCmdSize = 0;
     size_t authOffset;


### PR DESCRIPTION
`TSS2L_SYS_AUTH_COMMAND.count` is [defined as uint16_t](https://github.com/tpm2-software/tpm2-tss/blob/1c99117f4d102fd465655ed86aca58909a13c10d/include/tss2/tss2_sys.h#L32), so the counter variable should be `uint16_t` as well. This fixes two [LGTM.com alerts](https://lgtm.com/projects/g/tpm2-software/tpm2-tss/snapshot/5c97851f920c69d2f2ebaca5ec52cb8444369751/files/src/tss2-sys/api/Tss2_Sys_SetCmdAuths.c#x262ec6826876f970:1).