### PR TITLE
Fapi verify state of provisioning

### DIFF
--- a/src/tss2-fapi/api/Fapi_List.c
+++ b/src/tss2-fapi/api/Fapi_List.c
@@ -206,7 +206,10 @@ cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
     SAFE_FREE(command->searchPath);
     if (numPaths == 0 && (r == TSS2_RC_SUCCESS)) {
-        LOG_ERROR("Path not found: %s", command->searchPath);
+        if (command->searchPath)
+            LOG_ERROR("Path not found: %s", command->searchPath);
+        else
+            LOG_ERROR("No files found in /");
         r = TSS2_FAPI_RC_PATH_NOT_FOUND;
     }
     if (numPaths > 0) {

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -22,6 +22,7 @@
 #include "fapi_crypto.h"
 #include "fapi_policy.h"
 #include "ifapi_get_intl_cert.h"
+#include "ifapi_helpers.h"
 
 #define LOGMODULE fapi
 #include "util/log.h"
@@ -156,6 +157,8 @@ Fapi_Provision_Async(
     char const *authValueSh,
     char const *authValueLockout)
 {
+    char *profile_dir = NULL;
+
     LOG_TRACE("called for context:%p", context);
     LOG_TRACE("authValueEh: %s", authValueEh);
     LOG_TRACE("authValueSh: %s", authValueSh);
@@ -172,6 +175,18 @@ Fapi_Provision_Async(
     r = ifapi_session_init(context);
     goto_if_error(r, "Initialize Provision", end);
 
+    /* First it will be checked whether the profile is already provisioned. */
+    r = ifapi_asprintf(&profile_dir, "%s/%s", context->keystore.systemdir,
+                       context->keystore.defaultprofile);
+    goto_if_error(r, "Out of memory.", end);
+
+    if (ifapi_io_path_exists(profile_dir)) {
+        goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
+                   "Profile %s was already provisioned.", end,
+                   context->keystore.defaultprofile);
+    }
+    SAFE_FREE(profile_dir);
+
     /* Initialize context and duplicate parameters */
     strdup_check(command->authValueLockout, authValueLockout, r, end);
     strdup_check(command->authValueEh, authValueEh, r, end);
@@ -186,6 +201,7 @@ Fapi_Provision_Async(
     LOG_TRACE("finished");
     return TSS2_RC_SUCCESS;
 end:
+    SAFE_FREE(profile_dir);
     SAFE_FREE(command->authValueLockout);
     SAFE_FREE(command->authValueEh);
     SAFE_FREE(command->authValueSh);
@@ -729,12 +745,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
             /* Check whether object already exists in key store.*/
             r = ifapi_keystore_object_does_not_exist(&context->keystore, "HS/SRK", pkeyObject);
-            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup, "HS/SRK");
+            goto_if_error_reset_state(r, "Could not write: %s", error_cleanup, "HS/SRK");
 
             /* Start writing the SRK to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io, "HS/SRK",
                     pkeyObject);
-            goto_if_error_reset_state(r, "Could not open: %sh", error_cleanup, "HS/SRK");
+            goto_if_error_reset_state(r, "Could not open: %s", error_cleanup, "HS/SRK");
             context->state = PROVISION_SRK_WRITE;
             fallthrough;
 

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -502,6 +502,7 @@ typedef struct {
     TPML_PCR_SELECTION creationPCR;
     ESYS_TR handle;
     TPMI_DH_PERSISTENT persistent_handle;
+    TPMS_CAPABILITY_DATA *capabilityData;
 } IFAPI_CreatePrimary;
 
 /** The data structure holding internal state of key verify signature.
@@ -711,7 +712,9 @@ enum _FAPI_STATE_PRIMARY {
     PRIMARY_READ_HIERARCHY_FINISH,
     PRIMARY_AUTHORIZE_HIERARCHY,
     PRIMARY_HAUTH_SENT,
-    PRIMARY_CREATED
+    PRIMARY_CREATED,
+    PRIMARY_VERIFY_PERSISTENT,
+    PRIMARY_GET_CAP
 };
 
 /** The states for the FAPI's primary key regeneration */

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -771,6 +771,8 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
     TPMT_TK_CREATION *creationTicket = NULL;
     IFAPI_OBJECT *pkey_object = &context->createPrimary.pkey_object;
     IFAPI_KEY *pkey = &context->createPrimary.pkey_object.misc.key;
+    TPMS_CAPABILITY_DATA **capabilityData = &context->createPrimary.capabilityData;
+    TPMI_YES_NO moreData;
     ESYS_TR auth_session;
 
     LOG_TRACE("call");
@@ -794,10 +796,11 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
             } else {
                 context->srk_persistent = true;
             }
-            /* Persistent handle will be used. */
-            *handle = pkey_object->handle;
-            break;
-        } else {
+            /* It has to be checked whether the persistent handle exists. */
+            context->primary_state = PRIMARY_VERIFY_PERSISTENT;
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        }
+        else {
             if (pkey->creationTicket.hierarchy == TPM2_RH_EK) {
                 context->ek_persistent = false;
             } else {
@@ -868,6 +871,35 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
         context->primary_state = PRIMARY_INIT;
         break;
 
+    statecase(context->primary_state, PRIMARY_VERIFY_PERSISTENT);
+        /* Check the TPM capabilities for the persistent handle. */
+        r = Esys_GetCapability_Async(context->esys,
+                                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                                     TPM2_CAP_HANDLES,
+                                     pkey_object->misc.key.persistent_handle, 1);
+        goto_if_error(r, "Esys_GetCapability_Async", error_cleanup);
+        fallthrough;
+
+    statecase(context->primary_state, PRIMARY_GET_CAP);
+        r = Esys_GetCapability_Finish(context->esys, &moreData, capabilityData);
+        return_try_again(r);
+        goto_if_error_reset_state(r, "GetCapablity_Finish", error_cleanup);
+
+        /* Check whether the persistent handle exists. */
+        if ((*capabilityData)->data.handles.count != 0 &&
+            (*capabilityData)->data.handles.handle[0] ==
+            pkey_object->misc.key.persistent_handle) {
+            /* Persistent handle found. */
+            SAFE_FREE(*capabilityData);
+            *handle = pkey_object->handle;
+            break;
+        }
+        goto_error(r, TSS2_FAPI_RC_KEY_NOT_FOUND ,
+                   "The persistent handle 0x%x does not exist. "
+                   "The TPM state and the keystore state do not match."
+,                   error_cleanup, pkey_object->misc.key.persistent_handle);
+        fallthrough;
+
     statecasedefault(context->primary_state);
     }
     SAFE_FREE(outPublic);
@@ -878,6 +910,7 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
     return TSS2_RC_SUCCESS;
 
 error_cleanup:
+    SAFE_FREE(*capabilityData);
     SAFE_FREE(outPublic);
     SAFE_FREE(creationData);
     SAFE_FREE(creationHash);

--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -314,18 +314,26 @@ ifapi_io_remove_file(const char *file)
 /** Remove a directory recursively; i.e. including its subdirectories.
  *
  * @param[in] dirname The directory to be removed
+ * @param[in] keystore_path The path of the current keystore directory, which should
+ *            not be removed.
+ * @param[in] sub_dir The path of a sub directory of the keystore directory,
+ *            which should not be removed (can be NULL, if not needed).
+ *            It must start with a slash.
  * @retval TSS2_RC_SUCCESS if the directories were successfully removed
  * @retval TSS2_FAPI_RC_IO_ERROR if an I/O error occurred
  * @retval TSS2_FAPI_RC_MEMORY: if memory could not be allocated to hold the read data.
  */
 TSS2_RC
 ifapi_io_remove_directories(
-    const char *dirname)
+    const char *dirname,
+    const char *keystore_path,
+    const char *sub_dir)
 {
     DIR *dir;
     struct dirent *entry;
     TSS2_RC r;
     char *path;
+    size_t len_kstore_path, len_dir_path, diff_len, pos;
 
     LOG_TRACE("Removing directory: %s", dirname);
 
@@ -347,7 +355,7 @@ ifapi_io_remove_directories(
             r = ifapi_asprintf(&path, "%s/%s", dirname, entry->d_name);
             goto_if_error(r, "Out of memory", error_cleanup);
 
-            r = ifapi_io_remove_directories(path);
+            r = ifapi_io_remove_directories(path, keystore_path, sub_dir);
             free(path);
             goto_if_error(r, "remove directories.", error_cleanup);
 
@@ -369,10 +377,22 @@ ifapi_io_remove_directories(
         free(path);
     }
     closedir(dir);
-    LOG_TRACE("Removing target directory %s", dirname);
 
-    if (rmdir(dirname) != 0)
-        return_error2(TSS2_FAPI_RC_IO_ERROR, "Removing directory: %s", dirname);
+    /* Check whether current directory is a keystore directory. These directories should
+       not be deleted. */
+    len_kstore_path = strlen(keystore_path);
+    len_dir_path = strlen(dirname);
+    diff_len = len_dir_path - len_kstore_path;
+    if (diff_len > 1) {
+        pos = strlen(keystore_path);
+        if (keystore_path[pos - 1] == '/')
+            pos += 1;
+        /* Check whether current sub_dir of keystore path should not be deleted. */
+        if (!sub_dir || strcmp(&dirname[pos], sub_dir) != 0) {
+            if (rmdir(dirname) != 0)
+                return_error2(TSS2_FAPI_RC_IO_ERROR, "Removing directory: %s", dirname);
+        }
+    }
 
     LOG_TRACE("SUCCESS");
     return TSS2_RC_SUCCESS;
@@ -408,7 +428,7 @@ ifapi_io_dirfiles(
     check_not_null(files);
     check_not_null(numfiles);
 
-    LOG_TRACE("Removing directory: %s", dirname);
+    LOG_TRACE("List directory: %s", dirname);
 
     paths = calloc(10, sizeof(*paths));
     check_oom(paths);

--- a/src/tss2-fapi/ifapi_io.h
+++ b/src/tss2-fapi/ifapi_io.h
@@ -71,7 +71,9 @@ ifapi_io_remove_file(
 
 TSS2_RC
 ifapi_io_remove_directories(
-    const char *dirname);
+    const char *dirname,
+    const char *keystore_path,
+    const char *sub_dir);
 
 TSS2_RC
 ifapi_io_dirfiles(

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -284,6 +284,8 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
     size_t pos = 0;
     *file_name = NULL;
 
+    check_not_null(path);
+
     /* First it will be checked whether the only valid characters occur in the path. */
     r = check_valid_path(path);
     return_if_error(r, "Invalid path.");
@@ -985,28 +987,40 @@ ifapi_keystore_remove_directories(IFAPI_KEYSTORE *keystore, const char *dir_name
     char *absolute_dir_path = NULL;
     char *exp_dir_name = NULL;
     struct stat fbuffer;
+    size_t pos;
 
     r = expand_directory(keystore, dir_name, &exp_dir_name);
     return_if_error(r, "Expand path string.");
 
     /* Cleanup user part of the store */
-    r = ifapi_asprintf(&absolute_dir_path, "%s%s%s", keystore->userdir, IFAPI_FILE_DELIM,
-                       exp_dir_name ? exp_dir_name : "");
+    if (keystore->userdir[strlen(keystore->userdir) - 1] == '/')
+        pos = 1;
+    else
+        pos = 0;
+    r = ifapi_asprintf(&absolute_dir_path, "%s%s", keystore->userdir,
+                       exp_dir_name ? &exp_dir_name[pos] : "");
     goto_if_error(r, "Out of memory.", cleanup);
 
     if (stat(absolute_dir_path, &fbuffer) == 0) {
-        r = ifapi_io_remove_directories(absolute_dir_path);
+        r = ifapi_io_remove_directories(absolute_dir_path, keystore->userdir, NULL);
         goto_if_error2(r, "Could not remove: %s", cleanup, absolute_dir_path);
     }
     SAFE_FREE(absolute_dir_path);
 
     /* Cleanup system part of the store */
-    r = ifapi_asprintf(&absolute_dir_path, "%s%s%s", keystore->systemdir,
-                       IFAPI_FILE_DELIM, exp_dir_name ? exp_dir_name : "");
+    if (keystore->systemdir[strlen(keystore->systemdir) - 1] == '/')
+        /* For a final slash in system dir the startin slash of the
+           expanded path will be ignored. */
+        pos = 1;
+    else
+        pos = 0;
+    r = ifapi_asprintf(&absolute_dir_path, "%s%s", keystore->systemdir,
+                       exp_dir_name ? &exp_dir_name[pos] : "");
     goto_if_error(r, "Out of memory.", cleanup);
 
     if (stat(absolute_dir_path, &fbuffer) == 0) {
-        r = ifapi_io_remove_directories(absolute_dir_path);
+        r = ifapi_io_remove_directories(absolute_dir_path, keystore->systemdir,
+                                        "/" IFAPI_POLICY_DIR);
         goto_if_error2(r, "Could not remove: %s", cleanup, absolute_dir_path);
     }
 

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -99,9 +99,14 @@ ifapi_policy_store_initialize(
     char *policy_dir = NULL;
 
     memset(pstore, 0, sizeof(IFAPI_POLICY_STORE));
+    check_not_null(config_policydir);
+
     strdup_check(pstore->policydir, config_policydir, r, error);
 
-    r = ifapi_asprintf(&policy_dir, "%s%s%s", config_policydir, IFAPI_FILE_DELIM,
+    r = ifapi_asprintf(&policy_dir, "%s%s%s", config_policydir,
+                       (strcmp(&config_policydir[strlen(config_policydir) - 1],
+                               IFAPI_FILE_DELIM) == 0)
+                       ? IFAPI_FILE_DELIM : IFAPI_FILE_DELIM,
                        IFAPI_POLICY_PATH);
     goto_if_error(r, "Out of memory.", error);
 


### PR DESCRIPTION
* Some checks were added to get more understandable messages during provisioning.
* Directories which are created during installation or by Fapi_Initialize will
  not be deleted by Fapi_Delete.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>