### PR TITLE
tcti: fix invalid error code in case of wrong magic

### DIFF
--- a/src/tss2-tcti/tcti-common.c
+++ b/src/tss2-tcti/tcti-common.c
@@ -38,10 +38,15 @@ tcti_common_down_cast (TSS2_TCTI_COMMON_CONTEXT *ctx)
 
 TSS2_RC
 tcti_common_cancel_checks (
-    TSS2_TCTI_COMMON_CONTEXT *tcti_common)
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common,
+    uint64_t magic)
 {
     if (tcti_common == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    if (TSS2_TCTI_MAGIC(tcti_common) != magic) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 
     if (tcti_common->state != TCTI_STATE_RECEIVE) {
@@ -53,10 +58,15 @@ tcti_common_cancel_checks (
 TSS2_RC
 tcti_common_transmit_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
-    const uint8_t *command_buffer)
+    const uint8_t *command_buffer,
+    uint64_t magic)
 {
     if (command_buffer == NULL || tcti_common == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    if (TSS2_TCTI_MAGIC(tcti_common) != magic) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 
     if (tcti_common->state != TCTI_STATE_TRANSMIT) {
@@ -69,10 +79,15 @@ tcti_common_transmit_checks (
 TSS2_RC
 tcti_common_receive_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
-    size_t *response_size)
+    size_t *response_size,
+    uint64_t magic)
 {
     if (response_size == NULL || tcti_common == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    if (TSS2_TCTI_MAGIC(tcti_common) != magic) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 
     if (tcti_common->state != TCTI_STATE_RECEIVE) {
@@ -84,10 +99,15 @@ tcti_common_receive_checks (
 
 TSS2_RC
 tcti_common_set_locality_checks (
-    TSS2_TCTI_COMMON_CONTEXT *tcti_common)
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common,
+    uint64_t magic)
 {
     if (tcti_common == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    if (TSS2_TCTI_MAGIC(tcti_common) != magic) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 
     if (tcti_common->state != TCTI_STATE_TRANSMIT) {

--- a/src/tss2-tcti/tcti-common.h
+++ b/src/tss2-tcti/tcti-common.h
@@ -76,7 +76,8 @@ tcti_common_down_cast (TSS2_TCTI_COMMON_CONTEXT *ctx);
  */
 TSS2_RC
 tcti_common_cancel_checks (
-    TSS2_TCTI_COMMON_CONTEXT *tcti_common);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common,
+    uint64_t magic);
 /*
  * This function performs common checks on the context structure and the
  * buffer passed into TCTI 'transmit' functions.
@@ -84,7 +85,8 @@ tcti_common_cancel_checks (
 TSS2_RC
 tcti_common_transmit_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
-    const uint8_t *command_buffer);
+    const uint8_t *command_buffer,
+    uint64_t magic);
 /*
  * This function performs common checks on the context structure, buffer and
  * size parameter passed to the TCTI 'receive' functions.
@@ -92,14 +94,16 @@ tcti_common_transmit_checks (
 TSS2_RC
 tcti_common_receive_checks (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common,
-    size_t *response_size);
+    size_t *response_size,
+    uint64_t magic);
 /*
  * This function performs checks on the common context structure passed to a
  * TCTI 'set_locality' function.
  */
 TSS2_RC
 tcti_common_set_locality_checks (
-    TSS2_TCTI_COMMON_CONTEXT *tcti_common);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common,
+    uint64_t magic);
 /*
  * Just a function with the right prototype that returns the not implemented
  * RC for the TCTI layer.

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -69,18 +69,17 @@ static char *default_conf[] = {
 
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
- * type for the device TCTI context. The only safe-guard we have to ensure
- * this operation is possible is the magic number for the device TCTI context.
- * If passed a NULL context, or the magic number check fails, this function
- * will return NULL.
+ * type for the mssim TCTI context. If passed a NULL context the function
+ * returns a NULL ptr. The function doesn't check magic number anymore
+ * It should checked by the appropriate tcti_common_checks.
  */
 TSS2_TCTI_DEVICE_CONTEXT*
 tcti_device_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
 {
-    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_DEVICE_MAGIC) {
-        return (TSS2_TCTI_DEVICE_CONTEXT*)tcti_ctx;
-    }
-    return NULL;
+    if (tcti_ctx == NULL)
+        return NULL;
+
+    return (TSS2_TCTI_DEVICE_CONTEXT*)tcti_ctx;
 }
 /*
  * This function down-casts the device TCTI context to the common context
@@ -106,7 +105,9 @@ tcti_device_transmit (
     TSS2_RC rc = TSS2_RC_SUCCESS;
     ssize_t size;
 
-    rc = tcti_common_transmit_checks (tcti_common, command_buffer);
+    rc = tcti_common_transmit_checks (tcti_common,
+                                      command_buffer,
+                                      TCTI_DEVICE_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -167,7 +168,9 @@ tcti_device_receive (
     UINT32 partial_size;
 #endif
 
-    rc = tcti_common_receive_checks (tcti_common, response_size);
+    rc = tcti_common_receive_checks (tcti_common,
+                                     response_size,
+                                     TCTI_DEVICE_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -30,18 +30,17 @@
 
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
- * type for the mssim TCTI context. The only safeguard we have to ensure this
- * operation is possible is the magic number in the mssim TCTI context.
- * If passed a NULL context, or the magic number check fails, this function
- * will return NULL.
+ * type for the mssim TCTI context. If passed a NULL context the function
+ * returns a NULL ptr. The function doesn't check magic number anymore
+ * It should checked by the appropriate tcti_common_checks.
  */
 TSS2_TCTI_MSSIM_CONTEXT*
 tcti_mssim_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
 {
-    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_MSSIM_MAGIC) {
-        return (TSS2_TCTI_MSSIM_CONTEXT*)tcti_ctx;
-    }
-    return NULL;
+    if (tcti_ctx == NULL)
+        return NULL;
+
+    return (TSS2_TCTI_MSSIM_CONTEXT*)tcti_ctx;
 }
 /*
  * This function down-casts the mssim TCTI context to the common context
@@ -73,6 +72,11 @@ TSS2_RC tcti_platform_command (
     if (tcti_mssim == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
+
+    if (TSS2_TCTI_MAGIC (tcti_mssim) != TCTI_MSSIM_MAGIC) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+
     rc = Tss2_MU_UINT32_Marshal (cmd, buf, sizeof (cmd), NULL);
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR ("Failed to marshal platform command %" PRIu32 ", rc: 0x%"
@@ -190,7 +194,7 @@ tcti_mssim_transmit (
     tpm_header_t header;
     TSS2_RC rc;
 
-    rc = tcti_common_transmit_checks (tcti_common, cmd_buf);
+    rc = tcti_common_transmit_checks (tcti_common, cmd_buf, TCTI_MSSIM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -228,7 +232,7 @@ tcti_mssim_cancel (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_mssim_down_cast (tcti_mssim);
     TSS2_RC rc;
 
-    rc = tcti_common_cancel_checks (tcti_common);
+    rc = tcti_common_cancel_checks (tcti_common, TCTI_MSSIM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -252,7 +256,7 @@ tcti_mssim_set_locality (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_mssim_down_cast (tcti_mssim);
     TSS2_RC rc;
 
-    rc = tcti_common_set_locality_checks (tcti_common);
+    rc = tcti_common_set_locality_checks (tcti_common, TCTI_MSSIM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -305,7 +309,9 @@ tcti_mssim_receive (
     UINT32 trash;
     int ret;
 
-    rc = tcti_common_receive_checks (tcti_common, response_size);
+    rc = tcti_common_receive_checks (tcti_common,
+                                     response_size,
+                                     TCTI_MSSIM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -56,18 +56,17 @@
 
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
- * type for the swtpm TCTI context. The only safeguard we have to ensure this
- * operation is possible is the magic number in the swtpm TCTI context.
- * If passed a NULL context, or the magic number check fails, this function
- * will return NULL.
+ * type for the mssim TCTI context. If passed a NULL context the function
+ * returns a NULL ptr. The function doesn't check magic number anymore
+ * It should checked by the appropriate tcti_common_checks.
  */
 TSS2_TCTI_SWTPM_CONTEXT*
 tcti_swtpm_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
 {
-    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_SWTPM_MAGIC) {
-        return (TSS2_TCTI_SWTPM_CONTEXT*)tcti_ctx;
-    }
-    return NULL;
+    if (tcti_ctx == NULL)
+        return NULL;
+
+    return (TSS2_TCTI_SWTPM_CONTEXT*)tcti_ctx;
 }
 /*
  * This function down-casts the swtpm TCTI context to the common context
@@ -120,6 +119,10 @@ TSS2_RC tcti_control_command (
 
     if (tcti_swtpm == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
+    }
+
+    if (TSS2_TCTI_MAGIC (tcti_swtpm) != TCTI_SWTPM_MAGIC) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
     }
 
     if (cmd_sdu == NULL && cmd_sdu_len != 0) {
@@ -255,7 +258,7 @@ tcti_swtpm_transmit (
     tpm_header_t header;
     TSS2_RC rc;
 
-    rc = tcti_common_transmit_checks (tcti_common, cmd_buf);
+    rc = tcti_common_transmit_checks (tcti_common, cmd_buf, TCTI_SWTPM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -316,7 +319,7 @@ tcti_swtpm_set_locality (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_swtpm_down_cast (tcti_swtpm);
     TSS2_RC rc;
 
-    rc = tcti_common_set_locality_checks (tcti_common);
+    rc = tcti_common_set_locality_checks (tcti_common, TCTI_SWTPM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -376,7 +379,7 @@ tcti_swtpm_receive (
     TSS2_RC rc;
     int ret;
 
-    rc = tcti_common_receive_checks (tcti_common, response_size);
+    rc = tcti_common_receive_checks (tcti_common, response_size, TCTI_SWTPM_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -28,18 +28,18 @@
 
 /*
  * This function wraps the "up-cast" of the opaque TCTI context type to the
- * type for the TBS TCTI context. The only safe-guard we have to ensure
- * this operation is possible is the magic number for the TBS TCTI context.
- * If passed a NULL context, or the magic number check fails, this function
- * will return NULL.
+ * type for the mssim TCTI context. If passed a NULL context the function
+ * returns a NULL ptr. The function doesn't check magic number anymore
+ * It should checked by the appropriate tcti_common_checks.
  */
 TSS2_TCTI_TBS_CONTEXT*
 tcti_tbs_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
 {
-    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_TBS_MAGIC) {
-        return (TSS2_TCTI_TBS_CONTEXT*)tcti_ctx;
+    if (tcti_ctx == NULL) {
+        return NULL;
     }
-    return NULL;
+
+    return (TSS2_TCTI_TBS_CONTEXT*)tcti_ctx;
 }
 
 /*
@@ -65,7 +65,7 @@ tcti_tbs_transmit (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_tbs_down_cast (tcti_tbs);
     TSS2_RC rc = TSS2_RC_SUCCESS;
 
-    rc = tcti_common_transmit_checks (tcti_common, command_buffer);
+    rc = tcti_common_transmit_checks(tcti_common, command_buffer, TCTI_TBS_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -114,7 +114,7 @@ tcti_tbs_receive (
     TBS_RESULT tbs_rc;
     int original_size;
 
-    rc = tcti_common_receive_checks (tcti_common, response_size);
+    rc = tcti_common_receive_checks(tcti_common, response_size, TCTI_TBS_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }

--- a/test/fuzz/tcti/tcti-fuzzing.c
+++ b/test/fuzz/tcti/tcti-fuzzing.c
@@ -105,10 +105,10 @@ fuzz_fill (
 TSS2_TCTI_FUZZING_CONTEXT*
 tcti_fuzzing_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
 {
-    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_FUZZING_MAGIC) {
-        return (TSS2_TCTI_FUZZING_CONTEXT*)tcti_ctx;
-    }
-    return NULL;
+    if (tcti_ctx == NULL)
+        return NULL;
+
+    return (TSS2_TCTI_FUZZING_CONTEXT*)tcti_ctx;
 }
 
 /*
@@ -185,7 +185,9 @@ tcti_fuzzing_receive (
     TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_fuzzing_down_cast (tcti_fuzzing);
     TSS2_RC rc;
 
-    rc = tcti_common_receive_checks (tcti_common, response_size);
+    rc = tcti_common_receive_checks (tcti_common,
+                                     response_size,
+                                     TCTI_FUZZING_MAGIC);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }


### PR DESCRIPTION
The commit bc70b83 changed TCTIs to return TSS2_TCTI_RC_BAD_REFERENCE
instead of TSS2_TCTI_RC_BAD_CONTEXT when the ctx was NULL, to make it
spec compliant. After that another problem was found, where the
tcti cast functions still didn't handle it correctly.
The problem was that if the magic number was wrong a NULL was returned,
which caused the common_checks function to return wrong return code.
This PR changes the casts function to overwrite the magic to a known
bad value and common_check function to check for the expected magic
explicitly passed by each tcti type and return TSS2_TCTI_RC_BAD_CONTEXT
with compliance with the specification.