### PR TITLE
tcti: fix pcap timestamp for 32-bit platforms

### DIFF
--- a/src/tss2-tcti/tcti-pcap-builder.c
+++ b/src/tss2-tcti/tcti-pcap-builder.c
@@ -290,7 +290,7 @@ pcap_print (
     }
 
     ret = pcap_write_enhanced_packet_block (ctx, buf, pdu_len,
-                                            ts.tv_sec*1000000 + ts.tv_nsec/1000,
+                                            (uint64_t) ts.tv_sec*1000000 + ts.tv_nsec/1000,
                                             payload, payload_len, direction);
     if (ret < 0) {
         goto cleanup;

--- a/test/unit/tcti-pcap.c
+++ b/test/unit/tcti-pcap.c
@@ -32,10 +32,9 @@
 #define TCTI_PCAP_FD        0x01234567
 #define TCTI_PCAP_HOST_PORT_INPUT 0xcdf4 /* translates to port 0xcdef */
 #define TCTI_PCAP_HOST_PORT_BYTES 0xcd, 0xef
-/* sec/nsec translate to 0x00 0x11 0x22 ... 0x77 (note endianness) */
-#define TCTI_PCAP_TIMESTAMP_SEC   (0x3322110077665544UL / 1000000)
-#define TCTI_PCAP_TIMESTAMP_NSEC  ((0x3322110077665544UL % 1000000) * 1000)
-#define TCTI_PCAP_TIMESTAMP_BYTES 0x00, 0x11, 0x22, 0x33,  0x44, 0x55, 0x66, 0x77
+#define TCTI_PCAP_TIMESTAMP_SEC   ((uint64_t) 0x0001020304050607 / 1000000)
+#define TCTI_PCAP_TIMESTAMP_NSEC  (((uint64_t) 0x0001020304050607 % 1000000) * 1000)
+#define TCTI_PCAP_TIMESTAMP_BYTES 0x03, 0x02, 0x01, 0x00,  0x07, 0x06, 0x05, 0x04
 
 static const uint8_t pcap_header[] = {
     /* section header block */


### PR DESCRIPTION
On most 32-bit platforms, the unix epoch is stored in a 32-bit `long` (instead of a 64-bit `long`) which causes overflows in the pcap
builder and the test code. Add casts to account for 32-bit `longs`. For the test code: use a more realistic timestamp which is  small enough for a 32 bit `__time_t`.

Fixes #1826 