### PR TITLE
tcti: fix random fapi integ test hang after mssim async change

### DIFF
--- a/src/util/io.h
+++ b/src/util/io.h
@@ -78,7 +78,7 @@ socket_close (
     SOCKET *socket);
 TSS2_RC
 socket_set_nonblock (
-    SOCKET *sock);
+    SOCKET sock);
 ssize_t
 socket_recv_buf (
     SOCKET sock,
@@ -89,6 +89,10 @@ socket_xmit_buf (
     SOCKET sock,
     const void *buf,
     size_t size);
+TSS2_RC
+socket_poll (
+    SOCKET sock,
+    int timeout);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After mssim async change has been merged the FAPI integration
tests started to fail randomly on mssim. It looks like the
default timeout value for the poll that FAPI usese is zero,
which causes the return immediately if the response isn't ready, which
causes random hangs in the FAPI integ tests. The change also caused
appveyor CI build to fail. This also fixes the build for now,
by not enabling NONBLOCK on windows.
The way to do this would be to call ioctlsocket(*sock, FIONBIO);
in the socket_set_nonblock function.