### PR TITLE
FAPI: Fix return codes of Fapi_List  (Addresses #1888)

### DIFF
--- a/src/tss2-fapi/api/Fapi_List.c
+++ b/src/tss2-fapi/api/Fapi_List.c
@@ -212,14 +212,12 @@ Fapi_List_Finish(
 
 cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
-    SAFE_FREE(command->searchPath);
     if (numPaths == 0 && (r == TSS2_RC_SUCCESS)) {
-        if (command->searchPath && strcmp(command->searchPath,"/") !=0) {
-            LOG_ERROR("Path not found: %s", command->searchPath);
-            r = TSS2_FAPI_RC_NOT_PROVISIONED;
+        if (command->searchPath && strcmp(command->searchPath,"/") !=0
+            && strcmp(command->searchPath,"") !=0) {
+            LOG_WARNING("Path not found: %s", command->searchPath);
         } else {
-            LOG_ERROR("FAPI not provisioned.");
-            r = TSS2_FAPI_RC_NOT_PROVISIONED;
+            LOG_WARNING("FAPI not provisioned.");
         }
     }
     if (numPaths > 0) {
@@ -227,6 +225,7 @@ cleanup:
             SAFE_FREE(pathArray[i]);
         }
     }
+    SAFE_FREE(command->searchPath);
     SAFE_FREE(pathArray);
     return r;
 }

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -61,8 +61,7 @@ ifapi_check_valid_path(
  * @retval TSS2_FAPI_RC_MEMORY: If memory for the path list could not be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE If no explicit path can be derived from the
  *         implicit path.
- * @retval TSS2_FAPI_RC_PATH_NOT_FOUND if a FAPI object path was not found
- *         during authorization.
+ * @retval TSS2_FAPI_RC_BAD_PATH if no valid key path could be created.
  */
 static TSS2_RC
 initialize_explicit_key_path(
@@ -119,7 +118,7 @@ initialize_explicit_key_path(
         hierarchy = "HS";
     } else {
         LOG_ERROR("Hierarchy cannot be determined.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
     /* Add the used hierarchy to the linked list. */
@@ -129,7 +128,7 @@ initialize_explicit_key_path(
         goto error;
     }
     if (list_node == NULL) {
-        goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND, "Explicit path can't be determined.",
+        goto_error(r, TSS2_FAPI_RC_BAD_PATH, "Explicit path can't be determined.",
                    error);
     }
 
@@ -141,21 +140,21 @@ initialize_explicit_key_path(
     }
 
     if (hierarchy && strcmp(hierarchy, "HS") == 0 && strcmp(list_node->str, "EK") == 0) {
-        LOG_ERROR("Key EK cannot be create in the storage hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        LOG_ERROR("Key EK cannot be created in the storage hierarchy.");
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 
     if (hierarchy && strcmp(hierarchy, "HE") == 0 && strcmp(list_node->str, "SRK") == 0) {
         LOG_ERROR("Key EK cannot be create in the endorsement hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 
     if (hierarchy && strcmp(hierarchy, "HN") == 0 &&
         (strcmp(list_node->str, "SRK") == 0 || strcmp(list_node->str, "EK") == 0)) {
         LOG_ERROR("Key EK and SRK cannot be created in NULL hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 

--- a/test/integration/fapi-check-wrong-paths.int.c
+++ b/test/integration/fapi-check-wrong-paths.int.c
@@ -53,7 +53,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Wrong return code", error);
     }
 
@@ -64,7 +64,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Wrong return code", error);
     }
 
@@ -75,7 +75,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Error Fapi_CreateKey", error);
     }
 
@@ -86,7 +86,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Error Fapi_CreateNv", error);
     }
 


### PR DESCRIPTION
* If a certain path is not found only a warning will be produced.
   A null pointer will be returned for the object list.
* The return code "path not" found will be changed to "bad path" if
   the search path cannot be mapped to a possible FAPI entity.
* The test check wrong paths was adapted.
    
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
