### PR TITLE
Fapi backport fixes

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -268,6 +268,7 @@ if FAPI
 TESTS_LDADD += $(JSONC_LIBS)
 TESTS_CFLAGS +=  -DTOP_SOURCEDIR"=\"$(top_srcdir)\""
 FAPI_TESTS_INTEGRATION = \
+    test/integration/fapi-check-wrong-paths.fint \
     test/integration/fapi-data-crypt.fint \
     test/integration/fapi-data-crypt-rsa.fint \
     test/integration/fapi-duplicate.fint \
@@ -1362,6 +1363,13 @@ test_integration_sapi_policy_authorizeNV_int_SOURCES = test/integration/main-sap
     test/integration/sapi-policy-authorizeNV.int.c
 
 if FAPI
+
+test_integration_fapi_check_wrong_paths_fint_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_fapi_check_wrong_paths_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_check_wrong_paths_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_check_wrong_paths_fint_SOURCES = \
+    test/integration/fapi-check-wrong-paths.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_get_esys_blobs_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_get_esys_blobs_fint_LDADD   = $(TESTS_LDADD)

--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -214,6 +214,13 @@ Fapi_CreateNv_Async(
                            policyPath);
     goto_if_error(r, "Set key flags for NV object", error_cleanup);
 
+    if (nvCmd->public_templ.public.nvIndex) {
+        /* NV index was defined by the user, has to be checked whether the selected index
+           is appropriate for the used path. */
+        r = ifapi_check_nv_index(path, nvCmd->public_templ.public.nvIndex);
+        goto_if_error(r, "Check NV path and NV index", error_cleanup);
+    }
+
     /* Initialize the context state for this operation. */
     context->state = NV_CREATE_READ_PROFILE;
     LOG_TRACE("finished");

--- a/src/tss2-fapi/api/Fapi_GetInfo.c
+++ b/src/tss2-fapi/api/Fapi_GetInfo.c
@@ -249,7 +249,7 @@ Fapi_GetInfo_Finish(
         }
 
         infoObj->fapi_version = PACKAGE_STRING;
-        infoObj->fapi_config = "Properties of config have to specified by TCG";
+        infoObj->fapi_config = context->config;
 
         /* Serialize the information. */
         r = ifapi_json_IFAPI_INFO_serialize(infoObj, &jso);

--- a/src/tss2-fapi/api/Fapi_GetInfo.c
+++ b/src/tss2-fapi/api/Fapi_GetInfo.c
@@ -248,7 +248,7 @@ Fapi_GetInfo_Finish(
             return TSS2_FAPI_RC_TRY_AGAIN;
         }
 
-        infoObj->fapi_version = "OSSTSS 2.2.x";
+        infoObj->fapi_version = PACKAGE_STRING;
         infoObj->fapi_config = "Properties of config have to specified by TCG";
 
         /* Serialize the information. */

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -251,6 +251,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
     IFAPI_KEY * pkey = &pkeyObject->misc.key;
     IFAPI_PROFILE * defaultProfile = &context->profiles.default_profile;
     int curl_rc;
+    TPMA_OBJECT *attributes;
 
     switch (context->state) {
         statecase(context->state, PROVISION_READ_PROFILE);
@@ -300,6 +301,15 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
                      context->profiles.default_profile.ek_policy ? true : false,
                      &command->public_templ);
             goto_if_error(r, "Set key flags for SRK", error_cleanup);
+
+            /* If neither sign nor decrypt is set both flags
+               sign_encrypt and decrypt have to be set. */
+            attributes =  &command->public_templ.public.publicArea.objectAttributes;
+            if ( !(*attributes & TPMA_OBJECT_SIGN_ENCRYPT) &&
+                 !(*attributes & TPMA_OBJECT_DECRYPT) ) {
+                *attributes |= TPMA_OBJECT_SIGN_ENCRYPT;
+                *attributes |= TPMA_OBJECT_DECRYPT;
+            }
 
             r = ifapi_merge_profile_into_template(&context->profiles.default_profile,
                     &command->public_templ);
@@ -622,6 +632,15 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
                     context->profiles.default_profile.srk_policy ? true : false,
                     &command->public_templ);
             goto_if_error(r, "Set key flags for SRK", error_cleanup);
+
+            /* If neither sign nor decrypt is set both flags
+               sign_encrypt and decrypt have to be set. */
+            attributes =  &command->public_templ.public.publicArea.objectAttributes;
+            if ( !(*attributes & TPMA_OBJECT_SIGN_ENCRYPT) &&
+                 !(*attributes & TPMA_OBJECT_DECRYPT) ) {
+                *attributes |= TPMA_OBJECT_SIGN_ENCRYPT;
+                *attributes |= TPMA_OBJECT_DECRYPT;
+            }
 
             r = ifapi_merge_profile_into_template(&context->profiles.default_profile,
                     &command->public_templ);

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -143,7 +143,7 @@ typedef struct {
 
 typedef struct {
     char                                 *fapi_version;    /**< The version string of FAPI */
-    char                                  *fapi_config;    /**< The configuration information */
+    IFAPI_CONFIG                           fapi_config;    /**< The configuration information */
     IFAPI_CAP_INFO             cap[IFAPI_MAX_CAP_INFO];
 } IFAPI_INFO;
 
@@ -1026,7 +1026,7 @@ struct FAPI_CONTEXT {
     enum IFAPI_GET_CERT_STATE get_cert_state;
     enum _FAPI_FLUSH_STATE flush_object_state;  /**< The current state of a flush operation */
     enum IFAPI_CLEANUP_STATE cleanup_state;     /**< The state of cleanup after command execution */
-    IFAPI_CONFIG config;             /**< The profile independet configuration data */
+    IFAPI_CONFIG config;             /**< The profile independent configuration data */
     UINT32 nv_buffer_max;            /**< The maximal size for transfer of nv buffer content */
     IFAPI_CMD_STATE cmd;             /**< The state information of the currently executed
                                           command */

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -1624,7 +1624,7 @@ ifapi_load_key_finish(FAPI_CONTEXT *context, bool flush_parent)
         return_if_error(r, "read_finish failed");
 
         if (context->loadKey.key_object->objectType != IFAPI_KEY_OBJ)
-            goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "%s is no key", error_cleanup,
+            goto_error(r, TSS2_FAPI_RC_BAD_PATH, "%s is no key", error_cleanup,
                        context->loadKey.key_path);
 
         r = ifapi_initialize_object(context->esys, context->loadKey.key_object);

--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -15,6 +15,8 @@
 #include "ifapi_config.h"
 #include "ifapi_json_deserialize.h"
 #include "tpm_json_deserialize.h"
+#include "ifapi_json_serialize.h"
+#include "tpm_json_serialize.h"
 #include "ifapi_helpers.h"
 
 #define LOGMODULE fapi

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -110,10 +110,12 @@ ifapi_set_key_flags(const char *type, bool policy, IFAPI_KEY_TEMPLATE *template)
     else
         attributes |= TPMA_OBJECT_ADMINWITHPOLICY;
 
-    /* Check whether flags are appropriate */
+    /* Check whether flags are appropriate for restricted keys */
     if (attributes & TPMA_OBJECT_RESTRICTED &&
-            attributes & TPMA_OBJECT_SIGN_ENCRYPT &&
-            attributes & TPMA_OBJECT_DECRYPT) {
+        ((attributes & TPMA_OBJECT_SIGN_ENCRYPT &&
+          attributes & TPMA_OBJECT_DECRYPT)
+         || (!(attributes & TPMA_OBJECT_SIGN_ENCRYPT) &&
+             !(attributes & TPMA_OBJECT_DECRYPT)))) {
         goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
                    "Exactly either sign or decrypt must be set.",
                    error);

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1845,7 +1845,7 @@ ifapi_get_nv_start_index(const char *path, TPM2_HANDLE *start_nv_index)
         else if (strcmp(dir_list->next->str, "Endorsement_Certificate") == 0)
             *start_nv_index = 0x01c00000;
         else if (strcmp(dir_list->next->str, "Platform_Certificate") == 0)
-            *start_nv_index = 0x01c80000;
+            *start_nv_index = 0x01c08000;
         else if (strcmp(dir_list->next->str, "Component_OEM") == 0)
             *start_nv_index = 0x01c10000;
         else if (strcmp(dir_list->next->str, "TPM_OEM") == 0)
@@ -1854,7 +1854,7 @@ ifapi_get_nv_start_index(const char *path, TPM2_HANDLE *start_nv_index)
             *start_nv_index = 0x01c30000;
         else if (strcmp(dir_list->next->str, "PC-Client") == 0)
             *start_nv_index = 0x01c40000;
-        else if (strcmp(dir_list->next->str, "Sever") == 0)
+        else if (strcmp(dir_list->next->str, "Server") == 0)
             *start_nv_index = 0x01c50000;
         else if (strcmp(dir_list->next->str, "Virtualized_Platform") == 0)
             *start_nv_index = 0x01c60000;
@@ -1868,6 +1868,115 @@ ifapi_get_nv_start_index(const char *path, TPM2_HANDLE *start_nv_index)
         return TSS2_RC_SUCCESS;
 
     return_error2(TSS2_FAPI_RC_BAD_PATH, "Invalid NV path: %s", path);
+}
+
+/** Check whether NV index is appropriate for NV path.
+ *
+ * The value will be checked  based on e TCG handle registry.
+ *
+ * @param[in]  path The path used for the NV object.
+ * @param[out] nv_index The NV index to be used.
+ *
+ * @retval TSS2_RC_SUCCESS If the index for the path can be determined.
+ * @retval TSS2_FAPI_RC_BAD_PATH If the path is not valid.
+ * @retval TSS2_FAPI_RC_BAD_VALUE If the nv index is not appropriate for the path.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
+TSS2_RC
+ifapi_check_nv_index(const char *path, TPM2_HANDLE nv_index)
+{
+    TSS2_RC r;
+    NODE_STR_T *dir_list = split_string(path, IFAPI_FILE_DELIM);
+
+    return_if_null(dir_list, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+    if (dir_list->next && strcmp(dir_list->str, "nv") == 0 && dir_list->next->str) {
+        if (strcmp(dir_list->next->str, "TPM") == 0) {
+            if (nv_index < 0x01000000 || nv_index > 0x013fffff)
+                goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                           "NV TPM handle not in the range 0x01000000:0x013fffff",
+                           error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Platform") == 0) {
+            if (nv_index < 0x01400000 || nv_index > 0x017fffff)
+                goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                           "NV Platform handle not in the range 0x01400000:0x017fffff",
+                           error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Owner") == 0) {
+            if (nv_index < 0x01800000 || nv_index > 0x01bfffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV Owner handle not in the range 0x01800000:0x01bfffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Endorsement_Certificate") == 0) {
+            if (nv_index <  0x01c00000 || nv_index > 0x01c07fff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV Endorsement Certificate handle not in the range "
+                       "0x01c00000:0x01c07fff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Platform_Certificate") == 0) {
+            if (nv_index <  0x01c08000 || nv_index > 0x01c0ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV  Platform Certificate handle not in the range "
+                       "0x01c08000:0x01c0ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Component_OEM") == 0) {
+            if (nv_index <  0x01c10000 || nv_index > 0x01c1ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV Component OEM handle not in the range "
+                       "0x01c10000:0x01c1ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "TPM_OEM") == 0) {
+            if (nv_index < 0x01c20000 || nv_index > 0x01c2ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV TPM OEM handle not in the range "
+                       "0x01c20000:0x01c2ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Platform_OEM") == 0) {
+            if (nv_index < 0x01c30000 || nv_index > 0x01c3ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV Platform OEM handle not in the range "
+                       "0x01c30000:0x01c3ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "PC-Client") == 0) {
+            if (nv_index < 0x01c40000 || nv_index > 0x01c4ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV PC-Client handle not in the range "
+                       "0x01c40000:0x01c4ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Server") == 0) {
+            if (nv_index < 0x01c50000 || nv_index > 0x01c5ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV PC-Client handle not in the range "
+                       "0x01c50000:0x01c5ffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Virtualized_Platform") == 0) {
+            if (nv_index < 0x01c60000 || nv_index > 0x01c6ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV PC-Client handle not in the range "
+                       "0x01c60000:0x016cffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "MPWG") == 0) {
+            if (nv_index < 0x01c70000 || nv_index > 0x01c7ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV PC-Client handle not in the range "
+                       "0x01c70000:0x017cffff",
+                       error_cleanup);
+        } else if (strcmp(dir_list->next->str, "Embedded") == 0) {
+            if (nv_index < 0x01c80000 || nv_index >  0x01c8ffff)
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                       "NV PC-Client handle not in the range "
+                       "0x01c80000:0x018cffff",
+                       error_cleanup);
+        } else {
+            goto_error(r, TSS2_FAPI_RC_BAD_PATH, "Invalid nv path: %s", error_cleanup, path);
+        }
+    } else {
+        goto_error(r, TSS2_FAPI_RC_BAD_PATH, "Invalid nv path: %s", error_cleanup, path);
+    }
+    free_string_list(dir_list);
+    return TSS2_RC_SUCCESS;;
+
+ error_cleanup:
+    free_string_list(dir_list);
+    return r;
 }
 
 /** Compute new PCR value from a part of an event list.

--- a/src/tss2-fapi/ifapi_helpers.h
+++ b/src/tss2-fapi/ifapi_helpers.h
@@ -144,6 +144,9 @@ TSS2_RC
 ifapi_get_nv_start_index(const char *path, TPM2_HANDLE *start_nv_index);
 
 TSS2_RC
+ifapi_check_nv_index(const char *path, TPM2_HANDLE nv_index);
+
+TSS2_RC
 ifapi_check_profile_pcr_selection(
     const TPML_PCR_SELECTION *pcr_profile,
     const TPML_PCR_SELECTION *pcr_capablity);

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -15,6 +15,7 @@
 #include "tpm_json_serialize.h"
 #include "fapi_policy.h"
 #include "ifapi_policy_json_serialize.h"
+#include "ifapi_config.h"
 
 #define LOGMODULE fapijson
 #include "util/log.h"
@@ -585,7 +586,7 @@ ifapi_json_IFAPI_INFO_serialize(const IFAPI_INFO *in, json_object **jso)
 
     json_object_object_add(*jso, "version", jso2);
     jso2 = NULL;
-    r = ifapi_json_char_serialize(in->fapi_config, &jso2);
+    r = ifapi_json_IFAPI_CONFIG_serialize(&in->fapi_config, &jso2);
     return_if_error(r, "Serialize char");
 
     json_object_object_add(*jso, "fapi_config", jso2);
@@ -805,3 +806,94 @@ ifapi_json_IFAPI_EVENT_serialize(const IFAPI_EVENT *in, json_object **jso)
     json_object_object_add(*jso, "sub_event", jso2);
     return TSS2_RC_SUCCESS;
 }
+
+/** Serializes a configuration JSON object.
+ *
+ * @param[in] in value to be serialized.
+ * @param[out] jso pointer to the json object.
+ * @retval TSS2_RC_SUCCESS if the function call was a success.
+ * @retval TSS2_FAPI_RC_MEMORY: if the FAPI cannot allocate enough memory.
+ * @retval TSS2_FAPI_RC_BAD_VALUE if the value is not of type IFAPI_KEY.
+ * @retval TSS2_FAPI_RC_BAD_REFERENCE a invalid null pointer is passed.
+ */
+TSS2_RC
+ifapi_json_IFAPI_CONFIG_serialize(const IFAPI_CONFIG *in, json_object **jso)
+ {
+     TSS2_RC r;
+     json_object *jso2;
+
+     return_if_null(in, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
+
+     if (*jso == NULL)
+         *jso = json_object_new_object();
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->profile_dir, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "profile_dir", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->user_dir, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "user_dir", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->keystore_dir, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "system_dir", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->log_dir, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "log_dir", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->profile_name, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "profile_name", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->tcti, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "tcti", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_TPML_PCR_SELECTION_serialize(&in->system_pcrs, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "system_pcrs", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->ek_cert_file, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "ek_cert_file", jso2);
+
+     jso2 = NULL;
+     r = ifapi_json_TPMI_YES_NO_serialize(in->ek_cert_less, &jso2);
+     return_if_error(r, "Serialize yes no");
+
+     json_object_object_add(*jso, "ek_cert_less", jso2);
+
+     if (in->ek_fingerprint.hashAlg) {
+         jso2 = NULL;
+         ifapi_json_TPMT_HA_serialize(&in->ek_fingerprint, &jso2);
+         return_if_error(r, "Serialize char");
+
+         json_object_object_add(*jso, "ek_fingerprint", jso2);
+     }
+
+     jso2 = NULL;
+     r = ifapi_json_char_serialize(in->intel_cert_service, &jso2);
+     return_if_error(r, "Serialize char");
+
+     json_object_object_add(*jso, "intel_cert_service", jso2);
+
+     return TSS2_RC_SUCCESS;
+ }

--- a/src/tss2-fapi/ifapi_json_serialize.h
+++ b/src/tss2-fapi/ifapi_json_serialize.h
@@ -77,4 +77,8 @@ ifapi_json_IFAPI_EVENT_UNION_serialize(const IFAPI_EVENT_UNION *in,
 TSS2_RC
 ifapi_json_IFAPI_EVENT_serialize(const IFAPI_EVENT *in, json_object **jso);
 
+
+TSS2_RC
+ifapi_json_IFAPI_CONFIG_serialize(const IFAPI_CONFIG *in, json_object **jso);
+
 #endif /* IFAPI_JSON_SERIALIZE_H */

--- a/test/integration/fapi-check-wrong-paths.int.c
+++ b/test/integration/fapi-check-wrong-paths.int.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <json-c/json.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+
+#include "tss2_fapi.h"
+
+#include "test-fapi.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+#define EVENT_SIZE 10
+
+/** Test the wrong paths for object creation functions.
+ *
+ * Tested FAPI commands:
+ *  - Fapi_Provision()
+ *  - Fapi_CreateKey()
+ *  - Fapi_Delete()
+ *
+ * @param[in,out] context The FAPI_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_fapi_wrong_path(FAPI_CONTEXT *context)
+{
+    TSS2_RC r;
+
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+
+    goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = Fapi_CreateKey(context, "myKey", "sign,noDa", "", NULL);
+
+    if (r && r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+        goto_if_error(r, "Error Fapi_CreateKey", error);
+    }
+
+    r = Fapi_CreateKey(context, "/HE/SRK/myKey", "sign,noDa", "", NULL);
+
+    if (r && r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+        goto_if_error(r, "Error Fapi_CreateKey", error);
+    }
+
+    r = Fapi_CreateKey(context, "/HS/EK/Key", "sign,noDa", "", NULL);
+
+    if (r && r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+        goto_if_error(r, "Error Fapi_CreateKey", error);
+    }
+
+
+    Fapi_Delete(context, "/");
+
+    return EXIT_SUCCESS;
+
+error:
+    Fapi_Delete(context, "/");
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_fapi(FAPI_CONTEXT *fapi_context)
+{
+    return test_fapi_wrong_path(fapi_context);
+}

--- a/test/integration/fapi-check-wrong-paths.int.c
+++ b/test/integration/fapi-check-wrong-paths.int.c
@@ -64,6 +64,17 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto_if_error(r, "Error Fapi_CreateKey", error);
     }
 
+    r = Fapi_CreateNv(context, "myNv", "noda", 10, "", "");
+
+    if (r && r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+        goto_if_error(r, "Error Fapi_CreateNv", error);
+    }
+
+    r = Fapi_CreateNv(context, "/nv/Owner/myNv", "noda,0xff", 10, "", "");
+
+    if (r && r !=  TSS2_FAPI_RC_BAD_VALUE) {
+        goto_if_error(r, "Error Fapi_CreateNv", error);
+    }
 
     Fapi_Delete(context, "/");
 


### PR DESCRIPTION
* Several FAPI fixes which also should be back ported to 2.4.x
* Fix handle usage in Fapi_ChangeAuth.
* Fix setting of default flags for key creation.
* Fix path usage in Fapi_Import.
* Fix get version with Fapi_GetInfo.
*  Fix path checking for keys.
* Fix NV index and path handling in NV creation.
* Add content of the config file to FAPI Info.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>