### PR TITLE
FAPI: Fix memory leak in policy execution.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -524,6 +524,7 @@ execute_policy_signed(
     statecasedefault(current_policy->state);
     }
 cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     SAFE_FREE(current_policy->pem_key);
     SAFE_FREE(signature_ossl);
     SAFE_FREE(current_policy->buffer);
@@ -888,13 +889,17 @@ execute_policy_secret(
         r = Esys_PolicySecret_Finish(esys_ctx, NULL,
                                      NULL);
         return_try_again(r);
-        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", cleanup);
+        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", error_cleanup);
         break;
 
     statecasedefault(current_policy->state);
     }
 
 cleanup:
+    return r;
+
+ error_cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     return r;
 }
 


### PR DESCRIPTION
TPM nonces were not freed in error cases for policy signed and policy secret.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>