### PR TITLE
Fapi: Fix setting of the written flag of NV objects in FAPI NV commands

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -311,6 +311,7 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-key-create-policy-signed.fint \
     test/integration/fapi-key-create-policy-signed-ecc.fint \
     test/integration/fapi-key-create-policy-nv-sign.fint \
+    test/integration/fapi-key-create-policy-nv-counter-sign.fint \
     test/integration/fapi-key-create-policy-or-sign.fint \
     test/integration/fapi-key-create-policy-password-sign.fint \
     test/integration/fapi-key-create-policy-countertimer-sign.fint \
@@ -1582,6 +1583,15 @@ test_integration_fapi_key_create_policy_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_nv_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-nv-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_policy_nv_counter_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_fapi_key_create_policy_nv_counter_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_policy_nv_counter_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_policy_nv_counter_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-policy-nv-counter-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+
 
 test_integration_fapi_key_create_policy_or_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_or_sign_fint_LDADD   = $(TESTS_LDADD)

--- a/Makefile.am
+++ b/Makefile.am
@@ -515,6 +515,7 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_pcr16_0_or.json \
     test/data/fapi/policy/pol_pcr8_0.json \
     test/data/fapi/policy/pol_nv.json \
+    test/data/fapi/policy/pol_nv_counter.json \
     test/data/fapi/policy/pol_nv_written.json \
     test/data/fapi/policy/pol_signed.json \
     test/data/fapi/policy/pol_signed_ecc.json \

--- a/src/tss2-fapi/api/Fapi_NvExtend.c
+++ b/src/tss2-fapi/api/Fapi_NvExtend.c
@@ -427,6 +427,9 @@ Fapi_NvExtend_Finish(
                                                     JSON_C_TO_STRING_PRETTY),
             r, error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Perform esys serialization if necessary */
         r = ifapi_esys_serialize_object(context->esys, &command->nv_object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -307,6 +307,9 @@ Fapi_NvIncrement_Finish(
         return_try_again(r);
         goto_if_error_reset_state(r, "FAPI NV_Increment_Finish", error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Perform esys serialization if necessary */
         r = ifapi_esys_serialize_object(context->esys, &command->nv_object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_NvSetBits.c
+++ b/src/tss2-fapi/api/Fapi_NvSetBits.c
@@ -317,6 +317,9 @@ Fapi_NvSetBits_Finish(
         return_try_again(r);
         goto_if_error_reset_state(r, "FAPI NV_SetBits_Finish", error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Serialize the ESYS object for updating the metadata in the keystore. */
         r = ifapi_esys_serialize_object(context->esys, object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -1065,6 +1065,10 @@ ifapi_calculate_policy_nv(
 
     memset(&nv_name, 0, sizeof(TPM2B_NAME));
 
+    /* Written flag has to be set for policy calculation, because during
+       policy execution it will be set. */
+    policy->nvPublic.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
     /* Compute NV name from public info */
 
     r = ifapi_nv_get_name(&policy->nvPublic, &nv_name);

--- a/test/data/fapi/policy/pol_nv_counter.json
+++ b/test/data/fapi/policy/pol_nv_counter.json
@@ -1,0 +1,11 @@
+{
+    "description":"Description pol_nv",
+    "policy":[
+        {
+            "type": "POLICYNV",
+            "nvPath": "/nv/Owner/myNV",
+            "operandB": "0000000000000000",
+            "operation": "NEQ"
+        }
+    ]
+}

--- a/test/integration/fapi-key-create-policy-nv-counter-sign.int.c
+++ b/test/integration/fapi-key-create-policy-nv-counter-sign.int.c
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+#include <string.h>
+
+#include "tss2_fapi.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+#include "test-fapi.h"
+
+#define SIGN_TEMPLATE  "sign,noDa"
+#define PASSWORD NULL
+
+#define NV_SIZE 4
+
+/** Test the FAPI functions for NV writing and key usage with PolicyNV (counter)
+ *
+ * Tested FAPI commands:
+ *  - Fapi_Provision()
+ *  - Fapi_CreateKey()
+ *  - Fapi_NvWrite()
+ *  - Fapi_Import()
+ *  - Fapi_Sign()
+ *  - Fapi_Delete()
+ *
+ * Tested Policies:
+ *  - PolicyNv
+ *
+ * @param[in,out] context The FAPI_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_fapi_key_create_policy_nv_sign(FAPI_CONTEXT *context)
+{
+    TSS2_RC r;
+    char *policy_name = "/policy/pol_nv";
+    char *policy_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_nv_counter.json";;
+    FILE *stream = NULL;
+    char *json_policy = NULL;
+    uint8_t *signature = NULL;
+    char    *publicKey = NULL;
+    char    *certificate = NULL;
+    long policy_size;
+    char *nvPathOrdinary = "/nv/Owner/myNV";
+
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+    goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = Fapi_CreateNv(context, nvPathOrdinary, "noda,counter", 8,  "", "");
+    goto_if_error(r, "Error Fapi_CreateNv", error);
+
+    r = Fapi_NvIncrement(context, nvPathOrdinary);
+    goto_if_error(r, "Error Fapi_NvWrite", error);
+
+    stream = fopen(policy_file, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", policy_file);
+        goto error;
+    }
+    fseek(stream, 0L, SEEK_END);
+    policy_size = ftell(stream);
+    fclose(stream);
+    json_policy = malloc(policy_size + 1);
+    goto_if_null(json_policy,
+            "Could not allocate memory for the JSON policy",
+            TSS2_FAPI_RC_MEMORY, error);
+    stream = fopen(policy_file, "r");
+    ssize_t ret = read(fileno(stream), json_policy, policy_size);
+    if (ret != policy_size) {
+        LOG_ERROR("IO error %s.", policy_file);
+        goto error;
+    }
+    json_policy[policy_size] = '\0';
+
+    r = Fapi_Import(context, policy_name, json_policy);
+    goto_if_error(r, "Error Fapi_Import", error);
+
+    r = Fapi_CreateKey(context, "HS/SRK/mySignKey", SIGN_TEMPLATE,
+                       policy_name, PASSWORD);
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    r = Fapi_SetCertificate(context, "HS/SRK/mySignKey", "-----BEGIN "\
+        "CERTIFICATE-----[...]-----END CERTIFICATE-----");
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    size_t signatureSize = 0;
+
+    TPM2B_DIGEST digest = {
+        .size = 20,
+        .buffer = {
+            0x67, 0x68, 0x03, 0x3e, 0x21, 0x64, 0x68, 0x24, 0x7b, 0xd0,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f
+        }
+    };
+
+    r = Fapi_Sign(context, "HS/SRK/mySignKey", NULL,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, &certificate);
+    goto_if_error(r, "Error Fapi_Sign", error);
+    assert(signature != NULL);
+    assert(publicKey != NULL);
+    assert(certificate != NULL);
+    assert(strlen(publicKey) > ASSERT_SIZE);
+    assert(strlen(certificate) > ASSERT_SIZE);
+
+    r = Fapi_Delete(context, nvPathOrdinary);
+    goto_if_error(r, "Error Fapi_NV_Undefine", error);
+
+    r = Fapi_Delete(context, "/");
+    goto_if_error(r, "Error Fapi_Delete", error);
+
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(certificate);
+    SAFE_FREE(json_policy);
+    return EXIT_SUCCESS;
+
+error:
+    Fapi_Delete(context, "/");
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(certificate);
+    SAFE_FREE(json_policy);
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_fapi(FAPI_CONTEXT *fapi_context)
+{
+    return test_fapi_key_create_policy_nv_sign(fapi_context);
+}


### PR DESCRIPTION
* The written flag was not set for increment, set bits, and extend, which caused wrong computation
   of NV name after deserialization.
* For PolicyNV the WRITTEN bit is set during policy calculations, because during policy execution
    it will be set.
*  To check whether the nv written flag was set correctly after fapi increment this
    test was added.

 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>

