### PR TITLE
tcti: add pcap tcti

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -108,6 +108,9 @@ endif
 if ENABLE_TCTI_DEVICE
 TESTS_UNIT += test/unit/tcti-device
 endif
+if ENABLE_TCTI_PCAP
+TESTS_UNIT += test/unit/tcti-pcap
+endif
 if ENABLE_TCTI_CMD
 TESTS_UNIT += test/unit/tcti-cmd
 endif
@@ -398,6 +401,17 @@ test_unit_tcti_swtpm_LDFLAGS = -Wl,--wrap=connect,--wrap=read,--wrap=select,--wr
 test_unit_tcti_swtpm_SOURCES = test/unit/tcti-swtpm.c \
     src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-swtpm.c src/tss2-tcti/tcti-swtpm.h
+endif
+
+if ENABLE_TCTI_PCAP
+test_unit_tcti_pcap_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_pcap_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
+test_unit_tcti_pcap_LDFLAGS = -Wl,--wrap=getenv -Wl,--wrap=rand -Wl,--wrap=clock_gettime \
+        -Wl,--wrap=open -Wl,--wrap=read -Wl,--wrap=write -Wl,--wrap=close
+test_unit_tcti_pcap_SOURCES = test/unit/tcti-pcap.c \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-pcap.c src/tss2-tcti/tcti-pcap.h \
+    src/tss2-tcti/tcti-pcap-builder.c src/tss2-tcti/tcti-pcap-builder.h
 endif
 
 if ENABLE_TCTI_CMD

--- a/Makefile.am
+++ b/Makefile.am
@@ -334,6 +334,24 @@ src_tss2_tcti_libtss2_tcti_mssim_la_SOURCES  = \
     src/tss2-tcti/tcti-mssim.c
 endif # ENABLE_TCTI_MSSIM
 
+# tcti pcap library
+if ENABLE_TCTI_PCAP
+libtss2_tcti_pcap = src/tss2-tcti/libtss2-tcti-pcap.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_pcap.h
+lib_LTLIBRARIES += $(libtss2_tcti_pcap)
+pkgconfig_DATA += lib/tss2-tcti-pcap.pc
+EXTRA_DIST += lib/tss2-tcti-pcap.map # joho TODO enable tcti-pcap for Win (.def, visual studio files
+
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_pcap_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-pcap.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_pcap_la_LIBADD   = $(libtss2_tctildr) $(libtss2_mu) $(libutil)
+src_tss2_tcti_libtss2_tcti_pcap_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-pcap-builder.c \
+    src/tss2-tcti/tcti-pcap.c
+endif # ENABLE_TCTI_PCAP
+
 # tcti library for sub-process commands
 if ENABLE_TCTI_CMD
 libtss2_tcti_cmd = src/tss2-tcti/libtss2-tcti-cmd.la
@@ -695,6 +713,7 @@ EXTRA_DIST += \
     man/Tss2_TctiLdr_FreeInfo.3.in \
     man/Tss2_TctiLdr_GetInfo.3.in \
     man/Tss2_TctiLdr_Initialize.3.in \
+    man/tss2-tcti-pcap.7.in \
     man/tss2-tcti-device.7.in \
     man/man7/tss2-tcti-swtpm.7 \
     man/tss2-tcti-mssim.7.in \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -196,6 +196,12 @@ AC_ARG_ENABLE([tcti-swtpm],
             [enable_tcti_swtpm=yes])
 AM_CONDITIONAL([ENABLE_TCTI_SWTPM], [test "x$enable_tcti_swtpm" != xno])
 AS_IF([test "x$enable_tcti_swtpm" = "xyes"], AC_DEFINE([TCTI_SWTPM],[1], [TCTI FOR SWTPM]))
+
+AC_ARG_ENABLE([tcti-pcap],
+            [AS_HELP_STRING([--disable-tcti-pcap],
+                            [don't build the tcti-pcap module])],,
+            [enable_tcti_pcap=yes])
+AM_CONDITIONAL([ENABLE_TCTI_PCAP], [test "x$enable_tcti_pcap" != xno])
 
 AC_ARG_ENABLE([tcti-cmd],
             [AS_HELP_STRING([--disable-tcti-cmd],

--- a/include/tss2/tss2_tcti_pcap.h
+++ b/include/tss2/tss2_tcti_pcap.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+#ifndef TSS2_TCTI_PCAP_H
+#define TSS2_TCTI_PCAP_H
+
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Pcap_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_PCAP_H */

--- a/lib/tss2-tcti-pcap.def
+++ b/lib/tss2-tcti-pcap.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-pcap
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Pcap_Init

--- a/lib/tss2-tcti-pcap.map
+++ b/lib/tss2-tcti-pcap.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Pcap_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-pcap.pc.in
+++ b/lib/tss2-tcti-pcap.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-pcap
+Description: TCTI library for debugging at the TCTI interface.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Requires.private: tss2-tctildr
+Cflags: -I${includedir}
+Libs: -ltss2-tcti-pcap -L${libdir}

--- a/man/tss2-tcti-pcap.7.in
+++ b/man/tss2-tcti-pcap.7.in
@@ -1,0 +1,19 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-PCAP 8 "JULY 2020" "TPM2 Software Stack"
+.SH NAME
+tcti-pcap \- Debugging module with pcapng output
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for logging the TPM
+commands transmitted and received in pcapng format.
+.SH DESCRIPTION
+tcti-pcap is a library that logs TPM commands and responses and forwards them to
+another TCTI module. The child TCTI module will be loaded by the tss2-tctildr
+library. The config string passed to tcti-pcap specifies the child TCTI module
+to be loaded. For instance, passing "pcap:device:/dev/tpm0" to tss2-tctildr will
+result in tcti-pcap being loaded which will forward the TPM commands to the
+tcti-device module.
+The pcapng data is stored in a file tpm2_log.pcap. This path can be altered
+using the environment variable TCTI_PCAP_FILE. The strings "stdout"/"-" and
+"stderr" are valid values.

--- a/src/tss2-tcti/tcti-pcap-builder.c
+++ b/src/tss2-tcti/tcti-pcap-builder.c
@@ -1,0 +1,535 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+
+#include "tss2_common.h"
+#include "tcti-pcap-builder.h"
+#include "util/io.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+/**
+ * the host port is chosen randomly to enable having multiple tcti-pcap
+ * instances write into the same file
+ */
+#define TCP_HOST_PORT_MIN   50000
+#define TCP_HOST_PORT_MAX   60000
+#define TCP_TPM_PORT        2321    /* port recognized by the TPM 2.0 protocol dissector */
+
+/* constants used */
+#define PCAP_MAJOR                          0x0001
+#define PCAP_MINOR                          0x0000
+#define PCAP_BLOCK_TYPE_SHB                 0x0A0D0D0A
+#define PCAP_BLOCK_TYPE_IDB                 0x00000001
+#define PCAP_BLOCK_TYPE_EPB                 0x00000006
+#define PCAP_SHB_BYTE_ORDER_MAGIC           0x1A2B3C4D
+#define PCAP_SHB_SECTION_LEN_NOT_SPECIFIED  0xFFFFFFFFFFFFFFFFUL
+#define PCAP_IDB_LINKTYPE_IPv4              0x00E4
+#define PCAP_IDB_SNAP_LEN_NO_LIMIT          0x0000
+#define PCAP_EPB_INTERFACE_ID               0x00000000
+
+#define IPv4_VERSION                0x4
+#define IPv4_TOS_BEST_EFFORT        0x00
+#define IPv4_ID_UNUSED              0x0000
+#define IPv4_FLAGS_DONT_FRAGMENT    0x2
+#define IPv4_FRAGMENT_OFFSET_UNUSED 0x0000
+#define IPv4_TIME_TO_LIVE_MAX       0xFF
+#define IPv4_PROTOCOL_TCP           0x06
+#define IPv4_CHECKSUM_UNUSED        0x0000
+#define TCP_FLAGS_ACK               0x10
+#define TCP_WINDOW_SIZE_MAX         0xFFFF
+#define TCP_CHECKSUM_UNUSED         0x0000
+#define TCP_URGENT_PTR_UNUSED       0x0000
+
+#define UNUSED(param)               (void)(param)
+#define SIZEOF_IN_OCTETS(x)         (sizeof (x)/sizeof (uint32_t))
+#define TO_MULTIPLE_OF_4_BYTE(x)    (((x)-1)/4*4+4) * !!(x)
+
+/*
+ * complies to pcap-ng (IETF RFC draft-tuexen-opsawg-pcapng-01)
+ * https://tools.ietf.org/id/draft-tuexen-opsawg-pcapng-01.html
+ *
+ * pcap-ng file stucture:
+ *
+ *  * section header block          (shb)           |<-- file header
+ *  * interface statistics block    (idb)           |
+ *
+ *  * ┬ enhanced packet block       (epb)           |<-- single tpm req. or rsp.
+ *    | * header                    (epb_header)    |
+ *    | * ┬ ip package                              |
+ *    |   | * header                (ip_header)     |
+ *    |   | * ┬ tcp package                         |
+ *    |   |   | * header            (tcp_header)    |
+ *    |   ┴   ┴ * tpm req. or resp.                 |
+ *    ┴ * footer                    (epb_footer)    |
+ */
+
+/* section header block */
+typedef struct __attribute__((packed)) {
+    uint32_t block_type;
+    uint32_t block_len;
+    uint32_t byte_order_magic;
+    uint16_t major_version;
+    uint16_t minor_version;
+    uint64_t section_len;
+    /* options (optional) */
+    uint32_t block_len_cp;
+} shb;
+
+/* interface description block */
+typedef struct __attribute__((packed)) {
+    uint32_t block_type;
+    uint32_t block_len;
+    uint16_t link_type;
+    uint16_t reserved;
+    uint32_t snap_len;
+    /* options (optional) */
+    uint32_t block_len_cp;
+} idb;
+
+
+/* enhanced packet block */
+typedef struct __attribute__((packed)) {
+    uint32_t block_type;
+    uint32_t block_len;
+    uint32_t interface_id;
+    uint32_t timestamp_high;
+    uint32_t timestamp_low;
+    uint32_t captured_packet_len;
+    uint32_t original_packet_len;
+} epb_header;
+
+typedef struct __attribute__((packed)) {
+    /* options (optional) */
+    uint32_t block_len_cp;
+} epb_footer;
+
+/* ipv4 packet */
+typedef struct __attribute__((packed)) {
+    uint8_t version_header_len;
+    uint8_t type_of_service;
+    uint16_t packet_len;
+    uint16_t id;
+    uint16_t flags;
+    uint8_t time_to_live;
+    uint8_t protocol;
+    uint16_t checksum;
+    uint32_t source;
+    uint32_t destination;
+    /* options (optional) */
+} ip_header;
+
+/* tcp segment */
+typedef struct __attribute__((packed)) {
+    uint16_t source_port;
+    uint16_t destination_port;
+    uint32_t seq_no;
+    uint32_t ack_no;
+    uint16_t header_len_flags;
+    uint16_t window_size;
+    uint16_t checksum;
+    uint16_t urgent_ptr;
+    /* options (optional) */
+} tcp_header;
+
+static int
+pcap_write_section_header_block (
+    pcap_buider_ctx *ctx,
+    void *buf,
+    size_t buf_len);
+
+static int
+pcap_write_interface_description_block (
+    pcap_buider_ctx *ctx,
+    void *buf,
+    size_t buf_len);
+
+static int
+pcap_write_enhanced_packet_block (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    uint64_t timestamp,
+    const void* payload,
+    size_t payload_len,
+    int direction);
+
+static int
+pcap_write_ip_packet (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    const void* payload,
+    size_t payload_len,
+    int direction);
+
+static int
+pcap_write_tcp_segment (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    const void* payload,
+    size_t payload_len,
+    int direction);
+
+int
+pcap_init (pcap_buider_ctx *ctx)
+{
+    char *filename = getenv (ENV_PCAP_FILE);
+    size_t buf_len;
+    size_t offset;
+    size_t uret;
+    int ret;
+
+    if (filename == NULL) {
+        LOG_TRACE (ENV_PCAP_FILE " not set. Using default PCAP file: "
+                   DEFAULT_PCAP_FILE);
+        filename = DEFAULT_PCAP_FILE;
+    }
+
+    /* random host port to associate unique connection with this tcti instance */
+    srand (time (NULL));
+    ctx->tcp_host_port = rand () % (TCP_HOST_PORT_MAX + 1 - TCP_HOST_PORT_MIN)
+                         + TCP_HOST_PORT_MIN;
+
+    if (!strcmp (filename, "stdout") || !strcmp (filename, "-")) {
+        ctx->fd = STDOUT_FILENO;
+    } else if (!strcmp (filename, "stderr")) {
+        ctx->fd = STDERR_FILENO;
+    } else {
+        ctx->fd = open (filename, O_WRONLY | O_APPEND | O_CREAT | O_NONBLOCK, 0644);
+        if(ctx->fd < 0) {
+            LOG_ERROR ("Failed to open file %s: %s", filename, strerror (errno));
+            goto error;
+        }
+    }
+
+    uint8_t buf[sizeof (shb) + sizeof (idb)];
+    buf_len = sizeof (buf);
+    offset = 0;
+
+    ret = pcap_write_section_header_block (ctx, buf, buf_len);
+    if (ret < 0) {
+        return ret;
+    }
+    offset += ret;
+
+    ret = pcap_write_interface_description_block (ctx,
+                                                   buf + offset,
+                                                   buf_len - offset);
+    if (ret < 0) {
+        return ret;
+    }
+    offset += ret;
+
+    /* write file header: SHB and IDB (can be written multiple times to same file) */
+    uret = write_all (ctx->fd, buf, offset);
+    if (uret != offset) {
+        LOG_ERROR ("Failed to write to file %s: %s", filename, strerror (errno));
+        goto error;
+    }
+
+    return 0;
+
+error:
+    pcap_deinit (ctx);
+    return -1;
+}
+
+int
+pcap_print (
+    pcap_buider_ctx *ctx,
+    const void* payload,
+    size_t payload_len,
+    int direction)
+{
+    size_t pdu_len;
+    struct timespec ts;
+    size_t uret;
+    int ret;
+
+    if (!payload) {
+        return -1;
+    }
+
+    /* get required buffer size */
+    ret = pcap_write_enhanced_packet_block (ctx, NULL, 0, 0,
+                                            payload, payload_len, direction);
+    if (ret < 0) {
+        return ret;
+    }
+    pdu_len = ret;
+
+    uint8_t *buf = malloc (pdu_len);
+    if (!buf) {
+        LOG_ERROR ("Out of memory");
+        return -1;
+    }
+
+    uret = clock_gettime (CLOCK_REALTIME, &ts);
+    if (uret != 0) {
+        LOG_WARNING ("Failed to get time: %s", strerror (errno));
+        ts.tv_sec = 0;
+        ts.tv_nsec = 0;
+    }
+
+    ret = pcap_write_enhanced_packet_block (ctx, buf, pdu_len,
+                                            ts.tv_sec*1000000 + ts.tv_nsec/1000,
+                                            payload, payload_len, direction);
+    if (ret < 0) {
+        goto cleanup;
+    }
+    pdu_len = ret;
+
+    uret = write_all (ctx->fd, buf, pdu_len);
+    if (uret != pdu_len) {
+        LOG_ERROR ("Failed to write to file: %s", strerror (errno));
+        ret = -1;
+        goto cleanup;
+    }
+
+    ret = 0;
+
+cleanup:
+    free (buf);
+    return ret;
+}
+
+void
+pcap_deinit (pcap_buider_ctx *ctx)
+{
+    int ret;
+
+    if (ctx->fd != STDOUT_FILENO && ctx->fd != STDERR_FILENO) {
+        ret = close (ctx->fd);
+        if (ret != 0) {
+            LOG_WARNING ("Failed to close file: %s", strerror (errno));
+        }
+    }
+}
+
+static int
+pcap_write_section_header_block (
+    pcap_buider_ctx *ctx,
+    void *buf,
+    size_t buf_len)
+{
+    UNUSED (ctx);
+
+    if (buf) {
+        if (buf_len < sizeof (shb)) {
+            return -1;
+        }
+
+        shb section_header = {
+            .block_type = PCAP_BLOCK_TYPE_SHB,
+            .block_len = sizeof (shb),
+            .byte_order_magic = PCAP_SHB_BYTE_ORDER_MAGIC,
+            .major_version = PCAP_MAJOR,
+            .minor_version = PCAP_MINOR,
+            .section_len = PCAP_SHB_SECTION_LEN_NOT_SPECIFIED,
+            .block_len_cp = sizeof (shb),
+        };
+
+        memcpy (buf, &section_header, sizeof (shb));
+    }
+
+    return sizeof (shb);
+}
+
+static int
+pcap_write_interface_description_block (
+    pcap_buider_ctx *ctx,
+    void *buf,
+    size_t buf_len)
+{
+    UNUSED (ctx);
+
+    if (buf) {
+        if (buf_len < sizeof (idb)) {
+            return -1;
+        }
+
+        idb interface_description = {
+            .block_type = PCAP_BLOCK_TYPE_IDB,
+            .block_len = sizeof (idb),
+            .link_type = PCAP_IDB_LINKTYPE_IPv4,
+            .reserved = 0,
+            .snap_len = PCAP_IDB_SNAP_LEN_NO_LIMIT,
+            .block_len_cp = sizeof (idb),
+        };
+
+        memcpy (buf, &interface_description, sizeof (idb));
+    }
+
+    return sizeof (ip_header);
+}
+
+static int
+pcap_write_enhanced_packet_block (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    uint64_t timestamp,
+    const void* payload,
+    size_t payload_len,
+    int direction)
+{
+    UNUSED (ctx);
+
+    size_t pdu_len, sdu_len, sdu_padded_len;
+
+    /* get ip packet size */
+    sdu_len = pcap_write_ip_packet (ctx, NULL, 0,
+                                         payload, payload_len,
+                                         direction);
+
+    /* apply padding (multiple of 4 bytes) */
+    sdu_padded_len = TO_MULTIPLE_OF_4_BYTE (sdu_len);
+
+    pdu_len = sizeof (epb_header) + sdu_padded_len + sizeof (epb_footer);
+
+    epb_header header = {
+        .block_type = PCAP_BLOCK_TYPE_EPB,
+        .block_len = pdu_len,
+        .interface_id = PCAP_EPB_INTERFACE_ID,
+        .timestamp_high = (timestamp >> 32) & 0xFFFFFFFF,
+        .timestamp_low = timestamp & 0xFFFFFFFF,
+        .captured_packet_len = sdu_len,
+        .original_packet_len = sdu_len,
+    };
+
+    epb_footer footer = {
+        .block_len_cp = pdu_len,
+    };
+
+    if (buf) {
+        if (buf_len < pdu_len) {
+            return -1;
+        }
+
+        memcpy (buf, &header, sizeof (epb_header));
+        buf += sizeof (epb_header);
+        pcap_write_ip_packet (ctx, buf, sdu_len,
+                              payload, payload_len,
+                              direction);
+        buf += sdu_len;
+        memset (buf, 0x00, sdu_padded_len - sdu_len);
+        buf += (sdu_padded_len - sdu_len);
+        memcpy (buf, &footer, sizeof (epb_footer));
+    }
+
+    return pdu_len;
+}
+
+static int
+pcap_write_ip_packet (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    const void* payload,
+    size_t payload_len,
+    int direction)
+{
+    size_t pdu_len, sdu_len;
+
+    /* get tcp frame size */
+    sdu_len = pcap_write_tcp_segment (ctx, NULL, 0,
+                                      payload, payload_len,
+                                      direction);
+
+    pdu_len = sizeof (ip_header) + sdu_len;
+
+    ip_header header = {
+        .version_header_len = (IPv4_VERSION << 4) | SIZEOF_IN_OCTETS (ip_header),
+        .type_of_service = htons (IPv4_TOS_BEST_EFFORT),
+        .packet_len = htons (pdu_len),
+        .id = htons (IPv4_ID_UNUSED),
+        .flags = htons (IPv4_FLAGS_DONT_FRAGMENT << 13 | IPv4_FRAGMENT_OFFSET_UNUSED),
+        .time_to_live = IPv4_TIME_TO_LIVE_MAX,
+        .protocol = IPv4_PROTOCOL_TCP,
+        .checksum = htons (IPv4_CHECKSUM_UNUSED),
+        .source = htonl (0),
+        .destination = htonl (0),
+    };
+
+    if (buf) {
+        if (buf_len < pdu_len) {
+            return -1;
+        }
+
+        memcpy (buf, &header, sizeof (ip_header));
+        buf += sizeof (ip_header);
+        pcap_write_tcp_segment (ctx, buf, sdu_len,
+                                payload, payload_len,
+                                direction);
+    }
+
+    return pdu_len;
+}
+
+static int
+pcap_write_tcp_segment (
+    pcap_buider_ctx *ctx,
+    void* buf,
+    size_t buf_len,
+    const void* payload,
+    size_t payload_len,
+    int direction)
+{
+    size_t pdu_len;
+
+    pdu_len = sizeof (tcp_header) + payload_len;
+
+    tcp_header header = {
+        .ack_no = htonl (0),
+        .header_len_flags = htons ((SIZEOF_IN_OCTETS (tcp_header) << 12) | TCP_FLAGS_ACK),
+        .window_size = htons (TCP_WINDOW_SIZE_MAX),
+        .checksum = htons (TCP_CHECKSUM_UNUSED),
+        .urgent_ptr = htons (TCP_URGENT_PTR_UNUSED),
+    };
+
+    if (direction == PCAP_DIR_HOST_TO_TPM) {
+        header.source_port = htons (ctx->tcp_host_port);
+        header.destination_port = htons (TCP_TPM_PORT);
+        header.seq_no = htonl (ctx->tcp_sequence_no_host_to_tpm);
+    } else if (direction == PCAP_DIR_TPM_TO_HOST) {
+        header.source_port = htons (TCP_TPM_PORT);
+        header.destination_port = htons (ctx->tcp_host_port);
+        header.seq_no = htonl (ctx->tcp_sequence_no_tpm_to_host);
+    }
+
+    if (buf && payload) {
+        if (buf_len < pdu_len) {
+            return -1;
+        }
+
+        memcpy (buf, &header, sizeof (tcp_header));
+        buf += sizeof (tcp_header);
+        memcpy (buf, payload, payload_len);
+
+        if (direction == PCAP_DIR_HOST_TO_TPM) {
+            ctx->tcp_sequence_no_host_to_tpm += payload_len;
+        } else if (direction == PCAP_DIR_TPM_TO_HOST) {
+            ctx->tcp_sequence_no_tpm_to_host += payload_len;
+        }
+    }
+
+    return pdu_len;
+}

--- a/src/tss2-tcti/tcti-pcap-builder.h
+++ b/src/tss2-tcti/tcti-pcap-builder.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+#ifndef TCTI_PCAP_BUILDER_H
+#define TCTI_PCAP_BUILDER_H
+
+#include <stddef.h>
+
+#define PCAP_DIR_HOST_TO_TPM 0
+#define PCAP_DIR_TPM_TO_HOST 1
+
+#define ENV_PCAP_FILE     "TCTI_PCAP_FILE"
+#define DEFAULT_PCAP_FILE "tpm2_log.pcap"
+
+typedef struct {
+    int fd;
+    uint16_t tcp_host_port;
+    uint32_t tcp_sequence_no_host_to_tpm;
+    uint32_t tcp_sequence_no_tpm_to_host;
+} pcap_buider_ctx;
+
+int
+pcap_init (pcap_buider_ctx *ctx);
+int
+pcap_print (
+    pcap_buider_ctx *ctx,
+    const void* payload,
+    size_t payload_len,
+    int direction);
+void
+pcap_deinit (pcap_buider_ctx *ctx);
+
+#endif /* TCTI_PCAP_BUILDER_H */

--- a/src/tss2-tcti/tcti-pcap.c
+++ b/src/tss2-tcti/tcti-pcap.c
@@ -1,0 +1,302 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "tss2_tpm2_types.h"
+#include "tss2_common.h"
+#include "tss2_tcti.h"
+#include "tcti-common.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+#include "tcti-pcap.h"
+#include "tcti-pcap-builder.h"
+#include "tss2_tctildr.h"
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the pcap TCTI context. The only safeguard we have to ensure this
+ * operation is possible is the magic number in the pcap TCTI context.
+ * If passed a NULL context, or the magic number check fails, this function
+ * will return NULL.
+ */
+TSS2_TCTI_PCAP_CONTEXT*
+tcti_pcap_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_PCAP_MAGIC) {
+        return (TSS2_TCTI_PCAP_CONTEXT*)tcti_ctx;
+    }
+    return NULL;
+}
+
+/*
+ * This function down-casts the pcap TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+TSS2_TCTI_COMMON_CONTEXT*
+tcti_pcap_down_cast (TSS2_TCTI_PCAP_CONTEXT *tcti_pcap)
+{
+    if (tcti_pcap == NULL) {
+        return NULL;
+    }
+    return &tcti_pcap->common;
+}
+
+TSS2_RC
+tcti_pcap_transmit (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t size,
+    const uint8_t *cmd_buf)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tcti_ctx);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+    TSS2_RC rc;
+    int ret;
+
+    if (tcti_pcap == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    rc = tcti_common_transmit_checks (tcti_common, cmd_buf, TCTI_PCAP_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    LOGBLOB_DEBUG (cmd_buf, size, "sending %zu byte command buffer:", size);
+
+    /* handle errors of underlying TCTI later (always writes to PCAP file) */
+    ret = pcap_print (&tcti_pcap->pcap_builder,
+                      cmd_buf, size,
+                      PCAP_DIR_HOST_TO_TPM);
+    if (ret != 0) {
+        LOG_WARNING ("Failed to save transmission to PCAP file.");
+    }
+
+    rc = Tss2_Tcti_Transmit (tcti_pcap->tcti_child, size, cmd_buf);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed calling TCTI transmit of child TCTI module");
+        return rc;
+    }
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_pcap_receive (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    unsigned char *response_buffer,
+    int32_t timeout)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+    TSS2_RC rc;
+    int ret;
+
+    if (tcti_pcap == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    rc = tcti_common_receive_checks (tcti_common, response_size, TCTI_PCAP_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    rc = Tss2_Tcti_Receive (tcti_pcap->tcti_child,
+                            response_size, response_buffer,
+                            timeout);
+    /* handle errors of underlying TCTI directly (may not write to PCAP file) */
+    if (rc != TPM2_RC_SUCCESS) {
+        return rc;
+    }
+
+     /* partial read */
+    if (response_buffer == NULL) {
+        return rc;
+    }
+
+    LOGBLOB_DEBUG (response_buffer, *response_size, "Response Received");
+
+    ret = pcap_print (&tcti_pcap->pcap_builder,
+                      response_buffer, *response_size,
+                      PCAP_DIR_TPM_TO_HOST);
+    if (ret != 0) {
+        LOG_WARNING ("Failed to save transmission to PCAP file.");
+    }
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    return rc;
+}
+
+TSS2_RC
+tcti_pcap_cancel (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+    TSS2_RC rc;
+
+    if (tcti_pcap == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    rc = tcti_common_cancel_checks (tcti_common, TCTI_PCAP_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    LOG_WARNING ("Logging Tcti_Cancel to a PCAP file is not implemented");
+
+    rc = Tss2_Tcti_Cancel (tcti_pcap->tcti_child);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    return rc;
+}
+
+TSS2_RC
+tcti_pcap_set_locality (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+    TSS2_RC rc;
+
+    if (tcti_pcap == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+
+    rc = tcti_common_set_locality_checks (tcti_common, TCTI_PCAP_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    LOG_WARNING ("Logging Tcti_SetLocality to a PCAP file is not implemented");
+
+    rc = Tss2_Tcti_SetLocality (tcti_pcap->tcti_child, locality);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    tcti_common->locality = locality;
+    return rc;
+}
+
+TSS2_RC
+tcti_pcap_get_poll_handles (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tctiContext);
+
+    if (tcti_pcap == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+
+    return Tss2_Tcti_GetPollHandles (tcti_pcap->tcti_child, handles,
+                                     num_handles);
+}
+
+void
+tcti_pcap_finalize (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = tcti_pcap_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+
+    if (tcti_pcap == NULL) {
+        return;
+    }
+
+    Tss2_TctiLdr_Finalize (&tcti_pcap->tcti_child);
+    pcap_deinit (&tcti_pcap->pcap_builder);
+
+    tcti_common->state = TCTI_STATE_FINAL;
+}
+
+/*
+ * This is an implementation of the standard TCTI initialization function for
+ * this module.
+ */
+TSS2_RC
+Tss2_Tcti_Pcap_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf)
+{
+    TSS2_TCTI_PCAP_CONTEXT *tcti_pcap = (TSS2_TCTI_PCAP_CONTEXT*) tctiContext;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_pcap_down_cast (tcti_pcap);
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+    int ret;
+
+    if (tctiContext == NULL && size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    } else if (tctiContext == NULL) {
+        *size = sizeof (TSS2_TCTI_PCAP_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    if (conf == NULL) {
+        LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ""
+                   " no configuration will be used.",
+                   (uintptr_t)tctiContext, (uintptr_t)size);
+    } else {
+        LOG_TRACE ("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
+                   (uintptr_t)tctiContext, (uintptr_t)size, conf);
+    }
+
+    rc = Tss2_TctiLdr_Initialize (conf, &tcti_pcap->tcti_child);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Error loading TCTI: %s", conf);
+        return rc;
+    }
+
+    TSS2_TCTI_MAGIC (tcti_common) = TCTI_PCAP_MAGIC;
+    TSS2_TCTI_VERSION (tcti_common) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tcti_common) = tcti_pcap_transmit;
+    TSS2_TCTI_RECEIVE (tcti_common) = tcti_pcap_receive;
+    TSS2_TCTI_FINALIZE (tcti_common) = tcti_pcap_finalize;
+    TSS2_TCTI_CANCEL (tcti_common) = tcti_pcap_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tcti_common) = tcti_pcap_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_pcap_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tcti_common) = tcti_make_sticky_not_implemented;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    tcti_common->locality = 3;
+    memset (&tcti_common->header, 0, sizeof (tcti_common->header));
+
+    ret = pcap_init (&tcti_pcap->pcap_builder);
+    if (ret != 0) {
+        LOG_ERROR ("Failed to initialize PCAP TCTI");
+        Tss2_TctiLdr_Finalize (&tcti_pcap->tcti_child);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+/* public info structure */
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-pcap",
+    .description = "TCTI module for logging TPM commands in pcapng format.",
+    .config_help = "The child tcti module and its config string: <name>:<conf>",
+    .init = Tss2_Tcti_Pcap_Init,
+};
+
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-pcap.h
+++ b/src/tss2-tcti/tcti-pcap.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+
+#ifndef TCTI_PCAP_H
+#define TCTI_PCAP_H
+
+#include "tcti-pcap-builder.h"
+
+#include "tss2_tcti.h"
+#include "tcti-common.h"
+
+#define TCTI_PCAP_MAGIC 0x9cf45c5d7d9d0d3fULL
+
+typedef struct {
+    const char *child_tcti;
+} tcti_pcap_conf_t;
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    pcap_buider_ctx pcap_builder;
+    TSS2_TCTI_CONTEXT *tcti_child;
+} TSS2_TCTI_PCAP_CONTEXT;
+
+#endif /* TCTI_PCAP_H */

--- a/test/unit/tcti-pcap.c
+++ b/test/unit/tcti-pcap.c
@@ -1,0 +1,722 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_pcap.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-pcap.h"
+
+#define TCTI_STUB_CONF      "stub"
+#define TCTI_PCAP_ENV_VAR   "pcap_env_var"
+#define TCTI_PCAP_FILE      "pcap_file"
+#define TCTI_PCAP_FD        0x01234567
+#define TCTI_PCAP_HOST_PORT_INPUT 0xcdf4 /* translates to port 0xcdef */
+#define TCTI_PCAP_HOST_PORT_BYTES 0xcd, 0xef
+/* sec/nsec translate to 0x00 0x11 0x22 ... 0x77 (note endianness) */
+#define TCTI_PCAP_TIMESTAMP_SEC   (0x3322110077665544UL / 1000000)
+#define TCTI_PCAP_TIMESTAMP_NSEC  ((0x3322110077665544UL % 1000000) * 1000)
+#define TCTI_PCAP_TIMESTAMP_BYTES 0x00, 0x11, 0x22, 0x33,  0x44, 0x55, 0x66, 0x77
+
+static const uint8_t pcap_header[] = {
+    /* section header block */
+    0x0a, 0x0d, 0x0d, 0x0a,
+    0x1c, 0x00, 0x00, 0x00,
+    0x4d, 0x3c, 0x2b, 0x1a,
+    0x01, 0x00,
+    0x00, 0x00,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0x1c, 0x00, 0x00, 0x00,
+    /* interface description block */
+    0x01, 0x00, 0x00, 0x00,
+    0x14, 0x00, 0x00, 0x00,
+    0xE4, 0x00,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x14, 0x00, 0x00, 0x00
+};
+
+static uint8_t pcap_rx_epb_data[] = {
+    /* enhanced packet block header */
+    0x06, 0x00, 0x00, 0x00,
+    0x4c, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    TCTI_PCAP_TIMESTAMP_BYTES,
+    0x2b, 0x00, 0x00, 0x00,
+    0x2b, 0x00, 0x00, 0x00,
+    /* ipv4 header */
+    0x45,
+    0x00,
+    0x00, 0x2b,
+    0x00, 0x00,
+    0x40, 0x00,
+    0xff,
+    0x06,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    /* tcp header */
+    0x09, 0x11,
+    TCTI_PCAP_HOST_PORT_BYTES,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x50, 0x10,
+    0xff, 0xff,
+    0x00, 0x00,
+    0x00, 0x00,
+    /* data */
+    0x00, 0x01, 0x02,
+    /* epb padding */
+    0x00,
+    /* epb footer */
+    0x4c, 0x00, 0x00, 0x00
+};
+
+static uint8_t pcap_tx_epb_data[] = {
+    /* enhanced packet block header */
+    0x06, 0x00, 0x00, 0x00,
+    0x4c, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    TCTI_PCAP_TIMESTAMP_BYTES,
+    0x2b, 0x00, 0x00, 0x00,
+    0x2b, 0x00, 0x00, 0x00,
+    /* ipv4 header */
+    0x45,
+    0x00,
+    0x00, 0x2b,
+    0x00, 0x00,
+    0x40, 0x00,
+    0xff,
+    0x06,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    /* tcp header */
+    TCTI_PCAP_HOST_PORT_BYTES,
+    0x09, 0x11,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x50, 0x10,
+    0xff, 0xff,
+    0x00, 0x00,
+    0x00, 0x00,
+    /* data */
+    0x00, 0x01, 0x02,
+    /* epb padding */
+    0x00,
+    /* epb footer */
+    0x4c, 0x00, 0x00, 0x00
+};
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+} TSS2_TCTI_STUB_CONTEXT;
+
+TSS2_RC
+tcti_stub_transmit (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t size,
+    const uint8_t *cmd_buf)
+{
+    ssize_t ret = mock_type (ssize_t);
+    size_t expected_size = mock_type (int);
+    uint8_t *expected_buf = mock_type (uint8_t*);
+
+    assert_int_equal (expected_size, size);
+    assert_memory_equal (expected_buf, cmd_buf, size);
+
+    return ret;
+}
+
+TSS2_RC
+tcti_stub_receive (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    uint8_t *response_buffer,
+    int32_t timeout)
+{
+    ssize_t ret = mock_type (ssize_t);
+    *response_size = mock_type (int);
+    uint8_t *buf_in;
+
+    /* partial read */
+    if (response_buffer == NULL) {
+        return ret;
+    }
+
+    buf_in = mock_type (uint8_t*);
+    memcpy (response_buffer, buf_in, *response_size);
+
+    return ret;
+}
+
+TSS2_RC
+tcti_stub_cancel (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    return mock_type (ssize_t);
+}
+
+TSS2_RC
+tcti_stub_set_locality (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality)
+{
+    ssize_t ret = mock_type (ssize_t);
+    uint8_t expected_locality = mock_type (int);
+
+    assert_int_equal (expected_locality, locality);
+
+    return ret;
+}
+
+TSS2_RC
+tcti_stub_get_poll_handles (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    ssize_t ret = mock_type (ssize_t);
+
+    return ret;
+}
+
+TSS2_RC
+Tss2_TctiLdr_Initialize (const char *nameConf,
+                         TSS2_TCTI_CONTEXT **tctiContext)
+{
+    TSS2_TCTI_STUB_CONTEXT *tcti_pcap;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common;
+
+    *tctiContext = NULL;
+
+    if (nameConf != NULL && strcmp (nameConf, TCTI_STUB_CONF) == 0) {
+        /* create and return stub tcti */
+        tcti_pcap =  calloc (1, sizeof (TSS2_TCTI_STUB_CONTEXT));
+        tcti_common =  (TSS2_TCTI_COMMON_CONTEXT*) tcti_pcap;
+
+        TSS2_TCTI_MAGIC (tcti_common) = TCTI_PCAP_MAGIC;
+        TSS2_TCTI_VERSION (tcti_common) = TCTI_VERSION;
+        TSS2_TCTI_TRANSMIT (tcti_common) = tcti_stub_transmit;
+        TSS2_TCTI_RECEIVE (tcti_common) = tcti_stub_receive;
+        TSS2_TCTI_FINALIZE (tcti_common) = NULL;
+        TSS2_TCTI_CANCEL (tcti_common) = tcti_stub_cancel;
+        TSS2_TCTI_GET_POLL_HANDLES (tcti_common) = tcti_stub_get_poll_handles;
+        TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_stub_set_locality;
+        TSS2_TCTI_MAKE_STICKY (tcti_common) = NULL;
+        tcti_common->state = TCTI_STATE_TRANSMIT;
+
+        *tctiContext = (TSS2_TCTI_CONTEXT *) tcti_pcap;
+
+        return TPM2_RC_SUCCESS;
+    } else {
+        /* return mocked rc */
+        return mock_type (int);
+    }
+}
+
+void
+Tss2_TctiLdr_Finalize (TSS2_TCTI_CONTEXT **tctiContext)
+{
+    free (*tctiContext);
+}
+
+char *
+__real_getenv (const char *name);
+
+char *
+__wrap_getenv (const char *name)
+{
+    if (name != NULL && strcmp(name, ENV_PCAP_FILE) == 0) {
+        return TCTI_PCAP_FILE;
+    }
+
+    return __real_getenv(name);
+}
+
+int
+__wrap_rand (void)
+{
+    return TCTI_PCAP_HOST_PORT_INPUT;
+}
+
+int
+__wrap_clock_gettime (clockid_t clk_id, struct timespec *tp)
+{
+    if (clk_id == CLOCK_REALTIME) {
+        tp->tv_sec = TCTI_PCAP_TIMESTAMP_SEC;
+        tp->tv_nsec = TCTI_PCAP_TIMESTAMP_NSEC;
+        return EXIT_SUCCESS;
+    }
+
+    return EXIT_FAILURE;
+}
+
+
+int
+__real_open (const char *pathname, int flags, mode_t mode);
+
+int
+__wrap_open (const char *pathname, int flags, mode_t mode)
+{
+    if (pathname != NULL && strcmp (pathname, TCTI_PCAP_FILE) == 0) {
+        return mock_type (int);
+    } else {
+        return __real_open(pathname, flags, mode);
+    }
+}
+
+ssize_t
+__real_read (int fd, void *buffer, size_t buffer_size);
+
+ssize_t
+__wrap_read (int fd, void *buffer, size_t buffer_size)
+{
+    uint8_t *buf_in;
+    ssize_t ret;
+
+    if (fd == TCTI_PCAP_FD) {
+        ret = mock_type (ssize_t);
+        buf_in = mock_type (uint8_t*);
+
+        memcpy (buffer, buf_in, ret);
+        return ret;
+    } else {
+        return __real_read(fd, buffer, buffer_size);
+    }
+}
+
+int
+__real_close(int fd);
+
+int
+__wrap_close(int fd)
+{
+    if (fd == TCTI_PCAP_FD) {
+        return mock_type (int);
+    } else {
+        return __real_close (fd);
+    }
+}
+
+ssize_t
+__real_write (int fd, void *buffer, size_t buffer_size);
+
+ssize_t
+__wrap_write (int fd, void *buffer, size_t buffer_size)
+{
+    size_t expected_size;
+    uint8_t *expected_buffer;
+    ssize_t ret;
+
+    if (fd == TCTI_PCAP_FD) {
+        ret = mock_type (int);
+        expected_size = mock_type (int);
+        expected_buffer = mock_type (uint8_t*);
+
+        fprintf(stderr, "exp: ");
+        for (size_t i = 0; i < expected_size; i++)
+            fprintf(stderr, "%02x", ((uint8_t *) expected_buffer)[i]);
+        fprintf(stderr, "\n");
+
+        fprintf(stderr, "got: ");
+        for (size_t i = 0; i < buffer_size; i++)
+            fprintf(stderr, "%02x", ((uint8_t *) buffer)[i]);
+        fprintf(stderr, "\n");
+
+        assert_int_equal (expected_size, buffer_size);
+        assert_memory_equal (expected_buffer, buffer, buffer_size);
+
+        return ret;
+    } else {
+        return __real_write (fd, buffer, buffer_size);
+    }
+}
+
+static void
+update_tcp_seq (void* data, uint32_t size)
+{
+    const size_t offset = 52;
+    uint32_t seq_no;
+
+    seq_no =  *((uint32_t*) (data + offset));
+    /* from big endian to little endian */
+    seq_no = ((seq_no << 24) & 0xff000000) | /* byte 0 to byte 3 */
+             ((seq_no << 8)  & 0x00ff0000) | /* byte 1 to byte 2 */
+             ((seq_no >> 8)  & 0x0000ff00) | /* byte 2 to byte 1 */
+             ((seq_no >> 24) & 0x000000ff);  /* byte 3 to byte 0 */
+
+    seq_no += size;
+
+    /* from little endian to big endian */
+    seq_no = ((seq_no << 24) & 0xff000000) | /* byte 0 to byte 3 */
+             ((seq_no << 8)  & 0x00ff0000) | /* byte 1 to byte 2 */
+             ((seq_no >> 8)  & 0x0000ff00) | /* byte 2 to byte 1 */
+             ((seq_no >> 24) & 0x000000ff);  /* byte 3 to byte 0 */
+
+    *((uint32_t*) (data + offset)) = seq_no;
+}
+
+static void
+tcti_pcap_init_context_and_size_null_test (void **state)
+{
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_Pcap_Init (NULL, NULL, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
+}
+
+static void
+tcti_pcap_init_size_test (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_Pcap_Init (NULL, &tcti_size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (tcti_size, sizeof (TSS2_TCTI_PCAP_CONTEXT));
+}
+
+static void
+tcti_pcap_init_tctildr_fail_test (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_TCTI_PCAP_CONTEXT tcti_pcap = {0};
+    TSS2_TCTI_CONTEXT *tcti = (TSS2_TCTI_CONTEXT*) &tcti_pcap;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    will_return (Tss2_TctiLdr_Initialize, TSS2_TCTI_RC_MEMORY);
+    rc = Tss2_Tcti_Pcap_Init (tcti, &tcti_size, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_MEMORY);
+    assert_int_equal (tcti_pcap.pcap_builder.fd, 0);
+    assert_int_equal (tcti_pcap.pcap_builder.tcp_host_port, 0);
+}
+
+static void
+tcti_pcap_init_open_fail_test (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    ret = Tss2_Tcti_Pcap_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+
+    tcti = calloc (1, tcti_size);
+    assert_non_null (tcti);
+
+    will_return (__wrap_open, -1);
+    rc = Tss2_Tcti_Pcap_Init (tcti, &tcti_size, TCTI_STUB_CONF);
+    assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
+
+    free (tcti);
+}
+
+static void
+tcti_pcap_init_write_fail_test (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    ret = Tss2_Tcti_Pcap_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+
+    tcti = calloc (1, tcti_size);
+    assert_non_null (tcti);
+
+    will_return (__wrap_open, TCTI_PCAP_FD);
+    will_return (__wrap_write, -1);
+    will_return (__wrap_write, sizeof(pcap_header));
+    will_return (__wrap_write, pcap_header);
+    will_return (__wrap_close, 0); /* close pcap */
+    rc = Tss2_Tcti_Pcap_Init (tcti, &tcti_size, TCTI_STUB_CONF);
+    assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
+
+    free (tcti);
+}
+
+/* Setup functions to create the context for the pcap TCTI */
+static int
+tcti_pcap_setup (void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
+
+    ret = Tss2_Tcti_Pcap_Init (NULL, &tcti_size, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+
+    tcti = calloc (1, tcti_size);
+    assert_non_null (tcti);
+
+    will_return (__wrap_open, TCTI_PCAP_FD);
+    will_return (__wrap_write, sizeof(pcap_header));
+    will_return (__wrap_write, sizeof(pcap_header));
+    will_return (__wrap_write, pcap_header);
+    ret = Tss2_Tcti_Pcap_Init (tcti, &tcti_size, TCTI_STUB_CONF);
+    assert_true (ret == TSS2_RC_SUCCESS);
+
+    *state = tcti;
+    return 0;
+}
+
+static int
+tcti_pcap_teardown (void **state)
+{
+    TSS2_TCTI_CONTEXT *tcti = (TSS2_TCTI_CONTEXT*)*state;
+
+    will_return (__wrap_close, EXIT_SUCCESS);
+    Tss2_Tcti_Finalize (tcti);
+    free (tcti);
+
+    return 0;
+
+}
+
+static void
+tcti_pcap_receive_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast (ctx);
+    size_t partial_read_size = 123;
+    uint8_t mock_response_buffer[] = {0x00, 0x01, 0x02};
+    size_t mock_response_size = sizeof(mock_response_buffer);
+    uint8_t response_buffer[100] = {0};
+    size_t response_size = sizeof(response_buffer);
+    TSS2_RC rc;
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+
+    /* have tcti_common_receive_checks fail */
+    rc = Tss2_Tcti_Receive (ctx,
+                            NULL,
+                            NULL,
+                            TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+
+    /* partial read: give back response_size of 123 */
+    will_return (tcti_stub_receive, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_receive, partial_read_size);
+    rc = Tss2_Tcti_Receive (ctx,
+                            &response_size,
+                            NULL, /* NULL buffer */
+                            TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (response_size, partial_read_size);
+
+    /* underlying read fails */
+    will_return (tcti_stub_receive, TSS2_TCTI_RC_IO_ERROR);
+    will_return (tcti_stub_receive, 0);
+    will_return (tcti_stub_receive, NULL);
+    /* receive fails, it will not log to pcap */
+    rc = Tss2_Tcti_Receive (ctx,
+                            &response_size,
+                            response_buffer,
+                            TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
+
+    /* read successfully  */
+    will_return (tcti_stub_receive, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_receive, mock_response_size);
+    will_return (tcti_stub_receive, mock_response_buffer);
+    will_return (__wrap_write, sizeof(pcap_rx_epb_data));
+    will_return (__wrap_write, sizeof(pcap_rx_epb_data));
+    will_return (__wrap_write, pcap_rx_epb_data);
+    rc = Tss2_Tcti_Receive (ctx,
+                            &response_size,
+                            response_buffer,
+                            TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (response_size, mock_response_size);
+    assert_memory_equal (response_buffer, mock_response_buffer, response_size);
+
+    /* read successfully, but fail to write to pcap  */
+    tcti_common->state = TCTI_STATE_RECEIVE;
+    update_tcp_seq (pcap_rx_epb_data, mock_response_size);
+    will_return (tcti_stub_receive, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_receive, mock_response_size);
+    will_return (tcti_stub_receive, mock_response_buffer);
+    will_return (__wrap_write, -1); /* fail to write to pcap */
+    will_return (__wrap_write, sizeof(pcap_rx_epb_data));
+    will_return (__wrap_write, pcap_rx_epb_data);
+    rc = Tss2_Tcti_Receive (ctx,
+                            &response_size,
+                            response_buffer,
+                            TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (response_size, mock_response_size);
+    assert_memory_equal (response_buffer, mock_response_buffer, response_size);
+}
+
+static void
+tcti_pcap_transmit_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast (ctx);
+    uint8_t mock_transmit_buffer[] = {0x00, 0x01, 0x02};
+    size_t mock_transmit_size = sizeof(mock_transmit_buffer);
+    TSS2_RC rc;
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+
+    /* have tcti_common_transmit_checks fail (cmd_buf = NULL) */
+    rc = Tss2_Tcti_Transmit (ctx,
+                             0,
+                             NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+
+    /* underlying tranmit fails*/
+    will_return (tcti_stub_transmit, TSS2_TCTI_RC_IO_ERROR);
+    will_return (tcti_stub_transmit, mock_transmit_size); /* assert size */
+    will_return (tcti_stub_transmit, mock_transmit_buffer); /* assert buf */
+    /* transmit fails, but it still logs to pcap */
+    will_return (__wrap_write, sizeof(pcap_tx_epb_data));
+    will_return (__wrap_write, sizeof(pcap_tx_epb_data));
+    will_return (__wrap_write, pcap_tx_epb_data);
+    rc = Tss2_Tcti_Transmit (ctx,
+                             mock_transmit_size,
+                             mock_transmit_buffer); /* have tcti_common_transmit_checks fail */
+    assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
+
+    /* transmit successfully */
+    update_tcp_seq (pcap_tx_epb_data, mock_transmit_size);
+    will_return (tcti_stub_transmit, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_transmit, mock_transmit_size); /* assert size */
+    will_return (tcti_stub_transmit, mock_transmit_buffer); /* assert buf */
+    will_return (__wrap_write, sizeof(pcap_tx_epb_data));
+    will_return (__wrap_write, sizeof(pcap_tx_epb_data));
+    will_return (__wrap_write, pcap_tx_epb_data);
+    rc = Tss2_Tcti_Transmit (ctx,
+                             mock_transmit_size,
+                             mock_transmit_buffer);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* transmit successfully, but fail to write to pcap */
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    update_tcp_seq (pcap_tx_epb_data, mock_transmit_size);
+    will_return (tcti_stub_transmit, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_transmit, mock_transmit_size); /* assert size */
+    will_return (tcti_stub_transmit, mock_transmit_buffer); /* assert buf */
+    will_return (__wrap_write, -1); /* fail to write to pcap */
+    will_return (__wrap_write, sizeof(pcap_tx_epb_data));
+    will_return (__wrap_write, pcap_tx_epb_data);
+    rc = Tss2_Tcti_Transmit (ctx,
+                             mock_transmit_size,
+                             mock_transmit_buffer);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+}
+
+static void
+tcti_pcap_cancel_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast (ctx);
+    TSS2_RC rc;
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+
+    /* have tcti_common_cancel_checks fail */
+    rc = Tss2_Tcti_Cancel (NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+
+    /* cancel successfully */
+    will_return (tcti_stub_cancel, TSS2_RC_SUCCESS);
+    /* cancel will not write to pcap */
+    rc = Tss2_Tcti_Cancel (ctx);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+}
+
+static void
+tcti_pcap_set_locality_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast (ctx);
+    uint8_t mock_locality = 3;
+    TSS2_RC rc;
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+
+    /* have tcti_common_set_locality_checks fail */
+    rc = Tss2_Tcti_SetLocality (NULL, 0);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+
+    /* set_locality successfully */
+    will_return (tcti_stub_set_locality, TSS2_RC_SUCCESS);
+    will_return (tcti_stub_set_locality, mock_locality);
+    /* set_locality will not write to pcap */
+    rc = Tss2_Tcti_SetLocality (ctx, mock_locality);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+}
+
+static void
+tcti_pcap_get_poll_handles_test (void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast (ctx);
+    TSS2_TCTI_POLL_HANDLE handles [5] = {0};
+    size_t num_handles = sizeof(handles);
+    TSS2_RC rc;
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+
+    /* have tcti_common_get_poll_handles_checks fail */
+    rc = Tss2_Tcti_GetPollHandles (NULL, NULL, 0);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+
+    /* get_poll_handles successfully */
+    will_return (tcti_stub_get_poll_handles, TSS2_RC_SUCCESS);
+    /* get_poll_handles will not write to pcap */
+    rc = Tss2_Tcti_GetPollHandles (ctx, handles, &num_handles);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (tcti_pcap_init_context_and_size_null_test),
+        cmocka_unit_test (tcti_pcap_init_size_test),
+        cmocka_unit_test (tcti_pcap_init_tctildr_fail_test),
+        cmocka_unit_test (tcti_pcap_init_open_fail_test),
+        cmocka_unit_test (tcti_pcap_init_write_fail_test),
+        cmocka_unit_test_setup_teardown (tcti_pcap_receive_test,
+                                         tcti_pcap_setup,
+                                         tcti_pcap_teardown),
+        cmocka_unit_test_setup_teardown (tcti_pcap_transmit_test,
+                                         tcti_pcap_setup,
+                                         tcti_pcap_teardown),
+        cmocka_unit_test_setup_teardown (tcti_pcap_cancel_test,
+                                         tcti_pcap_setup,
+                                         tcti_pcap_teardown),
+        cmocka_unit_test_setup_teardown (tcti_pcap_set_locality_test,
+                                         tcti_pcap_setup,
+                                         tcti_pcap_teardown),
+        cmocka_unit_test_setup_teardown (tcti_pcap_get_poll_handles_test,
+                                         tcti_pcap_setup,
+                                         tcti_pcap_teardown),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
Although wireshark features a [neat TPM traffic dissector](https://www.wireshark.org/lists/wireshark-commits/201804/msg00451.html), there is no way to log+parse non-simulator TPM traffic. Additionally, to my knowledge, there is no alternative TPM traffic parser for Linux.

Add a TCTI module which prints TPM traffic to a file `tpm2_log.pcap` in **pcap-ng** format. Via the env. variable`TCTI_PCAP_FILE`, the output can be redirected to another path/stream (`stdout`, `-`, and `stderr` are valid values). If `tpm2_log.pcap` already exists, the logs are appended.

```
          +-----------+     +-----------+
SAPI ==>  | tcti-pcap | ==> | tcti-...  | ==> ...
          +-----------+     +-----------+
                ||
                \/
          tpm2_log.pcap
```

To use this TCTI, just prepend the TCTI name:conf string with "pcap", e.g.
```
"pcap:device:/dev/tpm0"
```

To inspect traffic in realtime with wireshark, it can be piped directly. Of course, in this example, the program must not output any additional information to `stdout`.
```bash
TCTI_PCAP_FILE=- tpm2_getrandom --tcti "pcap:device:/dev/tpm0" -o rand.bin 5 | wireshark -ki-
```

