### PR TITLE
FAPI: Fix cleanup of policy sessions in error case.

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -1071,6 +1071,9 @@ ifapi_non_tpm_mode_init(FAPI_CONTEXT *context)
 void
 ifapi_session_clean(FAPI_CONTEXT *context)
 {
+    if (context->policy_session && context->policy_session != ESYS_TR_NONE) {
+        Esys_FlushContext(context->esys, context->policy_session);
+    }
     if (context->session1 != ESYS_TR_NONE) {
         if (Esys_FlushContext(context->esys, context->session1) != TSS2_RC_SUCCESS) {
             LOG_ERROR("Cleanup session failed.");
@@ -1109,6 +1112,9 @@ TSS2_RC
 ifapi_cleanup_session(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
+
+    /* Policy sessions were closed after successful execution. */
+    context->policy_session = ESYS_TR_NONE;
 
     switch (context->cleanup_state) {
         statecase(context->cleanup_state, CLEANUP_INIT);

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -303,6 +303,8 @@ ifapi_policyutil_execute(FAPI_CONTEXT *context, ESYS_TR *session)
                 goto_if_error(r, "Create policy session", error);
 
                 pol_util_ctx->pol_exec_ctx->session = pol_util_ctx->policy_session;
+                /* Save policy session for cleanup in error case. */
+                context->policy_session = pol_util_ctx->policy_session;
             } else {
                 pol_util_ctx->pol_exec_ctx->session = *session;
             }


### PR DESCRIPTION
For successful execution policy sessions are closed automatically. In error cases the policy
sessions have to be flushed in the cleanup function.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>