### PR TITLE
Fapi backport fixes 3.0.x

### DIFF
--- a/src/tss2-fapi/api/Fapi_List.c
+++ b/src/tss2-fapi/api/Fapi_List.c
@@ -212,14 +212,12 @@ Fapi_List_Finish(
 
 cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
-    SAFE_FREE(command->searchPath);
     if (numPaths == 0 && (r == TSS2_RC_SUCCESS)) {
-        if (command->searchPath && strcmp(command->searchPath,"/") !=0) {
-            LOG_ERROR("Path not found: %s", command->searchPath);
-            r = TSS2_FAPI_RC_NOT_PROVISIONED;
+        if (command->searchPath && strcmp(command->searchPath,"/") !=0
+            && strcmp(command->searchPath,"") !=0) {
+            LOG_WARNING("Path not found: %s", command->searchPath);
         } else {
-            LOG_ERROR("FAPI not provisioned.");
-            r = TSS2_FAPI_RC_NOT_PROVISIONED;
+            LOG_WARNING("FAPI not provisioned.");
         }
     }
     if (numPaths > 0) {
@@ -227,6 +225,7 @@ cleanup:
             SAFE_FREE(pathArray[i]);
         }
     }
+    SAFE_FREE(command->searchPath);
     SAFE_FREE(pathArray);
     return r;
 }

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -374,6 +374,11 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_READ_HIERARCHY);
             path = command->pathlist[command->path_idx];
+            if (path == NULL) {
+                goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "Wrong path.",
+                           error_cleanup);
+            }
+
             r = ifapi_keystore_load_finish(&context->keystore, &context->io,
                                            &command->hierarchies[command->path_idx]);
             return_try_again(r);
@@ -381,6 +386,11 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
             /* Search for slash followed by hierarchy after profile  */
             path = strchr(&path[1], '/');
+            if (path == NULL) {
+                goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
+                           "Wrong path.",
+                           error_cleanup);
+            }
 
             /* Use the first appropriate hierarchy for provisioning. The first found
                hierarchy will be copied into the provisioning context.*/

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1640,6 +1640,11 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
         }
     }
 
+    /* No CRL dist point in the cert is legitimate */
+    if (url == NULL) {
+        goto cleanup;
+    }
+
     curl_rc = ifapi_get_curl_buffer(url, &crl_buffer, &crl_buffer_size);
     if (curl_rc != 0) {
         goto_error(r, TSS2_FAPI_RC_NO_CERT, "Get crl.", cleanup);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -61,8 +61,7 @@ ifapi_check_valid_path(
  * @retval TSS2_FAPI_RC_MEMORY: If memory for the path list could not be allocated.
  * @retval TSS2_FAPI_RC_BAD_VALUE If no explicit path can be derived from the
  *         implicit path.
- * @retval TSS2_FAPI_RC_PATH_NOT_FOUND if a FAPI object path was not found
- *         during authorization.
+ * @retval TSS2_FAPI_RC_BAD_PATH if no valid key path could be created.
  */
 static TSS2_RC
 initialize_explicit_key_path(
@@ -119,7 +118,7 @@ initialize_explicit_key_path(
         hierarchy = "HS";
     } else {
         LOG_ERROR("Hierarchy cannot be determined.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
     /* Add the used hierarchy to the linked list. */
@@ -129,7 +128,7 @@ initialize_explicit_key_path(
         goto error;
     }
     if (list_node == NULL) {
-        goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND, "Explicit path can't be determined.",
+        goto_error(r, TSS2_FAPI_RC_BAD_PATH, "Explicit path can't be determined.",
                    error);
     }
 
@@ -141,21 +140,21 @@ initialize_explicit_key_path(
     }
 
     if (hierarchy && strcmp(hierarchy, "HS") == 0 && strcmp(list_node->str, "EK") == 0) {
-        LOG_ERROR("Key EK cannot be create in the storage hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        LOG_ERROR("Key EK cannot be created in the storage hierarchy.");
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 
     if (hierarchy && strcmp(hierarchy, "HE") == 0 && strcmp(list_node->str, "SRK") == 0) {
         LOG_ERROR("Key EK cannot be create in the endorsement hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 
     if (hierarchy && strcmp(hierarchy, "HN") == 0 &&
         (strcmp(list_node->str, "SRK") == 0 || strcmp(list_node->str, "EK") == 0)) {
         LOG_ERROR("Key EK and SRK cannot be created in NULL hierarchy.");
-        r = TSS2_FAPI_RC_PATH_NOT_FOUND;
+        r = TSS2_FAPI_RC_BAD_PATH;
         goto error;
     }
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -93,6 +93,7 @@ ifapi_exec_auth_policy(
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -524,6 +524,7 @@ execute_policy_signed(
     statecasedefault(current_policy->state);
     }
 cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     SAFE_FREE(current_policy->pem_key);
     SAFE_FREE(signature_ossl);
     SAFE_FREE(current_policy->buffer);
@@ -889,13 +890,17 @@ execute_policy_secret(
         r = Esys_PolicySecret_Finish(esys_ctx, NULL,
                                      NULL);
         return_try_again(r);
-        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", cleanup);
+        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", error_cleanup);
         break;
 
     statecasedefault(current_policy->state);
     }
 
 cleanup:
+    return r;
+
+ error_cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     return r;
 }
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -608,6 +608,7 @@ execute_policy_authorize(
         /* Execute authorized policy. */
         ifapi_policyeval_EXEC_CB *cb = &current_policy->callbacks;
         r = cb->cbauthpol(&policy->keyPublic, hash_alg, &policy->approvedPolicy,
+                          &policy->policyRef,
                           &policy->signature, cb->cbauthpol_userdata);
         return_try_again(r);
         goto_if_error(r, "Execute authorized policy.", cleanup);

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -77,6 +77,7 @@ typedef TSS2_RC (*ifapi_policyexec_cbauthpol) (
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 

--- a/test/integration/fapi-check-wrong-paths.int.c
+++ b/test/integration/fapi-check-wrong-paths.int.c
@@ -53,7 +53,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Wrong return code", error);
     }
 
@@ -64,7 +64,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Wrong return code", error);
     }
 
@@ -75,7 +75,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Error Fapi_CreateKey", error);
     }
 
@@ -86,7 +86,7 @@ test_fapi_wrong_path(FAPI_CONTEXT *context)
         goto error;
     }
 
-    if (r !=  TSS2_FAPI_RC_PATH_NOT_FOUND) {
+    if (r !=  TSS2_FAPI_RC_BAD_PATH) {
         goto_if_error(r, "Error Fapi_CreateNv", error);
     }
 


### PR DESCRIPTION
* Include policyRef into policy search for policy authorize.
* Add check for path of hierarchies in provisioning.
* Fix memory leak in policy execution.
* Adapt return codes of the test check wrong paths.
* Fix return codes of Fapi_List (Addresses #1888)
* Accept certificates with no CRL dist points

 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
