### PR TITLE
Fapi several fixes

### DIFF
--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -326,6 +326,7 @@ Fapi_ChangeAuth_Finish(
                     &command->handle,
                     &command->key_object);
             return_try_again(r);
+            goto_if_error(r, "Load keys.", error_cleanup);
 
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Encrypt.c
+++ b/src/tss2-fapi/api/Fapi_Encrypt.c
@@ -328,7 +328,9 @@ Fapi_Encrypt_Finish(
                 goto_if_error(r, "Error esys rsa encrypt", error_cleanup);
 
                 context-> state = DATA_ENCRYPT_WAIT_FOR_RSA_ENCRYPTION;
-
+            } else if (encKeyObject->misc.key.public.publicArea.type == TPM2_ALG_ECC) {
+                goto_error(r, TSS2_FAPI_RC_NOT_IMPLEMENTED,
+                           "ECC Encryption not yet supported", error_cleanup);
             } else {
                 goto_error(r, TSS2_FAPI_RC_NOT_IMPLEMENTED,
                            "Unsupported algorithm (%" PRIu16 ")",

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -232,7 +232,7 @@ Fapi_Provision_Async(
     memset(&context->cmd.Provision, 0, sizeof(IFAPI_Provision));
 
     /* First it will be checked whether the profile is already provisioned. */
-    r = ifapi_asprintf(&profile_dir, "%s/%s", context->keystore.systemdir,
+    r = ifapi_asprintf(&profile_dir, "%s/%s/HS", context->keystore.systemdir,
                        context->keystore.defaultprofile);
     goto_if_error(r, "Out of memory.", end);
 

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -591,7 +591,7 @@ ifapi_init_primary_async(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype)
                                  &context->cmd.Provision.hash_size);
         if (r) {
             LOG_ERROR("Policy calculation");
-            free(policy);
+            SAFE_FREE(policy);
             return r;
         }
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -536,7 +536,7 @@ rel_path_to_abs_path(
         /* Check type of object which does not exist. */
         if (ifapi_path_type_p(rel_path, IFAPI_NV_PATH)) {
             /* NV directory does not exist. */
-            goto_error(r, TSS2_FAPI_RC_NOT_PROVISIONED,
+            goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND,
                     "FAPI not provisioned. File %s does not exist.",
                     cleanup, rel_path);
         } else if (ifapi_hierarchy_path_p(rel_path)) {

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1027,7 +1027,7 @@ expand_directory(IFAPI_KEYSTORE *keystore, const char *path, char **directory_na
              strncmp(&path[start_pos], "HE", 2) == 0) &&
             strlen(&path[start_pos]) <= 3) {
             /* Root directory is hierarchy */
-            r = ifapi_asprintf(directory_name, "%s/%s/", keystore->defaultprofile,
+            r = ifapi_asprintf(directory_name, "/%s/%s/", keystore->defaultprofile,
                                &path[start_pos]);
             return_if_error(r, "Out of memory.");
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -28,8 +28,8 @@
  * @retval TSS2_RC_SUCCESS If the pathname is ok.
  * @retval TSS2_FAPI_RC_BAD_PATH If not valid characters are detected.
  */
-static TSS2_RC
-check_valid_path(
+TSS2_RC
+ifapi_check_valid_path(
     const char *path)
 {
     for (size_t i = 0; i < strlen(path); i++) {
@@ -311,7 +311,7 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
     check_not_null(path);
 
     /* First it will be checked whether the only valid characters occur in the path. */
-    r = check_valid_path(path);
+    r = ifapi_check_valid_path(path);
     return_if_error(r, "Invalid path.");
 
     if (ifapi_hierarchy_path_p(path)) {

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -151,6 +151,8 @@ typedef struct _IFAPI_OBJECT {
 
 } IFAPI_OBJECT;
 
+TSS2_RC
+ifapi_check_valid_path(const char *path);
 
 TSS2_RC
 ifapi_keystore_initialize(

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -1388,6 +1388,7 @@ execute_policy_or(
         r = Esys_PolicyOR_Finish(esys_ctx);
         try_again_or_error(r, "Execute PolicyPCR_Finish.");
 
+        current_policy->state = POLICY_EXECUTE_INIT;
         return r;
 
     statecasedefault(current_policy->state);

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -173,11 +173,12 @@ ifapi_policyeval_instantiate_finish(
     IFAPI_POLICY_EVAL_INST_CTX *context)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    NODE_OBJECT_T *first_in_pol_list = context->policy_elements;
+    NODE_OBJECT_T *first_in_pol_list;
     size_t i_last;
 
     /* While not all policy elements are instantiated */
-    while (first_in_pol_list) {
+    while (context->policy_elements) {
+        first_in_pol_list = context->policy_elements;
         TPMT_POLICYELEMENT *pol_element = first_in_pol_list->object;
         switch (pol_element->type) {
         case POLICYSIGNED:

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -145,6 +145,10 @@ ifapi_policy_store_load_async(
 
     LOG_TRACE("Load policy: %s", path);
 
+    /* First it will be checked whether the only valid characters occur in the path. */
+    r = ifapi_check_valid_path(path);
+    return_if_error(r, "Invalid path.");
+
     /* Free old input buffer if buffer exists */
     SAFE_FREE(io->char_rbuffer);
 

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -49,6 +49,7 @@ new_policy(
 
     pol_exec_ctx = calloc(sizeof(IFAPI_POLICY_EXEC_CTX), 1);
     if (!pol_exec_ctx) {
+        SAFE_FREE(*current_policy);
         return_error(TSS2_FAPI_RC_MEMORY, "Out of memory");
     }
     (*current_policy)->pol_exec_ctx = pol_exec_ctx;
@@ -69,6 +70,7 @@ new_policy(
 
     pol_exec_cb_ctx = calloc(sizeof(IFAPI_POLICY_EXEC_CB_CTX), 1);
     if (!pol_exec_cb_ctx) {
+        SAFE_FREE(*current_policy);
         return_error(TSS2_FAPI_RC_MEMORY, "Out of memory");
     }
     pol_exec_ctx->app_data = pol_exec_cb_ctx;
@@ -228,7 +230,6 @@ error:
     while (context->policy.policyutil_stack) {
         clear_all_policies(context);
     }
-    SAFE_FREE(current_policy);
     return r;
 }
 /** State machine to Execute the TPM policy commands needed for the current policy.


### PR DESCRIPTION
* Policy execution was fixed.
* Pathname check was added for policy files.
* New provisioning after deleting /HS was enabled.
* A missing return code check for ChangeAuth was added.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>