### PR TITLE
FAPI: Remove unecassary code from Fapi_ExportKey

### DIFF
--- a/src/tss2-fapi/api/Fapi_ExportKey.c
+++ b/src/tss2-fapi/api/Fapi_ExportKey.c
@@ -336,12 +336,6 @@ Fapi_ExportKey_Finish(
             command->public_parent = parentKeyObject.misc.ext_pub_key.public;
             ifapi_cleanup_ifapi_object(&parentKeyObject);
 
-            /* Initialize a session used for authorization and parameter encryption. */
-            r = ifapi_get_sessions_async(context,
-                                         IFAPI_SESSION_GENEK | IFAPI_SESSION1,
-                                         TPMA_SESSION_DECRYPT, 0);
-            goto_if_error_reset_state(r, "Create sessions", cleanup);
-
             fallthrough;
 
         statecase(context->state, EXPORT_KEY_WAIT_FOR_KEY);


### PR DESCRIPTION
The async call to create sessions can be removed. The call is executed
in the function ifapi_load_key used by Fapi_ExportKey.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>