### PR TITLE
 FAPI: Improve error message for JSON deserialization.

### DIFF
--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -111,58 +111,58 @@ ifapi_json_IFAPI_KEY_deserialize(json_object *jso,  IFAPI_KEY *out)
 
 
     if (!ifapi_get_sub_object(jso, "persistent_handle", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"persistent_handle\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->persistent_handle);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"persistent_handle\".");
 
     if (ifapi_get_sub_object(jso, "with_auth", &jso2)) {
         r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->with_auth);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"with_auth\".");
 
     } else {
         out->with_auth = TPM2_NO;
     }
 
     if (!ifapi_get_sub_object(jso, "public", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"public\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_PUBLIC_deserialize(jso2, &out->public);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"public\".");
 
     if (!ifapi_get_sub_object(jso, "serialization", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"serialization\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT8_ARY_deserialize(jso2, &out->serialization);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"serialization\".");
 
     if (!ifapi_get_sub_object(jso, "private", &jso2)) {
         memset(&out->private, 0, sizeof(UINT8_ARY));
     } else {
         r = ifapi_json_UINT8_ARY_deserialize(jso2, &out->private);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"private\".");
     }
 
     if (!ifapi_get_sub_object(jso, "appData", &jso2)) {
         memset(&out->appData, 0, sizeof(UINT8_ARY));
     } else {
         r = ifapi_json_UINT8_ARY_deserialize(jso2, &out->appData);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"appData\".");
     }
 
     if (!ifapi_get_sub_object(jso, "policyInstance", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"policyInstance\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->policyInstance);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"policyInstance\".");
 
     if (ifapi_get_sub_object(jso, "creationData", &jso2)) {
         r = ifapi_json_TPM2B_CREATION_DATA_deserialize(jso2, &out->creationData);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"creationData\".");
 
     } else {
         memset(&out->creationData, 0, sizeof(TPM2B_CREATION_DATA));
@@ -170,45 +170,45 @@ ifapi_json_IFAPI_KEY_deserialize(json_object *jso,  IFAPI_KEY *out)
 
     if (ifapi_get_sub_object(jso, "creationTicket", &jso2)) {
         r = ifapi_json_TPMT_TK_CREATION_deserialize(jso2, &out->creationTicket);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"creationTicket\".");
 
     } else {
         memset(&out->creationData, 0, sizeof(TPMT_TK_CREATION));
     }
     if (!ifapi_get_sub_object(jso, "description", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"description\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->description);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"description\".");
 
     if (!ifapi_get_sub_object(jso, "certificate", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"certificate\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->certificate);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"certificate\".");
 
     if (out->public.publicArea.type != TPM2_ALG_KEYEDHASH) {
          /* Keyed hash objects to not need a signing scheme. */
         if (!ifapi_get_sub_object(jso, "signing_scheme", &jso2)) {
-            LOG_ERROR("Bad value");
+            LOG_ERROR("Field \"signing_scheme\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMT_SIG_SCHEME_deserialize(jso2, &out->signing_scheme);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"signing_scheme\".");
     }
 
     if (!ifapi_get_sub_object(jso, "name", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"name\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->name);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"name\".");
 
     if (ifapi_get_sub_object(jso, "reset_count", &jso2)) {
         r = ifapi_json_UINT32_deserialize(jso2, &out->reset_count);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"reset_count\".");
     } else {
         out->reset_count = 0;
     }
@@ -256,7 +256,7 @@ ifapi_json_import_IFAPI_KEY_deserialize(json_object *jso,  IFAPI_KEY *out)
     }
 
     if (!ifapi_get_sub_object(jso, "public", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"public\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT8_ARY_deserialize(jso2, &public_blob);
@@ -327,22 +327,22 @@ ifapi_json_IFAPI_EXT_PUB_KEY_deserialize(json_object *jso,
 
 
     if (!ifapi_get_sub_object(jso, "pem_ext_public", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pem_ext_public\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->pem_ext_public);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pem_ext_public\".");
 
     if (ifapi_get_sub_object(jso, "certificate", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->certificate);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"certificate\".");
     } else {
         out->certificate = NULL;
     }
 
     if (ifapi_get_sub_object(jso, "public", &jso2)) {
         r = ifapi_json_TPM2B_PUBLIC_deserialize(jso2, &out->public);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"public\".");
 
     } else {
         memset(&out->public, 0, sizeof(TPM2B_PUBLIC));
@@ -372,56 +372,56 @@ ifapi_json_IFAPI_NV_deserialize(json_object *jso,  IFAPI_NV *out)
         memset(&out->appData, 0, sizeof(UINT8_ARY));
     } else {
         r = ifapi_json_UINT8_ARY_deserialize(jso2, &out->appData);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"appData\".");
     }
 
     if (ifapi_get_sub_object(jso, "with_auth", &jso2)) {
         r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->with_auth);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"with_auth\".");
 
     } else {
         out->with_auth = TPM2_NO;
     }
 
     if (!ifapi_get_sub_object(jso, "public", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"public\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &out->public);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"public\".");
 
     if (!ifapi_get_sub_object(jso, "serialization", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"serialization\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT8_ARY_deserialize(jso2, &out->serialization);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"serialization\".");
 
     if (!ifapi_get_sub_object(jso, "hierarchy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hierarchy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->hierarchy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hierarchy\".");
 
     if (!ifapi_get_sub_object(jso, "policyInstance", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"policyInstance\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->policyInstance);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"policyInstance\".");
 
     if (!ifapi_get_sub_object(jso, "description", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"description\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->description);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"description\".");
 
     return_if_error(r, "BAD VALUE");
     if (ifapi_get_sub_object(jso, "event_log", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->event_log);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"event_log\".");
 
     } else {
         out->event_log = NULL;
@@ -449,29 +449,29 @@ ifapi_json_IFAPI_HIERARCHY_deserialize(json_object *jso,  IFAPI_HIERARCHY *out)
 
     if (ifapi_get_sub_object(jso, "with_auth", &jso2)) {
         r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->with_auth);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"with_auth\".");
 
     } else {
         out->with_auth = TPM2_NO;
     }
 
     if (!ifapi_get_sub_object(jso, "authPolicy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"authPolicy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->authPolicy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"authPolicy\".");
 
     if (!ifapi_get_sub_object(jso, "description", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"description\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->description);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"description\".");
 
     if (ifapi_get_sub_object(jso, "esysHandle", &jso2)) {
         r = ifapi_json_UINT32_deserialize(jso2, &out->esysHandle);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"esysHandle\".");
     } else {
         out->esysHandle = ESYS_TR_RH_OWNER;
     }
@@ -498,18 +498,18 @@ ifapi_json_FAPI_QUOTE_INFO_deserialize(json_object *jso,  FAPI_QUOTE_INFO *out)
 
 
     if (!ifapi_get_sub_object(jso, "sig_scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sig_scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SIG_SCHEME_deserialize(jso2, &out->sig_scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sig_scheme\".");
 
     if (!ifapi_get_sub_object(jso, "attest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"attest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMS_ATTEST_deserialize(jso2, &out->attest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"attest\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -532,42 +532,42 @@ ifapi_json_IFAPI_DUPLICATE_deserialize(json_object *jso, IFAPI_DUPLICATE *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "duplicate", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"duplicate\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
     r = ifapi_json_TPM2B_PRIVATE_deserialize(jso2, &out->duplicate);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"duplicate\".");
 
     if (!ifapi_get_sub_object(jso, "encrypted_seed", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"encrypted_seed\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_ENCRYPTED_SECRET_deserialize(jso2, &out->encrypted_seed);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"encrypted_seed\".");
 
     if (ifapi_get_sub_object(jso, "certificate", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->certificate);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"certificate\".");
 
     } else {
         out->certificate = NULL;
     }
 
     if (!ifapi_get_sub_object(jso, "public", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"public\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
     r = ifapi_json_TPM2B_PUBLIC_deserialize(jso2, &out->public);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"public\".");
     if (!ifapi_get_sub_object(jso, "public_parent", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"public_parent\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
     r = ifapi_json_TPM2B_PUBLIC_deserialize(jso2, &out->public_parent);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"public_parent\".");
 
     if (ifapi_get_sub_object(jso, "policy", &jso2)) {
         out->policy = calloc(1, sizeof(TPMS_POLICY));
@@ -633,41 +633,41 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "objectType", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"objectType\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
     out->rel_path = NULL;
 
     r = ifapi_json_IFAPI_OBJECT_TYPE_CONSTANT_deserialize(jso2, &out->objectType);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"objectType\".");
 
     switch (out->objectType) {
     case IFAPI_NV_OBJ:
         r = ifapi_json_IFAPI_NV_deserialize(jso, &out->misc.nv);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for NV object.");
         break;
 
     case IFAPI_DUPLICATE_OBJ:
         r = ifapi_json_IFAPI_DUPLICATE_deserialize(jso, &out->misc.key_tree);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for key tree");
 
         break;
 
     case IFAPI_EXT_PUB_KEY_OBJ:
         r = ifapi_json_IFAPI_EXT_PUB_KEY_deserialize(jso, &out->misc.ext_pub_key);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for external public key.");
 
         break;
 
     case IFAPI_HIERARCHY_OBJ:
         r = ifapi_json_IFAPI_HIERARCHY_deserialize(jso, &out->misc.hierarchy);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for hierarchy.");
 
         break;
     case IFAPI_KEY_OBJ:
         r = ifapi_json_IFAPI_KEY_deserialize(jso, &out->misc.key);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for key.");
 
         break;
     default:
@@ -677,7 +677,7 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out)
 
     if (ifapi_get_sub_object(jso, "system", &jso2)) {
         r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->system);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"system\".");
 
     } else {
         out->system = TPM2_NO;
@@ -784,11 +784,11 @@ ifapi_json_IFAPI_TSS_EVENT_deserialize(json_object *jso,  IFAPI_TSS_EVENT *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "data", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"data\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_EVENT_deserialize(jso2, &out->data);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"data\".");
 
     if (!ifapi_get_sub_object(jso, "event", &jso2)) {
         out->event = NULL;
@@ -822,18 +822,18 @@ ifapi_json_IFAPI_IMA_EVENT_deserialize(json_object *jso,  IFAPI_IMA_EVENT *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "eventData", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"eventData\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->eventData);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"eventData\".");
 
     if (!ifapi_get_sub_object(jso, "eventName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"eventName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->eventName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"eventName\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -885,39 +885,39 @@ ifapi_json_IFAPI_EVENT_deserialize(json_object *jso,  IFAPI_EVENT *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "recnum", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"recnum\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->recnum);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"recnum\".");
 
     if (!ifapi_get_sub_object(jso, "pcr", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcr\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_HANDLE_deserialize(jso2, &out->pcr);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcr\".");
 
     if (!ifapi_get_sub_object(jso, "digests", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"digests\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_DIGEST_VALUES_deserialize(jso2, &out->digests);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"digests\".");
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_IFAPI_EVENT_TYPE_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "sub_event", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sub_event\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_IFAPI_EVENT_UNION_deserialize(out->type, jso2, &out->sub_event);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sub_event\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/ifapi_json_deserialize.h
+++ b/src/tss2-fapi/ifapi_json_deserialize.h
@@ -22,7 +22,7 @@
         memset(&out->name, 0, sizeof(type)); \
     } else { \
         r =  ifapi_json_ ## type ## _deserialize (jso2, &out->name); \
-        return_if_error(r,"BAD VALUE"); \
+        return_if_error2(r, "Bad value for field \"%s\".", json_name);  \
     }
 
 bool

--- a/src/tss2-fapi/ifapi_policy_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_deserialize.c
@@ -178,14 +178,14 @@ ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
         memset(&out->cpHashA, 0, sizeof(TPM2B_DIGEST));
     } else {
         r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->cpHashA);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"cpHashA\".");
     }
 
     if (!ifapi_get_sub_object(jso, "policyRef", &jso2)) {
         memset(&out->policyRef, 0, sizeof(TPM2B_NONCE));
     } else {
         r = ifapi_json_TPM2B_NONCE_deserialize(jso2, &out->policyRef);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyRef\".");
     }
 
     out->expiration = 0;
@@ -195,7 +195,7 @@ ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->keyPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPath\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyPublic", &jso2)) {
@@ -203,7 +203,7 @@ ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPMT_PUBLIC_deserialize(jso2, &out->keyPublic);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPublic\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyPEM", &jso2)) {
@@ -211,21 +211,21 @@ ifapi_json_TPMS_POLICYSIGNED_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->keyPEM);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPEM\".");
     }
 
     if (!ifapi_get_sub_object(jso, "publicKeyHint", &jso2)) {
         out->publicKeyHint = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->publicKeyHint);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"publicKeyHint\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyPEMhashAlg", &jso2)) {
         out->keyPEMhashAlg = TPM2_ALG_SHA256;
     } else {
         r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->keyPEMhashAlg);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPEMhashAlg\".");
     }
 
     /* Check whether only one condition field found in policy. */
@@ -262,14 +262,14 @@ ifapi_json_TPMS_POLICYSECRET_deserialize(json_object *jso,
         memset(&out->cpHashA, 0, sizeof(TPM2B_DIGEST));
     } else {
         r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->cpHashA);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"cpHashA\".");
     }
 
     if (!ifapi_get_sub_object(jso, "policyRef", &jso2)) {
         memset(&out->policyRef, 0, sizeof(TPM2B_NONCE));
     } else {
         r = ifapi_json_TPM2B_NONCE_deserialize(jso2, &out->policyRef);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyRef\".");
     }
     out->expiration = 0;
 
@@ -278,7 +278,7 @@ ifapi_json_TPMS_POLICYSECRET_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->objectPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"objectPath\".");
     }
 
     if (!ifapi_get_sub_object(jso, "objectName", &jso2)) {
@@ -286,7 +286,7 @@ ifapi_json_TPMS_POLICYSECRET_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->objectName);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"objectName\".");
     }
     if (cond_cnt != 1) {
         return_error(TSS2_FAPI_RC_BAD_VALUE,
@@ -314,11 +314,11 @@ ifapi_json_TPMS_POLICYLOCALITY_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "locality", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"locality\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMA_LOCALITY_deserialize(jso2, &out->locality);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"locality\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -347,7 +347,7 @@ ifapi_json_TPMS_POLICYNV_deserialize(json_object *jso,  TPMS_POLICYNV *out)
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->nvPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nvPath\".");
     }
 
     if (!ifapi_get_sub_object(jso, "nvIndex", &jso2)) {
@@ -355,35 +355,35 @@ ifapi_json_TPMS_POLICYNV_deserialize(json_object *jso,  TPMS_POLICYNV *out)
     } else {
         cond_cnt++;
         r = ifapi_json_TPMI_RH_NV_INDEX_deserialize(jso2, &out->nvIndex);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nvIndex\".");
     }
 
     if (!ifapi_get_sub_object(jso, "nvPublic", &jso2)) {
         memset(&out->nvPublic, 0, sizeof(TPM2B_NV_PUBLIC));
     } else {
         r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &out->nvPublic);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nvPublic\".");
     }
 
     if (!ifapi_get_sub_object(jso, "operandB", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"operandB\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_OPERAND_deserialize(jso2, &out->operandB);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"operandB\".");
 
     if (!ifapi_get_sub_object(jso, "offset", &jso2)) {
         out->offset = 0;
     } else {
         r = ifapi_json_UINT16_deserialize(jso2, &out->offset);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"offset\".");
     }
 
     if (!ifapi_get_sub_object(jso, "operation", &jso2)) {
         out->operation = 0;
     } else {
         r = ifapi_json_TPM2_EO_deserialize(jso2, &out->operation);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"operation\".");
     }
     /* Check whether only one conditional is used. */
     if (cond_cnt != 1) {
@@ -413,25 +413,25 @@ ifapi_json_TPMS_POLICYCOUNTERTIMER_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "operandB", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"operandB\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_OPERAND_deserialize(jso2, &out->operandB);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"operandB\".");
 
     if (!ifapi_get_sub_object(jso, "offset", &jso2)) {
         out->offset = 0;
     } else {
         r = ifapi_json_UINT16_deserialize(jso2, &out->offset);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"offset\".");
     }
 
     if (!ifapi_get_sub_object(jso, "operation", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"operation\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_EO_deserialize(jso2, &out->operation);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"operation\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -454,11 +454,11 @@ ifapi_json_TPMS_POLICYCOMMANDCODE_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "code", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"code\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_CC_deserialize(jso2, &out->code);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"code\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -500,11 +500,11 @@ ifapi_json_TPMS_POLICYCPHASH_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "cpHash", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"cpHash\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->cpHash);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"cpHash\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -534,7 +534,7 @@ ifapi_json_TPMS_POLICYNAMEHASH_deserialize(json_object *jso,
     if (ifapi_get_sub_object(jso, "nameHash", &jso2)) {
         cond_cnt++;
         r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->nameHash);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nameHash\".");
 
         /* No need to deserialize namePaths or objectNames from which nameHash would
            be derived. */
@@ -553,7 +553,7 @@ ifapi_json_TPMS_POLICYNAMEHASH_deserialize(json_object *jso,
             for (i = 0; i < n_paths; i++) {
                 jso3 = json_object_array_get_idx(jso2, i);
                 r = ifapi_json_char_deserialize(jso3, &out->namePaths[i]);
-                return_if_error(r, "BAD VALUE");
+                return_if_error(r, "Bad value for field \"namePaths\".");
             }
             out->count = n_paths;
         } else {
@@ -643,7 +643,7 @@ ifapi_json_TPMS_POLICYDUPLICATIONSELECT_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->newParentPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"newParentPath\".");
     }
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {
@@ -679,27 +679,27 @@ ifapi_json_TPMS_POLICYAUTHORIZE_deserialize(json_object *jso,
         memset(&out->approvedPolicy, 0, sizeof(TPM2B_DIGEST));
     } else {
         r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->approvedPolicy);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"approvedPolicy\".");
     }
 
     if (!ifapi_get_sub_object(jso, "policyRef", &jso2)) {
         memset(&out->policyRef, 0, sizeof(TPM2B_NONCE));
     } else {
         r = ifapi_json_TPM2B_NONCE_deserialize(jso2, &out->policyRef);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyRef\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyName", &jso2)) {
         memset(&out->keyName, 0, sizeof(TPM2B_NAME));
     } else {
         r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->keyName);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyName\".");
     }
 
     if (ifapi_get_sub_object(jso, "keyPath", &jso2)) {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->keyPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPath\".");
     } else {
         out->keyPath = NULL;
     }
@@ -709,7 +709,7 @@ ifapi_json_TPMS_POLICYAUTHORIZE_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPMT_PUBLIC_deserialize(jso2, &out->keyPublic);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPublic\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyPEM", &jso2)) {
@@ -717,14 +717,14 @@ ifapi_json_TPMS_POLICYAUTHORIZE_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->keyPEM);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPEM\".");
     }
 
     if (!ifapi_get_sub_object(jso, "keyPEMhashAlg", &jso2)) {
         out->keyPEMhashAlg = 0;
     } else {
         r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->keyPEMhashAlg);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyPEMhashAlg\".");
     }
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {
@@ -795,7 +795,7 @@ ifapi_json_TPMS_POLICYNVWRITTEN_deserialize(json_object *jso,
         return TSS2_RC_SUCCESS;
     }
     r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->writtenSet);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"writtenSet\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -825,7 +825,7 @@ ifapi_json_TPMS_POLICYTEMPLATE_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->templateHash);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"templateHash\".");
     }
 
     if (!ifapi_get_sub_object(jso, "templatePublic", &jso2)) {
@@ -833,12 +833,12 @@ ifapi_json_TPMS_POLICYTEMPLATE_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPM2B_PUBLIC_deserialize(jso2, &out->templatePublic);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"templatePublic\".");
     }
 
     if (ifapi_get_sub_object(jso, "templateName", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->templateName);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"templateName\".");
     } else {
         out->templateName = NULL;
     }
@@ -878,7 +878,7 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_deserialize(json_object *jso,
     if (ifapi_get_sub_object(jso, "nvPath", &jso2)) {
         cond_cnt++;
         r = ifapi_json_char_deserialize(jso2, &out->nvPath);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nvPath\".");
     } else {
         out->nvPath = NULL;
     }
@@ -888,7 +888,7 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_deserialize(json_object *jso,
     } else {
         cond_cnt++;
         r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &out->nvPublic);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"nvPublic\".");
     }
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {
@@ -921,11 +921,11 @@ ifapi_json_TPMS_POLICYACTION_deserialize(json_object *jso,
     memset(out, 0, sizeof(*out));
 
     if (!ifapi_get_sub_object(jso, "action", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"action\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->action);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"action\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -948,24 +948,24 @@ ifapi_json_TPMS_PCRVALUE_deserialize(json_object *jso,  TPMS_PCRVALUE *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "pcr", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcr\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->pcr);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcr\".");
 
     if (!ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hashAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_ALG_ID_deserialize(jso2, &out->hashAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hashAlg\".");
     if (!ifapi_get_sub_object(jso, "digest", &jso2)) {
-        LOG_ERROR("BAD VALUE");
+        LOG_ERROR("Field \"digest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMU_HA_deserialize(out->hashAlg, jso2, &out->digest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"digest\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
@@ -1028,7 +1028,7 @@ ifapi_json_TPMS_POLICYPCR_deserialize(json_object *jso,  TPMS_POLICYPCR *out)
     if (ifapi_get_sub_object(jso, "pcrs", &jso2)) {
         cond_cnt++;
         r = ifapi_json_TPML_PCRVALUES_deserialize(jso2, &out->pcrs);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"pcrs\".");
     } else {
         memset(&out->pcrs, 0, sizeof(TPML_PCRVALUES));
     }
@@ -1036,7 +1036,7 @@ ifapi_json_TPMS_POLICYPCR_deserialize(json_object *jso,  TPMS_POLICYPCR *out)
     if (ifapi_get_sub_object(jso, "currentPCRs", &jso2)) {
         cond_cnt++;
         r = ifapi_json_TPMS_PCR_SELECT_deserialize(jso2, &out->currentPCRs);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"currentPCRs\".");
     } else {
         memset(&out->currentPCRs, 0, sizeof(TPMS_PCR_SELECT));
     }
@@ -1044,7 +1044,7 @@ ifapi_json_TPMS_POLICYPCR_deserialize(json_object *jso,  TPMS_POLICYPCR *out)
     if (ifapi_get_sub_object(jso, "currentPCRandBanks", &jso2)) {
         cond_cnt++;
         r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->currentPCRandBanks);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"currentPCRandBanks\".");
     } else {
         memset(&out->currentPCRandBanks, 0, sizeof(TPML_PCR_SELECTION));
     }
@@ -1078,32 +1078,32 @@ ifapi_json_TPMS_POLICYAUTHORIZATION_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "key", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"key\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_PUBLIC_deserialize(jso2, &out->key);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"key\".");
 
     if (!ifapi_get_sub_object(jso, "policyRef", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"policyRef\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NONCE_deserialize(jso2, &out->policyRef);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"policyRef\".");
 
     if (!ifapi_get_sub_object(jso, "signature", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"signature\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SIGNATURE_deserialize(jso2, &out->signature);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"signature\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1164,31 +1164,31 @@ ifapi_json_TPMS_POLICYBRANCH_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "name", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"name\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->name);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"name\".");
 
     if (!ifapi_get_sub_object(jso, "description", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"description\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->description);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"description\".");
 
     if (!ifapi_get_sub_object(jso, "policy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"policy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_POLICYELEMENTS_deserialize(jso2, &out->policy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"policy\".");
 
     if (!ifapi_get_sub_object(jso, "policyDigests", &jso2)) {
         memset(&out->policyDigests, 0, sizeof(TPML_DIGEST_VALUES));
     } else {
         r = ifapi_json_TPML_DIGEST_VALUES_deserialize(jso2, &out->policyDigests);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyDigests\".");
 
     }
 
@@ -1250,11 +1250,11 @@ ifapi_json_TPMS_POLICYOR_deserialize(json_object *jso,  TPMS_POLICYOR *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "branches", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"branches\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_POLICYBRANCHES_deserialize(jso2, &out->branches);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"branches\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1346,21 +1346,21 @@ ifapi_json_TPMT_POLICYELEMENT_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_POLICYTYPE_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "policyDigests", &jso2)) {
         memset(&out->policyDigests, 0, sizeof(TPML_DIGEST_VALUES));
     } else {
         r = ifapi_json_TPML_DIGEST_VALUES_deserialize(jso2, &out->policyDigests);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyDigests\".");
 
     }
     r = ifapi_json_TPMU_POLICYELEMENT_deserialize(out->type, jso, &out->element);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"element\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
@@ -1425,13 +1425,13 @@ ifapi_json_TPMS_POLICY_deserialize(json_object *jso,
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->description);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"description\".");
 
     if (!ifapi_get_sub_object(jso, "policyDigests", &jso2)) {
         memset(&out->policyDigests, 0, sizeof(TPML_DIGEST_VALUES));
     } else {
         r = ifapi_json_TPML_DIGEST_VALUES_deserialize(jso2, &out->policyDigests);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyDigests\".");
 
     }
     if (!ifapi_get_sub_object(jso, "policyAuthorizations", &jso2)) {
@@ -1439,15 +1439,15 @@ ifapi_json_TPMS_POLICY_deserialize(json_object *jso,
     } else {
         r = ifapi_json_TPML_POLICYAUTHORIZATIONS_deserialize(jso2,
                 &out->policyAuthorizations);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"policyAuthorizations\".");
 
     }
     if (!ifapi_get_sub_object(jso, "policy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"policy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_POLICYELEMENTS_deserialize(jso2, &out->policy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"policy\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -356,14 +356,14 @@ ifapi_json_TPMS_PCR_SELECTION_deserialize(json_object *jso,
 
     memset(out, 0, sizeof(TPMS_PCR_SELECTION));
     if (!ifapi_get_sub_object(jso, "hash", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hash\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hash);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hash\".");
 
     if (!ifapi_get_sub_object(jso, "pcrSelect", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcrSelect\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     return ifapi_json_pcr_selection_deserialize(jso2, &out->sizeofSelect,
@@ -1409,18 +1409,18 @@ ifapi_json_TPMT_HA_deserialize(json_object *jso,  TPMT_HA *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hashAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hashAlg\".");
     if (out->hashAlg != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "digest", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"digest\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_HA_deserialize(out->hashAlg, jso2, &out->digest);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"digest\".");
     }
 
     LOG_TRACE("true");
@@ -1609,28 +1609,28 @@ ifapi_json_TPMT_TK_CREATION_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "tag", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"tag\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_ST_deserialize(jso2, &out->tag);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"tag\".");
     if (out != NULL && out->tag != TPM2_ST_CREATION) {
         LOG_ERROR("BAD VALUE %zu != %zu", (size_t)out->tag, (size_t)TPM2_ST_CREATION);
     }
 
     if (!ifapi_get_sub_object(jso, "hierarchy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hierarchy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_RH_HIERARCHY_deserialize(jso2, &out->hierarchy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hierarchy\".");
 
     if (!ifapi_get_sub_object(jso, "digest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"digest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->digest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"digest\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1665,7 +1665,7 @@ ifapi_json_TPML_DIGEST_VALUES_deserialize(json_object *jso,
         for (i = 0; i < (size_t)json_object_array_length(jso); i++) {
             json_object *jso3 = json_object_array_get_idx(jso, i);
             r = ifapi_json_TPMT_HA_deserialize(jso3, &out->digests[i]);
-            return_if_error(r, "BAD VALUE");
+            return_if_error(r, "Bad value for field \"digests\".");
         }
         return TSS2_RC_SUCCESS;
     } else {
@@ -1706,7 +1706,7 @@ ifapi_json_TPML_PCR_SELECTION_deserialize(json_object *jso,
         for (i = 0; i < (size_t)json_object_array_length(jso); i++) {
             json_object *jso3 = json_object_array_get_idx(jso, i);
             r = ifapi_json_TPMS_PCR_SELECTION_deserialize(jso3, &out->pcrSelections[i]);
-            return_if_error(r, "BAD VALUE");
+            return_if_error(r, "Bad value for field \"pcrSelections\".");
         }
         return TSS2_RC_SUCCESS;
     } else {
@@ -1734,32 +1734,32 @@ ifapi_json_TPMS_CLOCK_INFO_deserialize(json_object *jso,  TPMS_CLOCK_INFO *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "clock", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"clock\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT64_deserialize(jso2, &out->clock);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"clock\".");
 
     if (!ifapi_get_sub_object(jso, "resetCount", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"resetCount\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->resetCount);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"resetCount\".");
 
     if (!ifapi_get_sub_object(jso, "restartCount", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"restartCount\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->restartCount);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"restartCount\".");
 
     if (!ifapi_get_sub_object(jso, "safe", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"safe\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->safe);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"safe\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1781,18 +1781,18 @@ ifapi_json_TPMS_TIME_INFO_deserialize(json_object *jso,  TPMS_TIME_INFO *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "time", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"time\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT64_deserialize(jso2, &out->time);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"time\".");
 
     if (!ifapi_get_sub_object(jso, "clockInfo", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"clockInfo\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMS_CLOCK_INFO_deserialize(jso2, &out->clockInfo);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"clockInfo\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1815,18 +1815,18 @@ ifapi_json_TPMS_TIME_ATTEST_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "time", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"time\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMS_TIME_INFO_deserialize(jso2, &out->time);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"time\".");
 
     if (!ifapi_get_sub_object(jso, "firmwareVersion", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"firmwareVersion\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT64_deserialize(jso2, &out->firmwareVersion);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"firmwareVersion\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1849,18 +1849,18 @@ ifapi_json_TPMS_CERTIFY_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "name", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"name\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->name);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"name\".");
 
     if (!ifapi_get_sub_object(jso, "qualifiedName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"qualifiedName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->qualifiedName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"qualifiedName\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1882,18 +1882,18 @@ ifapi_json_TPMS_QUOTE_INFO_deserialize(json_object *jso,  TPMS_QUOTE_INFO *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "pcrSelect", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcrSelect\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->pcrSelect);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcrSelect\".");
 
     if (!ifapi_get_sub_object(jso, "pcrDigest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcrDigest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->pcrDigest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcrDigest\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1916,32 +1916,32 @@ ifapi_json_TPMS_COMMAND_AUDIT_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "auditCounter", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"auditCounter\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT64_deserialize(jso2, &out->auditCounter);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"auditCounter\".");
 
     if (!ifapi_get_sub_object(jso, "digestAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"digestAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_ALG_ID_deserialize(jso2, &out->digestAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"digestAlg\".");
 
     if (!ifapi_get_sub_object(jso, "auditDigest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"auditDigest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->auditDigest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"auditDigest\".");
 
     if (!ifapi_get_sub_object(jso, "commandDigest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"commandDigest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->commandDigest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"commandDigest\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1964,18 +1964,18 @@ ifapi_json_TPMS_SESSION_AUDIT_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "exclusiveSession", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"exclusiveSession\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->exclusiveSession);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"exclusiveSession\".");
 
     if (!ifapi_get_sub_object(jso, "sessionDigest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sessionDigest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->sessionDigest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sessionDigest\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -1998,18 +1998,18 @@ ifapi_json_TPMS_CREATION_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "objectName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"objectName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->objectName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"objectName\".");
 
     if (!ifapi_get_sub_object(jso, "creationHash", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"creationHash\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->creationHash);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"creationHash\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2032,25 +2032,25 @@ ifapi_json_TPMS_NV_CERTIFY_INFO_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "indexName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"indexName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->indexName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"indexName\".");
 
     if (!ifapi_get_sub_object(jso, "offset", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"offset\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT16_deserialize(jso2, &out->offset);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"offset\".");
 
     if (!ifapi_get_sub_object(jso, "nvContents", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nvContents\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_MAX_NV_BUFFER_deserialize(jso2, &out->nvContents);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"nvContents\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2126,52 +2126,52 @@ ifapi_json_TPMS_ATTEST_deserialize(json_object *jso,  TPMS_ATTEST *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "magic", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"magic\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_GENERATED_deserialize(jso2, &out->magic);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"magic\".");
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ST_ATTEST_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "qualifiedSigner", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"qualifiedSigner\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->qualifiedSigner);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"qualifiedSigner\".");
 
     if (!ifapi_get_sub_object(jso, "extraData", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"extraData\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DATA_deserialize(jso2, &out->extraData);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"extraData\".");
 
     if (!ifapi_get_sub_object(jso, "clockInfo", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"clockInfo\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMS_CLOCK_INFO_deserialize(jso2, &out->clockInfo);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"clockInfo\".");
 
     if (!ifapi_get_sub_object(jso, "firmwareVersion", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"firmwareVersion\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT64_deserialize(jso2, &out->firmwareVersion);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"firmwareVersion\".");
     if (!ifapi_get_sub_object(jso, "attested", &jso2)) {
-        LOG_ERROR("BAD VALUE");
+        LOG_ERROR("Field \"attested\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMU_ATTEST_deserialize(out->type, jso2, &out->attested);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"attested\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
@@ -2266,28 +2266,28 @@ ifapi_json_TPMT_SYM_DEF_deserialize(json_object *jso,  TPMT_SYM_DEF *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "algorithm", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"algorithm\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_SYM_deserialize(jso2, &out->algorithm);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"algorithm\".");
     if (out->algorithm != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "keyBits", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"keyBits\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SYM_KEY_BITS_deserialize(out->algorithm, jso2,
                 &out->keyBits);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyBits\".");
     }
 
     if (out->algorithm != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "mode", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"mode\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SYM_MODE_deserialize(out->algorithm, jso2, &out->mode);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"mode\".");
     }
 
     LOG_TRACE("true");
@@ -2312,28 +2312,28 @@ ifapi_json_TPMT_SYM_DEF_OBJECT_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "algorithm", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"algorithm\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_SYM_OBJECT_deserialize(jso2, &out->algorithm);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"algorithm\".");
     if (out->algorithm != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "keyBits", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"keyBits\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SYM_KEY_BITS_deserialize(out->algorithm, jso2,
                 &out->keyBits);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyBits\".");
     }
 
     if (out->algorithm != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "mode", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"mode\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SYM_MODE_deserialize(out->algorithm, jso2, &out->mode);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"mode\".");
     }
 
     LOG_TRACE("true");
@@ -2358,11 +2358,11 @@ ifapi_json_TPMS_SYMCIPHER_PARMS_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "sym", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sym\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_deserialize(jso2, &out->sym);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sym\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2385,11 +2385,11 @@ ifapi_json_TPMS_SCHEME_HASH_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hashAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hashAlg\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2412,18 +2412,18 @@ ifapi_json_TPMS_SCHEME_ECDAA_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hashAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hashAlg\".");
 
     if (!ifapi_get_sub_object(jso, "count", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"count\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT16_deserialize(jso2, &out->count);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"count\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2477,18 +2477,18 @@ ifapi_json_TPMS_SCHEME_XOR_deserialize(json_object *jso,  TPMS_SCHEME_XOR *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hashAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hashAlg\".");
 
     if (!ifapi_get_sub_object(jso, "kdf", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"kdf\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_KDF_deserialize(jso2, &out->kdf);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"kdf\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -2543,19 +2543,19 @@ ifapi_json_TPMT_KEYEDHASH_SCHEME_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_KEYEDHASH_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SCHEME_KEYEDHASH_deserialize(out->scheme, jso2,
                 &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -2721,18 +2721,18 @@ ifapi_json_TPMT_SIG_SCHEME_deserialize(json_object *jso,  TPMT_SIG_SCHEME *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_SIG_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SIG_SCHEME_deserialize(out->scheme, jso2, &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -2892,18 +2892,18 @@ ifapi_json_TPMT_KDF_SCHEME_deserialize(json_object *jso,  TPMT_KDF_SCHEME *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_KDF_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_KDF_SCHEME_deserialize(out->scheme, jso2, &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -2988,18 +2988,18 @@ ifapi_json_TPMT_RSA_SCHEME_deserialize(json_object *jso,  TPMT_RSA_SCHEME *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_RSA_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_ASYM_SCHEME_deserialize(out->scheme, jso2, &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -3039,18 +3039,18 @@ ifapi_json_TPMT_RSA_DECRYPT_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_RSA_DECRYPT_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_ASYM_SCHEME_deserialize(out->scheme, jso2, &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -3141,18 +3141,18 @@ ifapi_json_TPMS_ECC_POINT_deserialize(json_object *jso,  TPMS_ECC_POINT *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "x", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"x\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_ECC_PARAMETER_deserialize(jso2, &out->x);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"x\".");
 
     if (!ifapi_get_sub_object(jso, "y", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"y\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_ECC_PARAMETER_deserialize(jso2, &out->y);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"y\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3204,18 +3204,18 @@ ifapi_json_TPMT_ECC_SCHEME_deserialize(json_object *jso,  TPMT_ECC_SCHEME *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_ECC_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     if (out->scheme != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "details", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"details\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_ASYM_SCHEME_deserialize(out->scheme, jso2, &out->details);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"details\".");
     }
 
     LOG_TRACE("true");
@@ -3240,18 +3240,18 @@ ifapi_json_TPMS_SIGNATURE_RSA_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hash", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hash\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hash);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hash\".");
 
     if (!ifapi_get_sub_object(jso, "sig", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sig\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_PUBLIC_KEY_RSA_deserialize(jso2, &out->sig);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sig\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3308,25 +3308,25 @@ ifapi_json_TPMS_SIGNATURE_ECC_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "hash", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"hash\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hash);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"hash\".");
 
     if (!ifapi_get_sub_object(jso, "signatureR", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"signatureR\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_ECC_PARAMETER_deserialize(jso2, &out->signatureR);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"signatureR\".");
 
     if (!ifapi_get_sub_object(jso, "signatureS", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"signatureS\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_ECC_PARAMETER_deserialize(jso2, &out->signatureS);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"signatureS\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3456,18 +3456,18 @@ ifapi_json_TPMT_SIGNATURE_deserialize(json_object *jso,  TPMT_SIGNATURE *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "sigAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sigAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_SIG_SCHEME_deserialize(jso2, &out->sigAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sigAlg\".");
     if (out->sigAlg != TPM2_ALG_NULL) {
         if (!ifapi_get_sub_object(jso, "signature", &jso2)) {
-            LOG_ERROR("BAD VALUE");
+            LOG_ERROR("Field \"signature\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMU_SIGNATURE_deserialize(out->sigAlg, jso2, &out->signature);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"signature\".");
     }
 
     LOG_TRACE("true");
@@ -3565,11 +3565,11 @@ ifapi_json_TPMS_KEYEDHASH_PARMS_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_KEYEDHASH_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3591,32 +3591,32 @@ ifapi_json_TPMS_RSA_PARMS_deserialize(json_object *jso,  TPMS_RSA_PARMS *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "symmetric", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"symmetric\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_deserialize(jso2, &out->symmetric);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"symmetric\".");
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_RSA_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
 
     if (!ifapi_get_sub_object(jso, "keyBits", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"keyBits\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_RSA_KEY_BITS_deserialize(jso2, &out->keyBits);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"keyBits\".");
 
     if (!ifapi_get_sub_object(jso, "exponent", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"exponent\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT32_deserialize(jso2, &out->exponent);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"exponent\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3638,32 +3638,32 @@ ifapi_json_TPMS_ECC_PARMS_deserialize(json_object *jso,  TPMS_ECC_PARMS *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "symmetric", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"symmetric\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_deserialize(jso2, &out->symmetric);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"symmetric\".");
 
     if (!ifapi_get_sub_object(jso, "scheme", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"scheme\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_ECC_SCHEME_deserialize(jso2, &out->scheme);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"scheme\".");
 
     if (!ifapi_get_sub_object(jso, "curveID", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"curveID\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ECC_CURVE_deserialize(jso2, &out->curveID);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"curveID\".");
 
     if (!ifapi_get_sub_object(jso, "kdf", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"kdf\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_KDF_SCHEME_deserialize(jso2, &out->kdf);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"kdf\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -3717,45 +3717,45 @@ ifapi_json_TPMT_PUBLIC_deserialize(json_object *jso,  TPMT_PUBLIC *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_PUBLIC_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "nameAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nameAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->nameAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"nameAlg\".");
 
     if (!ifapi_get_sub_object(jso, "objectAttributes", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"objectAttributes\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMA_OBJECT_deserialize(jso2, &out->objectAttributes);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"objectAttributes\".");
 
     if (!ifapi_get_sub_object(jso, "authPolicy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"authPolicy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->authPolicy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"authPolicy\".");
     if (!ifapi_get_sub_object(jso, "parameters", &jso2)) {
-        LOG_ERROR("BAD VALUE");
+        LOG_ERROR("Field \"parameters\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMU_PUBLIC_PARMS_deserialize(out->type, jso2, &out->parameters);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"parameters\".");
 
     if (!ifapi_get_sub_object(jso, "unique", &jso2)) {
-        LOG_ERROR("BAD VALUE");
+        LOG_ERROR("Field \"unique\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMU_PUBLIC_ID_deserialize(out->type, jso2, &out->unique);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"unique\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
@@ -3775,17 +3775,17 @@ ifapi_json_TPM2B_PUBLIC_deserialize(json_object *jso, TPM2B_PUBLIC *out)
     TSS2_RC res;
     LOG_TRACE("call");
     if (!ifapi_get_sub_object(jso, "size", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"size\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_UINT16_deserialize(jso2, &out->size);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"size\".");
     if (!ifapi_get_sub_object(jso, "publicArea", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"publicArea\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_TPMT_PUBLIC_deserialize(jso2, &out->publicArea);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"publicArea\".");
     return TSS2_RC_SUCCESS;
 }
 
@@ -3994,39 +3994,39 @@ ifapi_json_TPMS_NV_PUBLIC_deserialize(json_object *jso,  TPMS_NV_PUBLIC *out)
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "nvIndex", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nvIndex\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_RH_NV_INDEX_deserialize(jso2, &out->nvIndex);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"nvIndex\".");
 
     if (!ifapi_get_sub_object(jso, "nameAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nameAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->nameAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"nameAlg\".");
 
     if (!ifapi_get_sub_object(jso, "attributes", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"attributes\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMA_NV_deserialize(jso2, &out->attributes);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"attributes\".");
 
     if (!ifapi_get_sub_object(jso, "authPolicy", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"authPolicy\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->authPolicy);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"authPolicy\".");
 
     if (!ifapi_get_sub_object(jso, "dataSize", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"dataSize\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT16_deserialize(jso2, &out->dataSize);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"dataSize\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
@@ -4046,17 +4046,17 @@ ifapi_json_TPM2B_NV_PUBLIC_deserialize(json_object *jso, TPM2B_NV_PUBLIC *out)
     TSS2_RC res;
     LOG_TRACE("call");
     if (!ifapi_get_sub_object(jso, "size", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"size\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_UINT16_deserialize(jso2, &out->size);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"size\".");
     if (!ifapi_get_sub_object(jso, "nvPublic", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nvPublic\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_TPMS_NV_PUBLIC_deserialize(jso2, &out->nvPublic);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"nvPublic\".");
     return TSS2_RC_SUCCESS;
 }
 
@@ -4078,53 +4078,53 @@ ifapi_json_TPMS_CREATION_DATA_deserialize(json_object *jso,
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "pcrSelect", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcrSelect\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->pcrSelect);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcrSelect\".");
 
     if (!ifapi_get_sub_object(jso, "pcrDigest", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcrDigest\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->pcrDigest);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcrDigest\".");
 
     if (!ifapi_get_sub_object(jso, "locality", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"locality\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMA_LOCALITY_deserialize(jso2, &out->locality);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"locality\".");
 
     if (!ifapi_get_sub_object(jso, "parentNameAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"parentNameAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2_ALG_ID_deserialize(jso2, &out->parentNameAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"parentNameAlg\".");
 
     if (!ifapi_get_sub_object(jso, "parentName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"parentName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->parentName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"parentName\".");
 
     if (!ifapi_get_sub_object(jso, "parentQualifiedName", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"parentQualifiedName\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_NAME_deserialize(jso2, &out->parentQualifiedName);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"parentQualifiedName\".");
 
     if (!ifapi_get_sub_object(jso, "outsideInfo", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"outsideInfo\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPM2B_DATA_deserialize(jso2, &out->outsideInfo);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"outsideInfo\".");
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }
@@ -4144,16 +4144,16 @@ ifapi_json_TPM2B_CREATION_DATA_deserialize(json_object *jso,
     TSS2_RC res;
     LOG_TRACE("call");
     if (!ifapi_get_sub_object(jso, "size", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"size\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_UINT16_deserialize(jso2, &out->size);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"size\".");
     if (!ifapi_get_sub_object(jso, "creationData", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"creationData\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     res = ifapi_json_TPMS_CREATION_DATA_deserialize(jso2, &out->creationData);
-    return_if_error(res, "BAD VALUE");
+    return_if_error(res, "Bad value for field \"creationData\".");
     return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
* If mandatory fields are not found an error message with the field name
  will be displayed instead of "BAD VALUE"
* If a field value  cannot be deserialized now here also the field name will
  be part of the error message.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>