### PR TITLE
FAPI: Prevent overwriting ob objects in key store.

### DIFF
--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -427,6 +427,13 @@ Fapi_CreateNv_Finish(
             r = ifapi_esys_serialize_object(context->esys, &nvCmd->nv_object);
             goto_if_error(r, "Prepare serialization", error_cleanup);
 
+            /* Check whether object already exists in key store.*/
+            r = ifapi_keystore_object_does_not_exist(&context->keystore,
+                                                     nvCmd->nvPath,
+                                                     &nvCmd->nv_object);
+            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup,
+                                      nvCmd->nvPath);
+
             /* Start writing the NV object to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io,
                                            nvCmd->nvPath,

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -3069,7 +3069,14 @@ ifapi_key_create(
         r = ifapi_esys_serialize_object(context->esys, object);
         goto_if_error(r, "Prepare serialization", error_cleanup);
 
-        /* Start writing the NV object to the key store */
+        /* Check whether object already exists in key store.*/
+        r = ifapi_keystore_object_does_not_exist(&context->keystore,
+                                                 context->cmd.Key_Create.keyPath,
+                                                 object);
+        goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup,
+                                  context->cmd.Key_Create.keyPath);
+
+        /* Start writing the object to the key store */
         r = ifapi_keystore_store_async(&context->keystore, &context->io,
                                        context->cmd.Key_Create.keyPath, object);
         goto_if_error_reset_state(r, "Could not open: %sh", error_cleanup,

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -167,6 +167,12 @@ ifapi_keystore_load_finish(
     IFAPI_OBJECT *object);
 
 TSS2_RC
+ifapi_keystore_object_does_not_exist(
+    IFAPI_KEYSTORE *keystore,
+    const char *path,
+    const IFAPI_OBJECT *object);
+
+TSS2_RC
 ifapi_keystore_store_async(
     IFAPI_KEYSTORE *keystore,
     IFAPI_IO *io,

--- a/test/integration/fapi-nv-set-bits.int.c
+++ b/test/integration/fapi-nv-set-bits.int.c
@@ -57,6 +57,12 @@ test_fapi_nv_set_bits(FAPI_CONTEXT *context)
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+    if (r != TSS2_FAPI_RC_PATH_ALREADY_EXISTS) {
+        LOG_ERROR("Check whether provisioning directory exists failed.");
+        goto error;
+    }
+
     /* Test no password, noda set */
     r = Fapi_CreateNv(context, nvPathBitMap, "bitfield, noda", 0, "", "");
     goto_if_error(r, "Error Fapi_CreateNv", error);
@@ -81,13 +87,6 @@ test_fapi_nv_set_bits(FAPI_CONTEXT *context)
 
     r = Fapi_Delete(context, nvPathBitMap);
     goto_if_error(r, "Error Fapi_Delete", error);
-
-    /* Cleanup */
-    r = Fapi_Delete(context, "/HS/SRK");
-    goto_if_error(r, "Error Fapi_Delete", error);
-
-    r = Fapi_Provision(context, NULL, NULL, NULL);
-    goto_if_error(r, "Error Fapi_Provision", error);
 
     /* Test no password, noda set */
     r = Fapi_CreateNv(context, nvPathBitMap, "bitfield, noda", 0, "", "");


### PR DESCRIPTION
* During provisioning and object creation it will be checked whether
  the object already exists in key store.
* The test fapi-nv-set-bits which did include provisioning two times was
  modified to check whether second provisioning was recognized.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>