### PR TITLE
FAPI: accept certificates with no CRL dist points

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1640,6 +1640,11 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
         }
     }
 
+    /* No CRL dist point in the cert is legitimate */
+    if (url == NULL) {
+        goto cleanup;
+    }
+
     curl_rc = ifapi_get_curl_buffer(url, &crl_buffer, &crl_buffer_size);
     if (curl_rc != 0) {
         goto_error(r, TSS2_FAPI_RC_NO_CERT, "Get crl.", cleanup);


### PR DESCRIPTION
Vendor certificates are not guaranteed to include CRL distribution
points.  When seeing such a certificate, get_crl_from_cert still tries
to download the CRL from NULL url and fails due to an error returned
from libcurl; the error is then propagated up the stack and causes the
whole operation to fail.

Handle certificates with no CRL dist points gracefully, by returning
success and NULL crl.  The caller, ifapi_verify_ek_cert, is already
prepared to deal with NULL crls.

Signed-off-by: Roman Kagan <rvkagan@gmail.com>