### PR TITLE
doxygen: Fix doxygen warnings.

### DIFF
--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -2645,7 +2645,6 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC ifapi_json_TPML_TAGGED_PCR_PROPERTY_serialize(const TPML_TAGGED_PCR_PROPERTY *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPML_TAGGED_TPM_PROPERTY_serialize(const TPML_TAGGED_TPM_PROPERTY *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPMS_ALG_PROPERTY_serialize(const TPMS_ALG_PROPERTY *in, json_object **jso)
-\fn TSS2_RC ifapi_json_TPMS_ASYM_PARMS_serialize(const TPMS_ASYM_PARMS *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPMS_ATTEST_serialize(const TPMS_ATTEST *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPMS_CAPABILITY_DATA_serialize(const TPMS_CAPABILITY_DATA *in, json_object **jso)
 \fn TSS2_RC ifapi_json_TPMS_CERTIFY_INFO_serialize(const TPMS_CERTIFY_INFO *in, json_object **jso)
@@ -2985,8 +2984,6 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
 \fn TSS2_RC ifapi_json_TPMT_SYM_DEF_deserialize(json_object *jso,  TPMT_SYM_DEF *out)
 \fn TSS2_RC ifapi_json_TPMT_TK_CREATION_deserialize(json_object *jso,
                                         TPMT_TK_CREATION *out)
-\fn TSS2_RC ifapi_json_TPMT_TK_VERIFIED_deserialize(json_object *jso,
-                                        TPMT_TK_VERIFIED *out)
 \fn TSS2_RC ifapi_json_TPMU_ASYM_SCHEME_deserialize(
     UINT32 selector,
     json_object *jso,
@@ -3143,7 +3140,6 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
  \fn test_fapi_key_create_policy_authorize_sign(FAPI_CONTEXT *context)
  \fn test_fapi_key_create_policy_nv_sign(FAPI_CONTEXT *context)
  \fn test_fapi_key_create_policy_or_sign(FAPI_CONTEXT *context)
- \fn test_fapi_key_create_policy_password_sign(FAPI_CONTEXT *context)
  \fn test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
  \fn test_fapi_key_create_policy_secret_nv_sign(FAPI_CONTEXT *context)
  \fn test_fapi_key_create_policy_signed(FAPI_CONTEXT *context)

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1657,10 +1657,8 @@ cleanup:
  * @retval TSS2_RC_SUCCESS on success
  * @retval TSS2_FAPI_RC_BAD_REFERENCE if certBuffer or pemCert is NULL
  * @retval TSS2_FAPI_RC_MEMORY if memory could not be allocated
- * @retval TSS2_FAPI_RC_BAD_VALUE, if the certificate is invalid
+ * @retval TSS2_FAPI_RC_BAD_VALUE if the certificate is invalid
  * @retval TSS2_FAPI_RC_GENERAL_FAILURE if an error occurs in the crypto library
- * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
- *         the function.
  */
 TSS2_RC
 ifapi_cert_to_pem(


### PR DESCRIPTION
* Some FAPI functions which were removed from code are also removed from doxygen file.
* A duplicate doxygen return value declaration was removed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>