### PR TITLE
esys: zero out ctx->salt after on startAuthSession_finish

### DIFF
--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -493,6 +493,7 @@ Esys_StartAuthSession_Finish(
     goto_if_error(r, "Marshal session name", error_cleanup);
 
     sessionHandleNode->rsrc.name.size = offset;
+    memset(&esysContext->salt, '\0', sizeof(esysContext->salt));
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;


### PR DESCRIPTION
The ctx->salt is used to calculate session key during
startAuthSession call if the caller pass a valid tpmKey
parameter. There salt is calculated in the _Async call
and the the session key is calculated in the _Finish call.
The problem is that if in the same context an unsalted
session is created after a salted session the ctx->salt
will still hold the old value and it will incorrectly
be used for session key calculation in the the subsequent
_Finish call. To fix this the salt needs to be set to
cleaned after no longer needed.

Fixes: #1574