### PR TITLE
FAPI: Fix memory leak caused by fopen

### DIFF
--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -62,7 +62,7 @@ ifapi_io_read_async(
 
     fseek(io->stream, 0L, SEEK_END);
     long length = ftell(io->stream);
-    rewind(io->stream);
+    fclose(io->stream);
 
     io->stream = fopen(filename, "rt");
     io->char_rbuffer = malloc (length + 1);


### PR DESCRIPTION
Fixes #1643

After file size computation now fclose is called instead of rewind.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>