### PR TITLE
tpmclient: update swtpm return code to TSS2_TCTI_RC_BAD_REFERENCE

### DIFF
--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -151,8 +151,8 @@ static TSS2_RC TpmReset()
 #ifdef TCTI_SWTPM
     rval = Tss2_Tcti_Swtpm_Reset( resMgrTctiContext );
 
-    /* If TCTI is not swtpm, bad context is returned. */
-    if (rval != TSS2_TCTI_RC_BAD_CONTEXT) {
+    /* If TCTI is not swtpm, bad reference is returned. */
+    if (rval != TSS2_TCTI_RC_BAD_REFERENCE) {
         return rval;
     }
 #endif /* TCTI_SWTPM */


### PR DESCRIPTION
Commit bc70b835c2acbdff0c81ce97e21d9fb65354d309 changed the return code if a TCTI cannot be loaded from `TSS2_TCTI_RC_BAD_CONTEXT` to `TSS2_TCTI_RC_BAD_REFERENCE`, but did not update the [tpmclient](https://github.com/tpm2-software/tpm2-tss/blob/master/test/tpmclient/tpmclient.int.c) test. This leads to the following error when running the integration test suite with ibmswtpm2 instead of swtpm:
```
Execute the test script
ERROR:tcti:src/tss2-tcti/tcti-swtpm.c:241:Tss2_Tcti_Swtpm_Reset() Failed to reset TPM: 0xa0005
Script returned 1
FAIL test/tpmclient/tpmclient.int (exit status: 1)
```