### PR TITLE
Fapi fix delete policy file

### DIFF
--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -391,6 +391,13 @@ Fapi_Delete_Async(
                                 &command->numPaths);
     goto_if_error(r, "get entities.", error_cleanup);
 
+    /* Check whether a path for exactly one policy was passed. */
+    if (command->numPaths == 0 && ifapi_path_type_p(path, IFAPI_POLICY_PATH)) {
+        command->numPaths = 1;
+        command->pathlist = calloc(1, sizeof(char *));
+        strdup_check(command->pathlist[0], path, r, error_cleanup);
+    }
+
     command->path_idx = command->numPaths;
 
     if (command->numPaths == 0) {

--- a/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
@@ -194,6 +194,9 @@ test_fapi_key_create_policy_authorize_nv(FAPI_CONTEXT *context)
     assert(strlen(publicKey) > ASSERT_SIZE);
     assert(strlen(certificate) > ASSERT_SIZE);
 
+    r = Fapi_Delete(context, policy_authorize_nv);
+    goto_if_error(r, "Error Fapi_Delete", error);
+
     r = Fapi_Delete(context, nvPathPolicy);
     goto_if_error(r, "Error Fapi_NV_Undefine", error);
 


### PR DESCRIPTION
* Exactly one policy file passed to Fapi_Delete could not be deleted, because the passed
   path was used as directory.
* One integration test was extended to add this test case.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
