### PR TITLE
Test/FAPI: Add policy action test

### DIFF
--- a/test/integration/fapi-nv-ordinary.int.c
+++ b/test/integration/fapi-nv-ordinary.int.c
@@ -81,8 +81,8 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     size_t dest_size = NV_SIZE;
     char *description1 = "nvDescription";
     char *description2 = NULL;
-    char *policy_name = "/policy/pol_pcr16_0";
-    char *policy_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0.json";
+    char *policy_name = "/policy/pol_action";
+    char *policy_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_action.json";
     FILE *stream = NULL;
     char *json_policy = NULL;
     long policy_size;


### PR DESCRIPTION
Though there was a test sceletor for testing policy action, this was not triggered, since the wrong policy file was requested. Using the right policy to test policyAction.