### PR TITLE
FAPI:  Enable usage of PEM keys for  policy authorization.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -304,6 +304,8 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-key-create-sign-password-provision.fint \
     test/integration/fapi-key-create-sign-rsa.fint \
     test/integration/fapi-key-create-policy-authorize-sign.fint \
+    test/integration/fapi-key-create-policy-authorize-rsa-pem-sign.fint \
+    test/integration/fapi-key-create-policy-authorize-ecc-pem-sign.fint \
     test/integration/fapi-key-create-policy-authorize-sign-rsa.fint \
     test/integration/fapi-key-create-policy-authorize-nv-sign.fint \
     test/integration/fapi-key-create-policy-secret-nv-sign.fint \
@@ -1531,6 +1533,21 @@ test_integration_fapi_key_create_policy_authorize_sign_fint_LDFLAGS = $(TESTS_LD
 test_integration_fapi_key_create_policy_authorize_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-authorize-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_policy_authorize_rsa_pem_sign_fint_CFLAGS  = $(TESTS_CFLAGS) -DFAPI_PROFILE=\"P_RSA\"
+test_integration_fapi_key_create_policy_authorize_rsa_pem_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_policy_authorize_rsa_pem_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_policy_authorize_rsa_pem_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-policy-authorize-pem-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_policy_authorize_ecc_pem_sign_fint_CFLAGS  = $(TESTS_CFLAGS) -DTEST_ECC
+test_integration_fapi_key_create_policy_authorize_ecc_pem_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_policy_authorize_ecc_pem_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_policy_authorize_ecc_pem_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-policy-authorize-pem-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
 
 test_integration_fapi_key_create_policy_authorize_sign_rsa_fint_CFLAGS  = $(TESTS_CFLAGS) \
     -DFAPI_PROFILE=\"P_RSA256\" -DFAPI_TEST_EK_CERT_LESS

--- a/Makefile.am
+++ b/Makefile.am
@@ -511,6 +511,8 @@ EXTRA_DIST +=  \
     test/data/fapi/P_RSA256.json \
     test/data/fapi/P_ECC.json \
     test/data/fapi/policy/pol_pcr16_0.json \
+    test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json \
+    test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json \
     test/data/fapi/policy/pol_pcr16_0_fail.json \
     test/data/fapi/policy/pol_pcr16_0_or.json \
     test/data/fapi/policy/pol_pcr8_0.json \
@@ -520,6 +522,8 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_signed.json \
     test/data/fapi/policy/pol_signed_ecc.json \
     test/data/fapi/policy/pol_authorize.json \
+    test/data/fapi/policy/pol_authorize_rsa_pem.json \
+    test/data/fapi/policy/pol_authorize_ecc_pem.json \
     test/data/fapi/policy/pol_authorize_outer.json \
     test/data/fapi/policy/pol_authorize_nv.json \
     test/data/fapi/policy/pol_secret.json \

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -97,11 +97,7 @@ static const TPM2B_PUBLIC templateRsaSign = {
     .publicArea = {
         .type = TPM2_ALG_RSA,
         .nameAlg = TPM2_ALG_SHA1,
-        .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
-                             TPMA_OBJECT_SIGN_ENCRYPT |
-                             TPMA_OBJECT_RESTRICTED |
-                             TPMA_OBJECT_SENSITIVEDATAORIGIN
-                             ),
+        .objectAttributes = ( TPMA_OBJECT_SIGN_ENCRYPT ),
         .authPolicy = {
             .size = 0,
             .buffer = 0,
@@ -109,8 +105,6 @@ static const TPM2B_PUBLIC templateRsaSign = {
         .parameters.rsaDetail = {
             .symmetric = {
                 .algorithm = TPM2_ALG_NULL,
-                .keyBits.aes = 128,
-                .mode.aes = TPM2_ALG_CFB,
             },
             .scheme = {
                 .scheme = TPM2_ALG_RSAPSS,
@@ -134,21 +128,14 @@ static const TPM2B_PUBLIC templateEccSign = {
     .publicArea = {
         .type = TPM2_ALG_ECC,
         .nameAlg = TPM2_ALG_SHA1,
-        .objectAttributes = (
-                             TPMA_OBJECT_USERWITHAUTH |
-                             TPMA_OBJECT_RESTRICTED |
-                             TPMA_OBJECT_SIGN_ENCRYPT |
-                             TPMA_OBJECT_SENSITIVEDATAORIGIN
-                             ),
+        .objectAttributes = ( TPMA_OBJECT_SIGN_ENCRYPT ),
         .authPolicy = {
             .size = 0,
         },
 
         .parameters.eccDetail = {
             .symmetric = {
-                .algorithm = TPM2_ALG_NULL,
-                .keyBits.aes = 128,
-                .mode.aes = TPM2_ALG_ECB,
+                .algorithm = TPM2_ALG_NULL
             },
             .scheme = {
                 .scheme = TPM2_ALG_ECDSA,

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -712,6 +712,27 @@ ifapi_sign_buffer(
     return TSS2_RC_SUCCESS;
 }
 
+static bool
+cmp_policy_ref(TPM2B_NONCE *ref1, TPM2B_NONCE *ref2)
+{
+    if ((!ref1 || !ref1->size) && (!ref2 || !ref2->size)) {
+        return true;
+    }
+    if (!ref1 || !ref1->size || !ref2 || !ref2->size)  {
+        return false;
+    }
+
+    if (ref1->size != ref2->size) {
+        return false;
+    }
+
+    if (memcmp(&ref1->buffer[0], &ref2->buffer[0], ref1->size) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
 /**  Check whether public data of key is assigned to policy.
  *
  * It will be checked whether policy was authorized by abort key with public
@@ -719,18 +740,18 @@ ifapi_sign_buffer(
  *
  * @param[in] policy The policy to be checked.
  * @param[in] publicVoid The public information of the key.
- * @param[in] nameAlgVoid Not used for this compare function.
+ * @param[in] policyReferenceVoid The policy reverence to be compared.
  * @param[out] equal Switch whether check was successful.
  */
 static TSS2_RC
 equal_policy_authorization(
     TPMS_POLICY *policy,
     void *publicVoid,
-    void *nameAlgVoid,
+    void *policyRefVoid,
     bool *equal)
 {
     TPMT_PUBLIC *public = publicVoid;
-    (void)nameAlgVoid;
+    TPM2B_NONCE *policyRef = policyRefVoid;
     size_t i;
     TPML_POLICYAUTHORIZATIONS *authorizations = policy->policyAuthorizations;
     TSS2_RC r;
@@ -751,14 +772,21 @@ equal_policy_authorization(
                 }
                 pem_public.publicArea.nameAlg = authorizations->authorizations[i].keyPEMhashAlg;
 
-                if (ifapi_TPMT_PUBLIC_cmp(public, &pem_public.publicArea)) {
+                /* Check public information if key and policyRef */
+                if (ifapi_TPMT_PUBLIC_cmp(public, &pem_public.publicArea) &&
+                    cmp_policy_ref(policyRef,
+                                   &authorizations->authorizations[i].policyRef)) {
                     *equal = true;
                     return TSS2_RC_SUCCESS;
                 }
-            } else if (ifapi_TPMT_PUBLIC_cmp(public, &authorizations->authorizations[i].key)) {
-                *equal = true;
-                return TSS2_RC_SUCCESS;
-            }
+            } else
+                /* Check public information if key and policyRef */
+                if (ifapi_TPMT_PUBLIC_cmp(public, &authorizations->authorizations[i].key) &&
+                    cmp_policy_ref(policyRef,
+                                   &authorizations->authorizations[i].policyRef)) {
+                    *equal = true;
+                    return TSS2_RC_SUCCESS;
+                }
         }
     }
     return TSS2_RC_SUCCESS;
@@ -1119,6 +1147,7 @@ ifapi_exec_auth_policy(
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata)
 {
@@ -1157,7 +1186,7 @@ ifapi_exec_auth_policy(
         statecase(cb_ctx->cb_state, POL_CB_SEARCH_POLICY)
             r = search_policy(fapi_ctx,
                               equal_policy_authorization, true,
-                              key_public, NULL,
+                              key_public, policyRef,
                               &current_policy->policy_list);
             FAPI_SYNC(r, "Search policy", cleanup);
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -93,6 +93,7 @@ ifapi_exec_auth_policy(
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -607,6 +607,7 @@ execute_policy_authorize(
         /* Execute authorized policy. */
         ifapi_policyeval_EXEC_CB *cb = &current_policy->callbacks;
         r = cb->cbauthpol(&policy->keyPublic, hash_alg, &policy->approvedPolicy,
+                          &policy->policyRef,
                           &policy->signature, cb->cbauthpol_userdata);
         return_try_again(r);
         goto_if_error(r, "Execute authorized policy.", cleanup);

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -14,7 +14,6 @@
 #include "tss2_mu.h"
 #include "fapi_util.h"
 #include "fapi_crypto.h"
-//#include "fapi_policy.h"
 #include "ifapi_policy_execute.h"
 #include "ifapi_helpers.h"
 #include "ifapi_json_deserialize.h"
@@ -658,7 +657,7 @@ execute_policy_authorize(
 
     statecase(current_policy->state, POLICY_VERIFY);
         r = Esys_VerifySignature_Finish(esys_ctx, &ticket);
-        try_again_or_error(r, "Load external key.");
+        try_again_or_error(r, "Verify signature.");
 
         /* Execute policy authorize */
         policy->checkTicket = *ticket;

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -77,6 +77,7 @@ typedef TSS2_RC (*ifapi_policyexec_cbauthpol) (
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_types.h
+++ b/src/tss2-fapi/ifapi_policy_types.h
@@ -7,6 +7,7 @@
 #define IFAPI_POLICY_TYPES_H
 
 #include "tss2_tpm2_types.h"
+#include "fapi_types.h"
 
 typedef UINT32 TPMI_POLICYTYPE;
 #define POLICYELEMENTS                 0
@@ -44,6 +45,7 @@ typedef struct {
     TPMT_PUBLIC                               keyPublic;    /**< None */
     char                                        *keyPEM;    /**< <p>The TPM2B_NAME is constructed with a TPMT_PUBLIC from this */
     TPMI_ALG_HASH                         keyPEMhashAlg;    /**< (optional) Default = SHA256 */
+    TPMT_RSA_SCHEME                           rsaScheme;    /**< (optional) Default = TPM2_ALG_RSAPSS */
     TPMT_SIGNATURE                        signature_tpm;
 } TPMS_POLICYSIGNED;
 
@@ -128,6 +130,10 @@ typedef struct {
     TPMT_PUBLIC                                     key;    /**< Selector of the algorithm used for the signature and the pub */
     TPM2B_NONCE                               policyRef;    /**< None */
     TPMT_SIGNATURE                            signature;    /**< None */
+    TPMI_ALG_HASH                         keyPEMhashAlg;
+    UINT8_ARY                              pemSignature;
+    char                                        *keyPEM;
+    TPMT_RSA_SCHEME                           rsaScheme;
 } TPMS_POLICYAUTHORIZATION;
 
 typedef struct policy_object_node POLICY_OBJECT;
@@ -143,6 +149,7 @@ typedef struct {
     TPMT_PUBLIC                               keyPublic;    /**< None */
     char                                        *keyPEM;    /**< <p> everyone in favour<br /> The TPM2B_NAME is constructed w */
     TPMI_ALG_HASH                         keyPEMhashAlg;    /**< (optional) Default = SHA256 */
+    TPMT_RSA_SCHEME                           rsaScheme;    /**< (optional) Default = TPM2_ALG_RSAPSS */
     POLICY_OBJECT                          *policy_list;
     TPMS_POLICYAUTHORIZATION             *authorization;
     TPMT_SIGNATURE                            signature;

--- a/test/data/fapi/policy/pol_authorize_ecc_pem.json
+++ b/test/data/fapi/policy/pol_authorize_ecc_pem.json
@@ -1,0 +1,13 @@
+{
+    "description":"Description pol_authorize",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZE",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+			"keyPEM": "-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGrFjxBLlFFiZOvemP50H4xCQpL3b
+yeJqGISIHmNSPpTGS9K5kGoKw3gdR2DXsO97RkIZbpHKiA41PJ2KnXDS1Q==
+-----END PUBLIC KEY-----"
+		}
+    ]
+}

--- a/test/data/fapi/policy/pol_authorize_rsa_pem.json
+++ b/test/data/fapi/policy/pol_authorize_rsa_pem.json
@@ -1,0 +1,17 @@
+{
+    "description":"Description pol_authorize",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZE",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+			"keyPEM": "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoGL6IrCSAznmIIzBessI
+mW7tPOUy78uWTIaub32KnYHn78KXprrZ3ykp6WDrOQeMjv4AA+14mJbg77apVYXy
+EnkFdOMa1hszSJnp6cJvx7ILngLvFUxzbVki/ehvgS3nRk67Njal+nMTe8hpe3UK
+QeV/Ij+F0r6Yz91W+4LPmncAiUesRZLetI2BZsKwHYRMznmpIYpoua1NtS8QpEXR
+MmsUue19eS/XRAPmmCfnb5BX2Tn06iCpk6wO+RfMo9etcX5cLSAuIYEQYCvV2/0X
+TfEw607vttBN0Y54LrVOKno1vRXd5sxyRlfB0WL42F4VG5TfcJo5u1Xq7k9m9K57
+8wIDAQAB\n-----END PUBLIC KEY-----"
+		}
+    ]
+}

--- a/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json
+++ b/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json
@@ -1,0 +1,38 @@
+{
+    "description":"Policy PCR",
+    "policyDigests":[
+        {
+            "hashAlg":"sha256",
+            "digest":"17d552f8e39ad882f6b3c09ae139af59616bf6a63f4093d6d20e9e1b9f7cdb6e"
+        }
+    ],
+    "policyAuthorizations":[
+        {
+            "type": "pem",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "key": "-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGrFjxBLlFFiZOvemP50H4xCQpL3b
+yeJqGISIHmNSPpTGS9K5kGoKw3gdR2DXsO97RkIZbpHKiA41PJ2KnXDS1Q==
+-----END PUBLIC KEY-----",
+            "signature": "30450221009a6fa88aae6e1dde15765eacd1bae1757f4d2f0a03ba75f25daef15c72620098022006d8530ecbf7ae1d33baffe052859db9c7088cfb9c1b206732e0e9cda95383cb"
+        }
+    ],
+    "policy":[
+    {
+      "type":"POLICYPCR",
+      "policyDigests":[
+        {
+          "hashAlg":"sha256",
+          "digest":"17d552f8e39ad882f6b3c09ae139af59616bf6a63f4093d6d20e9e1b9f7cdb6e"
+        }
+      ],
+      "pcrs":[
+        {
+          "pcr":16,
+          "hashAlg":"sha1",
+          "digest":"0000000000000000000000000000000000000000"
+        }
+      ]
+    }
+  ]
+}

--- a/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json
+++ b/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json
@@ -1,0 +1,42 @@
+{
+    "description":"Policy PCR",
+    "policyDigests":[
+        {
+            "hashAlg":"SHA256",
+            "digest":"17d552f8e39ad882f6b3c09ae139af59616bf6a63f4093d6d20e9e1b9f7cdb6e"
+        }
+    ],
+    "policyAuthorizations":[
+        {
+            "type": "pem",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "key": "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoGL6IrCSAznmIIzBessI
+mW7tPOUy78uWTIaub32KnYHn78KXprrZ3ykp6WDrOQeMjv4AA+14mJbg77apVYXy
+EnkFdOMa1hszSJnp6cJvx7ILngLvFUxzbVki/ehvgS3nRk67Njal+nMTe8hpe3UK
+QeV/Ij+F0r6Yz91W+4LPmncAiUesRZLetI2BZsKwHYRMznmpIYpoua1NtS8QpEXR
+MmsUue19eS/XRAPmmCfnb5BX2Tn06iCpk6wO+RfMo9etcX5cLSAuIYEQYCvV2/0X
+TfEw607vttBN0Y54LrVOKno1vRXd5sxyRlfB0WL42F4VG5TfcJo5u1Xq7k9m9K57
+8wIDAQAB\n-----END PUBLIC KEY-----",
+            "signature": "17d50d0204e77354eccbc2839681b80b766987a3b59dba795cf137805a5deacce4ddbf3f3d4346bdb9d28c032f2fba4a922296b56622cb719f81237bf660ba9a7c2757b81d3e52a464c838a7e9b85ece76ead93bbb9b1c85b47422eb7436211c101a5b9cbac83c6b540c39f28d3a0d482ec65ada4be1a2d42cbc7a04e53a6db6a43f1eba4202acf2dc03499adae6a933781c55ff921fabd8bcfe981dd72495b800df8955f29dc27cf78e5b9d70d4fc103720cb954e754545b2030c15294fcb3e9f27089928f88b6d8639dbaa1d83477a9da1c7694c37b89d595e468eb78e2ab08b0b4452dbb488428859ec54bc3e6b951c51d8a77bdf75d4fe4c3e28e841bc5f"
+        }
+    ],
+    "policy":[
+    {
+      "type":"POLICYPCR",
+      "policyDigests":[
+        {
+          "hashAlg":"SHA256",
+          "digest":"17d552f8e39ad882f6b3c09ae139af59616bf6a63f4093d6d20e9e1b9f7cdb6e"
+        }
+      ],
+      "pcrs":[
+        {
+          "pcr":16,
+          "hashAlg":"SHA1",
+          "digest":"0000000000000000000000000000000000000000"
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -1,0 +1,186 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "tss2_fapi.h"
+
+#include "test-fapi.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+#define OBJECT_PATH "HS/SRK/mySignKey"
+#define USER_DATA "my user data"
+#define DESCRIPTION "PolicyAuthorize"
+
+/** Test the FAPI functions for PolicyAuthoirze with signing.
+ *
+ * Tested FAPI commands:
+ *  - Fapi_Provision()
+ *  - Fapi_SetBranchCB()
+ *  - Fapi_Import()
+ *  - Fapi_CreateKey()
+ *  - Fapi_Sign()
+ *  - Fapi_List()
+ *  - Fapi_Delete()
+ *
+ * Tested Policies:
+ *  - PolicyNameHash
+ *  - PolicyAuthorize
+ *  - PolicyCpHash (Not entered, only as alternative branch)
+ *
+ * @param[in,out] context The FAPI_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
+{
+    TSS2_RC r;
+    char *policy_pcr = "/policy/pol_pcr";
+#ifdef TEST_ECC
+    char *policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json";
+    char *policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem.json";
+#else
+    char *policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json";
+    char *policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_rsa_pem.json";
+#endif
+    char *policy_name_authorize = "/policy/pol_authorize";
+    // uint8_t policyRef[] = { 1, 2, 3, 4, 5 };
+    FILE *stream = NULL;
+    char *json_policy = NULL;
+    long policy_size;
+
+    uint8_t *signature = NULL;
+    char *publicKey = NULL;
+    char *pathList = NULL;
+
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+    goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = pcr_reset(context, 16);
+    goto_if_error(r, "Error pcr_reset", error);
+
+    /* Read in the first policy */
+    stream = fopen(policy_file_pcr, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", policy_file_pcr);
+        goto error;
+    }
+    fseek(stream, 0L, SEEK_END);
+    policy_size = ftell(stream);
+    fclose(stream);
+    json_policy = malloc(policy_size + 1);
+    goto_if_null(json_policy,
+            "Could not allocate memory for the JSON policy",
+            TSS2_FAPI_RC_MEMORY, error);
+    stream = fopen(policy_file_pcr, "r");
+    ssize_t ret = read(fileno(stream), json_policy, policy_size);
+    if (ret != policy_size) {
+        LOG_ERROR("IO error %s.", policy_file_pcr);
+        goto error;
+    }
+    json_policy[policy_size] = '\0';
+
+    r = Fapi_Import(context, policy_pcr, json_policy);
+    SAFE_FREE(json_policy);
+    goto_if_error(r, "Error Fapi_List", error);
+
+    /* Read in the authorize policy */
+    stream = fopen(policy_file_authorize, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", policy_file_authorize);
+        goto error;
+    }
+    fseek(stream, 0L, SEEK_END);
+    policy_size = ftell(stream);
+    fclose(stream);
+    json_policy = malloc(policy_size + 1);
+    goto_if_null(json_policy,
+            "Could not allocate memory for the JSON policy",
+            TSS2_FAPI_RC_MEMORY, error);
+    stream = fopen(policy_file_authorize, "r");
+    ret = read(fileno(stream), json_policy, policy_size);
+    if (ret != policy_size) {
+        LOG_ERROR("IO error %s.", policy_file_authorize);
+        goto error;
+    }
+    json_policy[policy_size] = '\0';
+
+    r = Fapi_Import(context, policy_name_authorize, json_policy);
+    SAFE_FREE(json_policy);
+    goto_if_error(r, "Error Fapi_Import", error);
+
+    /* Create key and use them to authorize the policy */
+    r = Fapi_CreateKey(context, "HS/SRK/myPolicySignKey", "sign,noDa",
+                       "", NULL);
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    /* Create the actual key */
+    r = Fapi_CreateKey(context, OBJECT_PATH, "sign, noda",
+                       policy_name_authorize, NULL);
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    /* Use the key */
+    size_t signatureSize = 0;
+
+    TPM2B_DIGEST digest = {
+        .size = 32,
+        .buffer = {
+            0x67, 0x68, 0x03, 0x3e, 0x21, 0x64, 0x68, 0x24, 0x7b, 0xd0,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x41, 0x42
+        }
+    };
+
+    r = Fapi_Sign(context, OBJECT_PATH, NULL,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, NULL);
+    goto_if_error(r, "Error Fapi_Sign", error);
+    assert(signature != NULL);
+    assert(publicKey != NULL);
+    assert(certificate != NULL);
+    assert(strlen(publicKey) > ASSERT_SIZE);
+    assert(strlen(certificate) > ASSERT_SIZE);
+
+    /* Cleanup */
+    r = Fapi_Delete(context, "/");
+    goto_if_error(r, "Error Fapi_Delete", error);
+
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+
+    return EXIT_SUCCESS;
+
+error:
+    Fapi_Delete(context, "/");
+    SAFE_FREE(json_policy);
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(pathList);
+    Fapi_Delete(context, "/");
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_fapi(FAPI_CONTEXT *fapi_context)
+{
+    return test_fapi_key_create_policy_authorize_pem_sign(fapi_context);
+}


### PR DESCRIPTION
 * Usage of PEM keys in Policy Authorizations is now supported. Externally produced
   signatures together with the public PEM key now can be added to the policy file.
*  policyRef is now included in the comparison for policy search.
*  A test for PolicyAuthorize with PEM keys was added.
    
 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
