### PR TITLE
Fapi add provisioning check

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -280,4 +280,10 @@ void
 ifapi_cleanup_ifapi_object(
     IFAPI_OBJECT *object);
 
+TSS2_RC
+ifapi_check_provisioned(
+    IFAPI_KEYSTORE *keystore,
+    const char *rel_path,
+    bool *ok);
+
 #endif /* IFAPI_KEYSTORE_H */

--- a/test/integration/fapi-get-random.int.c
+++ b/test/integration/fapi-get-random.int.c
@@ -42,6 +42,7 @@ test_fapi_get_random(FAPI_CONTEXT *context)
     size_t  bytesRequested = sizeof(TPMU_HA) + 10;
     uint8_t *randomBytes = NULL;
 
+
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 

--- a/test/integration/fapi-key-create-policy-authorize-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-sign.int.c
@@ -129,9 +129,26 @@ test_fapi_key_create_policy_authorize_sign(FAPI_CONTEXT *context)
     char *certificate = NULL;
     char *pathList = NULL;
 
+    r = Fapi_List(context, "/", &pathList);
+    if (r != TSS2_FAPI_RC_NOT_PROVISIONED) {
+        LOG_ERROR("It was not detected that provisioning was not made");
+        goto error;
+    }
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = Fapi_List(context, "/P_DOES_NOT_EXIST", &pathList);
+    if (r != TSS2_FAPI_RC_NOT_PROVISIONED) {
+        LOG_ERROR("It was not detected that provisioning was not made");
+        goto error;
+    }
+
+    r = Fapi_List(context, "/SRK/DOES_NOT_EXIST", &pathList);
+    if (r != TSS2_FAPI_RC_PATH_NOT_FOUND) {
+        LOG_ERROR("It was not detected that provisioning was not made");
+        goto error;
+    }
 
     r = pcr_reset(context, 16);
     goto_if_error(r, "Error pcr_reset", error);


### PR DESCRIPTION
* It will be checked whether the profile directory exists for expanded
   pathnames which start with a profile name.
   If the profile directory does not exist TSS2_FAPI_RC_NOT_PROVISIONED
   will be returned by Fapi_List, and the function which computes absolute
   pathnames to read objects from the keystore.
* One integration test was extended to test the profile checking.

 Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
