### PR TITLE
Fapi Fix missing retry check and update man page (Fixes #1782)

### DIFF
--- a/doc/fapi-config.md
+++ b/doc/fapi-config.md
@@ -10,8 +10,8 @@ The FAPI parameters which can be adjusted via the configuration file are:
 * tcti: The TCTI interface which will be used.
 * system_pcrs: The PCR registers which are used by the system.
 * log_dir: The directory for the event log.
-* ek_certless: A switch to disable certificate verification.
-* ek_fingerprint: The fingerprint of the endeorsment key (optional).
+* ek_certless: A switch to disable certificate verification (optional).
+* ek_fingerprint: The fingerprint of the endorsement key (optional).
 
 If not otherwise specified during TSS installation, the default location for the
 exemplary profiles is /etc/tpm2-tss/profiles/ and /etc/tpm2-tss/ for the FAPI

--- a/man/fapi-config.5.in
+++ b/man/fapi-config.5.in
@@ -26,9 +26,9 @@ system_pcrs: The PCR registers which are used by the system.
 .IP \[bu] 2
 log_dir: The directory for the event log.
 .IP \[bu] 2
-ek_certless: A switch to disable certificate verification.
+ek_certless: A switch to disable certificate verification (optional).
 .IP \[bu] 2
-ek_fingerprint: The fingerprint of the endeorsment key (optional).
+ek_fingerprint: The fingerprint of the endorsement key (optional).
 .PP
 If not otherwise specified during TSS installation, the default location
 for the exemplary profiles is /etc/tpm2\-tss/profiles/ and

--- a/src/tss2-fapi/api/Fapi_Initialize.c
+++ b/src/tss2-fapi/api/Fapi_Initialize.c
@@ -296,6 +296,7 @@ Fapi_Initialize_Finish(
 
     statecase((*context)->state, INITIALIZE_READ_TIME);
         r = Esys_ReadClock_Finish((*context)->esys, &currentTime);
+        return_try_again(r);
         goto_if_error(r, "ReadClock_Finish.", cleanup_return);
 
         (*context)->init_time = *currentTime;


### PR DESCRIPTION
* A missing retry check in Fapi_Initialize_Finish was added (Fixes #1782).
* The man page fapi-config was updated.

 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
