### PR TITLE
build: fix systemd-sysusers/-tmpfiles invocation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -612,20 +612,13 @@ install-man: install-man3 install-man7
 
 EXTRA_DIST += dist/tpm-udev.rules
 
-if WITH_UDEVRULESPREFIX
 install-data-hook:
-	mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
-
-uninstall-local:
-	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
-endif
-
-# Create tss user and FAPI directories directly after installation (vs. after a reboot)
-install-exec-hook:
+	-mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
 	(systemd-sysusers && systemd-tmpfiles --create) || \
 	($(call make_tss_user_and_group) && $(call make_fapi_dirs) && ($call set_fapi_permissions)) || true
 
-uninstall-hook:
+uninstall-local:
+	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
 	cd $(DESTDIR)$(man3dir) && \
 		[ -L Tss2_TctiLdr_Initialize_Ex.3 ] && \
 			rm -f Tss2_TctiLdr_Initialize_Ex.3 || true


### PR DESCRIPTION
systemd-sysusers/-tmpfiles needs to be executed in `install-data-hook` instead of `install-exec-hook`, otherwise the configuration files `sysusers/tmpfiles_DATA` are not installed yet.

Automake only allows a single hook of each type, and there is already one for prepending the udev rules file with a prefix, so these hooks need to be consolidated: if `WITH_UDEVRULESPREFIX` is false, `udevrulesprefix` is empty, so the `mv` operation fails since source and target are the same file. Ignore this error since it is harmless.

Also consolidate `uninstall-hook` into `uninstall-local` for simplicity.

Fixes: 7502887b57246923fa965bfc56b5eddb473d613d