### PR TITLE
Fapi: several fixes for 3.0.x

### DIFF
--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -442,6 +442,9 @@ Fapi_CreateNv_Finish(
             else
                 miscNv->with_auth = TPM2_NO;
 
+            /* NV objects will always be stored in the system store */
+            nvCmd->nv_object.system = TPM2_YES;
+
             /* Perform esys serialization if necessary */
             r = ifapi_esys_serialize_object(context->esys, &nvCmd->nv_object);
             goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -391,6 +391,13 @@ Fapi_Delete_Async(
                                 &command->numPaths);
     goto_if_error(r, "get entities.", error_cleanup);
 
+    /* Check whether a path for exactly one policy was passed. */
+    if (command->numPaths == 0 && ifapi_path_type_p(path, IFAPI_POLICY_PATH)) {
+        command->numPaths = 1;
+        command->pathlist = calloc(1, sizeof(char *));
+        strdup_check(command->pathlist[0], path, r, error_cleanup);
+    }
+
     command->path_idx = command->numPaths;
 
     if (command->numPaths == 0) {

--- a/src/tss2-fapi/api/Fapi_NvExtend.c
+++ b/src/tss2-fapi/api/Fapi_NvExtend.c
@@ -427,6 +427,9 @@ Fapi_NvExtend_Finish(
                                                     JSON_C_TO_STRING_PRETTY),
             r, error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Perform esys serialization if necessary */
         r = ifapi_esys_serialize_object(context->esys, &command->nv_object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -307,6 +307,9 @@ Fapi_NvIncrement_Finish(
         return_try_again(r);
         goto_if_error_reset_state(r, "FAPI NV_Increment_Finish", error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Perform esys serialization if necessary */
         r = ifapi_esys_serialize_object(context->esys, &command->nv_object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_NvSetBits.c
+++ b/src/tss2-fapi/api/Fapi_NvSetBits.c
@@ -317,6 +317,9 @@ Fapi_NvSetBits_Finish(
         return_try_again(r);
         goto_if_error_reset_state(r, "FAPI NV_SetBits_Finish", error_cleanup);
 
+        /* Set written bit in keystore */
+        context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
         /* Serialize the ESYS object for updating the metadata in the keystore. */
         r = ifapi_esys_serialize_object(context->esys, object);
         goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1183,6 +1183,11 @@ keystore_search_obj(
         path = keystore->key_search.pathlist[path_idx];
         LOG_TRACE("Check file: %s %zu", path, keystore->key_search.path_idx);
 
+        /* Skip policy files. */
+        if (ifapi_path_type_p(path, IFAPI_POLICY_PATH)) {
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        }
+
         r = ifapi_keystore_load_async(keystore, io, path);
         return_if_error2(r, "Could not open: %s", path);
 

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -1065,6 +1065,10 @@ ifapi_calculate_policy_nv(
 
     memset(&nv_name, 0, sizeof(TPM2B_NAME));
 
+    /* Written flag has to be set for policy calculation, because during
+       policy execution it will be set. */
+    policy->nvPublic.nvPublic.attributes |= TPMA_NV_WRITTEN;
+
     /* Compute NV name from public info */
 
     r = ifapi_nv_get_name(&policy->nvPublic, &nv_name);


### PR DESCRIPTION
* Fix setting written flag for NV commands and PolicyNV.
* Fix deleting exactly one policy file.
* Fix setting of the system flag of NV objects (Fixes #1869)
* Fix wrong file loading during object search.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>