### PR TITLE
ci: don't assume hardcode the location of test-suite.log

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -90,8 +90,5 @@ popd
 
 if [ "$ENABLE_COVERAGE" == "true" ]; then
     bash <(curl -s https://codecov.io/bash)
-else
-    echo "ENABLE_COVERAGE not true, got \"$ENABLE_COVERAGE\""
 fi
-
 exit 0


### PR DESCRIPTION
The location of the CI build log is different
for make check and make distcheck, and if the later
fails nothing gets printed.