### PR TITLE
FAPI: Fix memory leaks on error paths

### DIFF
--- a/src/tss2-fapi/api/Fapi_AuthorizePolicy.c
+++ b/src/tss2-fapi/api/Fapi_AuthorizePolicy.c
@@ -172,6 +172,13 @@ Fapi_AuthorizePolicy_Async(
     check_not_null(context);
     check_not_null(policyPath);
     check_not_null(keyPath);
+    if (policyRefSize > 0) {
+        check_not_null(policyRef);
+    }
+
+    if (policyRefSize > sizeof(policy->policyRef.buffer)) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "PolicyRef too large.");
+    }
 
     /* Reset all context-internal session state information. */
     r = ifapi_session_init(context);
@@ -350,7 +357,7 @@ Fapi_AuthorizePolicy_Finish(
         statecase(context->state, AUTHORIZE_NEW_WRITE_POLICY);
             r = ifapi_policy_store_store_finish(&context->pstore, &context->io);
             return_try_again(r);
-            return_if_error_reset_state(r, "write_finish failed");
+            goto_if_error_reset_state(r, "write_finish failed", cleanup);
 
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -196,17 +196,16 @@ Fapi_Import_Async(
 
         }
         r = ifapi_non_tpm_mode_init(context);
-        return_if_error(r, "Initialize Import in none TPM mode");
+        goto_if_error(r, "Initialize Import in none TPM mode", cleanup_error);
 
         context->state = IMPORT_KEY_WRITE_OBJECT_PREPARE;
 
     } else if (strcmp(importData, IFAPI_PEM_PRIVATE_KEY) == 0) {
-          return_error(TSS2_FAPI_RC_BAD_VALUE, "Invalid import data");
+        goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Invalid importData.", cleanup_error);
 
     } else {
-        /* Check whether TCTI and ESYS are initialized */
-        return_if_null(context->esys, "Command can't be executed in none TPM mode.",
-                       TSS2_FAPI_RC_NO_TPM);
+        r = ifapi_non_tpm_mode_init(context);
+        goto_if_error(r, "Initialize Import in none TPM mode", cleanup_error);
 
         /* If the async state automata of FAPI shall be tested, then we must not set
        the timeouts of ESYS to blocking mode.
@@ -215,15 +214,17 @@ Fapi_Import_Async(
        to block until a result is available. */
 #ifndef TEST_FAPI_ASYNC
         r = Esys_SetTimeout(context->esys, TSS2_TCTI_TIMEOUT_BLOCK);
-        return_if_error_reset_state(r, "Set Timeout to blocking");
+        goto_if_error_reset_state(r, "Set Timeout to blocking", cleanup_error);
 #endif /* TEST_FAPI_ASYNC */
 
         r = ifapi_session_init(context);
-        return_if_error(r, "Initialize Import");
+        goto_if_error(r, "Initialize Import", cleanup_error);
 
         /* Otherwise a JSON object has to be checked whether a key or policy is passed */
         jso = json_tokener_parse(importData);
-        return_if_null(jso, "Json error.", TSS2_FAPI_RC_BAD_VALUE);
+        if (!jso) {
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Invalid importData.", cleanup_error);
+        }
 
         if (ifapi_get_sub_object(jso, IFAPI_JSON_TAG_POLICY, &jso2) &&
             !(ifapi_get_sub_object(jso, IFAPI_JSON_TAG_DUPLICATE, &jso2))

--- a/src/tss2-fapi/api/Fapi_Quote.c
+++ b/src/tss2-fapi/api/Fapi_Quote.c
@@ -213,6 +213,10 @@ Fapi_Quote_Async(
     /* Helpful alias pointers */
     IFAPI_PCR * command = &context->cmd.pcr;
 
+    if (qualifyingDataSize > sizeof(command->qualifyingData.buffer)) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "qualifyingDataSize too large.");
+    }
+
     /* Reset all context-internal session state information. */
     r = ifapi_session_init(context);
     return_if_error(r, "Initialize Quote");

--- a/src/tss2-fapi/api/Fapi_VerifyQuote.c
+++ b/src/tss2-fapi/api/Fapi_VerifyQuote.c
@@ -184,6 +184,10 @@ Fapi_VerifyQuote_Async(
     /* Helpful alias pointers */
     IFAPI_PCR * command = &context->cmd.pcr;
 
+    if (qualifyingDataSize > sizeof(command->qualifyingData.buffer)) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "qualifyingDataSize too large.");
+    }
+
     r = ifapi_non_tpm_mode_init(context);
     return_if_error(r, "Initialize VerifyQuote");
 
@@ -207,7 +211,7 @@ Fapi_VerifyQuote_Async(
 
     /* Load the key for verification from the keystore. */
     r = ifapi_keystore_load_async(&context->keystore, &context->io, publicKeyPath);
-    return_if_error2(r, "Could not open: %s", publicKeyPath);
+    goto_if_error(r, "Could not open publicKeyPath", error_cleanup);
 
     /* Initialize the context state for this operation. */
     context->state = VERIFY_QUOTE_READ;
@@ -269,7 +273,7 @@ Fapi_VerifyQuote_Finish(
         statecase(context->state, VERIFY_QUOTE_READ);
             r = ifapi_keystore_load_finish(&context->keystore, &context->io, &key_object);
             return_try_again(r);
-            return_if_error_reset_state(r, "read_finish failed");
+            goto_if_error_reset_state(r, "read_finish failed", error_cleanup);
 
             /* Recalculate the quote-info and attest2b buffer. */
             r = ifapi_get_quote_info(command->quoteInfo, &attest2b,
@@ -296,7 +300,9 @@ Fapi_VerifyQuote_Finish(
 
             /* Parse the logData JSON. */
             command->event_list = json_tokener_parse(context->cmd.pcr.logData);
-            return_if_null(command->event_list, "Json error.", TSS2_FAPI_RC_BAD_VALUE);
+            if (!command->event_list) {
+                goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Bad value for logData", error_cleanup);
+            }
 
             /* Recalculate and verify the PCR digests. */
             r = ifapi_calculate_pcr_digest(command->event_list,

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -797,36 +797,54 @@ ifapi_json_IFAPI_EVENT_serialize(const IFAPI_EVENT *in, json_object **jso)
     return_if_null(in, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     TSS2_RC r;
-    json_object *jso2;
+    json_object *recnum = NULL;
+    json_object *pcr = NULL;
+    json_object *digests = NULL;
+    json_object *type = NULL;
+    json_object *sub_event = NULL;
 
-    if (*jso == NULL)
+    r = ifapi_json_UINT32_serialize(in->recnum, &recnum);
+    goto_if_error(r, "Serialize UINT32", error_cleanup);
+
+    r = ifapi_json_TPM2_HANDLE_serialize(in->pcr, &pcr);
+    goto_if_error(r, "Serialize TPM2_HANDLE", error_cleanup);
+
+    r = ifapi_json_TPML_DIGEST_VALUES_serialize(&in->digests, &digests);
+    goto_if_error(r, "Serialize TPML_DIGEST", error_cleanup);
+
+    r = ifapi_json_IFAPI_EVENT_TYPE_serialize(in->type, &type);
+    goto_if_error(r, "Serialize IFAPI_EVENT_TYPE", error_cleanup);
+
+    r = ifapi_json_IFAPI_EVENT_UNION_serialize(&in->sub_event, in->type, &sub_event);
+    goto_if_error(r, "Serialize IFAPI_EVENT_UNION", error_cleanup);
+
+    if (*jso == NULL) {
         *jso = json_object_new_object();
-    jso2 = NULL;
-    r = ifapi_json_UINT32_serialize(in->recnum, &jso2);
-    return_if_error(r, "Serialize UINT32");
+        if (!*jso) {
+            goto_error(r, TSS2_FAPI_RC_MEMORY, "OOM", error_cleanup);
+        }
+    }
 
-    json_object_object_add(*jso, "recnum", jso2);
-    jso2 = NULL;
-    r = ifapi_json_TPM2_HANDLE_serialize(in->pcr, &jso2);
-    return_if_error(r, "Serialize TPM2_HANDLE");
+    json_object_object_add(*jso, "recnum", recnum);
+    json_object_object_add(*jso, "pcr", pcr);
+    json_object_object_add(*jso, "digests", digests);
+    json_object_object_add(*jso, "type", type);
+    json_object_object_add(*jso, "sub_event", sub_event);
 
-    json_object_object_add(*jso, "pcr", jso2);
-    jso2 = NULL;
-    r = ifapi_json_TPML_DIGEST_VALUES_serialize(&in->digests, &jso2);
-    return_if_error(r, "Serialize TPML_DIGEST");
-
-    json_object_object_add(*jso, "digests", jso2);
-    jso2 = NULL;
-    r = ifapi_json_IFAPI_EVENT_TYPE_serialize(in->type, &jso2);
-    return_if_error(r, "Serialize IFAPI_EVENT_TYPE");
-
-    json_object_object_add(*jso, "type", jso2);
-    jso2 = NULL;
-    r = ifapi_json_IFAPI_EVENT_UNION_serialize(&in->sub_event, in->type, &jso2);
-    return_if_error(r, "Serialize IFAPI_EVENT_UNION");
-
-    json_object_object_add(*jso, "sub_event", jso2);
     return TSS2_RC_SUCCESS;
+
+error_cleanup:
+    if (recnum)
+        json_object_put(recnum);
+    if (pcr)
+        json_object_put(pcr);
+    if (digests)
+        json_object_put(digests);
+    if (type)
+        json_object_put(type);
+    if (sub_event)
+        json_object_put(sub_event);
+    return r;
 }
 
 /** Serializes a configuration JSON object.


### PR DESCRIPTION
This commit fixes some leaks on the error paths in FAPI.
Separate PR for 2.4.x coming.