### PR TITLE
FAPI: Switch default profile to ECC

### DIFF
--- a/dist/fapi-config.json.in
+++ b/dist/fapi-config.json.in
@@ -1,5 +1,5 @@
 {
-     "profile_name": "P_RSA2048SHA256",
+     "profile_name": "P_ECCP256SHA256",
      "profile_dir": "@sysconfdir@/tpm2-tss/fapi-profiles/",
      "user_dir": "~/@userstatedir@/tpm2-tss/user/keystore",
      "system_dir": "@localstatedir@/lib/tpm2-tss/system/keystore",

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -1407,7 +1407,11 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             } else {
                 /* No certificate was stored in the TPM and ek_cert_less was not set.*/
                 goto_error(r, TSS2_FAPI_RC_NO_CERT,
-                           "No certifcate was stored in the TPM.", error_cleanup);
+                           "No EK certifcate found for current crypto profile found. "
+                           "You may want to switch the profile in fapi-config or "
+                           "set the ek_cert_less or ek_cert_file options in fapi-config. "
+                           "See also https://tpm2-software.github.io/2020/07/22/Fapi_Crypto_Profiles.html",
+                           error_cleanup);
             }
 
             SAFE_FREE(*capabilityData);


### PR DESCRIPTION
Switch the default profile of FAPI to be ECC instead of RSA and provide a good error message if no ECC EK cert was found.

Fixes: #1784