### PR TITLE
FAPI: Add provisioning check for 3.0.x.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -280,4 +280,10 @@ void
 ifapi_cleanup_ifapi_object(
     IFAPI_OBJECT *object);
 
+TSS2_RC
+ifapi_check_provisioned(
+    IFAPI_KEYSTORE *keystore,
+    const char *rel_path,
+    bool *ok);
+
 #endif /* IFAPI_KEYSTORE_H */

--- a/test/integration/fapi-get-random.int.c
+++ b/test/integration/fapi-get-random.int.c
@@ -42,6 +42,7 @@ test_fapi_get_random(FAPI_CONTEXT *context)
     size_t  bytesRequested = sizeof(TPMU_HA) + 10;
     uint8_t *randomBytes = NULL;
 
+
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 


### PR DESCRIPTION
It will be checked whether the profile directory exists for expanded
pathnames which start with a profile name.
If the profile directory does not exist TSS2_FAPI_RC_NOT_PROVISIONED
will be returned by Fapi_List, and the function which computes absolute
pathnames to read objects from the keystore.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>