### PR TITLE
Build: Fix warning on FAPI_LDFLAGS

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -265,7 +265,7 @@ endif # TESTDEVICE
 endif #ESAPI
 
 if FAPI
-FAPI_LDFLAGS = -ljson-c
+TESTS_LDADD += $(JSONC_LIBS)
 TESTS_CFLAGS +=  -DTOP_SOURCEDIR"=\"$(top_srcdir)\""
 FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-data-crypt.fint \
@@ -1365,35 +1365,35 @@ if FAPI
 
 test_integration_fapi_get_esys_blobs_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_get_esys_blobs_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_get_esys_blobs_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_get_esys_blobs_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_get_esys_blobs_fint_SOURCES = \
     test/integration/fapi-get-esys-blobs.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_get_random_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_get_random_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_get_random_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_get_random_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_get_random_fint_SOURCES = \
     test/integration/fapi-get-random.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_platform_certificates_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_platform_certificates_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_platform_certificates_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_platform_certificates_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_platform_certificates_fint_SOURCES = \
     test/integration/fapi-platform-certificates.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_sign_password_provision_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_sign_password_provision_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_password_provision_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_password_provision_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_password_provision_fint_SOURCES = \
     test/integration/fapi-key-create-sign-password-provision.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1401,7 +1401,7 @@ test_integration_fapi_key_create_sign_password_provision_fint_SOURCES = \
 test_integration_fapi_key_create_sign_policy_provision_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA_sh_policy\" -DFAPI_TEST_EK_CERT_LESS
 test_integration_fapi_key_create_sign_policy_provision_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_policy_provision_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_policy_provision_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_policy_provision_fint_SOURCES = \
     test/integration/fapi-key-create-sign-policy-provision.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1409,7 +1409,7 @@ test_integration_fapi_key_create_sign_policy_provision_fint_SOURCES = \
 test_integration_fapi_key_create_sign_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_key_create_sign_rsa_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_rsa_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1417,7 +1417,7 @@ test_integration_fapi_key_create_sign_rsa_fint_SOURCES = \
 test_integration_fapi_key_create_sign_password_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PASSWORD
 test_integration_fapi_key_create_sign_password_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_password_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_password_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_password_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1425,7 +1425,7 @@ test_integration_fapi_key_create_sign_password_fint_SOURCES = \
 test_integration_fapi_key_create_sign_password_da_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PASSWORD -DFAPI_DA
 test_integration_fapi_key_create_sign_password_da_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_password_da_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_password_da_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_password_da_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1433,14 +1433,14 @@ test_integration_fapi_key_create_sign_password_da_fint_SOURCES = \
 test_integration_fapi_key_create_sign_persistent_fint_CFLAGS  = $(TESTS_CFLAGS) \
    -DFAPI_PROFILE=\"P_RSA_EK_persistent\" -DFAPI_TEST_EK_CERT_LESS
 test_integration_fapi_key_create_sign_persistent_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_sign_persistent_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_sign_persistent_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_persistent_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_authorize_sign_fint_CFLAGS  = $(TESTS_CFLAGS) -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_key_create_policy_authorize_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_authorize_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_authorize_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_authorize_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-authorize-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1448,14 +1448,14 @@ test_integration_fapi_key_create_policy_authorize_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DFAPI_PROFILE=\"P_RSA256\" -DFAPI_TEST_EK_CERT_LESS
 test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_SOURCES = \
     test/integration/fapi-key-create-policy-authorize-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_authorize_nv_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_authorize_nv_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_authorize_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_authorize_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_authorize_nv_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-authorize-nv-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1463,21 +1463,21 @@ test_integration_fapi_key_create_policy_authorize_nv_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_secret_nv_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DFAPI_PROFILE=\"P_RSA256\" -DFAPI_TEST_EK_CERT_LESS
 test_integration_fapi_key_create_policy_secret_nv_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_secret_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_secret_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_secret_nv_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-secret-nv-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_pcr_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_pcr_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_pcr_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_pcr_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_pcr_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-pcr-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_signed_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_signed_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_signed_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_signed_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_signed_fint_SOURCES = \
     test/integration/fapi-key-create-policy-signed.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1485,21 +1485,21 @@ test_integration_fapi_key_create_policy_signed_fint_SOURCES = \
 test_integration_fapi_key_create_policy_signed_ecc_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DTEST_ECC
 test_integration_fapi_key_create_policy_signed_ecc_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_signed_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_signed_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_signed_ecc_fint_SOURCES = \
     test/integration/fapi-key-create-policy-signed.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_nv_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_nv_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_nv_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-nv-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_or_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_or_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_or_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_or_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_or_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-or-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1507,7 +1507,7 @@ test_integration_fapi_key_create_policy_or_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_password_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_POLICY_PASSWORD -DTEST_PASSWORD
 test_integration_fapi_key_create_policy_password_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_password_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_password_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_password_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1515,7 +1515,7 @@ test_integration_fapi_key_create_policy_password_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_countertimer_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_POLICY_COUNTERTIMER
 test_integration_fapi_key_create_policy_countertimer_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_countertimer_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_countertimer_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_countertimer_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1523,7 +1523,7 @@ test_integration_fapi_key_create_policy_countertimer_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_physical_presence_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_POLICY_PHYSICAL_PRESENCE
 test_integration_fapi_key_create_policy_physical_presence_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_physical_presence_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_physical_presence_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_physical_presence_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1531,7 +1531,7 @@ test_integration_fapi_key_create_policy_physical_presence_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_locality_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_POLICY_LOCALITY
 test_integration_fapi_key_create_policy_locality_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_locality_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_locality_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_locality_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1539,7 +1539,7 @@ test_integration_fapi_key_create_policy_locality_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_command_code_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_POLICY_COMMAND_CODE
 test_integration_fapi_key_create_policy_command_code_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_command_code_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_command_code_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_command_code_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1547,7 +1547,7 @@ test_integration_fapi_key_create_policy_command_code_sign_fint_SOURCES = \
 test_integration_fapi_key_create_policy_auth_value_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DTEST_POLICY_AUTH_VALUE -DTEST_PASSWORD
 test_integration_fapi_key_create_policy_auth_value_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_policy_auth_value_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_policy_auth_value_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_auth_value_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policies-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1555,7 +1555,7 @@ test_integration_fapi_key_create_policy_auth_value_sign_fint_SOURCES = \
 test_integration_fapi_key_create_ckda_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_key_create_ckda_sign_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_ckda_sign_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_ckda_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_ckda_sign_fint_SOURCES = \
     test/integration/fapi-key-create-ckda-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1563,7 +1563,7 @@ test_integration_fapi_key_create_ckda_sign_fint_SOURCES = \
 test_integration_fapi_key_create_ckda_sign_password_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PASSWORD  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_key_create_ckda_sign_password_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_ckda_sign_password_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_ckda_sign_password_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_ckda_sign_password_fint_SOURCES = \
     test/integration/fapi-key-create-ckda-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1571,56 +1571,56 @@ test_integration_fapi_key_create_ckda_sign_password_fint_SOURCES = \
 test_integration_fapi_key_create_ckda_sign_password_da_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PASSWORD -DFAPI_DA  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_key_create_ckda_sign_password_da_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_create_ckda_sign_password_da_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_create_ckda_sign_password_da_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_ckda_sign_password_da_fint_SOURCES = \
     test/integration/fapi-key-create-ckda-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_change_auth_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_change_auth_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_key_change_auth_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_key_change_auth_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_change_auth_fint_SOURCES = \
     test/integration/fapi-key-change-auth.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_ordinary_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_ordinary_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_ordinary_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_ordinary_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_ordinary_fint_SOURCES = \
     test/integration/fapi-nv-ordinary.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_authorizenv_cphash_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_authorizenv_cphash_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_authorizenv_cphash_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_authorizenv_cphash_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_authorizenv_cphash_fint_SOURCES = \
     test/integration/fapi-nv-authorizenv-cphash.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_extend_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_extend_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_extend_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_extend_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_extend_fint_SOURCES = \
     test/integration/fapi-nv-extend.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_increment_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_increment_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_increment_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_increment_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_increment_fint_SOURCES = \
     test/integration/fapi-nv-increment.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_set_bits_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_set_bits_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_set_bits_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_set_bits_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_set_bits_fint_SOURCES = \
     test/integration/fapi-nv-set-bits.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_nv_written_policy_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_nv_written_policy_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_nv_written_policy_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_nv_written_policy_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_nv_written_policy_fint_SOURCES = \
     test/integration/fapi-nv-written-policy.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1628,14 +1628,14 @@ test_integration_fapi_nv_written_policy_fint_SOURCES = \
 test_integration_fapi_ext_public_key_fint_CFLAGS  = $(TESTS_CFLAGS) \
   -DFAPI_NONTPM
 test_integration_fapi_ext_public_key_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_ext_public_key_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_ext_public_key_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_ext_public_key_fint_SOURCES = \
     test/integration/fapi-ext-public-key.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_data_crypt_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_data_crypt_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_data_crypt_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_data_crypt_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_data_crypt_fint_SOURCES = \
     test/integration/fapi-data-crypt.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1643,28 +1643,28 @@ test_integration_fapi_data_crypt_fint_SOURCES = \
 test_integration_fapi_data_crypt_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_data_crypt_rsa_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_data_crypt_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_data_crypt_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_data_crypt_rsa_fint_SOURCES = \
     test/integration/fapi-data-crypt.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_duplicate_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_duplicate_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_duplicate_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_duplicate_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_duplicate_fint_SOURCES = \
     test/integration/fapi-duplicate.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_pcr_test_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_pcr_test_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_pcr_test_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_pcr_test_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_pcr_test_fint_SOURCES = \
     test/integration/fapi-pcr-test.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_quote_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_quote_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_quote_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_quote_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_quote_fint_SOURCES = \
     test/integration/fapi-quote.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1672,21 +1672,21 @@ test_integration_fapi_quote_fint_SOURCES = \
 test_integration_fapi_quote_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_quote_rsa_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_quote_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_quote_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_quote_rsa_fint_SOURCES = \
     test/integration/fapi-quote.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_info_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_info_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_info_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_info_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_info_fint_SOURCES = \
     test/integration/fapi-info.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_unseal_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_unseal_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_unseal_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_unseal_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_unseal_fint_SOURCES = \
     test/integration/fapi-unseal.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1694,7 +1694,7 @@ test_integration_fapi_unseal_fint_SOURCES = \
 test_integration_fapi_provision_fingerprint_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_TEST_FINGERPRINT  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_provision_fingerprint_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_provision_fingerprint_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_provision_fingerprint_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_provision_fingerprint_fint_SOURCES = \
     test/integration/fapi-get-random.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1702,7 +1702,7 @@ test_integration_fapi_provision_fingerprint_fint_SOURCES = \
 test_integration_fapi_provision_certificate_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_TEST_CERTIFICATE  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_provision_certificate_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_provision_certificate_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_provision_certificate_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_provision_certificate_fint_SOURCES = \
     test/integration/fapi-get-random.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1710,7 +1710,7 @@ test_integration_fapi_provision_certificate_fint_SOURCES = \
 test_integration_fapi_provision_fingerprint_ecc_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_TEST_FINGERPRINT_ECC  -DFAPI_PROFILE=\"P_ECC\"
 test_integration_fapi_provision_fingerprint_ecc_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_provision_fingerprint_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_provision_fingerprint_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_provision_fingerprint_ecc_fint_SOURCES = \
     test/integration/fapi-get-random.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
@@ -1718,7 +1718,7 @@ test_integration_fapi_provision_fingerprint_ecc_fint_SOURCES = \
 test_integration_fapi_provision_certificate_ecc_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_TEST_CERTIFICATE_ECC  -DFAPI_PROFILE=\"P_ECC\"
 test_integration_fapi_provision_certificate_ecc_fint_LDADD   = $(TESTS_LDADD)
-test_integration_fapi_provision_certificate_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS) $(FAPI_LDFLAGS)
+test_integration_fapi_provision_certificate_ecc_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_provision_certificate_ecc_fint_SOURCES = \
     test/integration/fapi-get-random.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h


### PR DESCRIPTION
Remove FAPI_LDFLAGS from Makefile-test.am alltogether. Instead use TESTS_LDADD to carry the JSONC_LIBS parameter to compilation units.

Fixes: #1725 