### PR TITLE
configure.ac: wrap PKG_CHECK_MODULES in braces

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -495,7 +495,7 @@ src_tss2_fapi_libtss2_fapi_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) $(libtss2_e
 
 src_tss2_fapi_libtss2_fapi_la_SOURCES = $(TSS2_FAPI_SRC)
 src_tss2_fapi_libtss2_fapi_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-fapi
-src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LIBS) $(JSON_C_LIBS) $(CURL_LIBS)
+src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LIBS) $(JSONC_LIBS) $(CURL_LIBS)
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_fapi_libtss2_fapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-fapi.map
 endif # HAVE_LD_VERSION_SCRIPT

--- a/configure.ac
+++ b/configure.ac
@@ -165,10 +165,10 @@ AS_IF([test "x$enable_fapi" != xno -a "x$with_crypto" != "xossl"],
     AC_MSG_ERROR([FAPI has to be compiled with OpenSSL]))
 
 AS_IF([test "x$enable_fapi" = xyes ],
-    PKG_CHECK_MODULES([JSON_C], [json-c]))
+      [PKG_CHECK_MODULES([JSONC], [json-c])])
 
 AS_IF([test "x$enable_fapi" = xyes ],
-    PKG_CHECK_MODULES([CURL], [libcurl]))
+      [PKG_CHECK_MODULES([CURL], [libcurl])])
 
 AC_ARG_WITH([tctidefaultmodule],
             [AS_HELP_STRING([--with-tctidefaultmodule],


### PR DESCRIPTION
PKG_CHECK_MODULES needs to be wrapped inside squere
brackets when inside AS_IF, or it spit out errors:

./configure: line 13054: JSONC_CFLAGS: command not found
./configure: line 13055: C: command not found
./configure: line 13056: JSONC_LIBS: command not found
./configure: line 13155: CURL_CFLAGS: command not found
./configure: line 13156: CURL_LIBS: command not found