### PR TITLE
Fix fapi load primary and hiearchy selection for Fapi_Delete

### DIFF
--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -490,7 +490,7 @@ Fapi_Delete_Finish(
         statecase(context->state, ENTITY_DELETE_WAIT_FOR_SESSION);
             /* If a TPM object (e.g. a persistent key) was referenced, then this
                is the entry point. */
-        r = ifapi_get_sessions_finish(context, &context->profiles.default_profile,
+            r = ifapi_get_sessions_finish(context, &context->profiles.default_profile,
                                       context->profiles.default_profile.nameAlg);
             return_try_again(r);
             goto_if_error(r, "Create FAPI session.", error_cleanup);
@@ -579,8 +579,13 @@ Fapi_Delete_Finish(
 
         statecase(context->state, ENTITY_DELETE_KEY);
             if (object->misc.key.persistent_handle) {
+                char *hierarchy_path;
+                if (object->misc.key.creationTicket.hierarchy == TPM2_RH_EK)
+                    hierarchy_path = "/HE";
+                else
+                    hierarchy_path = "/HS";
                 r = ifapi_keystore_load_async(&context->keystore, &context->io, "/HS");
-                return_if_error2(r, "Could not open hierarchy /HS");
+                return_if_error2(r, "Could not open hierarchy %s", hierarchy_path);
             }
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -640,12 +640,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
             /* Check whether object already exists in key store.*/
             r = ifapi_keystore_object_does_not_exist(&context->keystore, "HE/EK", pkeyObject);
-            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup, "HE/EK");
+            goto_if_error_reset_state(r, "Could not write: %s", error_cleanup, "HE/EK");
 
             /* Start writing the EK to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io, "HE/EK",
                     pkeyObject);
-            goto_if_error_reset_state(r, "Could not open: %sh", error_cleanup, "HE/EK");
+            goto_if_error_reset_state(r, "Could not open: %s", error_cleanup, "HE/EK");
 
             fallthrough;
 
@@ -849,12 +849,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             /* Check whether object already exists in key store.*/
             r = ifapi_keystore_object_does_not_exist(&context->keystore, "/LOCKOUT",
                                                      &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup, "/LOCKOUT");
+            goto_if_error_reset_state(r, "Could not write: %s", error_cleanup, "/LOCKOUT");
 
             /* Start writing the lockout hierarchy object to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io, "/LOCKOUT",
                     &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not open: %sh",
+            goto_if_error_reset_state(r, "Could not open: %s",
                     error_cleanup, "/LOCKOUT");
 
             context->state = PROVISION_WRITE_LOCKOUT;
@@ -916,12 +916,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             /* Check whether object already exists in key store.*/
             r = ifapi_keystore_object_does_not_exist(&context->keystore, "/HE",
                                                      &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup, "/HE");
+            goto_if_error_reset_state(r, "Could not write: %s", error_cleanup, "/HE");
 
             /* Start writing the endorsement hierarchy object to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io, "/HE",
                     &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not open: %sh", error_cleanup, "/HE");
+            goto_if_error_reset_state(r, "Could not open: %s", error_cleanup, "/HE");
 
             context->state = PROVISION_WRITE_EH;
             fallthrough;
@@ -983,12 +983,12 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             /* Check whether object already exists in key store.*/
             r = ifapi_keystore_object_does_not_exist(&context->keystore, "/HS",
                                                      &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not write: %sh", error_cleanup, "/HS");
+            goto_if_error_reset_state(r, "Could not write: %s", error_cleanup, "/HS");
 
             /* Start writing the owner hierarchy object to the key store */
             r = ifapi_keystore_store_async(&context->keystore, &context->io, "/HS",
                     &command->hierarchy);
-            goto_if_error_reset_state(r, "Could not open: %sh", error_cleanup, "/HS");
+            goto_if_error_reset_state(r, "Could not open: %s", error_cleanup, "/HS");
             context->state = PROVISION_WRITE_SH;
             fallthrough;
 

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -1211,6 +1211,8 @@ ifapi_get_sessions_finish(
         LOG_TRACE("**STATE** SESSION_WAIT_FOR_PRIMARY");
         r = ifapi_load_primary_finish(context, &context->srk_handle);
         return_try_again(r);
+
+        ifapi_cleanup_ifapi_object(&context->createPrimary.pkey_object);
         return_if_error(r, "Load primary.");
         fallthrough;
 
@@ -1678,9 +1680,11 @@ ifapi_load_key_finish(FAPI_CONTEXT *context, bool flush_parent)
 
         if (key->private.size == 0) {
             /* Create a deep copy of the primary key */
-            ifapi_cleanup_ifapi_key(key);
-            r = ifapi_copy_ifapi_key(key, &context->createPrimary.pkey_object.misc.key);
+            r = ifapi_copy_ifapi_key_object(&context->createPrimary.pkey_object,
+                                            context->loadKey.key_object);
             goto_if_error(r, "Could not copy primary key", error_cleanup);
+
+            ifapi_cleanup_ifapi_key(key);
             context->primary_state = PRIMARY_READ_HIERARCHY;
             context->loadKey.state = LOAD_KEY_WAIT_FOR_PRIMARY;
             return TSS2_FAPI_RC_TRY_AGAIN;


### PR DESCRIPTION
* A wrong execution of making a copy of the primary object during key loading was fixed.
* The selection of the hierarchy was added for EvictControl in Fapi_Delete.
* Some wrong format directives in Fapi_Provision were fixed.
