### PR TITLE
FAPI: Ensure default config adheres to JSON spec

### DIFF
--- a/dist/fapi-config.json.in
+++ b/dist/fapi-config.json.in
@@ -5,5 +5,5 @@
      "system_dir": "@localstatedir@/lib/tpm2-tss/system/keystore",
      "tcti": "",
      "system_pcrs" : [],
-     "log_dir" : "@runstatedir@/tpm2-tss/eventlog/",
+     "log_dir" : "@runstatedir@/tpm2-tss/eventlog/"
 }


### PR DESCRIPTION
Remove a trailing comma from the last line of the default FAPI config
file, making it valid JSON.

Fixes: #1650

Signed-off-by: John Andersen <john.s.andersen@intel.com>