### PR TITLE
build: change install-hook to mv udev file only if prefix not empty

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -675,7 +675,9 @@ if HOSTOS_LINUX
 endif
 
 install-data-hook: install-dirs
-	-mv -f $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+	-if [ ! -z "$(udevrulesprefix)" ]; then \
+		mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules; \
+	fi
 
 uninstall-local:
 	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules


### PR DESCRIPTION
Use install -C to install the udev files.
This will take care of a situation when the install
is trying to overwrite an existing installation and the files are the same.

Fixes: #1763