### PR TITLE
tcti: fix collisions with multi-threading

### DIFF
--- a/src/tss2-tcti/tcti-pcap-builder.h
+++ b/src/tss2-tcti/tcti-pcap-builder.h
@@ -16,9 +16,10 @@
 
 typedef struct {
     int fd;
-    uint16_t tcp_host_port;
-    uint32_t tcp_sequence_no_host_to_tpm;
-    uint32_t tcp_sequence_no_tpm_to_host;
+    uint32_t ip_host;
+    uint32_t ip_tpm;
+    uint32_t tcp_sequence_no_host;
+    uint32_t tcp_sequence_no_tpm;
 } pcap_buider_ctx;
 
 int


### PR DESCRIPTION
When multiple instances of tcti-pcap are writing to the same file at the same time collisions can appear. Fix the following three issues:

* The random host is seeded by the unix epoch in seconds. If multiple threads start roughly at the same time, their packages are associated with the same connection. Move to nanoseconds.
* A random port between 50k and 60k is prone to collisions. Instead use a fixed port and randomize both IP addresses.
* Wireshark sometimes seems to choke on the sequence and acknowledgement number not being implemented properly. Randomize their initial values and implement the acknowledge number properly.