### PR TITLE
udev: Allow tpm devices to be used as systemd dependencies

### DIFF
--- a/dist/tpm-udev.rules
+++ b/dist/tpm-udev.rules
@@ -1,4 +1,4 @@
 # tpm devices can only be accessed by the tss user but the tss
 # group members can access tpmrm devices
-KERNEL=="tpm[0-9]*", MODE="0660", OWNER="tss"
-KERNEL=="tpmrm[0-9]*", MODE="0660", OWNER="tss", GROUP="tss"
+KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
+KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss", GROUP="tss"


### PR DESCRIPTION
This will allow tpm2-abrmd.service to have `After=dev-tpm0.device` and similar dependencies.

Related tpm2-abrmd change: https://github.com/tpm2-software/tpm2-abrmd/pull/683