### PR TITLE
FAPI: fix compilation with optimisation enabled

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -894,8 +894,8 @@ ifapi_merge_profile_into_template(
 static void
 full_path_to_fapi_path(IFAPI_KEYSTORE *keystore, char *path)
 {
-    int start_pos, end_pos, i;
-    int path_length = strlen(path);
+    unsigned int start_pos, end_pos, i;
+    const unsigned int path_length = strlen(path);
     size_t keystore_length = strlen(keystore->userdir);
     char fapi_path_delim;
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -138,8 +138,8 @@ error:
 void
 full_path_to_fapi_path(IFAPI_KEYSTORE *keystore, char *path)
 {
-    int start_pos, end_pos, i;
-    int path_length = strlen(path);
+    unsigned int start_pos, end_pos, i;
+    const unsigned int path_length = strlen(path);
     size_t keystore_length = strlen(keystore->userdir);
     char fapi_path_delim;
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -290,7 +290,7 @@ ifapi_read_pcr(
             /* Only one bank will be used. The hash alg from profile will be used */
             pcr_selection->count = 1;
             pcr_selection->pcrSelections[0].sizeofSelect = pcr_select->sizeofSelect;
-            for (i = 0; i <= TPM2_PCR_SELECT_MAX; i++)
+            for (i = 0; i < TPM2_PCR_SELECT_MAX; i++)
                 pcr_selection->pcrSelections[0].pcrSelect[i] = pcr_select->pcrSelect[i];
         }
 


### PR DESCRIPTION
When compiling with optimisation enabled (`./configure CFLAGS=-O2`), some warnings are generated that make compilation fail due to `-Werror`. Fix these by using the correct array length and avoiding comparison of signed and unsigned integers, resp.