### PR TITLE
Esys_TestParams: silence expected errors

### DIFF
--- a/src/tss2-esys/api/Esys_TestParms.c
+++ b/src/tss2-esys/api/Esys_TestParms.c
@@ -92,9 +92,11 @@ Esys_TestParms(
 
     /* Restore the timeout value to the original value */
     esysContext->timeout = timeouttmp;
-    return_if_error(r, "Esys Finish");
+    if (!tss2_is_expected_error(r)) {
+        return_if_error(r, "Esys Finish");
+    }
 
-    return TSS2_RC_SUCCESS;
+    return r;
 }
 
 /** Asynchronous function for TPM2_TestParms
@@ -266,7 +268,9 @@ Esys_TestParms_Finish(
     }
     /* The following is the "regular error" handling. */
     if (iesys_tpm_error(r)) {
-        LOG_WARNING("Received TPM Error");
+        if (!tss2_is_expected_error(r)) {
+            LOG_WARNING("Received TPM Error");
+        }
         esysContext->state = _ESYS_STATE_INIT;
         return r;
     } else if (r != TSS2_RC_SUCCESS) {


### PR DESCRIPTION
The TestParams code is used to test paramters against the TPM to
understand if a specific algorithm and scheme is supported. Thus,
certain errors are expected. The expected errors are:
1. From any layer
2. Are Format 1 errors
3. Are P1 or Parameter 1 errors
4 are one of:
  - RC_CURVE
  - RC_VALUE
  - RC_ASSYMETRIC
  - RC_KEY_SIZE

Fixes: #1573

Signed-off-by: William Roberts <william.c.roberts@intel.com>