### PR TITLE
FAPI: use setgid for system keystore

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -598,7 +598,8 @@ endef
 
 define set_tss_permissions
     (chown -R tss:tss "$1") && \
-    (chmod -R 2775 "$1")
+    (chmod -R 2775 "$1") && \
+    (setfacl -m default:group:tss:rwx "$1")
 endef
 
 define make_fapi_dirs

--- a/Makefile.am
+++ b/Makefile.am
@@ -598,7 +598,7 @@ endef
 
 define set_tss_permissions
     (chown -R tss:tss "$1") && \
-    (chmod -R 775 "$1")
+    (chmod -R 2775 "$1")
 endef
 
 define make_fapi_dirs

--- a/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+++ b/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
@@ -1,3 +1,5 @@
 #Type   Path                                           Mode User Group Age         Argument
 d       @localstatedir@/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -
+a+      @localstatedir@/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx
 d       @runstatedir@/tpm2-tss/eventlog                2775 tss  tss   -           -
+a+      @runstatedir@/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx

--- a/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+++ b/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
@@ -1,3 +1,3 @@
 #Type   Path                                           Mode User Group Age         Argument
-d       @localstatedir@/lib/tpm2-tss/system/keystore   775  tss  tss   -           -
-d       @runstatedir@/tpm2-tss/eventlog                775  tss  tss   -           -
+d       @localstatedir@/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -
+d       @runstatedir@/tpm2-tss/eventlog                2775 tss  tss   -           -


### PR DESCRIPTION
Files in the system keystore should be modifiable by any user in the `tss` group, not only by the user that created them. Apply the setgid bit to the keystore directory to make sure that all directories and files under the keystore directory (recursively) are owned by the `tss` group.

This change will be applied to existing keystore directories as well, so newly created files will be owned by the `tss` group from now on. Modifying the owner of already existing files is out of scope for this PR.

Using setgid makes sure that all newly created directories and files in the system keystore are owned by the `tss` group. However, permissions for new files are controlled by the current umask, which might not grant write access to the group. To solve this, set a default ACL for the system keystore directory that allows read/write access for members of the `tss` group. The default ACL is inherited for newly created directories and files, granting access to the `tss` group regardless of the umask setting.

As for the setgid change, the default ACL is applied to an existing keystore directory as well, but not to existing directories and files below it.

Fixes: #1810