### PR TITLE
ESYS: Enable large auth value for keys and NV objects (Addresses #1008).

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -194,6 +194,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-create-session-auth-bound.int \
     test/integration/esys-create-session-auth-ecc.int \
     test/integration/esys-create-session-auth.int \
+    test/integration/esys-create-session-auth-long.int \
     test/integration/esys-create-session-auth-xor.int \
     test/integration/esys-ecc-parameters.int \
     test/integration/esys-ecdh-zgen.int \
@@ -213,6 +214,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-make-credential-session.int \
     test/integration/esys-nv-ram-counter.int \
     test/integration/esys-nv-ram-counter-session.int \
+    test/integration/esys-nv-ram-counter-session-long-auth.int \
     test/integration/esys-nv-ram-extend-index.int \
     test/integration/esys-nv-ram-extend-index-session.int \
     test/integration/esys-nv-ram-ordinary-index-rlock.int \
@@ -882,6 +884,15 @@ test_integration_esys_create_session_auth_int_SOURCES = \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
 
+test_integration_esys_create_session_auth_long_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTEST_AES_ENCRYPTION -DTEST_LARGE_AUTH $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_integration_esys_create_session_auth_long_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_create_session_auth_long_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_integration_esys_create_session_auth_long_int_SOURCES = \
+    $(ESYS_SRC_UTIL_CRYPTO_SRC) \
+    test/integration/esys-create-session-auth.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
 test_integration_esys_create_session_auth_bound_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_AES_ENCRYPTION -DTEST_BOUND_SESSION $(TSS2_ESYS_CFLAGS_CRYPTO)
 test_integration_esys_create_session_auth_bound_int_LDADD   = $(TESTS_LDADD)
@@ -1106,6 +1117,15 @@ test_integration_esys_nv_ram_counter_session_int_CFLAGS  = $(TESTS_CFLAGS) \
 test_integration_esys_nv_ram_counter_session_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_nv_ram_counter_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
 test_integration_esys_nv_ram_counter_session_int_SOURCES = \
+    $(ESYS_SRC_UTIL_CRYPTO_SRC) \
+    test/integration/esys-nv-ram-counter.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_nv_ram_counter_session_long_auth_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTEST_LONG_AUTH -DTEST_SESSION $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_integration_esys_nv_ram_counter_session_long_auth_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_nv_ram_counter_session_long_auth_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_integration_esys_nv_ram_counter_session_long_auth_int_SOURCES = \
     $(ESYS_SRC_UTIL_CRYPTO_SRC) \
     test/integration/esys-nv-ram-counter.int.c \
     test/integration/main-esys.c test/integration/test-esys.h

--- a/src/tss2-esys/api/Esys_CreatePrimary.c
+++ b/src/tss2-esys/api/Esys_CreatePrimary.c
@@ -207,6 +207,12 @@ Esys_CreatePrimary_Async(
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
     store_input_parameters (esysContext, inSensitive);
+    if (inPublic) {
+        r = iesys_hash_long_auth_values(
+            &esysContext->in.CreatePrimary.inSensitive->sensitive.userAuth,
+             inPublic->publicArea.nameAlg);
+        return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");
+    }
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, primaryHandle, &primaryHandleNode);
@@ -216,7 +222,8 @@ Esys_CreatePrimary_Async(
     r = Tss2_Sys_CreatePrimary_Prepare(esysContext->sys,
                                        (primaryHandleNode == NULL) ? TPM2_RH_NULL
                                         : primaryHandleNode->rsrc.handle,
-                                       inSensitive, inPublic, outsideInfo,
+                                       esysContext->in.CreatePrimary.inSensitive,
+                                       inPublic, outsideInfo,
                                        creationPCR);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 

--- a/src/tss2-esys/api/Esys_NV_DefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_DefineSpace.c
@@ -197,7 +197,14 @@ Esys_NV_DefineSpace_Async(
     /* Check input parameters */
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
+
     store_input_parameters(esysContext, auth, publicInfo);
+
+    if (publicInfo) {
+        r = iesys_hash_long_auth_values(esysContext->in.NV.auth,
+                                        publicInfo->nvPublic.nameAlg);
+        return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");
+    }
 
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
@@ -206,8 +213,8 @@ Esys_NV_DefineSpace_Async(
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_NV_DefineSpace_Prepare(esysContext->sys,
                                         (authHandleNode == NULL) ? TPM2_RH_NULL
-                                         : authHandleNode->rsrc.handle, auth,
-                                        publicInfo);
+                                        : authHandleNode->rsrc.handle,
+                                        esysContext->in.NV.auth, publicInfo);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 
     /* Calculate the cpHash Values */

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -43,6 +43,11 @@ typedef struct {
 } CreatePrimary_IN;
 
 typedef struct {
+    TPM2B_SENSITIVE_CREATE *inSensitive;
+    TPM2B_SENSITIVE_CREATE inSensitiveData;
+} Create_IN;
+
+typedef struct {
     ESYS_TR saveHandle;
 } ContextSave_IN;
 
@@ -112,6 +117,7 @@ typedef struct {
 typedef union {
     StartAuthSession_IN StartAuthSession;
     CreatePrimary_IN CreatePrimary;
+    Create_IN Create;
     ContextSave_IN ContextSave;
     ContextLoad_IN ContextLoad;
     Load_IN Load;

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1554,3 +1554,55 @@ iesys_tpm_error(TSS2_RC r)
              (r & TSS2_RC_LAYER_MASK) == TSS2_RESMGR_TPM_RC_LAYER ||
              (r & TSS2_RC_LAYER_MASK) == TSS2_RESMGR_RC_LAYER));
 }
+
+
+/** Replace auth value with Hash for long auth values.
+ *
+ * if the size of auth value exceeds hash_size the auth value
+ * will be replaced with the hash of the auth value.
+ *
+ * @param[in,out] auth_value The auth value to be adapted.
+ * @param[in] hash_alg The hash alg used for adaption.
+ * @retval TSS2_RC_SUCCESS if the function call was a success.
+ * @retval TSS2_ESYS_RC_BAD_VALUE if an invalid hash is passed.
+ * @retval TSS2_ESYS_RC_MEMORY if the ESAPI cannot allocate enough memory.
+ * @retval TSS2_ESYS_RC_GENERAL_FAILURE for a failure during digest
+ *         computation.
+ */
+TSS2_RC
+iesys_hash_long_auth_values(
+    TPM2B_AUTH *auth_value,
+    TPMI_ALG_HASH hash_alg)
+{
+    TSS2_RC r;
+    IESYS_CRYPTO_CONTEXT_BLOB *cryptoContext;
+    TPM2B_AUTH hash2b;
+    size_t hash_size;
+
+    r = iesys_crypto_hash_get_digest_size(hash_alg, &hash_size);
+    return_if_error(r, "Get digest size.");
+
+    if (auth_value && auth_value->size > hash_size) {
+        /* The auth value has to be adapted. */
+        r = iesys_crypto_hash_start(&cryptoContext, hash_alg);
+        return_if_error(r, "crypto hash start");
+
+        r = iesys_crypto_hash_update(cryptoContext, &auth_value->buffer[0],
+                                     auth_value->size);
+        goto_if_error(r, "crypto hash update", error_cleanup);
+
+        r = iesys_crypto_hash_finish(&cryptoContext, &hash2b.buffer[0],
+                                     &hash_size);
+        goto_if_error(r, "crypto hash finish", error_cleanup);
+
+        memcpy(&auth_value->buffer[0], &hash2b.buffer[0], hash_size);
+        auth_value->size = hash_size;
+    }
+    return r;
+
+ error_cleanup:
+    if (cryptoContext) {
+        iesys_crypto_hash_abort(&cryptoContext);
+    }
+    return r;
+}

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -167,6 +167,10 @@ TSS2_RC iesys_get_name(
 bool iesys_tpm_error(
     TSS2_RC r);
 
+TSS2_RC iesys_hash_long_auth_values(
+    TPM2B_AUTH *auth_value,
+    TPMI_ALG_HASH hash_alg);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -80,6 +80,12 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
         .buffer = {1, 2, 3, 4, 5}
     };
 
+#ifdef TEST_LARGE_AUTH
+    for (int i = 0; i < 33; i++)
+        authValuePrimary.buffer[i] = i;
+    authValuePrimary.size = 33;
+#endif
+
     TPM2B_SENSITIVE_CREATE inSensitivePrimary = {
         .size = 0,
         .sensitive = {
@@ -304,6 +310,12 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
         .size = 6,
         .buffer = {6, 7, 8, 9, 10, 11}
     };
+
+#ifdef TEST_LARGE_AUTH
+    for (int i = 0; i < 33; i++)
+        authKey2.buffer[i] = i;
+    authKey2.size = 33;
+#endif
 
     TPM2B_SENSITIVE_CREATE inSensitive2 = {
         .size = 0,

--- a/test/integration/esys-nv-ram-counter.int.c
+++ b/test/integration/esys-nv-ram-counter.int.c
@@ -73,6 +73,11 @@ test_esys_nv_ram_counter(ESYS_CONTEXT * esys_context)
     TPM2B_AUTH auth = {.size = 20,
                        .buffer={10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
+#ifdef TEST_LARGE_AUTH
+     for (int i = 0; i < 33; i++)
+        auth.buffer[i] = i;
+     auth.size = 33;
+#endif
 
     TPM2B_NV_PUBLIC publicInfo = {
         .size = 0,


### PR DESCRIPTION
* The size of the auth value for keys and NV objects is restricted to the size
  of the name hash algorithm of these objects.  Esapi will use the
  hash of the user auth values as auth value for these object.
  The maximal size will be sizeof(TPMU_HA).
* Test cases for keys and NV objects with large auth values were added.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>