### PR TITLE
FAPI: Remove duplicate json_object_put in event log processing.

### DIFF
--- a/src/tss2-fapi/ifapi_eventlog.c
+++ b/src/tss2-fapi/ifapi_eventlog.c
@@ -313,7 +313,6 @@ ifapi_eventlog_append_finish(
 
         r = ifapi_json_IFAPI_EVENT_serialize(&eventlog->event, &event);
         if (r) {
-            json_object_put(eventlog->log);
             goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Error serializing event data", error_cleanup);
         }
 


### PR DESCRIPTION
If an log string with invalid json is passed to Fapi_Extend fapi_object_put is
called twice. Depending on the version of lib-json-c this causes an error.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>