### PR TITLE
Add address sanitizer to CI

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -74,7 +74,7 @@ if [ "$SCANBUILD" == "yes" ]; then
 elif [ "$CC" == "clang" ]; then
   ../configure --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 else
-  ../configure --with-sanitizer=undefined --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+  ../configure --with-sanitizer=undefined,address --enable-tcti-partial-reads=$WITH_TCTI_PARTIAL --enable-tcti-device-async=$WITH_TCTI_ASYNC --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 fi
 
 if [ "$SCANBUILD" == "yes" ]; then

--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -21,7 +21,7 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
   echo "Running non-coverity build"
   # Do normal CI script
   ci_env=$(bash <(curl -s https://codecov.io/env))
-  docker run $ci_env --env-file .ci/docker.env \
+  docker run --cap-add SYS_PTRACE $ci_env --env-file .ci/docker.env \
     -v "$(pwd):/workspace/tpm2-tss" "tpm2software/tpm2-tss:$DOCKER_TAG" \
     /bin/bash -c '/workspace/tpm2-tss/.ci/docker.run'
 

--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,11 @@ AS_CASE(["x$with_sanitizer"],
             SANITIZER_CFLAGS="-fsanitize=undefined"
             SANITIZER_LDFLAGS="-lubsan"
         ],
+        ["xundefined,address"],
+        [
+            SANITIZER_CFLAGS="-fsanitize=undefined,address -fno-omit-frame-pointer"
+            SANITIZER_LDFLAGS="-lasan -lubsan"
+        ],
         [AC_MSG_ERROR([Bad value for --with-sanitizer])])
 AC_SUBST([SANITIZER_CFLAGS])
 AC_SUBST([SANITIZER_LDFLAGS])

--- a/test/integration/esys-ecc-parameters.int.c
+++ b/test/integration/esys-ecc-parameters.int.c
@@ -52,9 +52,13 @@ test_esys_ecc_parameters(ESYS_CONTEXT * esys_context)
     }
     goto_if_error(r, "Error: ECC_Parameters", error);
 
+    SAFE_FREE(parameters);
+
     return EXIT_SUCCESS;
 
  error:
+    SAFE_FREE(parameters);
+
     return failure_return;
 }
 

--- a/test/integration/esys-get-capability.int.c
+++ b/test/integration/esys-get-capability.int.c
@@ -45,9 +45,13 @@ test_esys_get_capability(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error esys get capability", error);
 
+    SAFE_FREE(capabilityData);
+
     return EXIT_SUCCESS;
 
  error:
+    SAFE_FREE(capabilityData);
+
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
This commit adds the address sanitizer to the build CI. 

- In order to run the address sanitizer, the capability SYS_PTRACE needs to be passed to Docker.
- The address sanitizer found leaks in 2 esys integration tests that are fixed with this PR.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>