### PR TITLE
all/pkg-config: add root dir to CFLAGS

### DIFF
--- a/lib/tss2-esys.pc.in
+++ b/lib/tss2-esys.pc.in
@@ -8,6 +8,6 @@ Description: TPM2 Enhanced System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu tss2-sys
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-esys -L${libdir}
 Libs.private: @LIBADD_DL@ @LIBSOCKET_LDFLAGS@ @TSS2_ESYS_LDFLAGS_CRYPTO@

--- a/lib/tss2-fapi.pc.in
+++ b/lib/tss2-fapi.pc.in
@@ -8,5 +8,5 @@ Description: TPM2 Feature API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu tss2-esys tss2-tctildr libcurl libcrypto json-c
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-fapi -L${libdir}

--- a/lib/tss2-mu.pc.in
+++ b/lib/tss2-mu.pc.in
@@ -7,5 +7,5 @@ Name: tss2-mu
 Description: TPM2 type marshaling and unmarshaling library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-mu -L${libdir}

--- a/lib/tss2-rc.pc.in
+++ b/lib/tss2-rc.pc.in
@@ -7,5 +7,5 @@ Name: tss2-rc
 Description: TPM2 error decoding library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-rc -L${libdir}

--- a/lib/tss2-sys.pc.in
+++ b/lib/tss2-sys.pc.in
@@ -8,6 +8,6 @@ Description: TPM2 System API library.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-sys -L${libdir}
 Libs.private: @LIBSOCKET_LDFLAGS@

--- a/lib/tss2-tcti-cmd.pc.in
+++ b/lib/tss2-tcti-cmd.pc.in
@@ -7,5 +7,5 @@ Name: tss2-tcti-cmd
 Description: TCTI library for communicating with a subproccess that can communicate with the TPM.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-tcti-cmd -L${libdir}

--- a/lib/tss2-tcti-device.pc.in
+++ b/lib/tss2-tcti-device.pc.in
@@ -8,5 +8,5 @@ Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-tcti-device -L${libdir}

--- a/lib/tss2-tcti-mssim.pc.in
+++ b/lib/tss2-tcti-mssim.pc.in
@@ -8,5 +8,5 @@ Description: TCTI library for communicating with the Microsoft TPM2 simulator.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-tcti-mssim -L${libdir}

--- a/lib/tss2-tcti-swtpm.pc.in
+++ b/lib/tss2-tcti-swtpm.pc.in
@@ -8,5 +8,5 @@ Description: TCTI library for communicating with swtpm.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Requires.private: tss2-mu
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/tss
 Libs: -ltss2-tcti-swtpm -L${libdir}

--- a/lib/tss2-tctildr.pc.in
+++ b/lib/tss2-tctildr.pc.in
@@ -7,5 +7,5 @@ Name: tss2-tctildr
 Description: Library to simplify management of TCTIs.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
-Cflags: -I@includedir@
+Cflags: -I@includedir@ -I${includedir}/tss
 Libs: -ltss2-tctildr -L@libdir@


### PR DESCRIPTION
Fall all PC files do:

Currently, software building against the various libraries all include
the header files via a suffix directory. However, moving from spec
compliant SAPI implementations should just require a reconfiguration of
the software build parameters, not of the software itself.

Client's could perform their own magic to do this. Some examples I have
seen are to use a macro to define at buildtime where to pull in the
header file. However, since the specifications define the file name, a
include directive of that file name should be sufficient.

For this reason, place the tss2, or suffic directory, on the build
include path returned by pkg-config, so compliant SAPI stacks can be
easily swapped via normal pkg-config semantics. Thus, removing
additional burdens on client applications when switching SAPI's.

Signed-off-by: William Roberts <william.c.roberts@intel.com>