### PR TITLE
Fapi: Fix memory leak

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -603,6 +603,7 @@ ifapi_keystore_load_async(
     return r;
 
  error_cleanup:
+    SAFE_FREE(abs_path);
     SAFE_FREE(keystore->rel_path);
     return r;
 }


### PR DESCRIPTION
Fix a memory leak in async keystore load.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>