### PR TITLE
TCTIs: Add missing events bits to pollhandles

### DIFF
--- a/src/tss2-tcti/tcti-cmd.c
+++ b/src/tss2-tcti/tcti-cmd.c
@@ -442,6 +442,7 @@ TSS2_RC tcti_cmd_get_poll_handles (TSS2_TCTI_CONTEXT *tctiContext,
             LOG_ERROR ("Could not get fileno: %s", strerror (errno));
             return TSS2_TCTI_RC_IO_ERROR;
         }
+        handles->events = POLLIN | POLLOUT;
     }
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -351,6 +351,7 @@ tcti_device_get_poll_handles (
     *num_handles = 1;
     if (handles != NULL) {
         handles->fd = tcti_dev->fd;
+        handles->events = POLLIN | POLLOUT;
     }
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -288,6 +288,7 @@ tcti_mssim_get_poll_handles (
 #else
         handles->fd = tcti_mssim->tpm_sock;
 #endif
+        handles->events = POLLIN | POLLOUT;
     }
 
     return TSS2_RC_SUCCESS;


### PR DESCRIPTION
TCTIs are supposed to populate the pollevent structure such that it can be used with the `poll()` syscall.
However many did not set the events field, leading to infinite waits in poll.

I'm not entirely sure on the bits each of the tctis needs.

@williamcroberts what are the poll-events for tcti-cmd for example ?