### PR TITLE
fapi: fix static analysis issue - identical branches

### DIFF
--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -106,9 +106,8 @@ ifapi_policy_store_initialize(
 
     r = ifapi_asprintf(&policy_dir, "%s%s%s", config_policydir,
                        (strcmp(&config_policydir[strlen(config_policydir) - 1],
-                               IFAPI_FILE_DELIM) == 0)
-                       ? IFAPI_FILE_DELIM : IFAPI_FILE_DELIM,
-                       IFAPI_POLICY_PATH);
+                        IFAPI_FILE_DELIM) == 0) ? "" : IFAPI_FILE_DELIM,
+					   IFAPI_POLICY_PATH);
     goto_if_error(r, "Out of memory.", error);
 
     r = ifapi_io_check_create_dir(policy_dir, FAPI_READ);


### PR DESCRIPTION
Coverity is complaining about identical code for different
branches. Doesn't actually have any functional difference,
but looks weird. Fixing by changing the true branch.