### PR TITLE
Fapi fix issues #1655 and #1658 wrong return code and wrong size checking.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1409,7 +1409,7 @@ ifapi_copy_ifapi_key_object(IFAPI_OBJECT * dest, const IFAPI_OBJECT * src) {
     /* Create the copy */
     dest->policy = ifapi_copy_policy(src->policy);
 
-    ifapi_copy_ifapi_key(&dest->misc.key, &src->misc.key);
+    r = ifapi_copy_ifapi_key(&dest->misc.key, &src->misc.key);
     goto_if_error(r, "Could not copy key", error_cleanup);
 
     dest->objectType = src->objectType;

--- a/src/tss2-fapi/tpm_json_serialize.c
+++ b/src/tss2-fapi/tpm_json_serialize.c
@@ -1247,7 +1247,7 @@ ifapi_json_TPM2B_DATA_serialize(const TPM2B_DATA *in, json_object **jso)
 {
     return_if_null(in, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
-    if (in->size > sizeof(TPMT_HA)) {
+    if (in->size > sizeof(TPMU_HA)) {
         LOG_ERROR("Too many bytes for array (%"PRIuPTR" > %"PRIuPTR" = sizeof(TPMT_HA))",
                   (size_t)in->size, (size_t)sizeof(TPMT_HA));
         return TSS2_FAPI_RC_BAD_VALUE;


### PR DESCRIPTION
* The return code was not assigned before return code checking.
* A wrong type was used for size checking. 

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>

Fixes #1658 
Fixes #1655 