### PR TITLE
FAPI: Fix wrong access to context of the command Key_Create.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -357,8 +357,8 @@ Fapi_Import_Finish(
 
     switch (context->state) {
        statecase(context->state, IMPORT_WAIT_FOR_SESSION);
-           r = ifapi_get_sessions_finish(context, context->cmd.Key_Create.profile,
-                                         context->cmd.Key_Create.profile->nameAlg);
+           r = ifapi_get_sessions_finish(context, &context->profiles.default_profile,
+                                         context->profiles.default_profile.nameAlg);
            return_try_again(r);
            goto_if_error_reset_state(r, " FAPI create session", error_cleanup);
 


### PR DESCRIPTION
The access to the context of Key_Create was replaces with access to the default profile.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>