### PR TITLE
mu: change warnings to debug in case of insufficient buffer

### DIFF
--- a/src/tss2-mu/base-types.c
+++ b/src/tss2-mu/base-types.c
@@ -44,7 +44,7 @@ Tss2_MU_##type##_Marshal ( \
     } else if (buffer_size < local_offset || \
                buffer_size - local_offset < sizeof (src)) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -106,7 +106,7 @@ Tss2_MU_##type##_Unmarshal ( \
     if (buffer_size < local_offset || \
         sizeof (*dest) > buffer_size - local_offset) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", buffer_size, local_offset, sizeof (*dest)); \
         return TSS2_MU_RC_INSUFFICIENT_BUFFER; \

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -44,7 +44,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
         return TSS2_RC_SUCCESS; \
     } else if (buffer_size < local_offset || \
                buffer_size - local_offset < (sizeof(src->size) + src->size)) { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -105,7 +105,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } else if (buffer_size < local_offset || \
                sizeof(size) > buffer_size - local_offset) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -128,7 +128,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
          size); \
 \
     if (size > buffer_size - local_offset) { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -137,7 +137,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         return TSS2_MU_RC_INSUFFICIENT_BUFFER; \
     } \
     if (sizeof(dest->buf_name) < size) { \
-        LOG_ERROR("The dest field size of %zu is too small to unmarshal %d bytes", \
+        LOG_DEBUG("The dest field size of %zu is too small to unmarshal %d bytes", \
                   sizeof(dest->buf_name), size); \
         return TSS2_MU_RC_INSUFFICIENT_BUFFER; \
     } \
@@ -178,7 +178,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
         return TSS2_MU_RC_BAD_REFERENCE; \
     } else if (buffer_size < local_offset || \
                buffer_size - local_offset < sizeof(src->size)) { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -238,7 +238,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } else if (buffer_size < local_offset || \
                sizeof(size) > buffer_size - local_offset) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -264,7 +264,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
          size); \
 \
     if (size > buffer_size - local_offset) { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -273,7 +273,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
         return TSS2_MU_RC_INSUFFICIENT_BUFFER; \
     } \
     if (sizeof(dest->member) < size) { \
-        LOG_ERROR("The dest field size of %zu is too small to unmarshal %d bytes", \
+        LOG_DEBUG("The dest field size of %zu is too small to unmarshal %d bytes", \
                   sizeof(dest->member), size); \
         return TSS2_MU_RC_INSUFFICIENT_BUFFER; \
     } \

--- a/src/tss2-mu/tpma-types.c
+++ b/src/tss2-mu/tpma-types.c
@@ -40,7 +40,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type src, uint8_t buffer[], \
     } else if (buffer_size < local_offset || \
                buffer_size - local_offset < sizeof (src)) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -103,7 +103,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } else if (buffer_size < local_offset || \
                sizeof (*dest) > buffer_size - local_offset) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \

--- a/src/tss2-mu/tpml-types.c
+++ b/src/tss2-mu/tpml-types.c
@@ -45,7 +45,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
         return TSS2_MU_RC_BAD_REFERENCE; \
     } else if (buffer_size < local_offset || \
                buffer_size - local_offset < sizeof(count)) { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
@@ -103,7 +103,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     } else if (buffer_size < local_offset || \
                sizeof(count) > buffer_size - local_offset) \
     { \
-        LOG_WARNING(\
+        LOG_DEBUG( \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -45,7 +45,7 @@ static TSS2_RC marshal_tab(BYTE const *src, uint8_t buffer[],
              *offset);
         return TSS2_RC_SUCCESS;
     } else if (buffer_size < local_offset || buffer_size - local_offset < size) {
-        LOG_ERROR("buffer_size: %zu with offset: %zu are insufficient for "
+        LOG_DEBUG("buffer_size: %zu with offset: %zu are insufficient for "
              "object of size %zu", buffer_size, local_offset, size);
         return TSS2_MU_RC_INSUFFICIENT_BUFFER;
     }
@@ -148,7 +148,7 @@ static TSS2_RC unmarshal_tab(uint8_t const buffer[], size_t buffer_size,
              *offset);
         return TSS2_RC_SUCCESS;
     } else if (buffer_size < local_offset || size > buffer_size - local_offset) {
-        LOG_WARNING("buffer_size: %zu with offset: %zu are insufficient for "
+        LOG_DEBUG("buffer_size: %zu with offset: %zu are insufficient for "
              "object of size %zu", buffer_size, local_offset, size);
         return TSS2_MU_RC_INSUFFICIENT_BUFFER;
     }


### PR DESCRIPTION
This is used to offset discovery and no warning needs
to be printed. Changed both marshal and unmarshal paths.

Fixes #1739 
