### PR TITLE
TCTI: tcti-device make non-async mode allways block

### DIFF
--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -185,9 +185,9 @@ tcti_device_receive (
      */
     if (timeout != TSS2_TCTI_TIMEOUT_BLOCK) {
         LOG_WARNING ("The underlying IPC mechanism does not support "
-                     "asynchronous I/O. The 'timeout' parameter must be "
+                     "asynchronous I/O. The 'timeout' parameter is set to "
                      "TSS2_TCTI_TIMEOUT_BLOCK");
-        return TSS2_TCTI_RC_BAD_VALUE;
+        timeout = TSS2_TCTI_TIMEOUT_BLOCK;
     }
 #endif
     if (response_buffer == NULL) {


### PR DESCRIPTION
One could only disable tcti-async which would disallow ESYS_SetTimeout(0) or not use tcti-async which would lead to indefinite blocking on some platforms.
Instead, we now switch to blocking mode whilst retaining a warning for the user.
This is needed in order to run FAPI on kernels < 5.0 (i.e. without async support)