### PR TITLE
FAPI: Fix compilation error for integration tests in debugging mode.

### DIFF
--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -156,9 +156,7 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_Sign", error);
     assert(signature != NULL);
     assert(publicKey != NULL);
-    assert(certificate != NULL);
     assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
 
     /* Cleanup */
     r = Fapi_Delete(context, "/");


### PR DESCRIPTION
If the integration tests were compiled with --enable-debug in one integration test
undeclared variables were used.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>