### PR TITLE
 FAPI: fix pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -470,7 +470,7 @@ src_tss2_fapi_libtss2_fapi_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) $(libtss2_e
 
 src_tss2_fapi_libtss2_fapi_la_SOURCES = $(TSS2_FAPI_SRC)
 src_tss2_fapi_libtss2_fapi_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-fapi
-src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) -ldl  -lssl -lcrypto C -ljson-c $(CURL_LIBS)
+src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LIBS) $(JSON_C_LIBS) $(CURL_LIBS)
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_fapi_libtss2_fapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-fapi.map
 endif # HAVE_LD_VERSION_SCRIPT

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AS_IF([test "x$enable_fapi" != xno -a "x$with_crypto" != "xossl"],
     AC_MSG_ERROR([FAPI has to be compiled with OpenSSL]))
 
 AS_IF([test "x$enable_fapi" = xyes ],
-    AC_CHECK_HEADER([json-c/json.h], [], [AC_MSG_ERROR([libjson-c (header) not found])], []))
+    PKG_CHECK_MODULES([JSON_C], [json-c]))
 
 AS_IF([test "x$enable_fapi" = xyes ],
     PKG_CHECK_MODULES([CURL], [libcurl]))

--- a/lib/tss2-fapi.pc.in
+++ b/lib/tss2-fapi.pc.in
@@ -3,10 +3,10 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: tss2-FAPI
+Name: tss2-fapi
 Description: TPM2 Feature API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Requires: tss2-mu tss2-esys tss2-tctildr
+Requires.private: tss2-mu tss2-esys tss2-tctildr libcurl libcrypto json-c
 Cflags: -I${includedir}
 Libs: -ltss2-fapi -L${libdir}


### PR DESCRIPTION
Fix the pkg-config file to include all required dependencies in <code>Requires<em>.private</em></code>, cf. #1417, and improve the linking a bit.