### PR TITLE
FAPI: Add test function to doxygen

### DIFF
--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -3159,5 +3159,6 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \fn test_fapi_platform_certificates(FAPI_CONTEXT *context)
  \fn test_fapi_quote(FAPI_CONTEXT *context)
  \fn test_fapi_unseal(FAPI_CONTEXT *context)
+ \fn test_fapi_key_create_policy_password_sign(FAPI_CONTEXT *context)
  \}
 */


### PR DESCRIPTION
The function test_fapi_key_create_policy_password_sign was added to dox file.
Fixes: #1681

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>