### PR TITLE
build: bump soname of libtss2-esys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -374,6 +374,11 @@ src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBSOCKET_LDFLAGS) \
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
 endif # HAVE_LD_VERSION_SCRIPT
+
+# Bump soname due to commit 9d48cc7922ad8dc3496444b04c94439c5bfbec8e breaking
+# the ABI of Esys_Hash(), Esys_HierarchyControl(), Esys_LoadExternal() and Esys_SequenceComplete()
+src_tss2_esys_libtss2_esys_la_LDFLAGS += -version-info 1:0:0
+
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC) $(TSS2_ESYS_SRC_CRYPTO) \
     src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h \
     src/tss2-tcti/tctildr-interface.h


### PR DESCRIPTION
Pull request #1531 broke ABI compatibility to align the library with the ESAPI specification. In addition to increasing the major version to 3 according to semantic versioning, I suggest bumping the soname from (the default) 0 to 1 as well. This signals an ABI-breaking change of the library and allows to collect a list of applications in need of a rebuild for the new tpm2-tss version more easily. Most Linux distributions have tooling to detect such soname version changes and perform the necessary rebuilds automatically, reducing the risk of broken packages.