### PR TITLE
CI: Fix int-log-compiler script for FAPI.

### DIFF
--- a/script/ekca/create_ca.sh
+++ b/script/ekca/create_ca.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+#set -x
 
 #set -euf
 

--- a/script/fint-log-compiler.sh
+++ b/script/fint-log-compiler.sh
@@ -17,10 +17,12 @@ sanity_test
 if [[ ${INTEGRATION_TCTI} == "mssim" || ${INTEGRATION_TCTI} == "swtpm" ]]; then
     echo "Trying to start simulator ${INTEGRATION_TCTI}"
     try_simulator_start
+    TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}"
+    TPM20TEST_TCTI="${INTEGRATION_TCTI}:host=${TPM20TEST_SOCKET_ADDRESS},port=${TPM20TEST_SOCKET_PORT}"
+else
+    # Device will be used.
+    TPM20TEST_TCTI="${INTEGRATION_TCTI}:${TPM20TEST_DEVICE_FILE}"
 fi
-
-TPM20TEST_SOCKET_PORT="${SIM_PORT_DATA}"
-TPM20TEST_TCTI="${INTEGRATION_TCTI}:host=${TPM20TEST_SOCKET_ADDRESS},port=${TPM20TEST_SOCKET_PORT}"
 
 while true; do
 
@@ -53,86 +55,89 @@ else
     fi
 fi
 
-EKPUB_FILE=${TEST_BIN}_ekpub.pem
-EKCERT_FILE=${TEST_BIN}_ekcert.crt
-EKCERT_PEM_FILE=${TEST_BIN}_ekcert.pem
+# Certificate generation for simulator tests
+if [ "${TPM20TEST_TCTI_NAME}" != "device" ]; then
+    EKPUB_FILE=${TEST_BIN}_ekpub.pem
+    EKCERT_FILE=${TEST_BIN}_ekcert.crt
+    EKCERT_PEM_FILE=${TEST_BIN}_ekcert.pem
 
-env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
-    TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
-    TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
-    TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
-    TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
-    G_MESSAGES_DEBUG=all ./test/helper/tpm_getek ${EKPUB_FILE}
-if [ $? -ne 0 ]; then
-    echo "TPM_getek failed"
-    ret=99
-    break
-fi
+    env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+        TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+        TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+        TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+        TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+        G_MESSAGES_DEBUG=all ./test/helper/tpm_getek ${EKPUB_FILE}
+    if [ $? -ne 0 ]; then
+        echo "TPM_getek failed"
+        ret=99
+        break
+    fi
 
-EKECCPUB_FILE=${TEST_BIN}_ekeccpub.pem
-EKECCCERT_FILE=${TEST_BIN}_ekecccert.crt
-EKECCCERT_PEM_FILE=${TEST_BIN}_ekecccert.pem
+    EKECCPUB_FILE=${TEST_BIN}_ekeccpub.pem
+    EKECCCERT_FILE=${TEST_BIN}_ekecccert.crt
+    EKECCCERT_PEM_FILE=${TEST_BIN}_ekecccert.pem
 
-env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
-    TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
-    TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
-    TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
-    TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
-    G_MESSAGES_DEBUG=all ./test/helper/tpm_getek_ecc ${EKECCPUB_FILE}
-if [ $? -ne 0 ]; then
-    echo "TPM_getek_ecc failed"
-    ret=99
-    break
-fi
+    env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+        TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+        TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+        TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+        TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+        G_MESSAGES_DEBUG=all ./test/helper/tpm_getek_ecc ${EKECCPUB_FILE}
+    if [ $? -ne 0 ]; then
+        echo "TPM_getek_ecc failed"
+        ret=99
+        break
+    fi
 
-INTERMEDCA_FILE=${TEST_BIN}_intermedecc-ca
-ROOTCA_FILE=${TEST_BIN}_root-ca
+    INTERMEDCA_FILE=${TEST_BIN}_intermedecc-ca
+    ROOTCA_FILE=${TEST_BIN}_root-ca
 
-SCRIPTDIR="$(dirname $(realpath $0))/"
-${SCRIPTDIR}/ekca/create_ca.sh "${EKPUB_FILE}" "${EKECCPUB_FILE}" "${EKCERT_FILE}" \
-                               "${EKECCCERT_FILE}" "${INTERMEDCA_FILE}" "${ROOTCA_FILE}" >${TEST_BIN}_ca.log 2>&1
-if [ $? -ne 0 ]; then
-    echo "ek-cert ca failed"
-    ret=99
-    break
-fi
+    SCRIPTDIR="$(dirname $(realpath $0))/"
+    ${SCRIPTDIR}/ekca/create_ca.sh "${EKPUB_FILE}" "${EKECCPUB_FILE}" "${EKCERT_FILE}" \
+                "${EKECCCERT_FILE}" "${INTERMEDCA_FILE}" "${ROOTCA_FILE}" >${TEST_BIN}_ca.log 2>&1
+    if [ $? -ne 0 ]; then
+        echo "ek-cert ca failed"
+        ret=99
+        break
+    fi
 
-# Determine the fingerprint of the RSA EK public.
-FINGERPRINT=$(openssl pkey -pubin -inform PEM -in ${EKPUB_FILE} -outform DER | shasum -a 256  | cut -f 1 -d ' ')
-export FAPI_TEST_FINGERPRINT=" { \"hashAlg\" : \"sha256\", \"digest\" : \"${FINGERPRINT}\" }"
-openssl x509 -inform DER -in ${EKCERT_FILE} -outform PEM -out ${EKCERT_PEM_FILE}
-export FAPI_TEST_CERTIFICATE="file:${EKCERT_PEM_FILE}"
+    # Determine the fingerprint of the RSA EK public.
+    FINGERPRINT=$(openssl pkey -pubin -inform PEM -in ${EKPUB_FILE} -outform DER | shasum -a 256  | cut -f 1 -d ' ')
+    export FAPI_TEST_FINGERPRINT=" { \"hashAlg\" : \"sha256\", \"digest\" : \"${FINGERPRINT}\" }"
+    openssl x509 -inform DER -in ${EKCERT_FILE} -outform PEM -out ${EKCERT_PEM_FILE}
+    export FAPI_TEST_CERTIFICATE="file:${EKCERT_PEM_FILE}"
 
-# Determine the fingerprint of the RSA EK public.
-FINGERPRINT_ECC=$(openssl pkey -pubin -inform PEM -in ${EKECCPUB_FILE} -outform DER | shasum -a 256  | cut -f 1 -d ' ')
-export FAPI_TEST_FINGERPRINT_ECC=" { \"hashAlg\" : \"sha256\", \"digest\" : \"${FINGERPRINT_ECC}\" }"
-openssl x509 -inform DER -in ${EKECCCERT_FILE} -outform PEM -out ${EKECCCERT_PEM_FILE}
-export FAPI_TEST_CERTIFICATE_ECC="file:${EKECCCERT_PEM_FILE}"
+    # Determine the fingerprint of the RSA EK public.
+    FINGERPRINT_ECC=$(openssl pkey -pubin -inform PEM -in ${EKECCPUB_FILE} -outform DER | shasum -a 256  | cut -f 1 -d ' ')
+    export FAPI_TEST_FINGERPRINT_ECC=" { \"hashAlg\" : \"sha256\", \"digest\" : \"${FINGERPRINT_ECC}\" }"
+    openssl x509 -inform DER -in ${EKECCCERT_FILE} -outform PEM -out ${EKECCCERT_PEM_FILE}
+    export FAPI_TEST_CERTIFICATE_ECC="file:${EKECCCERT_PEM_FILE}"
 
-cat $EKCERT_FILE | \
-env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
-    TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
-    TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
-    TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
-    TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
-    G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C00002
-if [ $? -ne 0 ]; then
-    echo "TPM_writeekcert failed"
-    ret=99
-    break
-fi
+    cat $EKCERT_FILE | \
+        env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+            TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+            TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+            TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+            TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+            G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C00002
+    if [ $? -ne 0 ]; then
+        echo "TPM_writeekcert failed"
+        ret=99
+        break
+    fi
 
-cat $EKECCCERT_FILE | \
-env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
-    TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
-    TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
-    TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
-    TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
-    G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C0000A
-if [ $? -ne 0 ]; then
-    echo "TPM_writeekcert failed"
-    ret=99
-fi
+    cat $EKECCCERT_FILE | \
+        env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+            TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+            TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+            TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+            TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+            G_MESSAGES_DEBUG=all ./test/helper/tpm_writeekcert 1C0000A
+    if [ $? -ne 0 ]; then
+        echo "TPM_writeekcert failed"
+        ret=99
+    fi
+fi # certificate generation
 
 TPMSTATE_FILE1=${TEST_BIN}_state1
 TPMSTATE_FILE2=${TEST_BIN}_state2
@@ -150,13 +155,24 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Execute the test script"
-env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
-    TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
-    TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
-    TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
-    FAPI_TEST_ROOT_CERT=${ROOTCA_FILE}.pem \
-    TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
-    G_MESSAGES_DEBUG=all ${@: -1}
+if [ "${TPM20TEST_TCTI_NAME}" == "device" ]; then
+    # No root certificate needed
+    env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+        TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+        TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+        TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+        TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+        G_MESSAGES_DEBUG=all ${@: -1}
+else
+    # Run test with generated certificate.
+    env TPM20TEST_TCTI_NAME="${TPM20TEST_TCTI_NAME}" \
+        TPM20TEST_SOCKET_ADDRESS="${TPM20TEST_SOCKET_ADDRESS}" \
+        TPM20TEST_SOCKET_PORT="${TPM20TEST_SOCKET_PORT}" \
+        TPM20TEST_TCTI="${TPM20TEST_TCTI}" \
+        FAPI_TEST_ROOT_CERT=${ROOTCA_FILE}.pem \
+        TPM20TEST_DEVICE_FILE="${TPM20TEST_DEVICE_FILE}" \
+        G_MESSAGES_DEBUG=all ${@: -1}
+fi
 ret=$?
 echo "Script returned $ret"
 
@@ -187,12 +203,14 @@ fi
 break
 done
 
-# This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
-# second after the test finishes the simulator will die too. Bug in the
-# simulator?
-sleep 1
-# teardown
-daemon_stop ${SIM_PID_FILE}
-rm -rf ${SIM_TMP_DIR} ${SIM_PID_FILE}
+if [ "${TPM20TEST_TCTI_NAME}" != "device" ]; then
+    # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
+    # second after the test finishes the simulator will die too. Bug in the
+    # simulator?
+    sleep 1
+    # teardown
+    daemon_stop ${SIM_PID_FILE}
+    rm -rf ${SIM_TMP_DIR} ${SIM_PID_FILE}
+fi
 
 exit $ret


### PR DESCRIPTION
The certificate generation is only needed for simulator tests but not for device tests.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>