### PR TITLE
test/esys-certifyX509: use TPMA_OBJECT_X509SIGN depending on integration_tcti

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,7 +328,8 @@ AS_IF([test "x$enable_integration" = "xyes"],
               AC_MSG_NOTICE([Falling back to testing with tcti-mssim.])
               AC_CHECK_PROG([result_tpm_server], [tpm_server], [yes], [no])
               AS_IF([test "x$result_tpm_server" = "xyes"],
-                    [integration_tcti=mssim],
+                    [integration_tcti=mssim
+                     AC_DEFINE([INTEGRATION_TCTI_MSSIM], [1], [use mssim TCTI for integration tests])],
                     [AC_MSG_WARN([Executable tpm_server not found in PATH (fallback)])])])
        AS_IF([test "x$integration_tcti" = "xnone"],
              [AC_MSG_ERROR([No simulator executable found in PATH for testing TCTI.])])

--- a/test/integration/esys-certifyX509.int.c
+++ b/test/integration/esys-certifyX509.int.c
@@ -79,7 +79,7 @@ test_esys_certifyx509(ESYS_CONTEXT * esys_context)
                     TPMA_OBJECT_USERWITHAUTH |
                     TPMA_OBJECT_RESTRICTED |
                     TPMA_OBJECT_SIGN_ENCRYPT |
-#if defined TCTI_MSSIM
+#if defined INTEGRATION_TCTI_MSSIM
                     TPMA_OBJECT_X509SIGN | /* This requires mssim >= v1628 Other simulators
                                               that do not implement 1.59 spec return 0x000002e1
                                               tpm:parameter(2):reserved bits not set to zero as required


### PR DESCRIPTION
Currently the `esys-certifyX509 integration` test enables `TPMA_OBJECT_X509SIGN`, which only works with the mssim TCTI at the moment, [depending on the existence of the `TCTI_MSSIM` macro](https://github.com/tpm2-software/tpm2-tss/blob/1361aa370994eea08b446f1de975f918f9574e8c/test/integration/esys-certifyX509.int.c#L82-L87). This macro is defined [if the mssim TCTI is enabled](https://github.com/tpm2-software/tpm2-tss/blob/1361aa370994eea08b446f1de975f918f9574e8c/configure.ac#L185-L191), i.e. if `libtss2-tcti-mssim` is built. This excludes that valid use case that the user wants to have the mssim TCTI enabled (e.g. for compatibility with other tpm2-software test suites), but also has swtpm available for running the tpm2-tss integration test suite with `libtss2-tcti-swtpm`. Introduce a new macro `INTEGRATION_TCTI_MSSIM` that is defined if [`$integration_tcti`](https://github.com/tpm2-software/tpm2-tss/blob/1361aa370994eea08b446f1de975f918f9574e8c/configure.ac#L310-L334) is set to `mssim` in configure so that users can run the test suite with swtpm without having to use `./configure --disable-tcti-mssim`.