### PR TITLE
FAPI: Fix usage of hierarchy in Fapi_Delete.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -579,13 +579,8 @@ Fapi_Delete_Finish(
 
         statecase(context->state, ENTITY_DELETE_KEY);
             if (object->misc.key.persistent_handle) {
-                char *hierarchy_path;
-                if (object->misc.key.creationTicket.hierarchy == TPM2_RH_EK)
-                    hierarchy_path = "/HE";
-                else
-                    hierarchy_path = "/HS";
                 r = ifapi_keystore_load_async(&context->keystore, &context->io, "/HS");
-                return_if_error2(r, "Could not open hierarchy %s", hierarchy_path);
+                return_if_error2(r, "Could not open hierarchy /HS");
             }
             fallthrough;
 


### PR DESCRIPTION
The check of the hierarchy of the creation ticket before evict control is not needed.
It will produce only a wrong error message.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>