### PR TITLE
FAPI: bump so-version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -500,6 +500,9 @@ if HAVE_LD_VERSION_SCRIPT
 src_tss2_fapi_libtss2_fapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-fapi.map
 endif # HAVE_LD_VERSION_SCRIPT
 
+# Bump soname due to commit e0636dd6fbec4f286cc908117ecef4d820a50f79 breaking
+# the API and ABI of Fapi_CB_{Auth,Sign,Branch,PolicyAction}
+src_tss2_fapi_libtss2_fapi_la_LDFLAGS += -version-info 1:0:0
 
 if DOXYMAN
 DOXYMAN3 += \


### PR DESCRIPTION
Bump soname due to commit e0636dd6fbec4f286cc908117ecef4d820a50f79 breaking the API and ABI of Fapi_CB_{Auth,Sign,Branch,PolicyAction}