### PR TITLE
CI: Dump log on cirrus-ci failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,4 +24,4 @@ task:
   script:
     ./bootstrap &&
     ./configure --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-mssim=yes --disable-dependency-tracking &&
-    gmake -j distcheck || { cat test-suite.log; exit 1; }
+    gmake -j distcheck || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }


### PR DESCRIPTION
Cirrus-ci does distcheck under /tmp/cirrus-ci-build/...
Dump the test-suit.log from there instead of current working dir.