### PR TITLE
Fapi backport fixes 2.4.x

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1640,6 +1640,11 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
         }
     }
 
+    /* No CRL dist point in the cert is legitimate */
+    if (url == NULL) {
+        goto cleanup;
+    }
+
     curl_rc = ifapi_get_curl_buffer(url, &crl_buffer, &crl_buffer_size);
     if (curl_rc != 0) {
         goto_error(r, TSS2_FAPI_RC_NO_CERT, "Get crl.", cleanup);

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -675,6 +675,27 @@ ifapi_sign_buffer(
     return TSS2_RC_SUCCESS;
 }
 
+static bool
+cmp_policy_ref(TPM2B_NONCE *ref1, TPM2B_NONCE *ref2)
+{
+    if ((!ref1 || !ref1->size) && (!ref2 || !ref2->size)) {
+        return true;
+    }
+    if (!ref1 || !ref1->size || !ref2 || !ref2->size)  {
+        return false;
+    }
+
+    if (ref1->size != ref2->size) {
+        return false;
+    }
+
+    if (memcmp(&ref1->buffer[0], &ref2->buffer[0], ref1->size) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
 /**  Check whether public data of key is assigned to policy.
  *
  * It will be checked whether policy was authorized by abort key with public
@@ -682,26 +703,28 @@ ifapi_sign_buffer(
  *
  * @param[in] policy The policy to be checked.
  * @param[in] publicVoid The public information of the key.
- * @param[in] nameAlgVoid Not used for this compare function.
+ * @param[in] policyReferenceVoid The policy reverence to be compared.
  * @param[out] equal Switch whether check was successful.
  */
 static TSS2_RC
 equal_policy_authorization(
     TPMS_POLICY *policy,
     void *publicVoid,
-    void *nameAlgVoid,
+    void *policyRefVoid,
     bool *equal)
 {
     TPMT_PUBLIC *public = publicVoid;
-    (void)nameAlgVoid;
+    TPM2B_NONCE *policyRef = policyRefVoid;
     size_t i;
     TPML_POLICYAUTHORIZATIONS *authorizations = policy->policyAuthorizations;
 
     *equal = false;
     if (authorizations) {
         for (i = 0; i < authorizations->count; i++) {
-            if (ifapi_TPMT_PUBLIC_cmp
-                (public, &authorizations->authorizations[i].key)) {
+            /* Check public information if key and policyRef */
+            if (ifapi_TPMT_PUBLIC_cmp(public, &authorizations->authorizations[i].key) &&
+                cmp_policy_ref(policyRef,
+                               &authorizations->authorizations[i].policyRef)) {
                 *equal = true;
                 return TSS2_RC_SUCCESS;
             }
@@ -1031,6 +1054,7 @@ ifapi_exec_auth_policy(
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata)
 {
@@ -1066,7 +1090,7 @@ ifapi_exec_auth_policy(
         statecase(cb_ctx->cb_state, POL_CB_SEARCH_POLICY)
             r = search_policy(fapi_ctx,
                               equal_policy_authorization, true,
-                              key_public, NULL,
+                              key_public, policyRef,
                               &current_policy->policy_list);
             FAPI_SYNC(r, "Search policy", cleanup);
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -93,6 +93,7 @@ ifapi_exec_auth_policy(
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -501,6 +501,7 @@ execute_policy_signed(
     statecasedefault(current_policy->state);
     }
 cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     SAFE_FREE(current_policy->pem_key);
     SAFE_FREE(signature_ossl);
     SAFE_FREE(current_policy->buffer);
@@ -827,13 +828,17 @@ execute_policy_secret(
         r = Esys_PolicySecret_Finish(esys_ctx, NULL,
                                      NULL);
         return_try_again(r);
-        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", cleanup);
+        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", error_cleanup);
         break;
 
     statecasedefault(current_policy->state);
     }
 
 cleanup:
+    return r;
+
+ error_cleanup:
+    SAFE_FREE(current_policy->nonceTPM);
     return r;
 }
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -576,6 +576,7 @@ execute_policy_authorize(
         /* Execute authorized policy. */
         ifapi_policyeval_EXEC_CB *cb = &current_policy->callbacks;
         r = cb->cbauthpol(&policy->keyPublic, hash_alg, &policy->approvedPolicy,
+                          &policy->policyRef,
                           &policy->signature, cb->cbauthpol_userdata);
         return_try_again(r);
         goto_if_error(r, "Execute authorized policy.", cleanup);

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -77,6 +77,7 @@ typedef TSS2_RC (*ifapi_policyexec_cbauthpol) (
     TPMT_PUBLIC *key_public,
     TPMI_ALG_HASH hash_alg,
     TPM2B_DIGEST *digest,
+    TPM2B_NONCE *policyRef,
     TPMT_SIGNATURE *signature,
     void *userdata);
 


### PR DESCRIPTION
* Include policyRef into policy search for policy authorize.
* Fix memory leak in policy execution.
* Accept certificates with no CRL dist points

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>