### PR TITLE
Fapi Declare functions static if possible and add doxygen headers.

### DIFF
--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -1596,7 +1596,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  Multiple implementations of these functions for different
  cryptographic backends may exist.
  \{
- \fn static TSS2_RC ecdsa_verify_signature(
+\fn static TSS2_RC ecdsa_verify_signature(
     EVP_PKEY *publicKey,
     const uint8_t *signature,
     size_t signatureSize,
@@ -1606,7 +1606,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn static TSS2_RC get_ecc_tpm2b_public_from_evp(
     EVP_PKEY *publicKey,
     TPM2B_PUBLIC *tpmPublic)
-\fn ENGINE * get_engine()
+\fn static ENGINE * get_engine()
 \fn static const EVP_MD * get_hash_md(TPM2_ALG_ID hashAlgorithm)
 \fn static const EVP_MD * get_ossl_hash_md(TPM2_ALG_ID hashAlgorithm)
 \fn static TSS2_RC get_rsa_tpm2b_public_from_evp(
@@ -1713,7 +1713,8 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \ingroup ifapi
  Provides functions for policy calculation (without TPM).
  \{
- \fn TSS2_RC ifapi_calculate_tree(
+
+\fn TSS2_RC ifapi_calculate_tree(
     FAPI_CONTEXT *context,
     const char *policyPath,
     TPMS_POLICY *policy,
@@ -1721,13 +1722,15 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     size_t *digest_idx,
     size_t *hash_size)
 
- \fn TSS2_RC calculate_policy_key_param(
+\fn static TSS2_RC calculate_policy_key_param(
     TPM2_CC command_code,
     TPM2B_NAME *name,
     TPM2B_NONCE *policyRef,
     size_t hash_size,
     TPMI_ALG_HASH current_hash_alg,
     TPMU_HA *digest)
+\fn static void copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
+                   size_t digest_idx, size_t hash_size, char *txt)
 \fn TSS2_RC ifapi_calculate_policy(
     TPML_POLICYELEMENTS *policy,
     TPML_DIGEST_VALUES *policyDigests,
@@ -1814,57 +1817,83 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     TPMS_POLICYPCR *policy,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
+\fn static void log_policy_digest(TPML_DIGEST_VALUES *dest, size_t digest_idx, size_t hash_size,
+                  char *txt)
 
  \}
 */
 
 /*!
- \defgroup ifapi_policy_callbacks Policy callback and execution module
+ \defgroup ifapi_policy_callbacks Policy callback functions.
  \ingroup ifapi
- Provides internal callbacks for policy execution and policy execution functions.
+ Provides internal callbacks functions for policy execution.
  \{
-\fn  TSS2_RC ifapi_policyeval_execute_prepare(
-    IFAPI_POLICY_EXEC_CTX *pol_ctx,
+\fn static void cleanup_policy_list(struct POLICY_LIST * list)
+\fn static TSS2_RC compare_policy_digest(
+    TPMS_POLICY *policy,
+    void *authPolicyVoid,
+    void *nameAlgVoid,
+    bool *equal)
+\fn static TSS2_RC equal_policy_authorization(
+    TPMS_POLICY *policy,
+    void *publicVoid,
+    void *nameAlgVoid,
+    bool *equal)
+\fn static void get_nv_auth_object(
+    IFAPI_OBJECT *nv_object,
+    ESYS_TR nv_index,
+    IFAPI_OBJECT *auth_object,
+    ESYS_TR *auth_index)
+\fn static TSS2_RC get_policy_digest(TPMS_POLICY *policy,
+                  TPMI_ALG_HASH hashAlg,
+                  TPM2B_DIGEST *digest)
+\fn static TSS2_RC get_policy_signature(
+    TPMS_POLICY *policy,
+    TPMT_PUBLIC *public,
+    TPMT_SIGNATURE *signature)
+\fn TSS2_RC ifapi_branch_selection(
+    TPML_POLICYBRANCHES *branches,
+    size_t *branch_idx,
+    void *userdata)
+\fn TSS2_RC ifapi_exec_auth_nv_policy(
+    TPM2B_NV_PUBLIC *nv_public,
     TPMI_ALG_HASH hash_alg,
-    TPMS_POLICY *policy)
-
-\fn TSS2_RC ifapi_policyeval_execute(
-    ESYS_CONTEXT *esys_ctx,
-    IFAPI_POLICY_EXEC_CTX *current_policy)
-
-\fn fn TSS2_RC ifapi_get_key_public(
+    void *userdata)
+\fn TSS2_RC ifapi_exec_auth_policy(
+    TPMT_PUBLIC *key_public,
+    TPMI_ALG_HASH hash_alg,
+    TPM2B_DIGEST *digest,
+    TPMT_SIGNATURE *signature,
+    void *userdata)
+\fn TSS2_RC ifapi_get_duplicate_name(
+    TPM2B_NAME *name,
+    void *userdata)
+\fn TSS2_RC ifapi_get_key_public(
     const char *path,
     TPMT_PUBLIC *public,
-    void *context)
-
-\fn TSS2_RC ifapi_get_object_name(
-    const char *path,
-    TPM2B_NAME *name,
-    void *context)
-
+    void *ctx)
 \fn TSS2_RC ifapi_get_nv_public(
     const char *path,
     TPM2B_NV_PUBLIC *nv_public,
-    void *context)
-
-\fn TSS2_RC ifapi_read_pcr(
-    TPMS_PCR_SELECT *pcr_select,
-    TPML_PCR_SELECTION *pcr_selection,
-    TPML_PCRVALUES **pcr_values,
     void *ctx)
-
+\fn TSS2_RC ifapi_get_object_name(
+    const char *path,
+    TPM2B_NAME *name,
+    void *ctx)
+\fn TSS2_RC ifapi_policy_action(
+    const char *action,
+    void *userdata)
 \fn TSS2_RC ifapi_policyeval_cbauth(
     TPM2B_NAME *name,
     ESYS_TR *object_handle,
     ESYS_TR *auth_handle,
     ESYS_TR *authSession,
     void *userdata)
-
-\fn TSS2_RC ifapi_branch_selection(
-    TPML_POLICYBRANCHES *branches,
-    size_t *branch_idx,
-    void *userdata)
-
+\fn TSS2_RC ifapi_read_pcr(
+    TPMS_PCR_SELECT *pcr_select,
+    TPML_PCR_SELECTION *pcr_selection,
+    TPML_PCRVALUES **pcr_values,
+    void *ctx)
 \fn TSS2_RC ifapi_sign_buffer(
     char *key_pem,
     char *public_key_hint,
@@ -1874,26 +1903,123 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     uint8_t **signature,
     size_t *signature_size,
     void *userdata)
+\fn static TSS2_RC search_policy(
+    FAPI_CONTEXT *context,
+    Policy_Compare_Object compare,
+    bool all_objects,
+    void *object1,
+    void *object2,
+    struct POLICY_LIST **policy_found)
 
-\fn TSS2_RC ifapi_exec_auth_policy(
-    TPMT_PUBLIC *key_public,
+ \}
+*/
+
+/*!
+ \defgroup ifapi_policy_execution Policy execution functions.
+ \ingroup ifapi
+ Provides internal functions for policy execution.
+ \{
+\fn static TSS2_RC compute_or_digest_list(
+    TPML_POLICYBRANCHES *branches,
+    TPMI_ALG_HASH current_hash_alg,
+    TPML_DIGEST *digest_list)
+\fn static TSS2_RC compute_policy_list(
+    IFAPI_POLICY_EXEC_CTX *pol_ctx,
+    TPML_POLICYELEMENTS *elements)
+\fn static TSS2_RC execute_policy_action(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYACTION *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_auth_value(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYAUTHVALUE *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_authorize(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYAUTHORIZE *policy,
     TPMI_ALG_HASH hash_alg,
-    TPM2B_DIGEST *digest,
-    TPMT_SIGNATURE *signature,
-    void *userdata)
-
-\fn TSS2_RC ifapi_exec_auth_nv_policy(
-    TPM2B_NV_PUBLIC *nv_public,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_authorize_nv(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYAUTHORIZENV *policy,
     TPMI_ALG_HASH hash_alg,
-    void *userdata)
-
-\fn TSS2_RC ifapi_get_duplicate_name(
-    TPM2B_NAME *name,
-    void *userdata)
-
-\fn TSS2_RC ifapi_policy_action(
-    const char *action,
-    void *userdata)
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_command_code(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYCOMMANDCODE *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_counter_timer(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYCOUNTERTIMER *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_cp_hash(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYCPHASH *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_duplicate(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYDUPLICATIONSELECT *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_element(
+    ESYS_CONTEXT *esys_ctx,
+    TPMT_POLICYELEMENT *policy,
+    TPMI_ALG_HASH hash_alg,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_locality(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYLOCALITY *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_name_hash(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYNAMEHASH *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_nv(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYNV *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_nv_written(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYNVWRITTEN *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_or(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYOR *policy,
+    TPMI_ALG_HASH current_hash_alg,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_password(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYPASSWORD *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_pcr(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYPCR *policy,
+    TPMI_ALG_HASH current_hash_alg,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_physical_presence(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYPHYSICALPRESENCE *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_secret(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYSECRET *policy,
+    TPMI_ALG_HASH hash_alg,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn static TSS2_RC execute_policy_signed(
+    ESYS_CONTEXT *esys_ctx,
+    TPMS_POLICYSIGNED *policy,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn TSS2_RC get_policy_digest_idx(TPML_DIGEST_VALUES *digest_values, TPMI_ALG_HASH hashAlg,
+                      size_t *idx)
+\fn TSS2_RC ifapi_extend_authorization(
+    TPMS_POLICY *policy,
+    TPMS_POLICYAUTHORIZATION *authorization)
+\fn TSS2_RC ifapi_policyeval_execute(
+    ESYS_CONTEXT *esys_ctx,
+    IFAPI_POLICY_EXEC_CTX *current_policy)
+\fn TSS2_RC ifapi_policyeval_execute_prepare(
+    IFAPI_POLICY_EXEC_CTX *pol_ctx,
+    TPMI_ALG_HASH hash_alg,
+    TPMS_POLICY *policy)
 
  \}
 */
@@ -1919,6 +2045,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     FAPI_CONTEXT *context,
     TPMS_POLICY *policy,
     IFAPI_POLICYUTIL_STACK **current_policy)
+
 \}
     */
 
@@ -1931,7 +2058,16 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC append_object_to_list(void *object, NODE_OBJECT_T **object_list)
 \fn static void cleanup_policy_element(TPMT_POLICYELEMENT *policy)
 \fn static void cleanup_policy_elements(TPML_POLICYELEMENTS *policy)
-\fn TSS2_RC copy_policy_element(const TPMT_POLICYELEMENT *from_policy, TPMT_POLICYELEMENT *to_policy)
+\fn static void cleanup_policy_object(POLICY_OBJECT * object)
+\fn static TSS2_RC copy_policy(TPMS_POLICY * dest,
+        const TPMS_POLICY * src)
+\fn static TPML_POLICYBRANCHES * copy_policy_branches(const TPML_POLICYBRANCHES *from_branches)
+\fn static TSS2_RC copy_policy_element(const TPMT_POLICYELEMENT *from_policy, TPMT_POLICYELEMENT *to_policy)
+\fn static TPML_POLICYELEMENTS * copy_policy_elements(const TPML_POLICYELEMENTS *from_policy)
+\fn static TSS2_RC copy_policy_object(POLICY_OBJECT * dest, const POLICY_OBJECT * src)
+\fn static TSS2_RC copy_policyauthorization(TPMS_POLICYAUTHORIZATION * dest,
+        const TPMS_POLICYAUTHORIZATION * src)
+\fn static TSS2_RC create_dirs(const char *supdir, NODE_STR_T *dir_list, mode_t mode)
 \fn void free_string_list(NODE_STR_T *node)
 \fn char * get_description(IFAPI_OBJECT *object)
 \fn bool ifapi_TPM2B_DIGEST_cmp(TPM2B_DIGEST *in1, TPM2B_DIGEST *in2)
@@ -1977,7 +2113,8 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     size_t pcr_count)
 \fn void ifapi_free_node_list(NODE_OBJECT_T *node)
 \fn void ifapi_free_object_list(NODE_OBJECT_T *node)
-\fn TSS2_RC ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer, size_t *buffer_size)
+\fn int ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
+                          size_t *buffer_size)
 \fn ESYS_TR ifapi_get_hierary_handle(const char *path)
 \fn TSS2_RC ifapi_get_name(TPMT_PUBLIC *publicInfo, TPM2B_NAME *name)
 \fn TSS2_RC ifapi_get_nv_start_index(const char *path, TPM2_HANDLE *start_nv_index)
@@ -2005,19 +2142,14 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     TPMT_SIGNATURE *tpm_signature,
     uint8_t **signature,
     size_t *signatureSize)
-\fn TSS2_RC init_explicit_key_path(
-    const char *context_profile,
-    const char *ipath,
-    NODE_STR_T **list_node1,
-    NODE_STR_T **current_list_node,
-    NODE_STR_T **result)
 \fn NODE_STR_T * init_string_list(const char *string)
 \fn bool object_with_auth(IFAPI_OBJECT *object)
-\fn size_t path_str_length(NODE_STR_T *node, int delim_length)
-\fn size_t policy_digest_size(IFAPI_OBJECT *object)
+\fn static size_t path_str_length(NODE_STR_T *node, int delim_length)
 \fn TSS2_RC push_object_to_list(void *object, NODE_OBJECT_T **object_list)
-\fn TSS2_RC push_object_with_size_to_list(void *object, size_t size, NODE_OBJECT_T **object_list)
 \fn NODE_STR_T * split_string(const char *string, char *delimiter)
+\fn int vasprintf(char **str, const char *fmt, va_list args)
+\fn static size_t write_curl_buffer_cb(void *contents, size_t size, size_t nmemb, void *userp)
+
  \}
 */
 
@@ -2031,6 +2163,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     IFAPI_KEYSTORE *keystore,
     const char *ipath,
     NODE_STR_T **result)
+\fn static size_t get_name_alg(FAPI_CONTEXT *context, IFAPI_OBJECT *object)
 \fn TSS2_RC ifapi_authorize_object(FAPI_CONTEXT *context, IFAPI_OBJECT *object, ESYS_TR *session)
 \fn TPM2_RC ifapi_capability_get(FAPI_CONTEXT *context, TPM2_CAP capability,
                      UINT32 count, TPMS_CAPABILITY_DATA **capability_data)
@@ -2151,7 +2284,15 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     IFAPI_OBJECT *auth_object,
     const char *description)
 \fn void ifapi_set_description(IFAPI_OBJECT *object, char *description)
-\fn TSS2_RC pop_object_from_list(FAPI_CONTEXT *context, NODE_OBJECT_T **object_list)
+\fn static TSS2_RC init_explicit_key_path(
+    const char *context_profile,
+    const char *ipath,
+    NODE_STR_T **list_node1,
+    NODE_STR_T **current_list_node,
+    NODE_STR_T **result)
+\fn static size_t policy_digest_size(IFAPI_OBJECT *object)
+\fn static TSS2_RC pop_object_from_list(FAPI_CONTEXT *context, NODE_OBJECT_T **object_list)
+\fn static TSS2_RC push_object_with_size_to_list(void *object, size_t size, NODE_OBJECT_T **object_list)
 
  \}
 */
@@ -2161,12 +2302,11 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \ingroup ifapi
  Provides internal basic IO functions for policy and key store module.
  \{
+\fn static TSS2_RC dirfiles_all(const char *dir_name, NODE_OBJECT_T **list, size_t *n)
 \fn TSS2_RC ifapi_io_check_create_dir(
     const char *dirname)
 \fn TSS2_RC ifapi_io_check_file_writeable(
     const char *file)
-\fn TSS2_RC ifapi_io_check_create_dir(
-    const char *dirname)
 \fn TSS2_RC ifapi_io_dirfiles(
     const char *dirname,
     char ***files,
@@ -2195,6 +2335,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     size_t length)
 \fn TSS2_RC ifapi_io_write_finish(
     struct IFAPI_IO *io)
+
  \}
 */
 
@@ -2203,7 +2344,19 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \ingroup ifapi
  Provides internal fapi functions for reading and writing to the key store.
  \{
+\fn static TSS2_RC copy_uint8_ary(UINT8_ARY *dest, const UINT8_ARY * src)
+\fn static TSS2_RC expand_directory(IFAPI_KEYSTORE *keystore, const char *path, char **directory_name)
+\fn static TSS2_RC expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
+\fn static TSS2_RC expand_path_to_object(
+    IFAPI_KEYSTORE *keystore,
+    const char *path,
+    const char *dir,
+    char **file_name)
 \fn void full_path_to_fapi_path(IFAPI_KEYSTORE *keystore, char *path)
+\fn static TSS2_RC get_explicit_key_path(
+    IFAPI_KEYSTORE *keystore,
+    const char *ipath,
+    NODE_STR_T **result)
 \fn void ifapi_cleanup_ifapi_duplicate(IFAPI_DUPLICATE * duplicate)
 \fn void ifapi_cleanup_ifapi_ext_pub_key(IFAPI_EXT_PUB_KEY * key)
 \fn void ifapi_cleanup_ifapi_hierarchy(IFAPI_HIERARCHY * hierarchy)
@@ -2262,6 +2415,17 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC ifapi_keystore_store_finish(
     IFAPI_KEYSTORE *keystore,
     IFAPI_IO *io)
+\fn static TSS2_RC initialize_explicit_key_path(
+    const char *context_profile,
+    const char *ipath,
+    NODE_STR_T **list_node1,
+    NODE_STR_T **current_list_node,
+    NODE_STR_T **result)
+\fn static TSS2_RC keystore_list_all_abs(
+    IFAPI_KEYSTORE *keystore,
+    const char *searchpath,
+    char ***results,
+    size_t *numresults)
 \fn static TSS2_RC keystore_search_obj(
     IFAPI_KEYSTORE *keystore,
     IFAPI_IO *io,
@@ -2272,41 +2436,6 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
         IFAPI_KEYSTORE *keystore,
         const char *rel_path,
         char **abs_path)
-
- \}
-*/
-
-/*!
- \defgroup ifapi_policy_store Policy store module
- \ingroup ifapi
- Provides internal fapi functions for reading and writing to the policy store.
- \{
-\fn TSS2_RC ifapi_policy_delete(
-    IFAPI_POLICY_STORE * pstore,
-    char *path)
-\fn TSS2_RC ifapi_policy_store_initialize(
-    IFAPI_POLICY_STORE *pstore,
-    const char *config_policydir)
-\fn TSS2_RC ifapi_policy_store_load_async(
-    IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io,
-    const char *path)
-\fn TSS2_RC ifapi_policy_store_load_finish(
-    IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io,
-    TPMS_POLICY *policy)
-\fn TSS2_RC ifapi_policy_store_store_async(
-    IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io,
-    const char *path,
-    const TPMS_POLICY *policy)
-\fn TSS2_RC ifapi_policy_store_store_finish(
-    IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io)
-\fn static TSS2_RC policy_rel_path_to_abs_path(
-    IFAPI_POLICY_STORE *pstore,
-    const char *rel_path,
-    char **abs_path)
 
  \}
 */
@@ -2389,11 +2518,10 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \}
 */
 
-
 /*!
  \defgroup ifapi_profile  Profile module
  \ingroup ifapi
- Provides functions for hanlding of profiles stored in the object store.
+ Provides functions for the handling of profiles stored in the object store.
 \{
 
 \fn static TSS2_RC ifapi_profile_checkpcrs(const TPML_PCR_SELECTION *pcr_profile)
@@ -2423,7 +2551,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \ingroup ifapi
  Provides functions for the serialization of FAPI objects to JSON.
  \{
-    \fn TSS2_RC ifapi_json_FAPI_QUOTE_INFO_serialize(const FAPI_QUOTE_INFO *in,
+\fn TSS2_RC ifapi_json_FAPI_QUOTE_INFO_serialize(const FAPI_QUOTE_INFO *in,
                                      json_object **jso)
 \fn TSS2_RC ifapi_json_IFAPI_CAP_INFO_serialize(const IFAPI_CAP_INFO *in, json_object **jso)
 \fn TSS2_RC ifapi_json_IFAPI_DUPLICATE_serialize(const IFAPI_DUPLICATE *in,
@@ -2454,69 +2582,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC ifapi_json_char_serialize(
     const char *in,
     json_object **jso)
-\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_serialize(const TPMI_POLICYTYPE in,
-                                     json_object **jso)
-\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_serialize_txt(
-    const TPMI_POLICYTYPE in,
-    json_object **str_jso)
-\fn TSS2_RC ifapi_json_TPML_PCRVALUES_serialize(const TPML_PCRVALUES *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPML_POLICYAUTHORIZATIONS_serialize(const TPML_POLICYAUTHORIZATIONS *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPML_POLICYBRANCHES_serialize(const TPML_POLICYBRANCHES *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPML_POLICYELEMENTS_serialize(const TPML_POLICYELEMENTS *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_PCRVALUE_serialize(const TPMS_PCRVALUE *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYACTION_serialize(const TPMS_POLICYACTION *in,
-                                       json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZATION_serialize(const TPMS_POLICYAUTHORIZATION *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZENV_serialize(const TPMS_POLICYAUTHORIZENV *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHVALUE_serialize(const TPMS_POLICYAUTHVALUE *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYBRANCH_serialize(const TPMS_POLICYBRANCH *in,
-                                       json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCOMMANDCODE_serialize(const TPMS_POLICYCOMMANDCODE *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCOUNTERTIMER_serialize(const TPMS_POLICYCOUNTERTIMER *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCPHASH_serialize(const TPMS_POLICYCPHASH *in,
-                                       json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
-        TPMS_POLICYDUPLICATIONSELECT *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYLOCALITY_serialize(const TPMS_POLICYLOCALITY *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNAMEHASH_serialize(const TPMS_POLICYNAMEHASH *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNVWRITTEN_serialize(const TPMS_POLICYNVWRITTEN *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYOR_serialize(const TPMS_POLICYOR *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPASSWORD_serialize(const TPMS_POLICYPASSWORD *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPCR_serialize(const TPMS_POLICYPCR *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPHYSICALPRESENCE_serialize(const
-        TPMS_POLICYPHYSICALPRESENCE *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYSECRET_serialize(const TPMS_POLICYSECRET *in,
-                                       json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
-                                       json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_POLICY_serialize(const TPMS_POLICY *in,
-        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMT_POLICYELEMENT_serialize(const TPMT_POLICYELEMENT *in,
-                                        json_object **jso)
-\fn TSS2_RC ifapi_json_TPMU_POLICYELEMENT_serialize(const TPMU_POLICYELEMENT *in,
-                                        UINT32 selector, json_object **jso)
-\fn static TSS2_RC ifapi_json_char_serialize(
-    const char *in,
-    json_object **jso)
-
-    \fn TSS2_RC ifapi_json_INT32_serialize(const INT32 in, json_object **jso)
+\fn TSS2_RC ifapi_json_INT32_serialize(const INT32 in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPM2B_CREATION_DATA_serialize(const TPM2B_CREATION_DATA *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPM2B_DATA_serialize(const TPM2B_DATA *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPM2B_DIGEST_serialize(const TPM2B_DIGEST *in, json_object **jso)
@@ -2661,6 +2727,69 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     const UINT8 sizeofSelect,
     const BYTE pcrSelect[],
     json_object **jso)
+    \fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_serialize(const TPMI_POLICYTYPE in,
+                                     json_object **jso)
+\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_serialize_txt(
+    const TPMI_POLICYTYPE in,
+    json_object **str_jso)
+\fn TSS2_RC ifapi_json_TPML_PCRVALUES_serialize(const TPML_PCRVALUES *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPML_POLICYAUTHORIZATIONS_serialize(const TPML_POLICYAUTHORIZATIONS
+        *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPML_POLICYBRANCHES_serialize(const TPML_POLICYBRANCHES *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPML_POLICYELEMENTS_serialize(const TPML_POLICYELEMENTS *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_PCRVALUE_serialize(const TPMS_PCRVALUE *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYACTION_serialize(const TPMS_POLICYACTION *in,
+                                       json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZATION_serialize(
+    const TPMS_POLICYAUTHORIZATION *in,
+    json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZENV_serialize(const TPMS_POLICYAUTHORIZENV *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHVALUE_serialize(const TPMS_POLICYAUTHVALUE *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYBRANCH_serialize(const TPMS_POLICYBRANCH *in,
+                                       json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCOMMANDCODE_serialize(const TPMS_POLICYCOMMANDCODE *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCOUNTERTIMER_serialize(const TPMS_POLICYCOUNTERTIMER *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCPHASH_serialize(const TPMS_POLICYCPHASH *in,
+                                       json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
+        TPMS_POLICYDUPLICATIONSELECT *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYLOCALITY_serialize(const TPMS_POLICYLOCALITY *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNAMEHASH_serialize(const TPMS_POLICYNAMEHASH *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNVWRITTEN_serialize(const TPMS_POLICYNVWRITTEN *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYOR_serialize(const TPMS_POLICYOR *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPASSWORD_serialize(const TPMS_POLICYPASSWORD *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPCR_serialize(const TPMS_POLICYPCR *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPHYSICALPRESENCE_serialize(const
+        TPMS_POLICYPHYSICALPRESENCE *in, json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYSECRET_serialize(const TPMS_POLICYSECRET *in,
+                                       json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
+                                       json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMS_POLICY_serialize(const TPMS_POLICY *in,
+        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMT_POLICYELEMENT_serialize(const TPMT_POLICYELEMENT *in,
+                                        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMU_POLICYELEMENT_serialize(const TPMU_POLICYELEMENT *in,
+                                        UINT32 selector, json_object **jso)
+\fn static TSS2_RC ifapi_json_char_serialize(
+    const char *in,
+    json_object **jso)
+
 
  \}
 */
@@ -2671,7 +2800,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \ingroup ifapi
  Provides functions for the deserialization from JSON to FAPI objects.
  \{
-    \fn static bool get_number(const char *token, int64_t *num)
+\fn static bool get_number(const char *token, int64_t *num)
 \fn static int get_token_start_idx(const char *token)
 \fn TSS2_RC ifapi_json_FAPI_QUOTE_INFO_deserialize(json_object *jso,  FAPI_QUOTE_INFO *out)
 \fn TSS2_RC ifapi_json_IFAPI_DUPLICATE_deserialize(json_object *jso, IFAPI_DUPLICATE *out)
@@ -2696,68 +2825,9 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC ifapi_json_char_deserialize(
     json_object *jso,
     char **out)
+\fn static TSS2_RC get_boolean_from_json(json_object *jso, TPMI_YES_NO *value)
 \fn static bool get_number(const char *token, int64_t *num)
-\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_deserialize(json_object *jso, TPMI_POLICYTYPE *out)
-\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_deserialize_txt(json_object *jso,
-        TPMI_POLICYTYPE *out)
-\fn TSS2_RC ifapi_json_TPML_PCRVALUES_deserialize(json_object *jso,  TPML_PCRVALUES **out)
-\fn TSS2_RC ifapi_json_TPML_POLICYAUTHORIZATIONS_deserialize(json_object *jso,
-        TPML_POLICYAUTHORIZATIONS **out)
-\fn TSS2_RC ifapi_json_TPML_POLICYBRANCHES_deserialize(json_object *jso,
-        TPML_POLICYBRANCHES **out)
-\fn TSS2_RC ifapi_json_TPML_POLICYELEMENTS_deserialize(json_object *jso,
-        TPML_POLICYELEMENTS **out)
-\fn TSS2_RC ifapi_json_TPMS_PCRVALUE_deserialize(json_object *jso,  TPMS_PCRVALUE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYACTION_deserialize(json_object *jso,
-        TPMS_POLICYACTION *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZATION_deserialize(json_object *jso,
-        TPMS_POLICYAUTHORIZATION *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZENV_deserialize(json_object *jso,
-        TPMS_POLICYAUTHORIZENV *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZE_deserialize(json_object *jso,
-        TPMS_POLICYAUTHORIZE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHVALUE_deserialize(json_object *jso,
-        TPMS_POLICYAUTHVALUE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYBRANCH_deserialize(json_object *jso,
-        TPMS_POLICYBRANCH *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCOMMANDCODE_deserialize(json_object *jso,
-        TPMS_POLICYCOMMANDCODE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCOUNTERTIMER_deserialize(json_object *jso,
-        TPMS_POLICYCOUNTERTIMER *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYCPHASH_deserialize(json_object *jso,
-        TPMS_POLICYCPHASH *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYDUPLICATIONSELECT_deserialize(json_object *jso,
-        TPMS_POLICYDUPLICATIONSELECT *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYLOCALITY_deserialize(json_object *jso,
-        TPMS_POLICYLOCALITY *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNAMEHASH_deserialize(json_object *jso,
-        TPMS_POLICYNAMEHASH *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNVWRITTEN_deserialize(json_object *jso,
-        TPMS_POLICYNVWRITTEN *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYNV_deserialize(json_object *jso,  TPMS_POLICYNV *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYOR_deserialize(json_object *jso,  TPMS_POLICYOR *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPASSWORD_deserialize(json_object *jso,
-        TPMS_POLICYPASSWORD *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPCR_deserialize(json_object *jso,  TPMS_POLICYPCR *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYPHYSICALPRESENCE_deserialize(json_object *jso,
-        TPMS_POLICYPHYSICALPRESENCE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYSECRET_deserialize(json_object *jso,
-        TPMS_POLICYSECRET *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
-        TPMS_POLICYSIGNED *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICYTEMPLATE_deserialize(json_object *jso,
-        TPMS_POLICYTEMPLATE *out)
-\fn TSS2_RC ifapi_json_TPMS_POLICY_deserialize(json_object *jso,
-        TPMS_POLICY *out)
-\fn TSS2_RC ifapi_json_TPMT_POLICYELEMENT_deserialize(json_object *jso,
-        TPMT_POLICYELEMENT *out)
-\fn TSS2_RC ifapi_json_TPMU_POLICYELEMENT_deserialize(
-    UINT32 selector,
-    json_object *jso,
-    TPMU_POLICYELEMENT *out)
-    \fn static TSS2_RC get_boolean_from_json(json_object *jso, TPMI_YES_NO *value)
-\fn static bool get_number(const char *token, int64_t *num)
-\fn TSS2_RC get_number_from_json(json_object *jso, int64_t *num)
+\fn static TSS2_RC get_number_from_json(json_object *jso, int64_t *num)
 \fn bool ifapi_get_sub_object(json_object *jso, char *name, json_object **sub_jso)
 \fn static TSS2_RC ifapi_hex_to_byte_ary(const char hex[], UINT32 vlen, BYTE val[])
 \fn TSS2_RC ifapi_json_BYTE_array_deserialize(size_t max, json_object *jso, BYTE *out)
@@ -2969,7 +3039,7 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     UINT8_ARY *out)
 \fn TSS2_RC ifapi_json_UINT8_deserialize(json_object *jso, UINT8 *out)
 \fn TSS2_RC ifapi_json_byte_deserialize(
-    json_object *jso2,
+    json_object *jso,
     UINT32 max,
     BYTE *out,
     UINT16 *out_size)
@@ -2978,6 +3048,66 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
     UINT8 *sizeofSelect,
     BYTE pcrSelect[])
 \fn static const char * strip_prefix(const char *in, ...)
+    \fn static bool get_number(const char *token, int64_t *num)
+\fn static int get_token_start_idx(const char *token)
+\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_deserialize(json_object *jso, TPMI_POLICYTYPE *out)
+\fn TSS2_RC ifapi_json_TPMI_POLICYTYPE_deserialize_txt(json_object *jso,
+        TPMI_POLICYTYPE *out)
+\fn TSS2_RC ifapi_json_TPML_PCRVALUES_deserialize(json_object *jso,  TPML_PCRVALUES **out)
+\fn TSS2_RC ifapi_json_TPML_POLICYAUTHORIZATIONS_deserialize(json_object *jso,
+        TPML_POLICYAUTHORIZATIONS **out)
+\fn TSS2_RC ifapi_json_TPML_POLICYBRANCHES_deserialize(json_object *jso,
+        TPML_POLICYBRANCHES **out)
+\fn TSS2_RC ifapi_json_TPML_POLICYELEMENTS_deserialize(json_object *jso,
+        TPML_POLICYELEMENTS **out)
+\fn TSS2_RC ifapi_json_TPMS_PCRVALUE_deserialize(json_object *jso,  TPMS_PCRVALUE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYACTION_deserialize(json_object *jso,
+        TPMS_POLICYACTION *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZATION_deserialize(json_object *jso,
+        TPMS_POLICYAUTHORIZATION *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZENV_deserialize(json_object *jso,
+        TPMS_POLICYAUTHORIZENV *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHORIZE_deserialize(json_object *jso,
+        TPMS_POLICYAUTHORIZE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYAUTHVALUE_deserialize(json_object *jso,
+        TPMS_POLICYAUTHVALUE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYBRANCH_deserialize(json_object *jso,
+        TPMS_POLICYBRANCH *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCOMMANDCODE_deserialize(json_object *jso,
+        TPMS_POLICYCOMMANDCODE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCOUNTERTIMER_deserialize(json_object *jso,
+        TPMS_POLICYCOUNTERTIMER *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYCPHASH_deserialize(json_object *jso,
+        TPMS_POLICYCPHASH *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYDUPLICATIONSELECT_deserialize(json_object *jso,
+        TPMS_POLICYDUPLICATIONSELECT *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYLOCALITY_deserialize(json_object *jso,
+        TPMS_POLICYLOCALITY *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNAMEHASH_deserialize(json_object *jso,
+        TPMS_POLICYNAMEHASH *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNVWRITTEN_deserialize(json_object *jso,
+        TPMS_POLICYNVWRITTEN *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYNV_deserialize(json_object *jso,  TPMS_POLICYNV *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYOR_deserialize(json_object *jso,  TPMS_POLICYOR *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPASSWORD_deserialize(json_object *jso,
+        TPMS_POLICYPASSWORD *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPCR_deserialize(json_object *jso,  TPMS_POLICYPCR *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYPHYSICALPRESENCE_deserialize(json_object *jso,
+        TPMS_POLICYPHYSICALPRESENCE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYSECRET_deserialize(json_object *jso,
+        TPMS_POLICYSECRET *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
+        TPMS_POLICYSIGNED *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICYTEMPLATE_deserialize(json_object *jso,
+        TPMS_POLICYTEMPLATE *out)
+\fn TSS2_RC ifapi_json_TPMS_POLICY_deserialize(json_object *jso,
+        TPMS_POLICY *out)
+\fn TSS2_RC ifapi_json_TPMT_POLICYELEMENT_deserialize(json_object *jso,
+        TPMT_POLICYELEMENT *out)
+\fn TSS2_RC ifapi_json_TPMU_POLICYELEMENT_deserialize(
+    UINT32 selector,
+    json_object *jso,
+    TPMU_POLICYELEMENT *out)
 
 
  \}

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -457,7 +457,7 @@ error_cleanup:
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an error occurs in the crypto library
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 static TSS2_RC
 ossl_ecc_pub_from_tpm(const TPM2B_PUBLIC *tpmPublicKey, EVP_PKEY *evpPublicKey)
@@ -554,7 +554,7 @@ error_cleanup:
  * @retval TSS2_FAPI_BAD_REFERENCE if tpmPublicKey or pemKeySize are NULL
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_pub_pem_key_from_tpm(
@@ -690,7 +690,7 @@ ifapi_ecc_der_sig_to_tpm(
  * @retval TSS2_FAPI_RC_BAD_REFERENCE if tpmPublic, signature or tpmSignature is NULL
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_der_sig_to_tpm(
@@ -953,7 +953,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an error occurs in the crypto library
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 static TSS2_RC
 get_ecc_tpm2b_public_from_evp(
@@ -1085,7 +1085,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TPM2_ALG_ID
 ifapi_get_signature_algorithm_from_pem(const char *pemKey) {
@@ -1130,7 +1130,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an error occurs in the crypto library
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_get_tpm2b_public_from_pem(
@@ -1593,8 +1593,9 @@ ifapi_crypto_hash_abort(IFAPI_CRYPTO_CONTEXT_BLOB **context)
  * Get url to download crl from certificate.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
+ * @retval TSS2_FAPI_RC_NO_CERT if an error did occur during certificate downloading.
  */
 TSS2_RC
 get_crl_from_cert(X509 *cert, X509_CRL **crl)
@@ -1661,6 +1662,8 @@ cleanup:
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated
  * @retval TSS2_FAPI_RC_BAD_VALUE, if the certificate is invalid
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an error occurs in the crypto library
+ * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
+ *         the function.
  */
 TSS2_RC
 ifapi_cert_to_pem(
@@ -1779,7 +1782,14 @@ ifapi_get_hash_alg_for_size(uint16_t size, TPMI_ALG_HASH *hashAlgorithm)
     }
 }
 
-static X509 *get_X509_from_pem(const char *pem_cert)
+/** Convert PEM certificate to OSSL format.
+ *
+ * @param[in] pem_cert Certificate in PEM format.
+ * @retval X509 OSSL certificate object.
+ * @retval NULL If the conversion fails.
+ */
+static X509
+*get_X509_from_pem(const char *pem_cert)
 {
     if (!pem_cert) {
         return NULL;
@@ -1841,8 +1851,13 @@ cleanup:
     return r;
 }
 
-/** Convert buffer from web to X509 certificate.
-  */
+/** Convert buffer from DER format to X509 certificate.
+ *
+ * @param[in] cert_buffer Certificate in DER format.
+ * @aparm[in] cert_buffer_size Size of DER certificate.
+ * @retval X509 OSSL certificate object.
+ * @retval NULL If the conversion fails.
+ */
 static X509
 *get_cert_from_buffer(unsigned char *cert_buffer, size_t cert_buffer_size)
 {
@@ -2057,7 +2072,7 @@ cleanup:
  * @retval TSS2_FAPI_BAD_REFERENCE if tpmPublicKey or pemKeySize are NULL
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_get_tpm_key_fingerprint(

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -214,7 +214,7 @@ ifapi_bn2binpad(const BIGNUM *bn, unsigned char *bin, int binSize)
  *
  * @retval A singleton hash engine
  */
-ENGINE *
+static ENGINE *
 get_engine()
 {
     /* If an engine is present, it is returned */
@@ -1843,7 +1843,8 @@ cleanup:
 
 /** Convert buffer from web to X509 certificate.
   */
-X509 * get_cert_from_buffer(unsigned char *cert_buffer, size_t cert_buffer_size)
+static X509
+*get_cert_from_buffer(unsigned char *cert_buffer, size_t cert_buffer_size)
 {
     unsigned char *buffer = cert_buffer;
     X509 *cert = NULL;

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -433,7 +433,7 @@ ifapi_get_free_handle_finish(FAPI_CONTEXT *fctx, TPM2_HANDLE *handle,
  *         initialized.
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 static TSS2_RC
 get_explicit_key_path(
@@ -569,7 +569,7 @@ ifapi_init_primary_async(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype)
  * @retval TSS2_FAPI_RC_BAD_VALUE if a wrong type was passed.
  * @retval TSS2_ESYS_RC_* possible error codes of ESAPI.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
@@ -722,7 +722,7 @@ ifapi_load_primary_async(FAPI_CONTEXT *context, char *path)
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_FAPI_RC_POLICY_UNKNOWN if policy search for a certain policy digest
  *         was not successful.
@@ -1062,7 +1062,7 @@ ifapi_primary_clean(FAPI_CONTEXT *context)
  *         of the primary.
  * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_IO_ERROR if an error occurred while accessing the
  *         object store.
  */
@@ -1123,12 +1123,12 @@ error_cleanup:
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_PATH_NOT_FOUND if a FAPI object path was not found
  *         during authorization.
  * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_FAPI_RC_POLICY_UNKNOWN if policy search for a certain policy digest
  *         was not successful.
@@ -1372,7 +1372,7 @@ full_path_to_fapi_path(IFAPI_KEYSTORE *keystore, char *path)
  * @retval TSS2_RC_SUCCESS If the preparation is successful.
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated for path names.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_load_keys_async(FAPI_CONTEXT *context, char const *keyPath)
@@ -1411,7 +1411,7 @@ ifapi_load_keys_async(FAPI_CONTEXT *context, char const *keyPath)
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  * @retval TSS2_FAPI_RC_PATH_NOT_FOUND if a FAPI object path was not found
@@ -1421,7 +1421,7 @@ ifapi_load_keys_async(FAPI_CONTEXT *context, char const *keyPath)
  *         object store.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_FAPI_RC_POLICY_UNKNOWN if policy search for a certain policy digest
  *         was not successful.
@@ -1705,6 +1705,13 @@ error_cleanup:
     return r;
 }
 
+/** Get the name alg corresponding to a FAPI object.
+ *
+ * @param[in] context The context with the default profile.
+ * @param[in] object The object to be checked.
+ * @retval TPMI_ALG_HASH The hash algorithm.
+ * @retval 0 If no name alg can be assigned to the object.
+ */
 static size_t
 get_name_alg(FAPI_CONTEXT *context, IFAPI_OBJECT *object)
 {
@@ -1764,6 +1771,7 @@ ifapi_flush_policy_session(FAPI_CONTEXT *context, ESYS_TR session, TSS2_RC r)
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_ESYS_RC_* possible error codes of ESAPI.
+ * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  */
 TSS2_RC
 ifapi_authorize_object(FAPI_CONTEXT *context, IFAPI_OBJECT *object, ESYS_TR *session)
@@ -2247,7 +2255,7 @@ error_cleanup:
  * @retval TSS2_ESYS_RC_* possible error codes of ESAPI.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_TRY_AGAIN if an I/O operation is not finished yet and
  *         this function needs to be called again.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
@@ -2639,14 +2647,14 @@ ifapi_esys_serialize_object(ESYS_CONTEXT *ectx, IFAPI_OBJECT *object)
 }
 
  /** Initialize the part of an IFAPI_OBJECT  which is not serialized.
- *
- * For persistent objects the correspodning ESYS object will be created.
- *
- * @param[in,out] ectx The ESYS context.
- * @param[out] object the deserialzed binary object.
- * @retval TSS2_RC_SUCCESS if the function call was a success.
- * @retval TSS2_FAPI_RC_BAD_VALUE if the json object can't be deserialized.
- */
+  *
+  * For persistent objects the correspodning ESYS object will be created.
+  *
+  * @param[in,out] ectx The ESYS context.
+  * @param[out] object the deserialzed binary object.
+  * @retval TSS2_RC_SUCCESS if the function call was a success.
+  * @retval TSS2_FAPI_RC_BAD_VALUE if the json object can't be deserialized.
+  */
 TSS2_RC
 ifapi_initialize_object(
     ESYS_CONTEXT *ectx,
@@ -2709,7 +2717,7 @@ cleanup:
  *         keystore.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_NO_TPM if FAPI was initialized in no-TPM-mode via its
  *         config file.
@@ -2760,7 +2768,7 @@ ifapi_key_create_prepare_auth(
  *         keystore.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_NO_TPM if FAPI was initialized in no-TPM-mode via its
  *         config file.
@@ -2822,7 +2830,7 @@ ifapi_key_create_prepare_sensitive(
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_key_create_prepare(
@@ -3189,7 +3197,7 @@ ifapi_get_sig_scheme(
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  */
 TSS2_RC
 ifapi_change_auth_hierarchy(
@@ -3290,7 +3298,7 @@ error:
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  */
 TSS2_RC
 ifapi_change_policy_hierarchy(
@@ -3498,7 +3506,7 @@ ifapi_capability_init(FAPI_CONTEXT *context)
  * @retval TSS2_ESYS_RC_* possible error codes of ESAPI.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  */
@@ -3658,7 +3666,7 @@ error_cleanup:
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_IO_ERROR if an error occurred while accessing the

--- a/src/tss2-fapi/ifapi_eventlog.c
+++ b/src/tss2-fapi/ifapi_eventlog.c
@@ -28,7 +28,7 @@
  * @retval TSS2_FAPI_RC_MEMORY if memory allocation failed.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_eventlog_initialize(
@@ -61,7 +61,7 @@ ifapi_eventlog_initialize(
  * @retval TSS2_FAPI_RC_IO_ERROR if creation of log_dir failed or log_dir is not writable.
  * @retval TSS2_FAPI_RC_MEMORY if memory allocation failed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  */
 TSS2_RC
@@ -105,7 +105,7 @@ ifapi_eventlog_get_async(
  * @retval TSS2_FAPI_RC_TRY_AGAIN if the I/O operation is not finished yet and this function needs
  *         to be called again.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
@@ -266,7 +266,7 @@ ifapi_eventlog_append_async(
  * @retval TSS2_FAPI_RC_TRY_AGAIN if the I/O operation is not finished yet and this function needs
  *         to be called again.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -470,6 +470,18 @@ ifapi_TPMT_PUBLIC_cmp(TPMT_PUBLIC *in1, TPMT_PUBLIC *in2)
     return true;
 }
 
+/** Print to allocated string.
+ *
+ * A list of parameters will be printed to an allocated string according to the
+ * format description in the first parameter.
+ *
+ * @param[out] str The allocated output string.
+ * @param[in] fmt The format string (printf formats can be used.)
+ * @param[in] args The list of objects to be printed.
+ *
+ * @retval int The size of the string ff the printing was successful.
+ * @retval -1 if not enough memory can be allocated.
+ */
 int
 vasprintf(char **str, const char *fmt, va_list args)
 {
@@ -492,7 +504,7 @@ vasprintf(char **str, const char *fmt, va_list args)
 
 /** Print to allocated string.
  *
- * A list of parameters will be printed to an allocates string according to the
+ * A list of parameters will be printed to an allocated string according to the
  * format description in the first parameter.
  *
  * @param[out] str The allocated output string.
@@ -500,7 +512,7 @@ vasprintf(char **str, const char *fmt, va_list args)
  * @param[in] ... The list of objects to be printed.
  *
  * @retval TSS2_RC_SUCCESS If the printing was successful.
- * @retval TSS2_FAPI_RC_MEMORY: if not enough memory can be allocated.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
 ifapi_asprintf(char **str, const char *fmt, ...)
@@ -910,6 +922,16 @@ get_description(IFAPI_OBJECT *object)
     }
 }
 
+/** Create a directory and all sub directories.
+ *
+ * @param[in] supdir The sup directory were the directories will be created.
+ * @param[in] dir_list A linked list with the directory strings.
+ * @param[in] mode The creation mode for the directory which will be used
+ *            for the mkdir function.
+ * @retval TSS2_RC_SUCCESS on success.
+ * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
+ *         the function.
+ */
 static TSS2_RC
 create_dirs(const char *supdir, NODE_STR_T *dir_list, mode_t mode)
 {
@@ -1079,7 +1101,16 @@ ifapi_cleanup_policy(TPMS_POLICY *policy)
     }
 }
 
-static void cleanup_policy_object(POLICY_OBJECT * object) {
+/** Free memory of a policy object.
+ *
+ * The memory allocated during deserialization of the policy will
+ * also be freed.
+ *
+ * @param[in] object The policy object to be cleaned up.
+ *
+ */
+static void
+cleanup_policy_object(POLICY_OBJECT * object) {
     if (object != NULL) {
         SAFE_FREE(object->path);
         ifapi_cleanup_policy(&object->policy);
@@ -1090,7 +1121,15 @@ static void cleanup_policy_object(POLICY_OBJECT * object) {
 static TPML_POLICYELEMENTS *
 copy_policy_elements(const TPML_POLICYELEMENTS *from_policy);
 
-static TSS2_RC copy_policy(TPMS_POLICY * dest,
+/** Copy policy structure.
+ *
+ * @param[in] src The policy structure to be copied.
+ * @param[out] dest The destination policy structure.
+ * @retval TSS2_RC_SUCCESS on success.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
+static TSS2_RC
+copy_policy(TPMS_POLICY * dest,
         const TPMS_POLICY * src) {
     /* Check for NULL references */
     if (dest == NULL || src == NULL) {
@@ -1110,6 +1149,13 @@ error_cleanup:
     return r;
 }
 
+/** Copy policy object.
+ *
+ * @param[in] src The policy object to be copied.
+ * @param[out] dest The destination policy object.
+ * @retval TSS2_RC_SUCCESS on success.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
 static TSS2_RC
 copy_policy_object(POLICY_OBJECT * dest, const POLICY_OBJECT * src) {
     /* Check for NULL references */
@@ -1138,6 +1184,14 @@ error_cleanup:
     return r;
 }
 
+/** Copy policy authorization.
+ *
+ * @param[in] src The policy authorization to be copied.
+ * @param[out] dest The destination policy authorization.
+ * @retval TSS2_RC_SUCCESS on success.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
 static TSS2_RC
 copy_policyauthorization(TPMS_POLICYAUTHORIZATION * dest,
         const TPMS_POLICYAUTHORIZATION * src) {
@@ -1157,6 +1211,12 @@ error_cleanup:
     return r;
 }
 
+/** Copy policy branches.
+ *
+ * @param[in] src The policy branches to be copied.
+ * @param[out] dest The destination policy branches.
+ * @retval TSS2_RC_SUCCESS on success.
+ */
 static TPML_POLICYBRANCHES *
 copy_policy_branches(const TPML_POLICYBRANCHES *from_branches)
 {
@@ -1305,6 +1365,13 @@ error:
     return r;
 }
 
+/** Copy a list of policy elements
+ *
+ * @param[in] form_policy The policy list to be copied.
+ * @retval NULL If the policy cannot be copied.
+ * @retval TPML_POLICYELEMENTS The copy of the policy list.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
 static TPML_POLICYELEMENTS *
 copy_policy_elements(const TPML_POLICYELEMENTS *from_policy)
 {
@@ -1342,8 +1409,6 @@ copy_policy_elements(const TPML_POLICYELEMENTS *from_policy)
 
 /** Copy policy.
  *
- * The object will not be freed (might be declared on the stack).
- *
  * @param[in] from_policy the policy to be copied.
  * @retval The new policy or NULL if not enough memory was available.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -1380,7 +1445,7 @@ ifapi_copy_policy(
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  */
 TSS2_RC
@@ -1511,7 +1576,7 @@ ifapi_nv_get_name(TPM2B_NV_PUBLIC *publicInfo, TPM2B_NAME *name)
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  */
 TSS2_RC
@@ -1586,7 +1651,7 @@ ifapi_object_cmp_nv_public(IFAPI_OBJECT *object, void *nv_public, bool *equal)
  *         not covered by other return codes (e.g. a unexpected openssl
  *         error).
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  */
 TSS2_RC
@@ -2263,6 +2328,15 @@ struct CurlBufferStruct {
   size_t size;
 };
 
+/** Callback for copying received curl data to a buffer.
+ *
+ * The buffer will be reallocated according to the size of retrieved data.
+ *
+ * @param[in]  contents The retrieved content.
+ * @param[in]  size the block size in the content.
+ * @param[in]  nmemb The number of blocks.
+ * @retval realsize The byte size of the data.
+ */
 static size_t
 write_curl_buffer_cb(void *contents, size_t size, size_t nmemb, void *userp)
 {
@@ -2291,7 +2365,8 @@ write_curl_buffer_cb(void *contents, size_t size, size_t nmemb, void *userp)
  * @retval 0 if buffer could be retrieved.
  * @retval -1 if an error did occur
  */
-int ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
+int
+ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
                           size_t *buffer_size) {
     int ret = -1;
     struct CurlBufferStruct curl_buffer = { .size = 0, .buffer = NULL };

--- a/src/tss2-fapi/ifapi_helpers.h
+++ b/src/tss2-fapi/ifapi_helpers.h
@@ -47,19 +47,8 @@ ifapi_init_hierarchy_object(
 char *
 get_description(IFAPI_OBJECT *object);
 
-TSS2_RC
-init_explicit_key_path(
-    const char *context_profile,
-    const char *ipath,
-    NODE_STR_T **list_node1,
-    NODE_STR_T **current_list_node,
-    NODE_STR_T **result);
-
 size_t
 ifapi_path_length(NODE_STR_T *node);
-
-size_t
-path_str_length(NODE_STR_T *node, int delim_length);
 
 void
 ifapi_free_object_list(NODE_OBJECT_T *node);
@@ -147,13 +136,6 @@ push_object_to_list(void *object, NODE_OBJECT_T **object_list);
 
 TSS2_RC
 append_object_to_list(void *object, NODE_OBJECT_T **object_list);
-
-TSS2_RC
-push_object_with_size_to_list(void *object, size_t size, NODE_OBJECT_T **object_list);
-
-size_t
-policy_digest_size(
-    IFAPI_OBJECT *object);
 
 bool
 object_with_auth(IFAPI_OBJECT *object);

--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -97,7 +97,7 @@ ifapi_io_read_async(
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
  * @retval TSS2_FAPI_RC_IO_ERROR: if an I/O error was encountered; such as the file was not found.
  * @retval TSS2_FAPI_RC_TRY_AGAIN: if the asynchronous operation is not yet complete.
-           Call this function again later.
+ *         Call this function again later.
  */
 TSS2_RC
 ifapi_io_read_finish(
@@ -207,7 +207,7 @@ ifapi_io_write_async(
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
  * @retval TSS2_FAPI_RC_IO_ERROR: if an I/O error was encountered; such as the file was not found.
  * @retval TSS2_FAPI_RC_TRY_AGAIN: if the asynchronous operation is not yet complete.
-           Call this function again later.
+ *         Call this function again later.
  */
 TSS2_RC
 ifapi_io_write_finish(
@@ -268,7 +268,7 @@ ifapi_io_check_file_writeable(
  * @retval TSS2_FAPI_RC_IO_ERROR if an I/O error occurred
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_io_check_create_dir(
@@ -459,6 +459,16 @@ error_oom:
     return TSS2_FAPI_RC_MEMORY;
 }
 
+/** Get a linked list of files in a directory and all sub directories.
+ *
+ * Enumerage the regular files (no directories, symlinks etc) from a given directory.
+ *
+ * @param[in]  dir_name The directory to list files from.
+ * @param[out] list  The linked list with the file names.
+ * @param[out] n The number of filesl
+ * @retval TSS2_RC_SUCCESS if the directories were successfully removed
+ * @retval TSS2_FAPI_RC_MEMORY: if memory could not be allocated to hold the read data.
+ */
 static TSS2_RC
 dirfiles_all(const char *dir_name, NODE_OBJECT_T **list, size_t *n)
 {

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -22,6 +22,18 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
+/** Copy policy digest.
+ *
+ * One digest is copied from certain position in a policy list to the
+ * same position in a second list.
+ *
+ * @param[out] dest The digest list to which the new value is added.
+ * @param[in]  src The digest list with the value to be copied.
+ * @param[in]  digest_idx The index of the digest to be copied.
+ * @param[in]  hash_size The number of bytes to be copied.
+ * @param[in]  txt Text which will be used for additional logging information..
+ * @retval TSS2_RC_SUCCESS on success.
+ */
 static void
 copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
                    size_t digest_idx, size_t hash_size, char *txt)
@@ -34,6 +46,13 @@ copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
     dest->count = src->count;
 }
 
+/** Logdefault policy digest.
+ *
+ * @param[in] dest The digest to be logged.
+ * @param[in] digest_idx The index of the digest to be logged
+ * @param[in] hash_size The number of bytes to be logged
+ * @param[in] txt Text which will be used for additional logging information.
+ */
 static void
 log_policy_digest(TPML_DIGEST_VALUES *dest, size_t digest_idx, size_t hash_size,
                   char *txt)
@@ -54,7 +73,7 @@ log_policy_digest(TPML_DIGEST_VALUES *dest, size_t digest_idx, size_t hash_size,
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -135,7 +154,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 static TSS2_RC
 calculate_policy_key_param(
@@ -199,7 +218,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -248,7 +267,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
@@ -304,7 +323,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -378,7 +397,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -431,7 +450,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -483,7 +502,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -558,7 +577,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -620,7 +639,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -653,7 +672,7 @@ ifapi_calculate_policy_physical_presence(
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -686,7 +705,7 @@ ifapi_calculate_policy_auth_value(
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -721,7 +740,7 @@ ifapi_calculate_policy_password(
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -752,7 +771,7 @@ ifapi_calculate_policy_command_code(
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -812,7 +831,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -877,7 +896,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -908,7 +927,7 @@ ifapi_calculate_policy_cp_hash(
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -965,7 +984,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -1027,7 +1046,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_calculate_policy_nv(
@@ -1104,7 +1123,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
@@ -1194,7 +1213,7 @@ cleanup:
  *
  * @retval TSS2_RC_SUCCESS on success.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -22,7 +22,7 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-void
+static void
 copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
                    size_t digest_idx, size_t hash_size, char *txt)
 {
@@ -34,7 +34,7 @@ copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
     dest->count = src->count;
 }
 
-void
+static void
 log_policy_digest(TPML_DIGEST_VALUES *dest, size_t digest_idx, size_t hash_size,
                   char *txt)
 {
@@ -137,7 +137,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
 *          the function.
  */
-TSS2_RC
+static TSS2_RC
 calculate_policy_key_param(
     TPM2_CC command_code,
     TPM2B_NAME *name,

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -24,7 +24,7 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
-TSS2_RC
+static TSS2_RC
 compute_or_digest_list(
     TPML_POLICYBRANCHES *branches,
     TPMI_ALG_HASH current_hash_alg,
@@ -267,7 +267,7 @@ execute_policy_nv(
     return r;
 }
 
-TSS2_RC
+static TSS2_RC
 execute_policy_signed(
     ESYS_CONTEXT *esys_ctx,
     TPMS_POLICYSIGNED *policy,
@@ -879,7 +879,7 @@ execute_policy_locality(
     return r;
 }
 
-TSS2_RC
+static TSS2_RC
 execute_policy_nv_written(
     ESYS_CONTEXT *esys_ctx,
     TPMS_POLICYNVWRITTEN *policy,
@@ -945,7 +945,7 @@ execute_policy_or(
 }
 
 
-TSS2_RC
+static TSS2_RC
 execute_policy_action(
     ESYS_CONTEXT *esys_ctx,
     TPMS_POLICYACTION *policy,

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -28,8 +28,7 @@ static TSS2_RC
 compute_or_digest_list(
     TPML_POLICYBRANCHES *branches,
     TPMI_ALG_HASH current_hash_alg,
-    TPML_DIGEST *digest_list,
-    const char *names[8])
+    TPML_DIGEST *digest_list)
 {
     size_t i;
     size_t digest_idx, hash_size;
@@ -58,7 +57,6 @@ compute_or_digest_list(
         if (i > 7) {
             return_error(TSS2_FAPI_RC_BAD_VALUE, "Too much or branches.");
         }
-        names[i] = branches->authorizations[i].name;
         digest_list->digests[i].size = hash_size;
         memcpy(&digest_list->digests[i].buffer[0],
                &branches->authorizations[i].policyDigests.
@@ -918,14 +916,13 @@ execute_policy_or(
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    const char *names[8];
 
     LOG_TRACE("call");
 
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)
         r = compute_or_digest_list(policy->branches, current_hash_alg,
-                                      &current_policy->digest_list, names);
+                                      &current_policy->digest_list);
         return_if_error(r, "Compute policy or digest list.");
 
         r = Esys_PolicyOR_Async(esys_ctx,

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -89,6 +89,14 @@ ifapi_policyeval_instantiate_async(
     return r;
 }
 
+/** Compute name and public information format a PEM key.
+ *
+ * @param[in]  keyPEM The key in PEM format.
+ * @param[out] keyPublic The public information of the PEM key.
+ * @param[out] name the name computed from the public information.
+ * @param[in]  hash_alg The name alg of the key has to passed.
+ * @retval TSS2_RC_SUCCESS on success.
+ */
 static TSS2_RC
 set_pem_key_param(
     const char *keyPEM,
@@ -141,7 +149,7 @@ set_pem_key_param(
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_SEQUENCE if the context has an asynchronous
  *         operation already pending.

--- a/src/tss2-fapi/ifapi_policy_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_deserialize.c
@@ -29,7 +29,6 @@ static char *tss_const_prefixes[] = { "TPM2_ALG_", "TPM2_", "TPM_", "TPMA_", "PO
  * @retval the position of the sub string after the prefix.
  * @retval 0 if no prefix is found.
  */
-
 static int
 get_token_start_idx(const char *token)
 {

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -88,7 +88,7 @@ cleanup:
  *         initialized.
  * @retval TSS2_FAPI_RC_MEMORY: if memory could not be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_policy_store_initialize(
@@ -169,7 +169,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an internal error occurred.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -220,7 +220,7 @@ cleanup:
  * @retval TSS2_FAPI_RC_MEMORY: If memory could not be allocated to hold the output data.
  * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_policy_store_store_async(

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -258,7 +258,7 @@ error:
  *         during authorization.
  * @retval TSS2_FAPI_RC_KEY_NOT_FOUND if a key was not found.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN if a required authorization callback
-*          is not set.
+ *         is not set.
  * @retval TSS2_FAPI_RC_AUTHORIZATION_FAILED if the authorization attempt fails.
  * @retval TSS2_ESYS_RC_* possible error codes of ESAPI.
  */

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -212,7 +212,7 @@ ifapi_get_sub_object(json_object *jso, char *name, json_object **sub_jso)
  * @retval TSS2_RC_SUCCESS if json object represents a number.
  * @retval TSS2_FAPI_RC_BAD_VALUE if the json object does not represent a number.
  */
-TSS2_RC
+static TSS2_RC
 get_number_from_json(json_object *jso, int64_t *num)
 {
     const char *token = json_object_get_string(jso);

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -259,7 +259,7 @@ get_boolean_from_json(json_object *jso, TPMI_YES_NO *value)
  * @param[out] sizeofSelect size of bit mask for used pcr registers.
  * @param[out] pcrSelect byte array with bit mask.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_pcr_selection_deserialize(
@@ -296,7 +296,7 @@ ifapi_json_pcr_selection_deserialize(
  * @param[out] out the deserialized object.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_UINT8_ARY_deserialize(
@@ -321,7 +321,7 @@ ifapi_json_UINT8_ARY_deserialize(
  * @param[in]  jso  json object to be deserialized.
  * @param[out] out the deserialized object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMS_PCR_SELECT_deserialize(json_object *jso,  TPMS_PCR_SELECT *out)
@@ -338,7 +338,7 @@ ifapi_json_TPMS_PCR_SELECT_deserialize(json_object *jso,  TPMS_PCR_SELECT *out)
  * @param[in]  jso json object to be deserialized.
  * @param[out] out the deserialized object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMS_PCR_SELECTION_deserialize(json_object *jso,
@@ -370,7 +370,7 @@ ifapi_json_TPMS_PCR_SELECTION_deserialize(json_object *jso,
  * @param[in] jso the JSON object with the byte array.
  * @param[in] out the byte array for deserialization.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_BYTE_array_deserialize(size_t max, json_object *jso, BYTE *out)
@@ -1233,7 +1233,7 @@ ifapi_json_TPMI_RH_HIERARCHY_deserialize(json_object *jso,
 /** Deserialize a TPMI_RH_NV_INDEX json object.
  *
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMI_RH_NV_INDEX_deserialize(json_object *jso, TPMI_RH_NV_INDEX *out)
@@ -2217,7 +2217,7 @@ ifapi_json_TPMS_ATTEST_deserialize(json_object *jso,  TPMS_ATTEST *out)
 /** Deserialize a TPMI_AES_KEY_BITS json object.
  *
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMI_AES_KEY_BITS_deserialize(json_object *jso, TPMI_AES_KEY_BITS *out)
@@ -3124,7 +3124,7 @@ ifapi_json_TPM2B_PUBLIC_KEY_RSA_deserialize(json_object *jso,
 /** Deserialize a TPMI_RSA_KEY_BITS json object.
  *
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMI_RSA_KEY_BITS_deserialize(json_object *jso,
@@ -3213,7 +3213,7 @@ ifapi_json_TPMI_ALG_ECC_SCHEME_deserialize(json_object *jso,
 /** Deserialize a TPMI_ECC_CURVE json object.
  *
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  */
 TSS2_RC
 ifapi_json_TPMI_ECC_CURVE_deserialize(json_object *jso, TPMI_ECC_CURVE *out)

--- a/src/tss2-fapi/tpm_json_serialize.c
+++ b/src/tss2-fapi/tpm_json_serialize.c
@@ -970,7 +970,7 @@ ifapi_json_TPMA_CC_serialize(const TPMA_CC in, json_object **jso)
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -992,7 +992,7 @@ ifapi_json_TPMI_YES_NO_serialize(const TPMI_YES_NO in, json_object **jso)
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -1044,7 +1044,7 @@ ifapi_json_TPMI_RH_NV_INDEX_serialize(const TPMI_RH_NV_INDEX in,
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -1060,7 +1060,7 @@ ifapi_json_TPMI_ALG_HASH_serialize(const TPMI_ALG_HASH in, json_object **jso)
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -1076,7 +1076,7 @@ ifapi_json_TPMI_ALG_SYM_OBJECT_serialize(const TPMI_ALG_SYM_OBJECT in,
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -1093,7 +1093,7 @@ ifapi_json_TPMI_ALG_SYM_MODE_serialize(const TPMI_ALG_SYM_MODE in,
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -1109,7 +1109,7 @@ ifapi_json_TPMI_ALG_KDF_serialize(const TPMI_ALG_KDF in, json_object **jso)
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -2162,7 +2162,7 @@ ifapi_json_TPMS_NV_CERTIFY_INFO_serialize(const TPMS_NV_CERTIFY_INFO *in, json_o
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -2458,7 +2458,7 @@ ifapi_json_TPMS_SCHEME_ECDAA_serialize(const TPMS_SCHEME_ECDAA *in, json_object 
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -2887,7 +2887,7 @@ ifapi_json_TPMT_KDF_SCHEME_serialize(const TPMT_KDF_SCHEME *in, json_object **js
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -2977,7 +2977,7 @@ ifapi_json_TPMT_ASYM_SCHEME_serialize(const TPMT_ASYM_SCHEME *in, json_object **
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -3133,7 +3133,7 @@ ifapi_json_TPMS_ECC_POINT_serialize(const TPMS_ECC_POINT *in, json_object **jso)
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC
@@ -3453,7 +3453,7 @@ ifapi_json_TPM2B_ENCRYPTED_SECRET_serialize(const TPM2B_ENCRYPTED_SECRET *in, js
  * @param[in] in variable to be serialized.
  * @param[out] jso pointer to the json object.
  * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
-*          the function.
+ *         the function.
  * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
  */
 TSS2_RC


### PR DESCRIPTION
* Functions were declared static if they were used only in one file.
* If necessary, functions were moved to the file where they were used.
* Dead code was removed.
* The doxygen documentation and inline comments were extended.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
