### PR TITLE
Fix fapi persistent keys

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -270,13 +270,16 @@ TESTS_CFLAGS +=  -DTOP_SOURCEDIR"=\"$(top_srcdir)\""
 FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-check-wrong-paths.fint \
     test/integration/fapi-data-crypt.fint \
+    test/integration/fapi-data-crypt-persistent.fint \
     test/integration/fapi-data-crypt-rsa.fint \
+    test/integration/fapi-data-crypt-rsa-persistent.fint \
     test/integration/fapi-duplicate.fint \
     test/integration/fapi-ext-public-key.fint \
     test/integration/fapi-get-esys-blobs.fint \
     test/integration/fapi-get-random.fint \
     test/integration/fapi-platform-certificates.fint \
     test/integration/fapi-key-create-sign.fint \
+    test/integration/fapi-key-create-sign-persistent-key.fint \
     test/integration/fapi-key-create-sign-password-provision.fint \
     test/integration/fapi-key-create-sign-rsa.fint \
     test/integration/fapi-key-create-policy-authorize-sign.fint \
@@ -311,7 +314,8 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-quote.fint \
     test/integration/fapi-quote-rsa.fint \
     test/integration/fapi-info.fint \
-    test/integration/fapi-unseal.fint
+    test/integration/fapi-unseal.fint \
+    test/integration/fapi-unseal-persistent.fint
 
 if TESTDEVICE
 if DEVICEDESTRUCTIVE
@@ -1399,6 +1403,15 @@ test_integration_fapi_key_create_sign_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
+test_integration_fapi_key_create_sign_persistent_key_fint_CFLAGS  = $(TESTS_CFLAGS) \
+-DPERSISTENT
+test_integration_fapi_key_create_sign_persistent_key_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_sign_persistent_key_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_sign_persistent_key_fint_SOURCES = \
+    test/integration/fapi-key-create-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+
 test_integration_fapi_key_create_sign_password_provision_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_sign_password_provision_fint_LDADD   = $(TESTS_LDADD)
 test_integration_fapi_key_create_sign_password_provision_fint_LDFLAGS = $(TESTS_LDFLAGS)
@@ -1648,11 +1661,27 @@ test_integration_fapi_data_crypt_fint_SOURCES = \
     test/integration/fapi-data-crypt.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
+test_integration_fapi_data_crypt_persistent_fint_CFLAGS  = $(TESTS_CFLAGS) \
+ -DPERSISTENT
+test_integration_fapi_data_crypt_persistent_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_data_crypt_persistent_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_data_crypt_persistent_fint_SOURCES = \
+    test/integration/fapi-data-crypt.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
 test_integration_fapi_data_crypt_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_PROFILE=\"P_RSA\"
 test_integration_fapi_data_crypt_rsa_fint_LDADD   = $(TESTS_LDADD)
 test_integration_fapi_data_crypt_rsa_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_data_crypt_rsa_fint_SOURCES = \
+    test/integration/fapi-data-crypt.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_data_crypt_rsa_persistent_fint_CFLAGS  = $(TESTS_CFLAGS) \
+ -DFAPI_PROFILE=\"P_RSA\" -DPERSISTENT
+test_integration_fapi_data_crypt_rsa_persistent_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_data_crypt_rsa_persistent_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_data_crypt_rsa_persistent_fint_SOURCES = \
     test/integration/fapi-data-crypt.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
@@ -1698,6 +1727,15 @@ test_integration_fapi_unseal_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_unseal_fint_SOURCES = \
     test/integration/fapi-unseal.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_unseal_persistent_fint_CFLAGS  = $(TESTS_CFLAGS) \
+ -DPERSISTENT
+test_integration_fapi_unseal_persistent_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_unseal_persistent_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_unseal_persistent_fint_SOURCES = \
+    test/integration/fapi-unseal.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
 
 test_integration_fapi_provision_fingerprint_fint_CFLAGS  = $(TESTS_CFLAGS) \
  -DFAPI_TEST_FINGERPRINT  -DFAPI_PROFILE=\"P_RSA\"

--- a/src/tss2-fapi/api/Fapi_Decrypt.c
+++ b/src/tss2-fapi/api/Fapi_Decrypt.c
@@ -333,17 +333,21 @@ Fapi_Decrypt_Finish(
             }
 
             /* Flush the used key. */
-            r = Esys_FlushContext_Async(context->esys,
-                                        command->key_handle);
-            goto_if_error(r, "Error: FlushContext", error_cleanup);
+            if (!command->key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Async(context->esys,
+                                            command->key_handle);
+                goto_if_error(r, "Error: FlushContext", error_cleanup);
+            }
 
             fallthrough;
 
         statecase(context->state, DATA_DECRYPT_WAIT_FOR_FLUSH);
-            r = Esys_FlushContext_Finish(context->esys);
-            return_try_again(r);
+            if (!command->key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Finish(context->esys);
+                return_try_again(r);
 
-            goto_if_error(r, "Error: FlushContext", error_cleanup);
+                goto_if_error(r, "Error: FlushContext", error_cleanup);
+            }
             command->key_handle = ESYS_TR_NONE;
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Encrypt.c
+++ b/src/tss2-fapi/api/Fapi_Encrypt.c
@@ -347,16 +347,20 @@ Fapi_Encrypt_Finish(
             SAFE_FREE(tpmCipherText);
 
             /* Flush the key from the TPM. */
-            r = Esys_FlushContext_Async(context->esys,
+            if (!command->key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Async(context->esys,
                                         command->key_handle);
-            goto_if_error(r, "Error: FlushContext", error_cleanup);
+                goto_if_error(r, "Error: FlushContext", error_cleanup);
+            }
             fallthrough;
 
         statecase(context->state, DATA_ENCRYPT_WAIT_FOR_FLUSH);
-            r = Esys_FlushContext_Finish(context->esys);
-            return_try_again(r);
+            if (!command->key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Finish(context->esys);
+                return_try_again(r);
 
-            goto_if_error(r, "Error: FlushContext", error_cleanup);
+                goto_if_error(r, "Error: FlushContext", error_cleanup);
+            }
             command->key_handle = ESYS_TR_NONE;
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_GetEsysBlob.c
+++ b/src/tss2-fapi/api/Fapi_GetEsysBlob.c
@@ -323,15 +323,19 @@ Fapi_GetEsysBlob_Finish(
             goto_if_error(r, "Cleanup policy session", error_cleanup);
 
             /* Flush current object used for blob computation. */
-            r = Esys_FlushContext_Async(context->esys, key_object->handle);
-            goto_if_error(r, "Flush Context", error_cleanup);
+            if (!key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Async(context->esys, key_object->handle);
+                goto_if_error(r, "Flush Context", error_cleanup);
+            }
 
             fallthrough;
 
         statecase(context->state, GET_ESYS_BLOB_WAIT_FOR_FLUSH);
-            r = Esys_FlushContext_Finish(context->esys);
-            return_try_again(r);
-            goto_if_error(r, "Flush Context", error_cleanup);
+            if (!key_object->misc.key.persistent_handle) {
+                r = Esys_FlushContext_Finish(context->esys);
+                return_try_again(r);
+                goto_if_error(r, "Flush Context", error_cleanup);
+            }
 
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -538,11 +538,14 @@ Fapi_Import_Finish(
             fallthrough;
 
         statecase(context->state, IMPORT_KEY_WAIT_FOR_FLUSH);
-            r = ifapi_flush_object(context, command->parent_object->handle);
-            ifapi_cleanup_ifapi_object(command->parent_object);
-            return_try_again(r);
-            goto_if_error(r, "Flush key", error_cleanup);
-
+            if (!command->parent_object->misc.key.persistent_handle) {
+                r = ifapi_flush_object(context, command->parent_object->handle);
+                return_try_again(r);
+                ifapi_cleanup_ifapi_object(command->parent_object);
+                goto_if_error(r, "Flush key", error_cleanup);
+            } else {
+                ifapi_cleanup_ifapi_object(command->parent_object);
+            }
             memset(newObject, 0, sizeof(IFAPI_OBJECT));
             newObject->objectType = IFAPI_KEY_OBJ;
             newObject->misc.key.public = keyTree->public;

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -984,7 +984,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             fallthrough;
 
         statecase(context->state, PROVISION_FINISHED);
-            if (!context->srk_persistent && context->srk_handle != ESYS_TR_NONE) {
+            if (context->srk_handle != ESYS_TR_NONE) {
                 /* Prepare the flushing of a non persistent SRK. */
                 r = Esys_FlushContext_Async(context->esys, context->srk_handle);
                 goto_if_error(r, "Flush SRK", error_cleanup);
@@ -993,14 +993,14 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         /* Flush the SRK if not persistent */
         statecase(context->state, PROVISION_FLUSH_SRK);
-            if (!context->srk_persistent && context->srk_handle != ESYS_TR_NONE) {
+            if (context->srk_handle != ESYS_TR_NONE) {
                 r = Esys_FlushContext_Finish(context->esys);
                 try_again_or_error_goto(r, "Flush SRK", error_cleanup);
 
                 context->srk_handle = ESYS_TR_NONE;
 
             }
-            if (!context->ek_persistent && context->ek_handle != ESYS_TR_NONE) {
+            if (context->ek_handle != ESYS_TR_NONE) {
                  /* Prepare the flushing of a non persistent EK. */
                 r = Esys_FlushContext_Async(context->esys, context->ek_handle);
                 goto_if_error(r, "Flush EK", error_cleanup);
@@ -1009,7 +1009,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
          /* Flush the EK if not persistent */
         statecase(context->state, PROVISION_FLUSH_EK);
-            if (!context->ek_persistent && context->ek_handle != ESYS_TR_NONE) {
+            if (context->ek_handle != ESYS_TR_NONE) {
                 r = Esys_FlushContext_Finish(context->esys);
                 try_again_or_error_goto(r, "Flush EK", error_cleanup);
 

--- a/src/tss2-fapi/api/Fapi_SetAppData.c
+++ b/src/tss2-fapi/api/Fapi_SetAppData.c
@@ -217,6 +217,9 @@ Fapi_SetAppData_Finish(
             return_try_again(r);
             return_if_error_reset_state(r, "read_finish failed");
 
+            r = ifapi_initialize_object(context->esys, object);
+            goto_if_error_reset_state(r, "Initialize key object", error_cleanup);
+
             /* Depending on the object type get the correct appData pointer. */
             switch (object->objectType) {
             case IFAPI_KEY_OBJ:

--- a/src/tss2-fapi/api/Fapi_SetCertificate.c
+++ b/src/tss2-fapi/api/Fapi_SetCertificate.c
@@ -220,6 +220,9 @@ Fapi_SetCertificate_Finish(
                 key_object->misc.key.certificate = *pem_cert_dup;
             }
 
+            r = ifapi_initialize_object(context->esys, key_object);
+            goto_if_error_reset_state(r, "Initialize key object", error_cleanup);
+
             /* Perform esys serialization if necessary */
             r = ifapi_esys_serialize_object(context->esys, key_object);
             goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_SetDescription.c
+++ b/src/tss2-fapi/api/Fapi_SetDescription.c
@@ -202,6 +202,9 @@ Fapi_SetDescription_Finish(
             return_try_again(r);
             goto_if_error_reset_state(r, "read_finish failed", error_cleanup);
 
+            r = ifapi_initialize_object(context->esys, object);
+            goto_if_error_reset_state(r, "Initialize key object", error_cleanup);
+
             /* Add new description to object and save object */
             ifapi_set_description(object, command->description);
 

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -314,9 +314,15 @@ enum IFAPI_KEY_CREATE_STATE {
     KEY_CREATE_WAIT_FOR_SESSION,
     KEY_CREATE_WAIT_FOR_PARENT,
     KEY_CREATE_AUTH_SENT,
+    KEY_CREATE_WAIT_FOR_LOAD_AUTHORIZATION,
+    KEY_CREATE_WAIT_FOR_KEY,
+    KEY_CREATE_WAIT_FOR_HIERARCHY,
+    KEY_CREATE_AUTHORIZE_HIERARCHY,
+    KEY_CREATE_WAIT_FOR_EVICT_CONTROL,
     KEY_CREATE_WRITE_PREPARE,
     KEY_CREATE_WRITE,
-    KEY_CREATE_FLUSH,
+    KEY_CREATE_FLUSH1,
+    KEY_CREATE_FLUSH2,
     KEY_CREATE_CALCULATE_POLICY,
     KEY_CREATE_WAIT_FOR_AUTHORIZATION,
     KEY_CREATE_CLEANUP,
@@ -333,6 +339,7 @@ typedef struct {
     IFAPI_OBJECT object;          /**< The current object. */
     IFAPI_KEY_TEMPLATE public_templ;  /**< The template for the keys public data */
     TPM2B_PUBLIC public;         /**< The public data of the key */
+    IFAPI_OBJECT hierarchy;     /**< The current used hierarchy for CreatePrimary */
     TPM2B_SENSITIVE_CREATE inSensitive;
     TPM2B_DATA outsideInfo;
     TPML_PCR_SELECTION creationPCR;

--- a/test/integration/fapi-data-crypt.int.c
+++ b/test/integration/fapi-data-crypt.int.c
@@ -241,8 +241,13 @@ test_fapi_data_crypt(FAPI_CONTEXT *context)
     r = Fapi_Import(context, policy_name, json_policy);
     goto_if_error(r, "Error Fapi_Import", error);
 
+#ifdef PERSISTENT
+    r = Fapi_CreateKey(context, "HS/SRK/myRsaCryptKey", "decrypt,0x81000004",
+                       policy_name, NULL);
+#else
     r = Fapi_CreateKey(context, "HS/SRK/myRsaCryptKey", "decrypt",
                        policy_name, NULL);
+#endif
     goto_if_error(r, "Error Fapi_CreateKey", error);
 
     uint8_t  plainText[SIZE];

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -121,8 +121,13 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
     r = Fapi_SetAuthCB(context, auth_callback, NULL);
     goto_if_error(r, "Error SetPolicyAuthCallback", error);
 
-    r = Fapi_CreateKey(context, "HS/SRK/mySignKey", SIGN_TEMPLATE, "",
+#ifdef PERSISTENT
+    r = Fapi_CreateKey(context, "HS/SRK/mySignKey", SIGN_TEMPLATE ",0x81000004", "",
                        PASSWORD);
+#else
+    r = Fapi_CreateKey(context, "HS/SRK/mySignKey", SIGN_TEMPLATE "", "",
+                       PASSWORD);
+#endif
     goto_if_error(r, "Error Fapi_CreateKey_Async", error);
 
     goto_if_error(r, "Error Fapi_CreateKey_Finish", error);

--- a/test/integration/fapi-unseal.int.c
+++ b/test/integration/fapi-unseal.int.c
@@ -10,7 +10,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-
+#include "tss2_esys.h"
 #include "tss2_fapi.h"
 
 #include "test-fapi.h"
@@ -49,9 +49,15 @@ test_fapi_unseal(FAPI_CONTEXT *context)
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 
-    r = Fapi_CreateSeal(context, "/HS/SRK/mySealObject", "noDa",
+#ifdef PERSISTENT
+    r = Fapi_CreateSeal(context, "/HS/SRK/mySealObject", "noDa,0x81000004",
                         digest.size,
                         "", "",  &digest.buffer[0]);
+#else
+    r = Fapi_CreateSeal(context, "/HS/SRK/mySealObject", "noDa,0x81000004",
+                        digest.size,
+                        "", "",  &digest.buffer[0]);
+#endif
     goto_if_error(r, "Error Fapi_CreateSeal", error);
 
     r = Fapi_Unseal(context, "/HS/SRK/mySealObject", &result,


### PR DESCRIPTION
FAPI: Fix usage of persistent handles.
    
* Persistent handles could not be defined for Fapi_CreateKey. The persistent handle
  now can be passed with the key flags and EvictControl is executed for the persistent key.
* The cleanup for keys had to be adapted.
* Tests for derived persistent keys were added,

    
    Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>