### PR TITLE
tss2-tcti: fix 'invalid application of 'sizeof' to a void type'

### DIFF
--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -53,6 +53,8 @@ typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 #elif defined(_WIN32)
 #include <windows.h>
 typedef HANDLE TSS2_TCTI_POLL_HANDLE;
+#elif defined(__ZEPHYR__)
+typedef void* TSS2_TCTI_POLL_HANDLE;
 #else
 typedef void TSS2_TCTI_POLL_HANDLE;
 #ifndef TSS2_TCTI_SUPPRESS_POLL_WARNINGS


### PR DESCRIPTION
This addresses one of the two issues mentioned in #1555.