### PR TITLE
io.c: don't remap AGAIN to TSS2_TCTI_RC_TRY_AGAIN

### DIFF
--- a/src/util/io.c
+++ b/src/util/io.c
@@ -57,9 +57,6 @@ read_all (
 #else
         TEMP_RETRY (recvd, read (fd, &data [recvd_total], size));
         if (recvd < 0) {
-            if (errno == EAGAIN) {
-                return TSS2_TCTI_RC_TRY_AGAIN;
-            }
             LOG_WARNING ("read on fd %d failed with errno %d: %s",
                          fd, errno, strerror (errno));
             return recvd_total;


### PR DESCRIPTION
Don't need to remap the AGAIN to TPM2 AGAIN since
we implement all retry logic araound the poll() calls.
All the error cases from the socket_recv_buf()
translate to TSS2_TCTI_RC_IO_ERROR in both mssim_tcti
and swtpm_tcti. These two are the only users of the
socket_recv_buf() function.

Fixes #1842