### PR TITLE
tcti: fix return codes from tcti macros

### DIFF
--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -86,14 +86,14 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 
 /* Macros to simplify invocation of functions from the common TCTI structure */
 #define Tss2_Tcti_Transmit(tctiContext, size, command) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
 #define Tss2_Tcti_Receive(tctiContext, size, response, timeout) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
@@ -109,28 +109,28 @@ typedef void TSS2_TCTI_POLL_HANDLE;
         } \
     } while (0)
 #define Tss2_Tcti_Cancel(tctiContext) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_CANCEL(tctiContext)(tctiContext))
 #define Tss2_Tcti_GetPollHandles(tctiContext, handles, num_handles) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, handles, num_handles))
 #define Tss2_Tcti_SetLocality(tctiContext, locality) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, locality))
 #define Tss2_Tcti_MakeSticky(tctiContext, handle, sticky) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 2) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_MAKE_STICKY(tctiContext) == NULL) ? \

--- a/src/tss2-tcti/tcti-common.c
+++ b/src/tss2-tcti/tcti-common.c
@@ -40,6 +40,10 @@ TSS2_RC
 tcti_common_cancel_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common)
 {
+    if (tcti_common == NULL) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
     if (tcti_common->state != TCTI_STATE_RECEIVE) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
@@ -51,11 +55,12 @@ tcti_common_transmit_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
     const uint8_t *command_buffer)
 {
+    if (command_buffer == NULL || tcti_common == NULL) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
     if (tcti_common->state != TCTI_STATE_TRANSMIT) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
-    }
-    if (command_buffer == NULL) {
-        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 
     return TSS2_RC_SUCCESS;
@@ -66,11 +71,12 @@ tcti_common_receive_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
     size_t *response_size)
 {
+    if (response_size == NULL || tcti_common == NULL) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
     if (tcti_common->state != TCTI_STATE_RECEIVE) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
-    }
-    if (response_size == NULL) {
-        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 
     return TSS2_RC_SUCCESS;
@@ -80,6 +86,10 @@ TSS2_RC
 tcti_common_set_locality_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common)
 {
+    if (tcti_common == NULL) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
     if (tcti_common->state != TCTI_STATE_TRANSMIT) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -106,9 +106,6 @@ tcti_device_transmit (
     TSS2_RC rc = TSS2_RC_SUCCESS;
     ssize_t size;
 
-    if (tcti_dev == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_transmit_checks (tcti_common, command_buffer);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -170,9 +167,6 @@ tcti_device_receive (
     UINT32 partial_size;
 #endif
 
-    if (tcti_dev == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_receive_checks (tcti_common, response_size);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -369,11 +363,7 @@ tcti_device_get_poll_handles (
 #ifdef TCTI_ASYNC
     TSS2_TCTI_DEVICE_CONTEXT *tcti_dev = tcti_device_context_cast (tctiContext);
 
-    if (tcti_dev == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
-
-    if (num_handles == NULL) {
+    if (num_handles == NULL || tcti_dev == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -71,7 +71,7 @@ TSS2_RC tcti_platform_command (
     ssize_t read_ret;
 
     if (tcti_mssim == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     rc = Tss2_MU_UINT32_Marshal (cmd, buf, sizeof (cmd), NULL);
     if (rc != TSS2_RC_SUCCESS) {
@@ -190,9 +190,6 @@ tcti_mssim_transmit (
     tpm_header_t header;
     TSS2_RC rc;
 
-    if (tcti_mssim == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_transmit_checks (tcti_common, cmd_buf);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -231,9 +228,6 @@ tcti_mssim_cancel (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_mssim_down_cast (tcti_mssim);
     TSS2_RC rc;
 
-    if (tcti_mssim == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_cancel_checks (tcti_common);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -258,9 +252,6 @@ tcti_mssim_set_locality (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_mssim_down_cast (tcti_mssim);
     TSS2_RC rc;
 
-    if (tcti_mssim == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_set_locality_checks (tcti_common);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -314,9 +305,6 @@ tcti_mssim_receive (
     UINT32 trash;
     int ret;
 
-    if (tcti_mssim == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_receive_checks (tcti_common, response_size);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -119,7 +119,7 @@ TSS2_RC tcti_control_command (
     uint32_t response_code;
 
     if (tcti_swtpm == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 
     if (cmd_sdu == NULL && cmd_sdu_len != 0) {
@@ -255,9 +255,6 @@ tcti_swtpm_transmit (
     tpm_header_t header;
     TSS2_RC rc;
 
-    if (tcti_swtpm == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_transmit_checks (tcti_common, cmd_buf);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -319,9 +316,6 @@ tcti_swtpm_set_locality (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_swtpm_down_cast (tcti_swtpm);
     TSS2_RC rc;
 
-    if (tcti_swtpm == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_set_locality_checks (tcti_common);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -382,9 +376,6 @@ tcti_swtpm_receive (
     TSS2_RC rc;
     int ret;
 
-    if (tcti_swtpm == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_receive_checks (tcti_common, response_size);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -65,9 +65,6 @@ tcti_tbs_transmit (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_tbs_down_cast (tcti_tbs);
     TSS2_RC rc = TSS2_RC_SUCCESS;
 
-    if (tcti_tbs == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
     rc = tcti_common_transmit_checks (tcti_common, command_buffer);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
@@ -116,10 +113,6 @@ tcti_tbs_receive (
     TSS2_RC rc = TSS2_RC_SUCCESS;
     TBS_RESULT tbs_rc;
     int original_size;
-
-    if (tcti_tbs == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
-    }
 
     rc = tcti_common_receive_checks (tcti_common, response_size);
     if (rc != TSS2_RC_SUCCESS) {
@@ -216,6 +209,9 @@ tcti_tbs_cancel (
     TSS2_RC rc = TSS2_RC_SUCCESS;
     TSS2_TCTI_TBS_CONTEXT *tcti_tbs = tcti_tbs_context_cast (tctiContext);
 
+    if (tcti_tbs == NULL) {
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
     tbs_rc = Tbsip_Cancel_Commands (tcti_tbs->hContext);
     if (tbs_rc != TBS_SUCCESS) {
         LOG_WARNING ("Failed to cancel commands with TBS error: 0x%x", tbs_rc);

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -188,7 +188,7 @@ tctildr_transmit (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_Transmit (ldr_ctx->tcti, command_size, command_buffer);
 }
@@ -201,7 +201,7 @@ tctildr_receive (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_Receive (ldr_ctx->tcti,
                               response_size,
@@ -214,7 +214,7 @@ tctildr_cancel (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_Cancel (ldr_ctx->tcti);
 }
@@ -226,7 +226,7 @@ tctildr_get_poll_handles (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_GetPollHandles (ldr_ctx->tcti, handles, num_handles);
 }
@@ -237,7 +237,7 @@ tctildr_set_locality (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_SetLocality (ldr_ctx->tcti, locality);
 }
@@ -249,7 +249,7 @@ tctildr_make_sticky (
 {
     TSS2_TCTILDR_CONTEXT *ldr_ctx = tctildr_context_cast (tctiContext);
     if (ldr_ctx == NULL) {
-        return TSS2_TCTI_RC_BAD_CONTEXT;
+        return TSS2_TCTI_RC_BAD_REFERENCE;
     }
     return Tss2_Tcti_MakeSticky (ldr_ctx->tcti, handle, sticky);
 }

--- a/test/unit/tcti-swtpm.c
+++ b/test/unit/tcti-swtpm.c
@@ -335,7 +335,7 @@ tcti_swtpm_receive_null_test (void **state)
     TSS2_RC rc;
 
     rc = Tss2_Tcti_Receive (NULL, NULL, NULL, TSS2_TCTI_TIMEOUT_BLOCK);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 /*
  */
@@ -530,7 +530,7 @@ tcti_swtpm_transmit_null_test (void **state)
     TSS2_RC rc = TSS2_RC_SUCCESS;
 
     rc = Tss2_Tcti_Transmit (NULL, 0, NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 /*
  * This test exercises the header check of the transmit function.
@@ -615,7 +615,7 @@ tcti_swtpm_control_command_null_test (void **state)
 
     /* tcti context NULL */
     rc = tcti_control_command (NULL, 0, NULL, 0, NULL, NULL, NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 
     /* cmd_sdu NULL with cmd_sdu_len not 0 */
     rc = tcti_control_command (ctx, 0, NULL, 4, NULL, NULL, NULL);
@@ -677,7 +677,7 @@ tcti_swtpm_locality_test (void **state)
 
     /* test NULL check */
     rc = Tss2_Tcti_SetLocality (NULL, 3);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 
     /* fail due to non-success response code */
     response = 0xFFFFFFFF;

--- a/test/unit/tctildr-tcti.c
+++ b/test/unit/tctildr-tcti.c
@@ -156,7 +156,7 @@ tctildr_transmit_null_test (void **state)
     size_t size = sizeof (buffer);
 
     rc = tctildr_transmit (NULL, size, buffer);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 static void
 tctildr_receive_test (void **state)
@@ -180,7 +180,7 @@ tctildr_receive_null_test (void **state)
     int32_t timeout = TSS2_TCTI_TIMEOUT_BLOCK;
 
     rc = tctildr_receive (NULL, &size, buffer, timeout);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 static void
 tctildr_cancel_test (void **state)
@@ -199,7 +199,7 @@ tctildr_cancel_null_test (void **state)
     UNUSED (state);
 
     rc = tctildr_cancel (NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 #define TEST_NUM_HANDLES 3
 static void
@@ -220,10 +220,9 @@ tctildr_get_poll_handles_null_test (void **state)
     TSS2_RC rc;
     TSS2_TCTI_POLL_HANDLE handles [TEST_NUM_HANDLES] = { 0 };
     size_t num_handles = sizeof (handles);
-    UNUSED (state);
 
     rc = tctildr_get_poll_handles (NULL, handles, &num_handles);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 static void
 tctildr_set_locality_test (void **state)
@@ -242,7 +241,7 @@ tctildr_set_locality_null_test (void **state)
     UNUSED (state);
 
     rc = tctildr_set_locality (NULL, 1);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 #define TEST_HANDLE 0x1
 static void
@@ -264,7 +263,7 @@ tctildr_make_sticky_null_test (void **state)
     UNUSED (state);
 
     rc = tctildr_make_sticky (NULL, &handle, TPM2_YES);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 /*
  * This test covers the 'sanity test' path in the tctildr finalize


### PR DESCRIPTION
Return codes from macros in TCTI header are not
compliant with the spec. If context is NULL
TSS2_TCTI_RC_BAD_REFERENCE should be returned instead of
TSS2_TCTI_RC_BAD_CONTEX. TSS2_TCTI_RC_BAD_CONTEX is for
bad version and/or wrong magic field in the context.
Fixes: #1431 