### PR TITLE
sys: add auth arrays to Tss2_Sys_ReadClock

### DIFF
--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -1794,7 +1794,9 @@ TSS2_RC Tss2_Sys_ReadClock_Complete(
 
 TSS2_RC Tss2_Sys_ReadClock(
     TSS2_SYS_CONTEXT *sysContext,
-    TPMS_TIME_INFO *currentTime);
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TPMS_TIME_INFO *currentTime,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray);
 
 TSS2_RC Tss2_Sys_ClockSet_Prepare(
     TSS2_SYS_CONTEXT *sysContext,

--- a/src/tss2-sys/api/Tss2_Sys_ReadClock.c
+++ b/src/tss2-sys/api/Tss2_Sys_ReadClock.c
@@ -54,7 +54,9 @@ TSS2_RC Tss2_Sys_ReadClock_Complete(
 
 TSS2_RC Tss2_Sys_ReadClock(
     TSS2_SYS_CONTEXT *sysContext,
-    TPMS_TIME_INFO *currentTime)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TPMS_TIME_INFO *currentTime,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
@@ -63,7 +65,7 @@ TSS2_RC Tss2_Sys_ReadClock(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(ctx, 0, 0);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 


### PR DESCRIPTION
In addition to commit 1414f739 Tss2_Sys_ReadClock needs
to be extended with auths arrays.