### PR TITLE
2.4.x fapi several fixes

### DIFF
--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -321,6 +321,7 @@ Fapi_ChangeAuth_Finish(
                     &command->handle,
                     &command->key_object);
             return_try_again(r);
+            goto_if_error(r, "Load keys.", error_cleanup);
 
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -178,7 +178,7 @@ Fapi_Provision_Async(
     memset(&context->cmd.Provision, 0, sizeof(IFAPI_Provision));
 
     /* First it will be checked whether the profile is already provisioned. */
-    r = ifapi_asprintf(&profile_dir, "%s/%s", context->keystore.systemdir,
+    r = ifapi_asprintf(&profile_dir, "%s/%s/HS", context->keystore.systemdir,
                        context->keystore.defaultprofile);
     goto_if_error(r, "Out of memory.", end);
 

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -984,6 +984,9 @@ ifapi_non_tpm_mode_init(FAPI_CONTEXT *context)
 void
 ifapi_session_clean(FAPI_CONTEXT *context)
 {
+    if (context->policy_session && context->policy_session != ESYS_TR_NONE) {
+        Esys_FlushContext(context->esys, context->policy_session);
+    }
     if (context->session1 != ESYS_TR_NONE) {
         if (Esys_FlushContext(context->esys, context->session1) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup session failed.");
@@ -1022,6 +1025,9 @@ TSS2_RC
 ifapi_cleanup_session(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
+
+    /* Policy sessions were closed after successful execution. */
+    context->policy_session = ESYS_TR_NONE;
 
     switch (context->cleanup_state) {
         statecase(context->cleanup_state, CLEANUP_INIT);

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -531,7 +531,7 @@ ifapi_init_primary_async(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype)
                                  &context->cmd.Provision.hash_size);
         if (r) {
             LOG_ERROR("Policy calculation");
-            free(policy);
+            SAFE_FREE(policy);
             return r;
         }
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -28,8 +28,8 @@
  * @retval TSS2_RC_SUCCESS If the pathname is ok.
  * @retval TSS2_FAPI_RC_BAD_PATH If not valid characters are detected.
  */
-static TSS2_RC
-check_valid_path(
+TSS2_RC
+ifapi_check_valid_path(
     const char *path)
 {
     for (size_t i = 1; i < strlen(path); i++) {
@@ -287,7 +287,7 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
     check_not_null(path);
 
     /* First it will be checked whether the only valid characters occur in the path. */
-    r = check_valid_path(path);
+    r = ifapi_check_valid_path(path);
     return_if_error(r, "Invalid path.");
 
     if (ifapi_hierarchy_path_p(path)) {

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -940,7 +940,7 @@ expand_directory(IFAPI_KEYSTORE *keystore, const char *path, char **directory_na
              strncmp(&path[start_pos], "HE", 2) == 0) &&
             strlen(&path[start_pos]) <= 3) {
             /* Root directory is hierarchy */
-            r = ifapi_asprintf(directory_name, "%s/%s/", keystore->defaultprofile,
+            r = ifapi_asprintf(directory_name, "/%s/%s/", keystore->defaultprofile,
                                &path[start_pos]);
             return_if_error(r, "Out of memory.");
 

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -146,6 +146,8 @@ typedef struct _IFAPI_OBJECT {
 
 } IFAPI_OBJECT;
 
+TSS2_RC
+ifapi_check_valid_path(const char *path);
 
 TSS2_RC
 ifapi_keystore_initialize(

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -1324,6 +1324,7 @@ execute_policy_or(
         r = Esys_PolicyOR_Finish(esys_ctx);
         try_again_or_error(r, "Execute PolicyPCR_Finish.");
 
+        current_policy->state = POLICY_EXECUTE_INIT;
         return r;
 
     statecasedefault(current_policy->state);

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -165,11 +165,12 @@ ifapi_policyeval_instantiate_finish(
     IFAPI_POLICY_EVAL_INST_CTX *context)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    NODE_OBJECT_T *first_in_pol_list = context->policy_elements;
+    NODE_OBJECT_T *first_in_pol_list;
     size_t i_last;
 
     /* While not all policy elements are instantiated */
-    while (first_in_pol_list) {
+    while (context->policy_elements) {
+        first_in_pol_list = context->policy_elements;
         TPMT_POLICYELEMENT *pol_element = first_in_pol_list->object;
         switch (pol_element->type) {
         case POLICYSIGNED:

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -144,6 +144,10 @@ ifapi_policy_store_load_async(
 
     LOG_TRACE("Load policy: %s", path);
 
+    /* First it will be checked whether the only valid characters occur in the path. */
+    r = ifapi_check_valid_path(path);
+    return_if_error(r, "Invalid path.");
+
     /* Free old input buffer if buffer exists */
     SAFE_FREE(io->char_rbuffer);
 

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -244,6 +244,10 @@ ifapi_policy_store_store_async(
 
     LOG_TRACE("Store policy: %s", path);
 
+    /* First it will be checked whether the only valid characters occur in the path. */
+    r = ifapi_check_valid_path(path);
+    return_if_error(r, "Invalid path.");
+
     /* Convert relative path to absolute path in the policy store */
     r = policy_rel_path_to_abs_path(pstore, path, &abs_path);
     goto_if_error2(r, "Path %s could not be created.", cleanup, path);

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -49,6 +49,7 @@ new_policy(
 
     pol_exec_ctx = calloc(sizeof(IFAPI_POLICY_EXEC_CTX), 1);
     if (!pol_exec_ctx) {
+        SAFE_FREE(*current_policy);
         return_error(TSS2_FAPI_RC_MEMORY, "Out of memory");
     }
     (*current_policy)->pol_exec_ctx = pol_exec_ctx;
@@ -69,6 +70,7 @@ new_policy(
 
     pol_exec_cb_ctx = calloc(sizeof(IFAPI_POLICY_EXEC_CB_CTX), 1);
     if (!pol_exec_cb_ctx) {
+        SAFE_FREE(*current_policy);
         return_error(TSS2_FAPI_RC_MEMORY, "Out of memory");
     }
     pol_exec_ctx->app_data = pol_exec_cb_ctx;
@@ -226,7 +228,6 @@ error:
     while (context->policy.policyutil_stack) {
         clear_all_policies(context);
     }
-    SAFE_FREE(current_policy);
     return r;
 }
 /** State machine to Execute the TPM policy commands needed for the current policy.

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -298,6 +298,8 @@ ifapi_policyutil_execute(FAPI_CONTEXT *context, ESYS_TR *session)
                 goto_if_error(r, "Create policy session", error);
 
                 pol_util_ctx->pol_exec_ctx->session = pol_util_ctx->policy_session;
+                /* Save policy session for cleanup in error case. */
+                context->policy_session = pol_util_ctx->policy_session;
             } else {
                 pol_util_ctx->pol_exec_ctx->session = *session;
             }


### PR DESCRIPTION
* Policy execution was fixed.
* Pathname check was added for policy files.
* New provisioning after deleting /HS was enabled.
* A missing return code check for ChangeAuth was added.

 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>