### PR TITLE
FAPI: Fix setting of the system flag of NV objects (Fixes #1869)

### DIFF
--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -442,6 +442,9 @@ Fapi_CreateNv_Finish(
             else
                 miscNv->with_auth = TPM2_NO;
 
+            /* NV objects will always be stored in the system store */
+            nvCmd->nv_object.system = TPM2_YES;
+
             /* Perform esys serialization if necessary */
             r = ifapi_esys_serialize_object(context->esys, &nvCmd->nv_object);
             goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1183,6 +1183,11 @@ keystore_search_obj(
         path = keystore->key_search.pathlist[path_idx];
         LOG_TRACE("Check file: %s %zu", path, keystore->key_search.path_idx);
 
+        /* Skip policy files. */
+        if (ifapi_path_type_p(path, IFAPI_POLICY_PATH)) {
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        }
+
         r = ifapi_keystore_load_async(keystore, io, path);
         return_if_error2(r, "Could not open: %s", path);
 


### PR DESCRIPTION
* Searching for objects in the key store did not work if policies did occur in the
   path list before the object to be compared. The policy files are now skipped during searching.

*  The system flag for NV objects was set to TPM2_NO. So NV objects were
    saved in the user store. The system flag now is set to TPM2_YES to
    assure that NV objects are stored in the system store.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>