### PR TITLE
test/esys: Check unsupported symmetric  cipher used for Esys_EncryptD…

### DIFF
--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -207,6 +207,12 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
                     &outPrivate2,
                     &outPublic2,
                     &creationData2, &creationHash2, &creationTicket2);
+
+    if (r == 0x2c2) { /*<< tpm:parameter(2):inconsistent attributes */
+        LOG_WARNING("Unsupported symmetric cipher.");
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
     goto_if_error(r, "Error esys create ", error);
 
     LOG_INFO("AES key created.");


### PR DESCRIPTION
…ecrypt test.

The key type TPM2_ALG_SYMCIPHER might not be supported. In this case the test will be
skipped.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>