### PR TITLE
FAPI: Fix path error handling for not existing files.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -550,12 +550,12 @@ rel_path_to_abs_path(
         if (ifapi_path_type_p(rel_path, IFAPI_NV_PATH)) {
             /* NV directory does not exist. */
             goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND,
-                    "FAPI not provisioned. File %s does not exist.",
+                    "File %s does not exist.",
                     cleanup, rel_path);
         } else if (ifapi_hierarchy_path_p(rel_path)) {
             /* Hierarchy which should be created during provisioning could not be loaded. */
-            goto_error(r, TSS2_FAPI_RC_NOT_PROVISIONED,
-                    "FAPI not provisioned. Hierarchy file %s does not exist.",
+            goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND,
+                    "Hierarchy file %s does not exist.",
                     cleanup, rel_path);
         } else {
             /* Object file for key does not exist in keystore */


### PR DESCRIPTION
* Misleading error messages were changed.
* The return code for not existing hierarchies was fixed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>