### PR TITLE
build: force install udev rule files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -642,7 +642,7 @@ if HOSTOS_LINUX
 endif
 
 install-data-hook: install-dirs
-	-mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+	-mv -f $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
 
 uninstall-local:
 	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules


### PR DESCRIPTION
Force overwrite udevrules in case they already exist.

Fixes: #1763

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>