### PR TITLE
Revert "build: bump soname of libtss2-esys"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -399,11 +399,6 @@ src_tss2_esys_libtss2_esys_la_LDFLAGS = $(AM_LDFLAGS) $(LIBSOCKET_LDFLAGS) \
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_esys_libtss2_esys_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-esys.map
 endif # HAVE_LD_VERSION_SCRIPT
-
-# Bump soname due to commit 9d48cc7922ad8dc3496444b04c94439c5bfbec8e breaking
-# the ABI of Esys_Hash(), Esys_HierarchyControl(), Esys_LoadExternal() and Esys_SequenceComplete()
-src_tss2_esys_libtss2_esys_la_LDFLAGS += -version-info 1:0:0
-
 src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC) $(TSS2_ESYS_SRC_CRYPTO) \
     src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h \
     src/tss2-tcti/tctildr-interface.h


### PR DESCRIPTION
PR #1796 makes libtss2-esys ABI compatible with tpm2-tss 2.4, so applications using this library don't need to be recompiled right away, hence no need for a soname version bump. Since no version with the bumped soname has been released, we can just revert it.

This reverts commit c94a14e65cd482cb9b3767a49535976cfd66a687.