### PR TITLE
CI: switch to github container registry

### DIFF
--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -2,10 +2,10 @@
 
 set -e
 
-# if no DOCKER_TAG is set, warn and default to fedora-32
-if [ -z "$DOCKER_TAG" ]; then
-  echo "WARN: DOCKER_TAG is not set, defaulting to fedora-32"
-  export DOCKER_TAG="fedora-32"
+# if no DOCKER_IMAGE is set, warn and default to fedora-32
+if [ -z "$DOCKER_IMAGE" ]; then
+  echo "WARN: DOCKER_IMAGE is not set, defaulting to fedora-32"
+  export DOCKER_IMAGE="fedora-32"
 fi
 
   #
@@ -22,7 +22,7 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
   # Do normal CI script
   ci_env=$(bash <(curl -s https://codecov.io/env))
   docker run --cap-add SYS_PTRACE $ci_env --env-file .ci/docker.env \
-    -v "$(pwd):/workspace/tpm2-tss" "tpm2software/tpm2-tss:$DOCKER_TAG" \
+    -v "$(pwd):/workspace/tpm2-tss" "ghcr.io/tpm2-software/$DOCKER_IMAGE" \
     /bin/bash -c '/workspace/tpm2-tss/.ci/docker.run'
 
     exit 0
@@ -52,7 +52,7 @@ mv cov-analysis-* cov-analysis
 
 # perform the scan
 docker run --env-file .ci/docker.env \
-  -v "$(pwd):/workspace/tpm2-tss" "tpm2software/tpm2-tss:$DOCKER_TAG" \
+  -v "$(pwd):/workspace/tpm2-tss" "ghcr.io/tpm2-software/$DOCKER_IMAGE" \
   /bin/bash -c '/workspace/tpm2-tss/.ci/coverity.run'
 
 # upload the results

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,34 +8,34 @@ compiler:
 env:
   matrix:
    # ubuntu 18.04
-  - DOCKER_TAG=ubuntu-18.04
+  - DOCKER_IMAGE=ubuntu-18.04
    # ubuntu 20.04
-  - DOCKER_TAG=ubuntu-20.04
+  - DOCKER_IMAGE=ubuntu-20.04
     # fedora-32
-  - DOCKER_TAG=fedora-32
+  - DOCKER_IMAGE=fedora-32
    # opensuse-leap
-  - DOCKER_TAG=opensuse-leap
+  - DOCKER_IMAGE=opensuse-leap
 
 matrix:
   include:
   # scan build check
-  - env: DOCKER_TAG=fedora-32 SCANBUILD=yes
+  - env: DOCKER_IMAGE=fedora-32 SCANBUILD=yes
     compiler: clang
   # check config for different tcti targets
-  - env: DOCKER_TAG=fedora-32 TEST_TCTI_CONFIG=true
+  - env: DOCKER_IMAGE=fedora-32 TEST_TCTI_CONFIG=true
     compiler: gcc
-  - env: DOCKER_TAG=ubuntu-20.04
+  - env: DOCKER_IMAGE=ubuntu-20.04
     compiler: clang
   # mbedTLS testing
-  - env: DOCKER_TAG=ubuntu-20.04 WITH_CRYPTO=mbed
+  - env: DOCKER_IMAGE=ubuntu-20.04 WITH_CRYPTO=mbed
     compiler: gcc
-  - env: DOCKER_TAG=fedora-32 WITH_TCTI=mssim
+  - env: DOCKER_IMAGE=fedora-32 WITH_TCTI=mssim
     compiler: gcc
   # coverage check
-  - env: DOCKER_TAG=ubuntu-18.04 ENABLE_COVERAGE=true
+  - env: DOCKER_IMAGE=ubuntu-18.04 ENABLE_COVERAGE=true
     compiler: gcc
   # check fuzz targets
-  - env: DOCKER_TAG=fedora-32 GEN_FUZZ=1 CXX=clang++ CC=clang
+  - env: DOCKER_IMAGE=fedora-32 GEN_FUZZ=1 CXX=clang++ CC=clang
     compiler: clang
 
 script:


### PR DESCRIPTION
Switch from Dockerhub to Github Container Registry. This is due to
Dockerhub limiting pulls for unauthenticated users. Also, change
DOCKER_TAG to DOCKER_IMAGE since it's no longer a "tag" and is the name
of the image itself.

Signed-off-by: William Roberts <william.c.roberts@intel.com>