### PR TITLE
Esys_TestParams: silence expected errors

### DIFF
--- a/src/tss2-esys/api/Esys_TestParms.c
+++ b/src/tss2-esys/api/Esys_TestParms.c
@@ -92,9 +92,11 @@ Esys_TestParms(
 
     /* Restore the timeout value to the original value */
     esysContext->timeout = timeouttmp;
-    return_if_error(r, "Esys Finish");
+    if (!tss2_is_expected_error(r)) {
+        return_if_error(r, "Esys Finish");
+    }
 
-    return TSS2_RC_SUCCESS;
+    return r;
 }
 
 /** Asynchronous function for TPM2_TestParms
@@ -266,7 +268,9 @@ Esys_TestParms_Finish(
     }
     /* The following is the "regular error" handling. */
     if (iesys_tpm_error(r)) {
-        LOG_WARNING("Received TPM Error");
+        if (!tss2_is_expected_error(r)) {
+            LOG_WARNING("Received TPM Error");
+        }
         esysContext->state = _ESYS_STATE_INIT;
         return r;
     } else if (r != TSS2_RC_SUCCESS) {


### PR DESCRIPTION
This is a backport of commit 6eb5a49a1f55325accb46b51e775857a3ea6ec57 from the master branch to branch 2.4.x to silence unneeded error messages when probing for supported algorithms, as discussed in issue tpm2-software/tpm2-pkcs11#515.