### PR TITLE
FAPI: fix provisioning check in rel_path_to_abs_path()

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -537,10 +537,7 @@ rel_path_to_abs_path(
         r = ifapi_check_provisioned(keystore, rel_path, &provision_check_ok);
         goto_if_error(r, "Provisioning check.", cleanup);
 
-        if (provision_check_ok) {
-            goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND,
-            "Path not found: %s.", cleanup, rel_path);
-        } else {
+        if (!provision_check_ok) {
             goto_error(r, TSS2_FAPI_RC_NOT_PROVISIONED,
                        "FAPI not provisioned for path: %s.",
                        cleanup, rel_path);


### PR DESCRIPTION
Commit 05d9ebd1c3ffe7011fc5062211c3a7013f9b33df added a provisioning check to `rel_path_to_abs_path()` that always returns early with `TSS2_FAPI_RC_PATH_NOT_FOUND` if the FAPI is provisioned. This leads to dead code in the rest of the function and possibly wrong return codes, breaking software that relies on a return value of `TSS2_FAPI_RC_KEY_NOT_FOUND` instead of `TSS2_FAPI_RC_PATH_NOT_FOUND`, e.g. [tpm2-pkcs11](https://github.com/tpm2-software/tpm2-pkcs11/blob/8f2b96fbbbeb6c236d719857f86fdc672bf3b6fc/src/lib/backend_fapi.c#L385-L387).