### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -182,7 +182,8 @@ get_info_default(const TSS2_TCTI_INFO **info,
     else if (handle == NULL)
         return TSS2_TCTI_RC_IO_ERROR;
 #else
-    for (size_t i = 0; i < ARRAY_SIZE(tctis); i++) {
+    size_t i;
+    for (i = 0; i < ARRAY_SIZE(tctis); i++) {
         name = tctis[i].file;
         LOG_DEBUG("name: %s", name);
         if (name == NULL) {
@@ -234,8 +235,9 @@ tctildr_get_default(TSS2_TCTI_CONTEXT ** tcticontext, void **dlhandle)
 #else /* ESYS_TCTI_DEFAULT_MODULE */
 
     TSS2_RC r;
+    size_t i;
 
-    for (size_t i = 0; i < ARRAY_SIZE(tctis); i++) {
+    for (i = 0; i < ARRAY_SIZE(tctis); i++) {
         LOG_DEBUG("Attempting to connect using standard TCTI: %s",
                   tctis[i].description);
         r = tcti_from_file(tctis[i].file, tctis[i].conf, tcticontext,

--- a/src/util/log.c
+++ b/src/util/log.c
@@ -86,11 +86,12 @@ doLogBlob(log_level loglevel, const char *module, log_level logdefault,
     if (loglevel > *status)
         return;
 
+    size_t i, off;
     size_t width = 8;
     size_t buffer_size = (size * 2) + (size / width) * 2 + 1;
     char buffer[buffer_size];
     buffer[0] = '\0';
-    for (size_t i = 0, off = 0; i < size && off < buffer_size; i++, off+=2) {
+    for (i = 0, off = 0; i < size && off < buffer_size; i++, off+=2) {
         if (width < buffer_size && i % width == 0) {
             *(&buffer[0] + off) = '\n';
             off += 1;
@@ -144,7 +145,8 @@ doLog(log_level loglevel, const char *module, log_level logdefault,
 static log_level
 log_stringlevel(const char *n)
 {
-    for(log_level i = 0; i < sizeof(log_strings)/sizeof(log_strings[0]); i++) {
+    log_level i;
+    for(i = 0; i < sizeof(log_strings)/sizeof(log_strings[0]); i++) {
         if (case_insensitive_strncmp(log_strings[i], n, strlen(log_strings[i])) == 0) {
             return i;
         }


### PR DESCRIPTION
tpm2-tss fails to build with gcc 4.8 due to initial declarations in for
loops:

```
src/tss2-tcti/tctildr-dl.c: In function 'get_info_default':
src/tss2-tcti/tctildr-dl.c:185:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < ARRAY_SIZE(tctis); i++) {
     ^
src/tss2-tcti/tctildr-dl.c:185:5: note: use option -std=c99 or -std=gnu99 to compile your code
src/tss2-tcti/tctildr-dl.c: In function 'tctildr_get_default':
src/tss2-tcti/tctildr-dl.c:238:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < ARRAY_SIZE(tctis); i++) {
     ^
make[3]: *** [Makefile:11004: src/tss2-tcti/tss2_esys_libtss2_esys_la-tctildr-dl.lo] Error 1
make[3]: *** Attente des tâches non terminées....
src/util/log.c: In function 'doLogBlob':
src/util/log.c:93:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (size_t i = 0, off = 0; i < size && off < buffer_size; i++, off+=2) {
     ^
src/util/log.c:93:5: note: use option -std=c99 or -std=gnu99 to compile your code
src/util/log.c: In function 'log_stringlevel':
src/util/log.c:147:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for(log_level i = 0; i < sizeof(log_strings)/sizeof(log_strings[0]); i++) {
     ^
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>