### PR TITLE
ci: fix not having branch ref in git diff --check

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -134,7 +134,8 @@ fi # TEST_TCTI_CONFIG
 # so people can verify the rest of their patch works in CI before dying.
 # git diff --check fails with a non-zero return code causing the shell to die
 # as it has a set -e executed.
-[ -z "$TRAVIS_TAG" ] && git diff --check origin/${TRAVIS_BRANCH:-master}
+check_branch="origin/${TRAVIS_BRANCH:-master}"
+[ -z "$TRAVIS_TAG" ] && git fetch "$check_branch" && git diff --check "$check_branch"
 
 if [ "$ENABLE_COVERAGE" == "true" ]; then
     bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
It appears the ref isn't available on checkouts, so fetch the full ref
when doing git diff --check

Clone command:
1.21s$ git clone --depth=50 https://github.com/tpm2-software/tpm2-tss.git tpm2-software/tpm2-tss
Cloning into 'tpm2-software/tpm2-tss'...
$ cd tpm2-software/tpm2-tss
3.11s$ git fetch origin +refs/pull/1706/merge:
From https://github.com/tpm2-software/tpm2-tss
 * branch              refs/pull/1706/merge -> FETCH_HEAD
$ git checkout -qf FETCH_HEAD

Fixes:
fatal: ambiguous argument 'origin/2.4.x': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
The command "./.ci/travis.run" exited with 128.

Signed-off-by: William Roberts <william.c.roberts@intel.com>