### PR TITLE
ci: fix mssim-tcti build on travis

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -74,7 +74,7 @@ if [ "$SCANBUILD" == "yes" ]; then
 elif [ "$CC" == "clang" ]; then
   ../configure --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 else
-  if [ "$WITH_TCTI" == "mssim"]; then
+  if [ "$WITH_TCTI" == "mssim" ]; then
     ../configure --with-sanitizer=undefined,address --disable-tcti-swtpm --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
   else
     ../configure --with-sanitizer=undefined,address --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS


### PR DESCRIPTION
A missing space meant that the mssim test run was [never executed](https://travis-ci.org/github/tpm2-software/tpm2-tss/jobs/715021461#L948):
```
/workspace/tpm2-tss/.ci/docker.run: line 77: [: missing `]'
```