### PR TITLE
Tpm_clear auth

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -145,6 +145,7 @@ if ESAPI
 ESYS_TESTS_INTEGRATION_DESTRUCTIVE = \
     test/integration/esys-change-eps.int \
     test/integration/esys-clear.int \
+    test/integration/esys-tpm-clear-auth.int \
     test/integration/esys-clear-session.int \
     test/integration/esys-field-upgrade.int \
     test/integration/esys-firmware-read.int \
@@ -1304,6 +1305,13 @@ test_integration_esys_auto_session_flags_int_LDADD = $(TESTS_LDADD)
 test_integration_esys_auto_session_flags_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_auto_session_flags_int_SOURCES = \
     test/integration/esys-auto-session-flags.int.c \
+    test/integration/main-esapi.c test/integration/test-esapi.h
+
+test_integration_esys_tpm_clear_auth_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_tpm_clear_auth_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_tpm_clear_auth_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_tpm_clear_auth_int_SOURCES = \
+    test/integration/esys-tpm-clear-auth.int.c \
     test/integration/main-esapi.c test/integration/test-esapi.h
 
 endif #ESAPI

--- a/src/tss2-esys/api/Esys_Clear.c
+++ b/src/tss2-esys/api/Esys_Clear.c
@@ -199,6 +199,11 @@ Esys_Clear_Async(
     return_state_if_error(r, _ESYS_STATE_INTERNALERROR,
                           "Finish (Execute Async)");
 
+    /* If the command authorization is LOCKOUT we need to
+     * recompute session value with an empty auth */
+    if (authHandle == ESYS_TR_RH_LOCKOUT)
+        iesys_compute_session_value(esysContext->session_tab[0], NULL, NULL);
+
     esysContext->state = _ESYS_STATE_SENT;
 
     return r;

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -151,6 +151,7 @@ iesys_DeleteAllResourceObjects(ESYS_CONTEXT * esys_context)
         next_node_rsrc = node_rsrc->next;
         SAFE_FREE(node_rsrc);
     }
+    esys_context->rsrc_list = NULL;
 }
 /**  Compute the TPM nonce of the session used for parameter encryption.
  *

--- a/test/integration/esys-tpm-clear-auth.int.c
+++ b/test/integration/esys-tpm-clear-auth.int.c
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright (c) 2020, Intel Corporation
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+
+#include "esys_iutil.h"
+#include "test-esapi.h"
+#define LOGDEFAULT LOGLEVEL_INFO
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+/** Test auth verification in clear command
+ *
+ * After TPM2_Clear command is executed all auth values for
+ * owner, platofrm and lockout are set to empty buffers and
+ * the empty auth values should be used fot HMAC verification
+ * in the response.
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_SUCCESS
+ * @retval EXIT_SKIP
+ * @retval EXIT_FAILURE
+ */
+int
+test_esys_clear_auth(ESYS_CONTEXT * esys_context)
+{
+    TSS2_RC r;
+    ESYS_TR session = ESYS_TR_NONE;
+    int failure_return = EXIT_FAILURE;
+
+    TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_XOR,
+                              .keyBits = { .exclusiveOr = TPM2_ALG_SHA1 },
+                              .mode = {.aes = TPM2_ALG_CFB}};
+
+    /* Test lockout authorization */
+    LOG_DEBUG("Test LOCKOUT authorization");
+    LOG_DEBUG("Start Auth Session");
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              NULL,
+                              TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA1,
+                              &session);
+    goto_if_error(r, "Error: During initialization of session", error);
+
+    TPM2B_AUTH auth = {
+            .size = 16,
+            .buffer = "deadbeefdeadbeef",
+    };
+
+    LOG_DEBUG("Set Auth");
+    r = Esys_HierarchyChangeAuth(esys_context, ESYS_TR_RH_LOCKOUT,
+                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 &auth);
+
+    goto_if_error(r, "Error: During Esys_ObjectChangeAuth", error);
+    Esys_TR_SetAuth(esys_context, ESYS_TR_RH_LOCKOUT, &auth);
+
+    LOG_DEBUG("Clear");
+    r = Esys_Clear(esys_context, ESYS_TR_RH_LOCKOUT, session,
+                   ESYS_TR_NONE, ESYS_TR_NONE);
+    goto_if_error(r, "Error: During Esys_Clear", error);
+
+    r = Esys_FlushContext(esys_context, session);
+    goto_if_error(r, "Error: During Esys_FlushContext", error);
+
+    /* Test platform authorization */
+    LOG_DEBUG("Test PLATFORM authorization");
+    LOG_DEBUG("Start Auth Session");
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              NULL,
+                              TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA1,
+                              &session);
+    goto_if_error(r, "Error: During initialization of session", error);
+
+    LOG_DEBUG("Set Auth");
+    r = Esys_HierarchyChangeAuth(esys_context, ESYS_TR_RH_PLATFORM,
+                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 &auth);
+
+    if ((r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH ||
+        (r & ~TPM2_RC_N_MASK) == TPM2_RC_HIERARCHY) {
+        /* Platform authorization not possible test will be skipped */
+        LOG_WARNING("Platform authorization not possible.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+    goto_if_error(r, "Error: During Esys_ObjectChangeAuth", error);
+
+    Esys_TR_SetAuth(esys_context, ESYS_TR_RH_PLATFORM, &auth);
+
+    LOG_DEBUG("Clear");
+    r = Esys_Clear(esys_context, ESYS_TR_RH_PLATFORM, session,
+                   ESYS_TR_NONE, ESYS_TR_NONE);
+    goto_if_error(r, "Error: During Esys_Clear", error);
+
+    r = Esys_FlushContext(esys_context, session);
+    goto_if_error(r, "Error: During Esys_FlushContext", error);
+
+    Esys_TR_SetAuth(esys_context, ESYS_TR_RH_PLATFORM, &auth);
+
+    LOG_DEBUG("Set Auth");
+    r = Esys_HierarchyChangeAuth(esys_context, ESYS_TR_RH_PLATFORM,
+                                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 NULL);
+
+    goto_if_error(r, "Error: During Esys_ObjectChangeAuth", error);
+
+    return EXIT_SUCCESS;
+
+ error:
+    LOG_ERROR("\nError Code: %x\n", r);
+
+    if (session != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, session) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup session failed.");
+        }
+    }
+    return failure_return;
+}
+
+int
+test_invoke_esapi(ESYS_CONTEXT * esys_context) {
+    return test_esys_clear_auth(esys_context);
+}


### PR DESCRIPTION
After tpm2_clear command is executed it sets all ownerAuth, endorsementAuth, and lockoutAuth to the Empty Buffer and then this is used for a response auth calculation.
This requires to recalculate the esys session auth value after tpm2_clear is executed or the calculated response HMAC value will be invalid.

Fixes: #1641 