### PR TITLE
WIP: tcti-mssim: Add ability to set platform port

### DIFF
--- a/man/Tss2_Tcti_Mssim_Init.3.in
+++ b/man/Tss2_Tcti_Mssim_Init.3.in
@@ -67,10 +67,12 @@ The host may be an IPv4 address, an IPv6 address, or a host name. The port
 must be a valid uint16_t in string form. If a NULL
 .I conf
 string is provided by the caller then the default of
-"host=localhost,port=2321" is used. If either
+"host=localhost,port=2321,pport=2322" is used. If either
 .B host
 or
 .B port
+or
+.B pport
 are omitted then their respective default value will be used.
 .sp
 Once initialized, the TCTI context returned exposes the Trusted Computing
@@ -114,7 +116,7 @@ TCTI initialization fragment:
 TSS2_RC rc;
 TSS2_TCTI_CONTEXT *tcti_context;
 size_t size;
-const char *conf = "host=localhost,port=2321"
+const char *conf = "host=localhost,port=2321,pport=2322"
 
 rc = Tss2_Tcti_Mssim_Init (NULL, &size, NULL);
 if (rc != TSS2_RC_SUCCESS) {

--- a/script/int-log-compiler.sh
+++ b/script/int-log-compiler.sh
@@ -228,7 +228,8 @@ while true; do
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_startup
 if [ $? -ne 0 ]; then
     echo "TPM_StartUp failed"
@@ -244,7 +245,8 @@ EKCERT_PEM_FILE=${TEST_BIN}_ekcert.pem
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_getek>$EKPUB_FILE
 if [ $? -ne 0 ]; then
     echo "TPM_getek failed"
@@ -259,7 +261,8 @@ EKECCCERT_PEM_FILE=${TEST_BIN}_ekecccert.pem
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_getek_ecc>$EKECCPUB_FILE
 if [ $? -ne 0 ]; then
     echo "TPM_getek_ecc failed"
@@ -295,7 +298,8 @@ cat $EKCERT_FILE | \
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C00002
 if [ $? -ne 0 ]; then
     echo "TPM_writeekcert failed"
@@ -307,7 +311,8 @@ cat $EKECCCERT_FILE | \
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C0000A
 if [ $? -ne 0 ]; then
     echo "TPM_writeekcert failed"
@@ -317,7 +322,8 @@ fi
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_transientempty
 if [ $? -ne 0 ]; then
     echo "TPM transient area not empty => skipping"
@@ -331,7 +337,8 @@ TPMSTATE_FILE2=${TEST_BIN}_state2
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_dumpstate>$TPMSTATE_FILE1
 if [ $? -ne 0 ]; then
     echo "Error during dumpstate"
@@ -343,7 +350,8 @@ echo "Execute the test script"
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     FAPI_TEST_ROOT_CERT=${ROOTCA_FILE}.pem \
     G_MESSAGES_DEBUG=all $@
 ret=$?
@@ -353,7 +361,8 @@ echo "Script returned $ret"
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_dumpstate>$TPMSTATE_FILE2
 if [ $? -ne 0 ]; then
     echo "Error during dumpstate"
@@ -379,7 +388,8 @@ break
 env TPM20TEST_TCTI_NAME="socket" \
     TPM20TEST_SOCKET_ADDRESS="127.0.0.1" \
     TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}" \
-    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA}" \
+    TPM20TEST_SOCKET_PPORT="$((${SIM_PORT_DATA}+1))" \
+    TPM20TEST_TCTI="mssim:host=127.0.0.1,port=${SIM_PORT_DATA},pport=$((${SIM_PORT_DATA}+1))" \
     G_MESSAGES_DEBUG=all ./test/helper/tpm_dumpstate>$TPMSTATE_FILE2
 if [ $? -ne 0 ]; then
     echo "Error during dumpstate"

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -484,6 +484,12 @@ mssim_kv_callback (const key_value_t *key_value,
             return TSS2_TCTI_RC_BAD_VALUE;
         }
         return TSS2_RC_SUCCESS;
+    } else if (strcmp (key_value->key, "pport") == 0) {
+        mssim_conf->pport = string_to_port (key_value->value);
+        if (mssim_conf->pport == 0) {
+            return TSS2_TCTI_RC_BAD_VALUE;
+        }
+        return TSS2_RC_SUCCESS;
     } else {
         return TSS2_TCTI_RC_BAD_VALUE;
     }
@@ -559,8 +565,9 @@ Tss2_Tcti_Mssim_Init (
             goto fail_out;
         }
     }
-    LOG_DEBUG ("Initializing mssim TCTI with host: %s, port: %" PRIu16,
-               mssim_conf.host, mssim_conf.port);
+    LOG_DEBUG ("Initializing mssim TCTI with host: %s, port: %" PRIu16
+               " pport: %" PRIu16,
+               mssim_conf.host, mssim_conf.port, mssim_conf.pport);
 
     tcti_mssim->tpm_sock = -1;
     tcti_mssim->platform_sock = -1;
@@ -573,7 +580,7 @@ Tss2_Tcti_Mssim_Init (
     }
 
     rc = socket_connect (mssim_conf.host,
-                         mssim_conf.port + 1,
+                         mssim_conf.pport,
                          &tcti_mssim->platform_sock);
     if (rc != TSS2_RC_SUCCESS) {
         goto fail_out;
@@ -605,7 +612,7 @@ const TSS2_TCTI_INFO tss2_tcti_info = {
     .version = TCTI_VERSION,
     .name = "tcti-socket",
     .description = "TCTI module for communication with the Microsoft TPM2 Simulator.",
-    .config_help = "Key / value string in the form \"host=localhost,port=2321\".",
+    .config_help = "Key / value string in the form \"host=localhost,port=2321,pport=2322\".",
     .init = Tss2_Tcti_Mssim_Init,
 };
 

--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -14,14 +14,16 @@
 
 /*
  * longest possible conf string:
- * HOST_NAME_MAX + max char uint16 (5) + strlen ("host=,port=") (11)
+ * HOST_NAME_MAX + max char uint16 (5) * 2 + strlen ("host=,port=,pport=") (18)
  */
-#define TCTI_MSSIM_CONF_MAX (_HOST_NAME_MAX + 16)
+#define TCTI_MSSIM_CONF_MAX (_HOST_NAME_MAX + 28)
 #define TCTI_MSSIM_DEFAULT_HOST "localhost"
 #define TCTI_MSSIM_DEFAULT_PORT 2321
+#define TCTI_MSSIM_DEFAULT_PPORT 2322
 #define MSSIM_CONF_DEFAULT_INIT { \
     .host = TCTI_MSSIM_DEFAULT_HOST, \
     .port = TCTI_MSSIM_DEFAULT_PORT, \
+    .pport = TCTI_MSSIM_DEFAULT_PPORT, \
 }
 
 #define TCTI_MSSIM_MAGIC 0xf05b04cd9f02728dULL
@@ -29,6 +31,7 @@
 typedef struct {
     char *host;
     uint16_t port;
+    uint16_t pport;
 } mssim_conf_t;
 
 typedef struct {

--- a/test/integration/sapi-context-util.c
+++ b/test/integration/sapi-context-util.c
@@ -66,14 +66,14 @@ tcti_device_init(char const *device_path)
  * function. This structure must be freed by the caller.
  */
 TSS2_TCTI_CONTEXT *
-tcti_socket_init(char const *host, uint16_t port)
+tcti_socket_init(char const *host, uint16_t port, uint16_t pport)
 {
     size_t size;
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;
     char conf_str[TCTI_MSSIM_CONF_MAX] = { 0 };
 
-    snprintf(conf_str, TCTI_MSSIM_CONF_MAX, "host=%s,port=%" PRIu16, host, port);
+    snprintf(conf_str, TCTI_MSSIM_CONF_MAX, "host=%s,port=%,pport=%" PRIu16, host, port, pport);
     rc = Tss2_Tcti_Mssim_Init(NULL, &size, conf_str);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf(stderr, "Faled to get allocation size for tcti context: "
@@ -200,7 +200,9 @@ tcti_init_from_opts(test_opts_t * options)
 #endif /* TCTI_DEVICE */
 #ifdef TCTI_MSSIM
     case SOCKET_TCTI:
-        return tcti_socket_init(options->socket_address, options->socket_port);
+        return tcti_socket_init(options->socket_address,
+                                options->socket_port,
+                                options->socket_pport);
 #endif /* TCTI_MSSIM */
 #ifdef TCTI_FUZZING
     case FUZZING_TCTI:

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -19,12 +19,14 @@
 /* Defaults for Socket TCTI connections */
 #define HOSTNAME_DEFAULT "127.0.0.1"
 #define PORT_DEFAULT     2321
+#define PPORT_DEFAULT     2322
 
 /* environment variables holding TCTI config */
 #define ENV_TCTI_NAME      "TPM20TEST_TCTI_NAME"
 #define ENV_DEVICE_FILE    "TPM20TEST_DEVICE_FILE"
 #define ENV_SOCKET_ADDRESS "TPM20TEST_SOCKET_ADDRESS"
 #define ENV_SOCKET_PORT    "TPM20TEST_SOCKET_PORT"
+#define ENV_SOCKET_PPORT   "TPM20TEST_SOCKET_PPORT"
 
 typedef enum {
     UNKNOWN_TCTI,
@@ -39,6 +41,7 @@ typedef struct {
     const char *device_file;
     const char *socket_address;
     uint16_t socket_port;
+    uint16_t socket_pport;
 } test_opts_t;
 
 /* functions to get test options from the user and to print helpful stuff */


### PR DESCRIPTION
So I was playing around with the simulator hoping to get it to be able to bind to any available port (port 0), to help us avoid the random number dance. But, I went to go grab the newly bound port from stdout, turns out its `write`ing to the tty...

```
write(1</dev/pts/25<char 136:25>>, "Platform server listening on por"..., 40Platform server listening on port 37543
```

Wasn't expecting this. I’m currently trying to run it from a Python subprocess [here](https://github.com/pdxjohnny/tpm2-pytss/blob/38ced89a9f55bef59b3ab55e5414e36aa6748a08/tpm2_pytss/util/simulator.py#L93-L151)

stracing the python that runs `tpm2-simulator` the ports are bound to be the above `write` never happens... werid. Not sure whats up. Or if I'll pursue this further, but thought I'd post the WIP here and then close later in case anyone else has interest, or I have an epiphany. 