### PR TITLE
Tests/ESYS: Move ChangeEPS to destructive

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -141,6 +141,7 @@ endif # !TESTPTPM
 
 if ESAPI
 ESYS_TESTS_INTEGRATION_DESTRUCTIVE = \
+    test/integration/esys-change-eps.int \
     test/integration/esys-clear.int \
     test/integration/esys-clear-session.int \
     test/integration/esys-field-upgrade.int \
@@ -215,7 +216,6 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
 
 ESYS_TESTS_INTEGRATION_OPTIONAL = \
     test/integration/esys-audit.int \
-    test/integration/esys-change-eps.int \
     test/integration/esys-createloaded.int \
     test/integration/esys-createloaded-session.int \
     test/integration/esys-duplicate.int \


### PR DESCRIPTION
ChangeEPS was listed as optional test, even though it "bricks"TPMs' ability to use EKs.
Moved to destructive.

Should be backported.