### PR TITLE
FAPI: Fix certificate handling for TPMs without stored certificate.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -1006,7 +1006,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
                 SAFE_FREE(cert_buffer);
                 goto_if_error_reset_state(r, "Convert certificate buffer to PEM.",
                                           error_cleanup);
+            } else {
+                /* No certificate was stored in the TPM and ek_cert_less was not set.*/
+                goto_error(r, TSS2_FAPI_RC_NO_CERT,
+                           "No certifcate was stored in the TPM.", error_cleanup);
             }
+
             SAFE_FREE(*capabilityData);
             context->state = PROVISION_EK_WRITE_PREPARE;
             return TSS2_FAPI_RC_TRY_AGAIN;


### PR DESCRIPTION
For TPMs without stored certificate and without an implementation
of a special handling in TSS  now TSS2_FAPI_RC_NO_CERT instead of
TSS2_RC_SUCCESS will be returned.
This PR should be merged after PR 1969 for the tpm-tools has been merged, because otherwise the
tpm-tool integration tests would fail with the current tss master branch.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>