### PR TITLE
tcti: try to open /dev/tpmrm0 before /dev/tpm0 during tcti-device init

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -239,7 +239,8 @@ CLEANFILES += \
 if UNIT
 test_unit_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
-test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,--wrap=write, -Wl,--wrap=poll
+test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,--wrap=write, -Wl,--wrap=poll  \
+        -Wl,--wrap=open
 test_unit_tcti_device_SOURCES = test/unit/tcti-device.c \
     src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-device.c src/tss2-tcti/tcti-device.h

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -56,11 +56,16 @@
 #define LOGMODULE tcti
 #include "util/log.h"
 
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
+static char *default_conf[] = {
 #ifdef __VXWORKS__
-#define TCTI_DEVICE_DEFAULT "/tpm0"
+    "/tpm0"
 #else
-#define TCTI_DEVICE_DEFAULT "/dev/tpm0"
-#endif
+    "/dev/tpmrm0",
+    "/dev/tpm0",
+#endif /* __VX_WORKS__ */
+};
 
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
@@ -404,6 +409,15 @@ tcti_device_set_locality (
     return TSS2_TCTI_RC_NOT_IMPLEMENTED;
 }
 
+static int open_tpm (
+    const char* pathname) {
+#ifdef __VXWORKS__
+        return open (pathname, O_RDWR, (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
+#else
+        return open (pathname, O_RDWR | O_NONBLOCK);
+#endif
+}
+
 TSS2_RC
 Tss2_Tcti_Device_Init (
     TSS2_TCTI_CONTEXT *tctiContext,
@@ -412,7 +426,6 @@ Tss2_Tcti_Device_Init (
 {
     TSS2_TCTI_DEVICE_CONTEXT *tcti_dev;
     TSS2_TCTI_COMMON_CONTEXT *tcti_common;
-    const char *dev_path = conf != NULL ? conf : TCTI_DEVICE_DEFAULT;
 
     if (tctiContext == NULL && size == NULL) {
         return TSS2_TCTI_RC_BAD_VALUE;
@@ -437,16 +450,38 @@ Tss2_Tcti_Device_Init (
     memset (&tcti_common->header, 0, sizeof (tcti_common->header));
     tcti_common->locality = 3;
 
-#ifdef __VXWORKS__
-    tcti_dev->fd = open (dev_path, O_RDWR, (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
-#else
-    tcti_dev->fd = open (dev_path, O_RDWR | O_NONBLOCK);
-#endif
-    if (tcti_dev->fd < 0) {
-        LOG_ERROR ("Failed to open device file %s: %s",
-                   dev_path, strerror (errno));
-        return TSS2_TCTI_RC_IO_ERROR;
+    if (conf == NULL) {
+        LOG_TRACE ("No TCTI device file specified");
+
+        for (size_t i = 0; i < ARRAY_LEN(default_conf); i++) {
+            LOG_DEBUG ("Trying to open default TCTI device file %s",
+                       default_conf[i]);
+            tcti_dev->fd = open_tpm (default_conf[i]);
+            if (tcti_dev->fd >= 0) {
+                LOG_TRACE ("Successfully opened default TCTI device file %s",
+                           default_conf[i]);
+                    break;
+            } else {
+                    LOG_WARNING ("Failed to open default TCTI device file %s: %s",
+                                 default_conf[i], strerror (errno));
+                }
+            }
+            if (tcti_dev->fd < 0) {
+                LOG_ERROR ("Could not open any default TCTI device file");
+                return TSS2_TCTI_RC_IO_ERROR;
+            }
+    } else {
+        LOG_DEBUG ("Trying to open specified TCTI device file %s", conf);
+        tcti_dev->fd = open_tpm (conf);
+        if (tcti_dev->fd < 0) {
+            LOG_ERROR ("Failed to open specified TCTI device file %s: %s",
+                       conf, strerror (errno));
+            return TSS2_TCTI_RC_IO_ERROR;
+        } else {
+            LOG_TRACE ("Successfully opened specified TCTI device file %s", conf);
+        }
     }
+
 
     return TSS2_RC_SUCCESS;
 }

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -9,6 +9,7 @@
 #endif
 
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -38,6 +39,21 @@ static uint8_t tpm2_buf [BUF_SIZE] = {
     0xca, 0xfe, 0xba, 0xbe,
     0xfe, 0xef
 };
+int
+__real_open(const char *pathname, int flags, ...);
+/* wrap function for open required to test init */
+int
+__wrap_open(const char *pathname, int flags, ...)
+{
+    const char* pathname_prefix_dev = "/dev";
+    if (strncmp(pathname, pathname_prefix_dev, strlen(pathname_prefix_dev)) == 0) {
+        return mock_type (int);
+    } else {
+        /* only mock opening of device files as the open() syscall is needed
+           for code coverage reports as well */
+        return __real_open(pathname, flags);
+    }
+}
 /**
  * When passed all NULL values ensure that we get back the expected RC
  * indicating bad values.
@@ -62,6 +78,63 @@ tcti_device_init_size_test (void **state)
 
     ret = Tss2_Tcti_Device_Init (NULL, &tcti_size, NULL);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
+}
+/* Test the failure of opening a specified device file */
+static void
+tcti_device_init_conf_fail (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Device_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    ctx = calloc (1, tcti_size);
+    assert_non_null (ctx);
+    errno = ENOENT; /* No such file or directory */
+    will_return (__wrap_open, -1);
+    ret = Tss2_Tcti_Device_Init (ctx, &tcti_size, "/dev/nonexistent");
+    assert_true (ret == TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+/* Test the device file recognition if no config string was specified */
+static void
+tcti_device_init_conf_default_fail (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Device_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    ctx = calloc (1, tcti_size);
+    assert_non_null (ctx);
+    errno = EACCES; /* Permission denied */
+    will_return (__wrap_open, -1);
+    will_return (__wrap_open, -1);
+    ret = Tss2_Tcti_Device_Init (ctx, &tcti_size, NULL);
+    assert_true (ret == TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+/* Test the device file recognition if no config string was specified */
+static void
+tcti_device_init_conf_default_success (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Device_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    ctx = calloc (1, tcti_size);
+    assert_non_null (ctx);
+    will_return (__wrap_open, 3);
+    ret = Tss2_Tcti_Device_Init (ctx, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+
+    free(ctx);
 }
 /* wrap functions for read & write required to test receive / transmit */
 ssize_t
@@ -104,6 +177,7 @@ tcti_device_setup (void **state)
     assert_true (ret == TSS2_RC_SUCCESS);
     ctx = calloc (1, tcti_size);
     assert_non_null (ctx);
+    will_return (__wrap_open, 3);
     ret = Tss2_Tcti_Device_Init (ctx, &tcti_size, "/dev/null");
     assert_true (ret == TSS2_RC_SUCCESS);
 
@@ -355,6 +429,9 @@ main(int argc, char* argv[])
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_device_init_all_null_test),
         cmocka_unit_test(tcti_device_init_size_test),
+        cmocka_unit_test(tcti_device_init_conf_fail),
+        cmocka_unit_test(tcti_device_init_conf_default_fail),
+        cmocka_unit_test(tcti_device_init_conf_default_success),
         cmocka_unit_test_setup_teardown (tcti_device_get_poll_handles_test,
                                          tcti_device_setup,
                                          tcti_device_teardown),


### PR DESCRIPTION
The tctildr library tries to open `/dev/tpmrm0` before `/dev/tpm0` if no tcti was specified. Previously, if the tcti `device` was specified, the tcti-device module would try to open `/dev/tpm0` only.

To streamline the loading behavior, have tcti-device try to open `/dev/tpmrm0` and fallback to `/dev/tpm0`.

Fixes #1564.