### PR TITLE
ci: don't hardcode location of test-suite.log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ script:
   - ./.ci/travis.run
 
 after_failure:
-  - cat build/test-suite.log
+  - cat `find ../ -name test-suite.log`


### PR DESCRIPTION
The location of the CI build log is different
for 'make check' and 'make distcheck', and currently
if the later fails nothing gets printed.