### PR TITLE
cirrus: drop freebsd-13-CURRENT image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,6 @@ task:
   freebsd_instance:
     matrix:
       image_family: freebsd-12-1-snap
-      image_family: freebsd-13-0-snap
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
Looks like the current tree is not stable.