### PR TITLE
esys: make hiearchy API value change backwards compat

### DIFF
--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -61,8 +61,6 @@ typedef uint32_t ESYS_TR;
 #define ESYS_TR_RH_AUTH_FIRST  0x110U
 #define ESYS_TR_RH_AUTH(x) (ESYS_TR_RH_AUTH_FIRST + (ESYS_TR)(x))
 
-#define ESYS_TR_MIN_OBJECT (TPM2_RH_LAST + 1 + 0x1000)
-
 typedef struct ESYS_CONTEXT ESYS_CONTEXT;
 
 /*

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -61,7 +61,7 @@ typedef uint32_t ESYS_TR;
 #define ESYS_TR_RH_AUTH_FIRST  0x110U
 #define ESYS_TR_RH_AUTH(x) (ESYS_TR_RH_AUTH_FIRST + (ESYS_TR)(x))
 
-#define ESYS_TR_MIN_OBJECT 0x1000U
+#define ESYS_TR_MIN_OBJECT (TPM2_RH_LAST + 1 + 0x1000)
 
 typedef struct ESYS_CONTEXT ESYS_CONTEXT;
 

--- a/src/tss2-esys/api/Esys_Hash.c
+++ b/src/tss2-esys/api/Esys_Hash.c
@@ -155,8 +155,12 @@ Esys_Hash_Async(
     }
 
     r = iesys_handle_to_tpm_handle(hierarchy, &tpm_hierarchy);
-    if (r != TSS2_RC_SUCCESS)
-        return r;
+    if (r != TSS2_RC_SUCCESS) {
+        if (!iesys_is_platform_handle(hierarchy)) {
+            return r;
+        }
+        tpm_hierarchy = hierarchy;
+    }
 
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)

--- a/src/tss2-esys/api/Esys_HierarchyControl.c
+++ b/src/tss2-esys/api/Esys_HierarchyControl.c
@@ -169,8 +169,12 @@ Esys_HierarchyControl_Async(
     }
 
     r = iesys_handle_to_tpm_handle(enable, &tpm_enable);
-    if (r != TSS2_RC_SUCCESS)
-        return r;
+    if (r != TSS2_RC_SUCCESS) {
+        if (!iesys_is_platform_handle(enable)) {
+            return r;
+        }
+        tpm_enable = enable;
+    }
 
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -161,8 +161,12 @@ Esys_LoadExternal_Async(
     }
 
     r = iesys_handle_to_tpm_handle(hierarchy, &tpm_hierarchy);
-    if (r != TSS2_RC_SUCCESS)
-        return r;
+    if (r != TSS2_RC_SUCCESS) {
+        if (!iesys_is_platform_handle(hierarchy)) {
+            return r;
+        }
+        tpm_hierarchy = hierarchy;
+    }
 
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)

--- a/src/tss2-esys/api/Esys_SequenceComplete.c
+++ b/src/tss2-esys/api/Esys_SequenceComplete.c
@@ -168,8 +168,12 @@ Esys_SequenceComplete_Async(
     }
 
     r = iesys_handle_to_tpm_handle(hierarchy, &tpm_hierarchy);
-    if (r != TSS2_RC_SUCCESS)
-        return r;
+    if (r != TSS2_RC_SUCCESS) {
+        if (!iesys_is_platform_handle(hierarchy)) {
+            return r;
+        }
+        tpm_hierarchy = hierarchy;
+    }
 
     r = iesys_check_sequence_async(esysContext);
     if (r != TSS2_RC_SUCCESS)

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -389,6 +389,32 @@ iesys_handle_to_tpm_handle(ESYS_TR esys_handle, TPM2_HANDLE * tpm_handle)
     LOG_ERROR("Error: Esys invalid ESAPI handle (%x).", esys_handle);
     return TSS2_ESYS_RC_BAD_VALUE;
 }
+
+/**
+ * Determines if an ESYS_TR (UINT32) is assigned a raw TPM2_HANDLE (UINT32)
+ * hierarchy type.
+ *
+ * @param handle [in] The handle to check if it's a hierarchy or not.
+ * @return
+ *  true if it is a hierarchy, false otherwise.
+ */
+bool
+iesys_is_platform_handle(ESYS_TR handle) {
+
+    switch(handle) {
+    case TPM2_RH_OWNER:
+    case TPM2_RH_PLATFORM:
+    case TPM2_RH_PLATFORM_NV:
+    case TPM2_RH_ENDORSEMENT:
+    case TPM2_RH_NULL:
+        LOG_WARNING("Convert handle from TPM2_RH to ESYS_TR, got: 0x%x",
+                handle);
+        return true;
+    default:
+        return false;
+    }
+}
+
 /** Get the type of a tpm handle.
  *
  * @parm handle[in] The tpm handle.

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -61,6 +61,10 @@ TSS2_RC iesys_handle_to_tpm_handle(
     ESYS_TR esys_handle,
     TPM2_HANDLE *tpm_handle);
 
+bool
+iesys_is_platform_handle(
+        ESYS_TR handle);
+
 TSS2_RC esys_GetResourceObject(
     ESYS_CONTEXT *esys_context,
     ESYS_TR rsrc_handle,

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -18,6 +18,19 @@
 extern "C" {
 #endif
 
+/*
+ * Start issuing ESYS_TR objects past the TPM2_RH_LAST namespace
+ * and give ourselves 0x1000 handle space in case of differing
+ * header files between the library build and the client build.
+ *
+ * Due to an API mistake, TPM2_RH constants are valid for a few
+ * select ESYS API calls.
+ *
+ * More details can be found here:
+ *   - https://github.com/tpm2-software/tpm2-tss/issues/1750
+ */
+#define ESYS_TR_MIN_OBJECT (TPM2_RH_LAST + 1 + 0x1000)
+
 /** An entry in a cpHash or rpHash table. */
 typedef struct {
     TPM2_ALG_ID alg;                 /**< The hash algorithm. */

--- a/test/integration/esys-hash.int.c
+++ b/test/integration/esys-hash.int.c
@@ -25,19 +25,19 @@
  *  - Esys_Hash() (M)
  *
  * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @param[in] hierarchy the hierarchy to perform the hash in.
  * @retval EXIT_FAILURE
  * @retval EXIT_SUCCESS
  */
 
 int
-test_esys_hash(ESYS_CONTEXT * esys_context)
+test_esys_hash(ESYS_CONTEXT * esys_context, ESYS_TR hierarchy)
 {
     TSS2_RC r;
     TPM2B_MAX_BUFFER data = { .size = 20,
                               .buffer={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
                                        1, 2, 3, 4, 5, 6, 7, 8, 9}};
     TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
-    ESYS_TR hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST *outHash = NULL;
     TPMT_TK_HASHCHECK *validation = NULL;
 
@@ -65,5 +65,13 @@ test_esys_hash(ESYS_CONTEXT * esys_context)
 
 int
 test_invoke_esys(ESYS_CONTEXT * esys_context) {
-    return test_esys_hash(esys_context);
+    int rc = test_esys_hash(esys_context, ESYS_TR_RH_OWNER);
+    if (rc)
+        return rc;
+
+    /*
+     * Test that backwards compat API change is still working, see:
+     *   - https://github.com/tpm2-software/tpm2-tss/issues/1750
+     */
+    return test_esys_hash(esys_context, TPM2_RH_OWNER);
 }

--- a/test/integration/esys-hashsequencestart.int.c
+++ b/test/integration/esys-hashsequencestart.int.c
@@ -30,12 +30,13 @@
  * Used compiler defines: TEST_SESSION
  *
  * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @param[in] hierarchy the hierarchy to start the hash sequence in.
  * @retval EXIT_FAILURE
  * @retval EXIT_SUCCESS
  */
 
 int
-test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
+test_esys_hashsequencestart(ESYS_CONTEXT * esys_context, ESYS_TR hierarchy)
 {
     TSS2_RC r;
 
@@ -112,7 +113,7 @@ test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
                               ESYS_TR_NONE,
                               ESYS_TR_NONE,
                               &buffer,
-                              ESYS_TR_RH_OWNER,
+                              hierarchy,
                               &result,
                               &validation
                               );
@@ -143,5 +144,13 @@ test_esys_hashsequencestart(ESYS_CONTEXT * esys_context)
 
 int
 test_invoke_esys(ESYS_CONTEXT * esys_context) {
-    return test_esys_hashsequencestart(esys_context);
+    int rc = test_esys_hashsequencestart(esys_context, ESYS_TR_RH_OWNER);
+    if (rc)
+        return rc;
+
+    /*
+     * Test that backwards compat API change is still working, see:
+     *   - https://github.com/tpm2-software/tpm2-tss/issues/1750
+     */
+    return test_esys_hashsequencestart(esys_context, TPM2_RH_OWNER);
 }

--- a/test/integration/esys-hierarchy-control.int.c
+++ b/test/integration/esys-hierarchy-control.int.c
@@ -31,17 +31,17 @@
  *  - Esys_HierarchyControl() (M)
  *
  * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @param[in] enable The hierarchy to enable or disable.
  * @retval EXIT_FAILURE
  * @retval EXIT_SKIP
  * @retval EXIT_SUCCESS
  */
 int
-test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
+test_esys_hierarchy_control(ESYS_CONTEXT * esys_context, ESYS_TR enable)
 {
     TSS2_RC r;
 
     ESYS_TR authHandle_handle = ESYS_TR_RH_PLATFORM;
-    ESYS_TR enable = ESYS_TR_RH_OWNER;
     TPMI_YES_NO state = TPM2_NO;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
     int failure_return = EXIT_FAILURE;
@@ -179,5 +179,13 @@ test_esys_hierarchy_control(ESYS_CONTEXT * esys_context)
 
 int
 test_invoke_esys(ESYS_CONTEXT * esys_context) {
-    return test_esys_hierarchy_control(esys_context);
+    int rc = test_esys_hierarchy_control(esys_context, ESYS_TR_RH_OWNER);
+    if (rc)
+        return rc;
+
+    /*
+     * Test that backwards compat API change is still working, see:
+     *   - https://github.com/tpm2-software/tpm2-tss/issues/1750
+     */
+    return test_esys_hierarchy_control(esys_context, TPM2_RH_OWNER);
 }

--- a/test/integration/esys-make-credential.int.c
+++ b/test/integration/esys-make-credential.int.c
@@ -292,13 +292,22 @@ test_esys_make_credential(ESYS_CONTEXT * esys_context)
 
     LOG_INFO("\nSecond key created.");
 
+    /*
+     * Their is no individual stand-alone test for Esys_LoadExternal, so modify
+     * a single Esys_LoadExternal call to test that the backwards compat change
+     * from TPM2_RH to ESYS_TR works as expected. Their are other Esys_LoadExternal
+     * calls that use the expected ESYS_TR type.
+     *
+     * For more details, see:
+     *   - https://github.com/tpm2-software/tpm2-tss/issues/1750
+     */
     r = Esys_LoadExternal(esys_context,
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
                           ESYS_TR_NONE,
                           NULL,
                           outPublic2,
-                          ESYS_TR_RH_OWNER,
+                          TPM2_RH_OWNER,
                           &loadedKeyHandle);
     goto_if_error(r, "Error esys load external", error);
 

--- a/test/unit/esys-dummy-defs.h
+++ b/test/unit/esys-dummy-defs.h
@@ -12,6 +12,8 @@
 #endif
 
 #include "tss2_esys.h"
+#include "tss2-esys/esys_iutil.h"
+
 /*
  * Esys handles for dummy session and key objects, and initialization values for
  * other objects, which can be used in ESAPI test calls


### PR DESCRIPTION
Since:
  - 9d48cc7 esys: change the hierarchy type according to the spec

The interface types changed from TPMI_RH_HIERARCHY and TPMI_RH_ENABLES
to ESYS_TR, which from the ABI perspective nothing changed, asthey are
still just UINT32. However, ESYS_TR's do not equal the older TPM2_RH
values they replaced. However, their is no overlap, so we can detect
when a non ESYS_TR hiearchy value is passed and accept it. However, we
want to be noisy about it and the resulting logs will result:

ERROR:esys:src/tss2-esys/esys_iutil.c:389:iesys_handle_to_tpm_handle() Error: Esys invalid ESAPI handle (40000001).
WARNING:esys:src/tss2-esys/esys_iutil.c:411:iesys_is_platform_handle() Convert handle from TPM2_RH to ESYS_TR, got: 0x40000001

This will allow users/distro's to easily upgrade packages without having
to immediatley make code changes. However, they will be encouraged to
use the proper handle values.

Fixes: #1750

Signed-off-by: William Roberts <william.c.roberts@intel.com>