### PR TITLE
Fapi change callback API

### DIFF
--- a/include/tss2/tss2_fapi.h
+++ b/include/tss2/tss2_fapi.h
@@ -676,9 +676,9 @@ TSS2_RC Fapi_NvSetBits_Finish(
     FAPI_CONTEXT   *context);
 
 typedef TSS2_RC (*Fapi_CB_Auth)(
-    FAPI_CONTEXT   *context,
+    char     const *objectPath,
     char     const *description,
-    char          **auth,
+    char    const **auth,
     void           *userData);
 
 TSS2_RC Fapi_SetAuthCB(
@@ -687,7 +687,7 @@ TSS2_RC Fapi_SetAuthCB(
     void           *userData);
 
 typedef TSS2_RC (*Fapi_CB_Branch)(
-    FAPI_CONTEXT   *context,
+    char     const *objectPath,
     char     const *description,
     char    const **branchNames,
     size_t          numBranches,
@@ -700,14 +700,14 @@ TSS2_RC Fapi_SetBranchCB(
     void           *userData);
 
 typedef TSS2_RC (*Fapi_CB_Sign)(
-    FAPI_CONTEXT   *context,
+    char     const *objectPath,
     char     const *description,
     char     const *publicKey,
     char     const *publicKeyHint,
     uint32_t        hashAlg,
     uint8_t  const *dataToSign,
     size_t          dataToSignSize,
-    uint8_t       **signature,
+    uint8_t const **signature,
     size_t         *signatureSize,
     void           *userData);
 
@@ -717,7 +717,7 @@ TSS2_RC Fapi_SetSignCB(
     void           *userData);
 
 typedef TSS2_RC (*Fapi_CB_PolicyAction)(
-    FAPI_CONTEXT   *context,
+    char     const *objectPath,
     char     const *action,
     void           *userData);
 

--- a/src/tss2-fapi/api/fapi_callback.c
+++ b/src/tss2-fapi/api/fapi_callback.c
@@ -31,7 +31,7 @@
  * @param[in] userData A pointer that is provided to all callback invocations
  *
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
- * @retval TSS2_FAPI_RC_BAD_REFERENCE: if context or callback is NULL.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE: if the context is NULL.
  * @retval TSS2_FAPI_RC_BAD_CONTEXT: if context corruption is detected.
  * @retval TSS2_FAPI_RC_MEMORY: if the FAPI cannot allocate enough memory for
  *         internal operations or return parameters.
@@ -52,7 +52,6 @@ Fapi_SetBranchCB(
 
     /* Check for NULL parameters */
     check_not_null(context);
-    check_not_null(callback);
 
     /* Store the callback and userdata pointer. */
     context->callbacks.branch = callback;
@@ -71,7 +70,7 @@ Fapi_SetBranchCB(
  * @param[in] userData A pointer that is provided to all callback invocations
  *
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
- * @retval TSS2_FAPI_RC_BAD_REFERENCE: if context or callback is NULL.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE: if the context is NULL.
  * @retval TSS2_FAPI_RC_BAD_CONTEXT: if context corruption is detected.
  * @retval TSS2_FAPI_RC_MEMORY: if the FAPI cannot allocate enough memory for
  *         internal operations or return parameters.
@@ -92,7 +91,6 @@ Fapi_SetAuthCB(
 
     /* Check for NULL parameters */
     check_not_null(context);
-    check_not_null(callback);
 
     /* Store the callback and userdata pointer. */
     context->callbacks.auth = callback;
@@ -111,7 +109,7 @@ Fapi_SetAuthCB(
  * @param[in] userData A pointer that is provided to all callback invocations
  *
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
- * @retval TSS2_FAPI_RC_BAD_REFERENCE: if context or callback is NULL.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE: if the context is NULL.
  * @retval TSS2_FAPI_RC_BAD_CONTEXT: if context corruption is detected.
  * @retval TSS2_FAPI_RC_MEMORY: if the FAPI cannot allocate enough memory for
  *         internal operations or return parameters.
@@ -132,7 +130,6 @@ Fapi_SetSignCB(
 
     /* Check for NULL parameters */
     check_not_null(context);
-    check_not_null(callback);
 
     /* Store the callback and userdata pointer. */
     context->callbacks.sign = callback;
@@ -152,7 +149,7 @@ Fapi_SetSignCB(
  * @param[in] userData A pointer that is provided to all callback invocations
  *
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
- * @retval TSS2_FAPI_RC_BAD_REFERENCE: if context or callback is NULL.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE: if the context is NULL.
  * @retval TSS2_FAPI_RC_BAD_CONTEXT: if context corruption is detected.
  * @retval TSS2_FAPI_RC_MEMORY: if the FAPI cannot allocate enough memory for
  *         internal operations or return parameters.
@@ -173,7 +170,6 @@ Fapi_SetPolicyActionCB(
 
     /* Check for NULL parameters */
     check_not_null(context);
-    check_not_null(callback);
 
     /* Store the callback and userdata pointer. */
     context->callbacks.action = callback;

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -1051,6 +1051,7 @@ struct FAPI_CONTEXT {
     enum IFAPI_IO_STATE io_state;
     NODE_OBJECT_T *object_list;
     IFAPI_OBJECT *duplicate_key; /**< Will be needed for policy execution */
+    IFAPI_OBJECT *current_auth_object;
 };
 
 #define VENDOR_IFX  0x49465800

--- a/src/tss2-fapi/fapi_util.h
+++ b/src/tss2-fapi/fapi_util.h
@@ -33,6 +33,9 @@ TSS2_RC
 ifapi_get_session_finish(ESYS_CONTEXT *esys, ESYS_TR *session,
                          TPMA_SESSION flags);
 
+const char *
+ifapi_get_object_path(IFAPI_OBJECT *object);
+
 TSS2_RC
 ifapi_set_auth(
     FAPI_CONTEXT *context,

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -622,6 +622,8 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out)
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
+    out->rel_path = NULL;
+
     r = ifapi_json_IFAPI_OBJECT_TYPE_CONSTANT_deserialize(jso2, &out->objectType);
     return_if_error(r, "BAD VALUE");
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -565,8 +565,6 @@ ifapi_keystore_load_finish(
     LOG_TRACE("Return %x", r);
     SAFE_FREE(keystore->rel_path);
     return r;
-
-
 }
 
 /**  Start writing FAPI object to the key store.

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -113,6 +113,7 @@ typedef struct IFAPI_KEYSTORE {
     char *userdir;
     char *defaultprofile;
     IFAPI_KEY_SEARCH key_search;
+    const char* rel_path;
 } IFAPI_KEYSTORE;
 
 
@@ -143,6 +144,7 @@ typedef struct _IFAPI_OBJECT {
     ESYS_TR                                      handle;    /**< Handle used by ESAPI */
     enum IFAPI_AUTHORIZATION_STATE  authorization_state;    /**< State of object authorization state machine */
     enum IFAPI_IO_STATE                           state;
+    const char                                *rel_path;    /**< The relative path in keystore. */
 
 } IFAPI_OBJECT;
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -570,6 +570,8 @@ ifapi_branch_selection(
     FAPI_CONTEXT *fapi_ctx = userdata;
     size_t i;
     const char *names[8];
+    IFAPI_OBJECT *auth_object;
+    const char* object_path;
 
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
 
@@ -580,7 +582,13 @@ ifapi_branch_selection(
     for (i = 0; i < branches->count; i++)
         names[i] = branches->authorizations[i].name;
 
-    r = fapi_ctx->callbacks.branch(fapi_ctx, "PolicyOR",
+    /* Determine path of object to be authenticated. */
+    auth_object = fapi_ctx->policy.util_current_policy->pol_exec_ctx->auth_object;
+    return_if_null(auth_object, "No object passed.", TSS2_FAPI_RC_BAD_REFERENCE);
+
+    object_path = ifapi_get_object_path(auth_object);
+
+    r = fapi_ctx->callbacks.branch(object_path, "PolicyOR",
                                    &names[0],
                                    branches->count,
                                    branch_idx,
@@ -612,13 +620,22 @@ ifapi_policy_action(
 {
     TSS2_RC r;
     FAPI_CONTEXT *fapi_ctx = userdata;
+    IFAPI_OBJECT *auth_object;
+    const char* object_path;
+
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!fapi_ctx->callbacks.action) {
         return_error(TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN,
                      "No action callback");
     }
-    r = fapi_ctx->callbacks.action(fapi_ctx, action,
+
+    /* Determine path of object to be authenticated. */
+    auth_object = fapi_ctx->policy.util_current_policy->pol_exec_ctx->auth_object;
+    return_if_null(auth_object, "No object passed.", TSS2_FAPI_RC_BAD_REFERENCE);
+
+    object_path = ifapi_get_object_path(auth_object);
+    r = fapi_ctx->callbacks.action(object_path, action,
                                    fapi_ctx->callbacks.actionData);
     return_if_error(r, "ifapi_policy_action callback");
 
@@ -650,20 +667,28 @@ ifapi_sign_buffer(
     TPMI_ALG_HASH key_pem_hash_alg,
     uint8_t *buffer,
     size_t buffer_size,
-    uint8_t **signature,
+    const uint8_t **signature,
     size_t *signature_size,
     void *userdata)
 {
     TSS2_RC r;
     FAPI_CONTEXT *fapi_ctx = userdata;
+    IFAPI_OBJECT *auth_object;
+    const char* object_path;
 
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
+
+    /* Determine path of object to be authenticated. */
+    auth_object = fapi_ctx->policy.util_current_policy->pol_exec_ctx->auth_object;
+    return_if_null(auth_object, "No object passed.", TSS2_FAPI_RC_BAD_REFERENCE);
+
+    object_path = ifapi_get_object_path(auth_object);
 
     if (!fapi_ctx->callbacks.sign) {
         return_error2(TSS2_FAPI_RC_AUTHORIZATION_UNKNOWN,
                       "No signature callback.");
     }
-    r = fapi_ctx->callbacks.sign(fapi_ctx, "PolicySigned", key_pem,
+    r = fapi_ctx->callbacks.sign(object_path, "PolicySigned", key_pem,
                                  public_key_hint ? public_key_hint : "",
                                  key_pem_hash_alg,
                                  buffer, buffer_size,
@@ -1042,6 +1067,9 @@ ifapi_exec_auth_policy(
     const char **names = NULL;
     size_t branch_idx;
     bool policy_set = false;
+    IFAPI_OBJECT *auth_object;
+    const char* object_path;
+
 
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
     return_if_null(fapi_ctx->policy.policyutil_stack, "Policy not initialized.",
@@ -1093,8 +1121,15 @@ ifapi_exec_auth_policy(
                     branch = branch->next;
                 } while (branch);
 
+                /* Determine path of object to be authenticated. */
+                auth_object = fapi_ctx->policy.util_current_policy->pol_exec_ctx->auth_object;
+                goto_if_null2(auth_object, "No object passed.", r, TSS2_FAPI_RC_BAD_REFERENCE,
+                              cleanup);
+
+                object_path = ifapi_get_object_path(auth_object);
+
                 /* Policy selection */
-                r = fapi_ctx->callbacks.branch(fapi_ctx, "PolicyAuthorize",
+                r = fapi_ctx->callbacks.branch(object_path, "PolicyAuthorize",
                                                &names[0], n, &branch_idx,
                                                fapi_ctx->callbacks.branchData);
                 goto_if_error(r, "policyBranchSelectionCallback", cleanup);
@@ -1251,7 +1286,7 @@ ifapi_exec_auth_nv_policy(
             ifapi_cleanup_ifapi_object(&cb_ctx->object);
             get_nv_auth_object(&cb_ctx->object,
                                current_policy->nv_index,
-                               &current_policy->auth_object,
+                               &current_policy->auth_objectNV,
                                &current_policy->auth_handle);
             fallthrough;
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -84,7 +84,7 @@ ifapi_sign_buffer(
     TPMI_ALG_HASH key_pem_hash_alg,
     uint8_t *buffer,
     size_t buffer_size,
-    uint8_t **signature,
+    const uint8_t **signature,
     size_t *signature_size,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -390,7 +390,7 @@ execute_policy_signed(
     size_t offset = 0;
     //TPMT_SIGNATURE signature_tpm;
     size_t signature_size;
-    uint8_t *signature_ossl = NULL;
+    const uint8_t *signature_ossl = NULL;
 
     LOG_TRACE("call");
 
@@ -451,8 +451,6 @@ execute_policy_signed(
                                  signature_size, policy->keyPEMhashAlg,
                                  &policy->signature_tpm);
         goto_if_error2(r, "Convert der signature into TPM format", cleanup);
-
-        SAFE_FREE(signature_ossl);
 
         TPM2B_PUBLIC inPublic;
         inPublic.size = 0;

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -69,7 +69,7 @@ typedef TSS2_RC (*ifapi_policyexec_cbsign) (
     TPMI_ALG_HASH key_pem_hash_alg,
     uint8_t *buffer,
     size_t buffer_size,
-    uint8_t **signature,
+    const uint8_t **signature,
     size_t *signature_size,
     void *userdata);
 
@@ -138,7 +138,8 @@ struct IFAPI_POLICY_EXEC_CTX {
     ESYS_TR object_handle;
     ESYS_TR nv_index;
     ESYS_TR auth_handle;
-    IFAPI_OBJECT auth_object;       /**< Object used for authentication */
+    IFAPI_OBJECT auth_objectNV;       /**< Object used for NV authentication */
+    IFAPI_OBJECT *auth_object;        /**< Object to be authorized */
     ESYS_TR auth_session;
     TPMI_ALG_HASH hash_alg;
     void  *app_data;                /**< Application data  for policy execution callbacks */

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -217,6 +217,8 @@ ifapi_policyutil_execute_prepare(
     r = new_policy(context, policy, &current_policy);
     goto_if_error(r, "Create new policy.", error);
 
+    current_policy->pol_exec_ctx->auth_object = context->current_auth_object;
+
     r = ifapi_policyeval_execute_prepare(current_policy->pol_exec_ctx, hash_alg, policy);
     goto_if_error(r, "Prepare policy execution.", error);
 

--- a/test/integration/fapi-data-crypt.int.c
+++ b/test/integration/fapi-data-crypt.int.c
@@ -77,22 +77,29 @@ char *userDataTest = "test";
                              r = TSS2_FAPI_RC_GENERAL_FAILURE; \
                              goto error_cleanup; }
 
+static  uint8_t *global_signature = NULL;
+
 static TSS2_RC
 signatureCallback(
-    FAPI_CONTEXT  *context,
-    char    const *description,
-    char    const *publicKey,
-    char    const *publicKeyHint,
-    uint32_t       hashAlg,
-    uint8_t const *dataToSign,
-    size_t         dataToSignSize,
-    uint8_t      **signature,
-    size_t        *signatureSize,
-    void          *userData)
+    char    const  *objectPath,
+    char    const  *description,
+    char    const  *publicKey,
+    char    const  *publicKeyHint,
+    uint32_t        hashAlg,
+    uint8_t const  *dataToSign,
+    size_t          dataToSignSize,
+    uint8_t const **signature,
+    size_t         *signatureSize,
+    void           *userData)
 {
     (void)description;
     (void)publicKey;
     (void)publicKeyHint;
+    uint8_t *aux_signature = NULL;
+
+    if (strcmp(objectPath, "P_RSA/HS/SRK/myRsaCryptKey") != 0) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
+    }
 
     if (userData != userDataTest) {
         LOG_ERROR("userData is not correct, %p != %p", userData, userDataTest);
@@ -145,13 +152,25 @@ signatureCallback(
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign final.",
                    error_cleanup);
     }
-    *signature = malloc(*signatureSize);
-    chknull(*signature);
-    if (1 != EVP_DigestSignFinal(mdctx, *signature, signatureSize)) {
+    aux_signature = malloc(*signatureSize);
+    global_signature = aux_signature;
+
+    chknull(aux_signature);
+    if (1 != EVP_DigestSignFinal(mdctx, aux_signature, signatureSize)) {
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign final.",
                    error_cleanup);
     }
-error_cleanup:
+    *signature = aux_signature;
+
+    if (priv_key)
+        EVP_PKEY_free(priv_key);
+    if (mdctx)
+        EVP_MD_CTX_destroy(mdctx);
+    if (bufio)
+        BIO_free(bufio);
+    return r;
+
+ error_cleanup:
     if (priv_key)
         EVP_PKEY_free(priv_key);
     if (mdctx)
@@ -261,6 +280,7 @@ test_fapi_data_crypt(FAPI_CONTEXT *context)
     Fapi_Free(plainText2);
     Fapi_Free(json_policy);
     Fapi_Delete(context, "/");
+    SAFE_FREE(global_signature);
 
     return EXIT_SUCCESS;
 
@@ -268,12 +288,14 @@ error:
     Fapi_Free(cipherText);
     Fapi_Free(json_policy);
     Fapi_Delete(context, "/");
+    SAFE_FREE(global_signature);
 
     return EXIT_FAILURE;
 
  skip:
     Fapi_Free(json_policy);
     Fapi_Delete(context, "/");
+    SAFE_FREE(global_signature);
 
     return EXIT_SKIP;
 }

--- a/test/integration/fapi-get-esys-blobs.int.c
+++ b/test/integration/fapi-get-esys-blobs.int.c
@@ -43,15 +43,19 @@ get_json_hex_string(const uint8_t *buffer, size_t size)
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-key-change-auth.int.c
+++ b/test/integration/fapi-key-change-auth.int.c
@@ -21,15 +21,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-key-create-ckda-sign.int.c
+++ b/test/integration/fapi-key-create-ckda-sign.int.c
@@ -23,15 +23,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (strcmp(objectPath, "P_RSA/HS/SRK/mySignKey") != 0) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 #else /*FAPI_PASSWORD */

--- a/test/integration/fapi-key-create-policies-sign.int.c
+++ b/test/integration/fapi-key-create-policies-sign.int.c
@@ -30,15 +30,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 #define SIGN_TEMPLATE  "sign,noDa"

--- a/test/integration/fapi-key-create-policy-authorize-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-sign.int.c
@@ -28,7 +28,7 @@ static bool cb_called = false;
 
 static TSS2_RC
 branch_callback(
-    FAPI_CONTEXT *context,
+    char   const *objectPath,
     char   const *description,
     char  const **branchNames,
     size_t        numBranches,
@@ -37,6 +37,10 @@ branch_callback(
 {
     (void) description;
     (void) userData;
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
 
     if (numBranches != 2) {
         LOG_ERROR("Wrong number of branches");

--- a/test/integration/fapi-key-create-policy-or-sign.int.c
+++ b/test/integration/fapi-key-create-policy-or-sign.int.c
@@ -31,7 +31,7 @@ static bool cb_called = false;
 
 static TSS2_RC
 branch_callback(
-    FAPI_CONTEXT *context,
+    char   const *objectPath,
     char   const *description,
     char  const **branchNames,
     size_t        numBranches,
@@ -40,6 +40,10 @@ branch_callback(
 {
     (void) description;
     (void) userData;
+
+    if (strcmp(objectPath, "P_ECC/HS/SRK/mySignKey") != 0) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
+    }
 
     if (numBranches != 2) {
         LOG_ERROR("Wrong number of branches");

--- a/test/integration/fapi-key-create-policy-secret-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-secret-nv-sign.int.c
@@ -31,15 +31,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-key-create-sign-password-provision.int.c
+++ b/test/integration/fapi-key-create-sign-password-provision.int.c
@@ -26,18 +26,23 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
     char *pw = PASSWORD;
     if (!pw)
         return TSS2_FAPI_RC_GENERAL_FAILURE;
 
-    *auth = strdup(pw);
+    *auth = pw;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-key-create-sign-policy-provision.int.c
+++ b/test/integration/fapi-key-create-sign-policy-provision.int.c
@@ -23,18 +23,23 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
     char *pw = PASSWORD;
     if (!pw)
         return TSS2_FAPI_RC_GENERAL_FAILURE;
 
-    *auth = strdup(pw);
+    *auth = pw;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -41,15 +41,19 @@ get_json_hex_string(const uint8_t *buffer, size_t size)
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-nv-extend.int.c
+++ b/test/integration/fapi-nv-extend.int.c
@@ -27,15 +27,19 @@ static char *password;
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(password);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = password;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-nv-increment.int.c
+++ b/test/integration/fapi-nv-increment.int.c
@@ -25,15 +25,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/integration/fapi-nv-ordinary.int.c
+++ b/test/integration/fapi-nv-ordinary.int.c
@@ -29,27 +29,34 @@ static char *password;
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
-    (void)(context);
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 
 static TSS2_RC
 action_callback(
-    FAPI_CONTEXT *context,
+    const char *objectPath,
     const char *action,
     void *userData)
 {
-    (void)(context);
     (void)(userData);
+
+    if (strcmp(objectPath, "/nv/Owner/myNV") != 0) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
+    }
+
     if (strcmp(action, "myaction")) {
         LOG_ERROR("Bad action: %s", action);
         return TSS2_FAPI_RC_GENERAL_FAILURE;

--- a/test/integration/fapi-nv-set-bits.int.c
+++ b/test/integration/fapi-nv-set-bits.int.c
@@ -23,15 +23,19 @@
 
 static TSS2_RC
 auth_callback(
-    FAPI_CONTEXT *context,
+    char const *objectPath,
     char const *description,
-    char **auth,
+    const char **auth,
     void *userData)
 {
     (void)description;
     (void)userData;
-    *auth = strdup(PASSWORD);
-    return_if_null(*auth, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
 }
 


### PR DESCRIPTION
* For callbacks instead of the FAPI context the object path of the object to be authorized will be  passed and callback parameters which should not be changed are declared const.
* The integration tests were adapted.
  
 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
