### PR TITLE
Bugfix: Update the public key object with the response from the TPM.

### DIFF
--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -392,6 +392,8 @@ Esys_CreateLoaded_Finish(
             "in Public name not equal name in response", error_cleanup);
 
     /* Update the meta data of the ESYS_TR object */
+    objectHandleNode->rsrc.rsrcType = IESYSC_KEY_RSRC;
+    objectHandleNode->rsrc.misc.rsrc_key_pub = *loutPublic;
     objectHandleNode->rsrc.name = name;
     objectHandleNode->auth = esysContext->in.CreateLoaded.inSensitive->sensitive.userAuth;
     if (outPublic != NULL)

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -511,6 +511,8 @@ Esys_TRSess_SetAttributes(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     esys_object->rsrc.misc.rsrc_session.sessionAttributes =
         (esys_object->rsrc.misc.rsrc_session.
          sessionAttributes & ~mask) | (flags & mask);
+    if (esys_object->rsrc.misc.rsrc_session.sessionAttributes & TPMA_SESSION_AUDIT)
+        esys_object->rsrc.misc.rsrc_session.bound_entity.size = 0;
     return TSS2_RC_SUCCESS;
 }
 


### PR DESCRIPTION
This fix will populate the returned public in the key object with the proper unique object.