### PR TITLE
sysapi_util: Remove InitSysContext and TeardownSysContext helpers

### DIFF
--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -110,13 +110,6 @@ TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *pub);
 TSS2_RC ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info);
 TSS2_RC ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection);
 
-TSS2_SYS_CONTEXT *InitSysContext(
-    UINT16 maxCommandSize,
-    TSS2_TCTI_CONTEXT *tctiContext,
-    TSS2_ABI_VERSION *abiVersion);
-
-void TeardownSysContext(TSS2_SYS_CONTEXT **ctx);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
These functions have been declared as part of the SAPI for years but
were never _defined_ as part of the SAPI, only as part of test code.

The defintions of these functions in the test code were removed as part
of the 2.0 release, so there's no reason to keep their declarations.

See: https://github.com/tpm2-software/tpm2-tss/issues/331#issuecomment-280378592

Signed-off-by: Joe Richey <joerichey@google.com>