### PR TITLE
FAPI: Add description for primary keys to profile.

### DIFF
--- a/dist/fapi-profiles/P_ECCP256SHA256.json
+++ b/dist/fapi-profiles/P_ECCP256SHA256.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_ECC",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {
         "scheme":"TPM2_ALG_ECDSA",
         "details":{

--- a/dist/fapi-profiles/P_RSA2048SHA256.json
+++ b/dist/fapi-profiles/P_RSA2048SHA256.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_RSA",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {
         "scheme":"TPM2_ALG_RSAPSS",
         "details":{

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -675,7 +675,21 @@ ifapi_init_primary_finish(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype)
     pkey->policyInstance = NULL;
     pkey->creationData = *creationData;
     pkey->creationTicket = *creationTicket;
-    pkey->description = NULL;
+
+    /* Add description of primary stored in profile, if available. */
+    if (ktype == TSS2_EK) {
+        if (context->profiles.default_profile.ek_description) {
+            strdup_check(pkey->description,
+                         context->profiles.default_profile.ek_description, r,
+                         error_cleanup);
+        }
+    } else {
+        if (context->profiles.default_profile.srk_description) {
+            strdup_check(pkey->description,
+                         context->profiles.default_profile.srk_description, r,
+                         error_cleanup);
+        }
+    }
     pkey->certificate = NULL;
 
     /* Cleanup unused information */

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -293,6 +293,9 @@ ifapi_profiles_finalize(
         SAFE_FREE(profile->srk_template);
         SAFE_FREE(profile->ek_template);
 
+        SAFE_FREE(profile->srk_description);
+        SAFE_FREE(profile->ek_description);
+
         ifapi_cleanup_policy(profile->eh_policy);
         SAFE_FREE(profile->eh_policy);
 
@@ -349,12 +352,26 @@ ifapi_profile_json_deserialize(
     out->srk_template = strdup(json_object_get_string(jso2));
     return_if_null(out->srk_template, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
+    if (!ifapi_get_sub_object(jso, "srk_description", &jso2)) {
+        out->srk_description = NULL;
+    } else {
+        out->srk_description = strdup(json_object_get_string(jso2));
+        return_if_null(out->srk_description, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+    }
+
     if (!ifapi_get_sub_object(jso, "ek_template", &jso2)) {
         LOG_ERROR("Bad value");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     out->ek_template = strdup(json_object_get_string(jso2));
     return_if_null(out->ek_template, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+
+    if (!ifapi_get_sub_object(jso, "ek_description", &jso2)) {
+        out->ek_description = NULL;
+    } else {
+        out->ek_description = strdup(json_object_get_string(jso2));
+        return_if_null(out->ek_description, "Out of memory.", TSS2_FAPI_RC_MEMORY);
+    }
 
     if (!ifapi_get_sub_object(jso, "ecc_signing_scheme", &jso2)) {
         memset(&out->ecc_signing_scheme, 0, sizeof(TPMT_SIG_SCHEME));

--- a/src/tss2-fapi/ifapi_profiles.h
+++ b/src/tss2-fapi/ifapi_profiles.h
@@ -14,15 +14,17 @@
  */
 typedef struct IFAPI_PROFILE {
     TPMI_ALG_PUBLIC                                type;    /**< The algorithm used for key creation */
-    char                                  *srk_template;    /**< name of SRK template */
-    char                                   *ek_template;    /**< name of EK template */
-    TPMT_SIG_SCHEME                  ecc_signing_scheme;    /**< < Signing scheme for the ECC key. */
-    TPMT_SIG_SCHEME                  rsa_signing_scheme;    /**< < Signing scheme for the RSA key. */
-    TPMT_RSA_DECRYPT                 rsa_decrypt_scheme;    /**< < Decrypt scheme for the RSA key. */
-    TPMI_ALG_SYM_MODE                          sym_mode;    /**< < Mode for symmectric encryption. */
-    TPMT_SYM_DEF_OBJECT                  sym_parameters;    /**< < Parameters for symmectric encryption. */
-    UINT16                               sym_block_size;    /**< < Block size for symmectric encryption. */
-    TPML_PCR_SELECTION                    pcr_selection;    /**< < Parameters for symmectric encryption. */
+    char                                  *srk_template;    /**< SRK template */
+    char                                   *ek_template;    /**< EK template */
+    char                               *srk_description;    /**< SRK description */
+    char                                *ek_description;    /**< EK description */
+    TPMT_SIG_SCHEME                  ecc_signing_scheme;    /**< Signing scheme for the ECC key. */
+    TPMT_SIG_SCHEME                  rsa_signing_scheme;    /**< Signing scheme for the RSA key. */
+    TPMT_RSA_DECRYPT                 rsa_decrypt_scheme;    /**< Decrypt scheme for the RSA key. */
+    TPMI_ALG_SYM_MODE                          sym_mode;    /**< Mode for symmectric encryption. */
+    TPMT_SYM_DEF_OBJECT                  sym_parameters;    /**< Parameters for symmectric encryption. */
+    UINT16                               sym_block_size;    /**< Block size for symmectric encryption. */
+    TPML_PCR_SELECTION                    pcr_selection;    /**< Parameters for symmectric encryption. */
     TPMI_ALG_HASH                               nameAlg;
     TPMI_RSA_KEY_BITS                           keyBits;
     UINT32                                     exponent;

--- a/test/data/fapi/P_ECC.json
+++ b/test/data/fapi/P_ECC.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_ECC",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {
         "scheme":"TPM2_ALG_ECDSA",
         "details":{

--- a/test/data/fapi/P_RSA.json
+++ b/test/data/fapi/P_RSA.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_RSA",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {
         "scheme":"TPM2_ALG_RSAPSS",
         "details":{

--- a/test/data/fapi/P_RSA256.json
+++ b/test/data/fapi/P_RSA256.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_RSA",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {
         "scheme":"TPM2_ALG_ECDSA",
         "details":{

--- a/test/data/fapi/P_RSA_EK_persistent.json
+++ b/test/data/fapi/P_RSA_EK_persistent.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_RSA",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt",
+     "srk_description": "Storage root key SRK",
     "srk_persistent": 0,
     "ek_template": "system,restricted,decrypt,0x81000000",
+    "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {
         "scheme":"TPM2_ALG_ECDSA",
         "details":{

--- a/test/data/fapi/P_RSA_sh_policy.json
+++ b/test/data/fapi/P_RSA_sh_policy.json
@@ -2,8 +2,10 @@
     "type": "TPM2_ALG_RSA",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
     "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
+    "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {
         "scheme":"TPM2_ALG_RSAPSS",
         "details":{

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -110,6 +110,8 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
     size_t         publicsize;
     size_t         privatesize;
     json_object   *jso = NULL;
+    char           *description = NULL;
+
 
     if (strcmp("P_ECC", fapi_profile) != 0)
         sigscheme = "RSA_PSS";
@@ -193,6 +195,22 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
     r = Fapi_ChangeAuth(context, "/HS", NULL);
     goto_if_error(r, "Error Fapi_ChangeAuth", error);
 
+    r = Fapi_GetDescription(context, "/HS/SRK", &description);
+    goto_if_error(r, "Error GetDescription", error);
+
+    if (description) {
+        LOG_INFO("SRK description: %s", description);
+        SAFE_FREE(description);
+    }
+
+    r = Fapi_GetDescription(context, "/HE/EK", &description);
+    goto_if_error(r, "Error GetDescription", error);
+
+    if (description) {
+        LOG_INFO("EK description: %s", description);
+        SAFE_FREE(description);
+    }
+
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);
 
@@ -213,6 +231,7 @@ error:
     SAFE_FREE(privateblob);
     SAFE_FREE(publicKey);
     SAFE_FREE(signature);
+    SAFE_FREE(description);
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
* Now it's possible to define a description for the EK and the SRK int the profile.
  The description will be added to the key object.
* Getting the description of an EK and SRK was added to an integration test.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>