### PR TITLE
Makefile.am: add --enable-debug to distcheck flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -190,6 +190,7 @@ endif #DOXYMAN
 include src_vars.mk
 
 # Add test definitions
+AM_DISTCHECK_CONFIGURE_FLAGS="--enable-debug"
 include Makefile-test.am
 
 # Add fuzz definitions


### PR DESCRIPTION
make check should be run with a debug build so add --enable-debug
to distcheck flags. This will fix make distcheck with clang 6.0 not
being able to use ld --wrap to hijack various libc routines needed for
cmocka tests.

Signed-off-by: William Roberts <william.c.roberts@intel.com>