### PR TITLE
build: remove double definition of GITIGNOREFILES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ MAINTAINERCLEANFILES = \
     $(DIST_ARCHIVES) \
     AUTHORS
 
-GITIGNOREFILES = \
+TSS_GITIGNOREFILES = \
     $(GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL) \
     $(GITIGNORE_MAINTAINERCLEANFILES_MAKEFILE_IN) \
     $(GITIGNORE_MAINTAINERCLEANFILES_M4_LIBTOOL) \
@@ -49,6 +49,7 @@ GITIGNOREFILES = \
     m4/ax_valgrind_check.m4 \
     m4/pkg.m4
 
+GITIGNOREFILES = ""
 ### Add ax_* rules ###
 # ax_code_coverage
 if AUTOCONF_CODE_COVERAGE_2019_01_06
@@ -58,6 +59,7 @@ distclean-local: code-coverage-dist-clean
 else
 @CODE_COVERAGE_RULES@
 endif
+GITIGNOREFILES += $(TSS_GITIGNOREFILES)
 CODE_COVERAGE_DIRECTORY = $(top_builddir)/src $(top_builddir)/test
 
 # ax_valgrind_check


### PR DESCRIPTION
The auto-generaed aminclude_static.am file defines GITIGNOREFILES under
certain conditions and, the same is redefined in Makefile.am,
which triggers a warning when ./bootstrap it executed:

$ ./bootstrap
Generating file lists: src_vars.mk
aminclude_static.am:63: warning: GITIGNOREFILES was already defined in
condition TRUE, which includes condition AUTOCONF_CODE_COVERAGE_2019_01_06
and CODE_COVERAGE_ENABLED ...
Makefile.am:55:   'aminclude_static.am' included from here
Makefile.am:27: ... 'GITIGNOREFILES' previously defined here

Fixes: #1636