### PR TITLE
sys: Minor static analysis cleanup in Tss2_Sys_CertifyCreation_Complete

### DIFF
--- a/src/tss2-sys/api/Tss2_Sys_CertifyCreation.c
+++ b/src/tss2-sys/api/Tss2_Sys_CertifyCreation.c
@@ -106,10 +106,10 @@ TSS2_RC Tss2_Sys_CertifyCreation_Complete(
     if (rval)
         return rval;
 
-    return rval = Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
-                                                   ctx->maxCmdSize,
-                                                   &ctx->nextData,
-                                                   signature);
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData,
+                                            signature);
 }
 
 TSS2_RC Tss2_Sys_CertifyCreation(


### PR DESCRIPTION
No need to assign to rval since we are returning here.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>