### PR TITLE
FAPI: Improve error messages for reading of config and profile files.

### DIFF
--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -53,60 +53,60 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
         out->profile_dir = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->profile_dir);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"profile_dir\".");
     }
 
     if (!ifapi_get_sub_object(jso, "user_dir", &jso2)) {
         out->user_dir = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->user_dir);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"user_dir\".");
     }
 
     if (!ifapi_get_sub_object(jso, "system_dir", &jso2)) {
         out->keystore_dir = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->keystore_dir);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keystore_dir\".");
     }
 
     if (!ifapi_get_sub_object(jso, "log_dir", &jso2)) {
         out->log_dir = DEFAULT_LOG_DIR;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->log_dir);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"log_dir\".");
     }
 
     if (!ifapi_get_sub_object(jso, "profile_name", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"profile_name\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->profile_name);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"profile_name\".");
     if (!ifapi_get_sub_object(jso, "tcti", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"tcti\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_char_deserialize(jso2, &out->tcti);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"tcti\".");
 
     if (!ifapi_get_sub_object(jso, "system_pcrs", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"system_pcrs\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->system_pcrs);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"system_pcrs\".");
 
     if (!ifapi_get_sub_object(jso, "ek_cert_file", &jso2)) {
         out->ek_cert_file = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->ek_cert_file);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"ek_cert_file\".");
     }
 
     if (ifapi_get_sub_object(jso, "ek_cert_less", &jso2)) {
         r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->ek_cert_less);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"ek_cert_less\".");
 
     } else {
         out->ek_cert_less = TPM2_NO;
@@ -114,7 +114,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
 
     if (ifapi_get_sub_object(jso, "ek_fingerprint", &jso2)) {
         r = ifapi_json_TPMT_HA_deserialize(jso2, &out->ek_fingerprint);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"ek_fingerprint\".");
     } else {
         out->ek_fingerprint.hashAlg = 0;
     }
@@ -123,7 +123,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
         out->intel_cert_service = NULL;
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->intel_cert_service);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"intel_cert_service\".");
     }
 
     LOG_TRACE("true");

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -339,14 +339,14 @@ ifapi_profile_json_deserialize(
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"type\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_PUBLIC_deserialize(jso2, &out->type);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"type\".");
 
     if (!ifapi_get_sub_object(jso, "srk_template", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"srk_template\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     out->srk_template = strdup(json_object_get_string(jso2));
@@ -360,7 +360,7 @@ ifapi_profile_json_deserialize(
     }
 
     if (!ifapi_get_sub_object(jso, "ek_template", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"ek_template\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     out->ek_template = strdup(json_object_get_string(jso2));
@@ -377,87 +377,87 @@ ifapi_profile_json_deserialize(
         memset(&out->ecc_signing_scheme, 0, sizeof(TPMT_SIG_SCHEME));
     } else {
         r = ifapi_json_TPMT_SIG_SCHEME_deserialize(jso2, &out->ecc_signing_scheme);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"ecc_signing_scheme\".");
     }
 
     if (!ifapi_get_sub_object(jso, "rsa_signing_scheme", &jso2)) {
         memset(&out->rsa_signing_scheme, 0, sizeof(TPMT_SIG_SCHEME));
     } else {
         r = ifapi_json_TPMT_SIG_SCHEME_deserialize(jso2, &out->rsa_signing_scheme);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"rsa_signing_scheme\".");
     }
 
     if (!ifapi_get_sub_object(jso, "rsa_decrypt_scheme", &jso2)) {
         memset(&out->rsa_decrypt_scheme, 0, sizeof(TPMT_RSA_DECRYPT));
     } else {
         r = ifapi_json_TPMT_RSA_DECRYPT_deserialize(jso2, &out->rsa_decrypt_scheme);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"rsa_decrypt_scheme\".");
     }
 
     if (!ifapi_get_sub_object(jso, "sym_mode", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sym_mode\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_SYM_MODE_deserialize(jso2, &out->sym_mode);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sym_mode\".");
 
     if (!ifapi_get_sub_object(jso, "sym_parameters", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sym_parameters\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_deserialize(jso2, &out->sym_parameters);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sym_parameters\".");
 
     if (!ifapi_get_sub_object(jso, "sym_block_size", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"sym_block_size\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_UINT16_deserialize(jso2, &out->sym_block_size);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"sym_block_size\".");
 
     if (!ifapi_get_sub_object(jso, "pcr_selection", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"pcr_selection\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->pcr_selection);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"pcr_selection\".");
 
     if (!ifapi_get_sub_object(jso, "nameAlg", &jso2)) {
-        LOG_ERROR("Bad value");
+        LOG_ERROR("Field \"nameAlg\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
     r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->nameAlg);
-    return_if_error(r, "BAD VALUE");
+    return_if_error(r, "Bad value for field \"nameAlg\".");
 
     if (out->type == TPM2_ALG_RSA) {
         if (!ifapi_get_sub_object(jso, "exponent", &jso2)) {
-            LOG_ERROR("Bad value");
+            LOG_ERROR("Field \"exponent\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_UINT32_deserialize(jso2, &out->exponent);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"exponent\".");
         if (!ifapi_get_sub_object(jso, "keyBits", &jso2)) {
-            LOG_ERROR("Bad value");
+            LOG_ERROR("Field \"keyBits\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
 
         }
         r = ifapi_json_TPMI_RSA_KEY_BITS_deserialize(jso2, &out->keyBits);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"keyBits\".");
 
     } else if (out->type == TPM2_ALG_ECC) {
         if (!ifapi_get_sub_object(jso, "curveID", &jso2)) {
-            LOG_ERROR("Bad value");
+            LOG_ERROR("Field \"curveID\" not found.");
             return TSS2_FAPI_RC_BAD_VALUE;
         }
         r = ifapi_json_TPMI_ECC_CURVE_deserialize(jso2, &out->curveID);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"curveID\".");
     }
 
     if (!ifapi_get_sub_object(jso, "session_symmetric", &jso2)) {
         out->session_symmetric = session_symmetric_default;
     } else {
         r = ifapi_json_TPMT_SYM_DEF_deserialize(jso2, &out->session_symmetric);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"session_symmetric\".");
     }
 
     if (ifapi_get_sub_object(jso, "eh_policy", &jso2)) {
@@ -509,21 +509,21 @@ ifapi_profile_json_deserialize(
         out->newMaxTries = 5;
     } else {
         r = ifapi_json_UINT32_deserialize(jso2, &out->newMaxTries);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"newMaxTries\".");
     }
 
     if (!ifapi_get_sub_object(jso, "newRecoveryTime", &jso2)) {
         out->newRecoveryTime = 1000;
     } else {
         r = ifapi_json_UINT32_deserialize(jso2, &out->newRecoveryTime);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"newRecoveryTime\".");
     }
 
     if (!ifapi_get_sub_object(jso, "lockoutRecovery", &jso2)) {
         out->lockoutRecovery = 1000;
     } else {
         r = ifapi_json_UINT32_deserialize(jso2, &out->lockoutRecovery);
-        return_if_error(r, "BAD VALUE");
+        return_if_error(r, "Bad value for field \"lockoutRecovery\".");
     }
 
     LOG_TRACE("true");


### PR DESCRIPTION
* If mandatory fields are not found an error message with the field name
  will be displayed instead of "BAD VALUE"
* If a field value  cannot be deserialized now here also the field name will
  be part of the error message.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>