### PR TITLE
Building now continues correctly if the "$enable_doxygen_doc" flag is not set. Fixed #1329

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,10 +453,11 @@ DX_XML_FEATURE(OFF)
 DX_PDF_FEATURE(OFF)
 DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN($PACKAGE_NAME, [Doxyfile], [doxygen-doc])
-AM_CONDITIONAL(DOXYMAN, [test $DX_FLAG_man -eq 1])
 
-AS_IF([test "x$enable_doxygen_doc" != xno],
-      [ERROR_IF_NO_PROG([doxygen])])
+AM_CONDITIONAL(DOXYMAN, [test $DX_FLAG_doc -eq 1])
+AS_IF([test $DX_FLAG_doc -ne 1],
+	[AS_IF([test "x$enable_doxygen_doc" = xyes],
+                     [ERROR_IF_NO_PROG([doxygen])])])
 
 AX_CODE_COVERAGE
 m4_ifdef([_AX_CODE_COVERAGE_RULES],


### PR DESCRIPTION
Previously, when running ./configure in the source directory of tpm2-tss in a system without doxygen installed a building error occurred stopping the installation completely. Doxygen is not required for tpm2-tss to work so it should continue building by default.
The changes were made to mantain the uses of --disable-doxygen-doc and --enable-doxygen-doc parameters coherent to the documentation (By default if the user does not use any parameters and doxygen is installed on the system, documentation will be generated, if not installed, the building continues without generated documentation).