### PR TITLE
FAPI: Wrong property in doc (fixes #1851)

### DIFF
--- a/doc/fapi-config.md
+++ b/doc/fapi-config.md
@@ -10,7 +10,7 @@ The FAPI parameters which can be adjusted via the configuration file are:
 * tcti: The TCTI interface which will be used.
 * system_pcrs: The PCR registers which are used by the system.
 * log_dir: The directory for the event log.
-* ek_certless: A switch to disable certificate verification (optional).
+* ek_cert_less: A switch to disable certificate verification (optional).
 * ek_fingerprint: The fingerprint of the endorsement key (optional).
 
 If not otherwise specified during TSS installation, the default location for the
@@ -38,7 +38,7 @@ The FAPI configuration file is JSON encoded:
  If the certificate checking is not needed the option:
 
  ```
-    "ek_certless": "yes"
+    "ek_cert_less": "yes"
  ```
 can be added to the config file. Alternative to the standard certificate checking a
 fingerprint (hash of the public key) for the stored endorsement key can be defined

--- a/man/fapi-config.5.in
+++ b/man/fapi-config.5.in
@@ -26,7 +26,7 @@ system_pcrs: The PCR registers which are used by the system.
 .IP \[bu] 2
 log_dir: The directory for the event log.
 .IP \[bu] 2
-ek_certless: A switch to disable certificate verification (optional).
+ek_cert_less: A switch to disable certificate verification (optional).
 .IP \[bu] 2
 ek_fingerprint: The fingerprint of the endorsement key (optional).
 .PP
@@ -57,7 +57,7 @@ For this example the default TCTI of the system will be used.
 The certificates for the stored endorsement keys will be checked.
 If the certificate checking is not needed the option:
 .PP
-\f[C]"ek_certless":\ "yes"\f[] can be added to the config file.
+\f[C]"ek_cert_less":\ "yes"\f[] can be added to the config file.
 Alternative to the standard certificate checking a fingerprint (hash of
 the public key) for the stored endorsement key can be defined in the
 config file:


### PR DESCRIPTION
The property ek_cert_less was documented as ek_certless.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>