### PR TITLE
FAPI: Fix determination of object type from path (2.4.x).

### DIFF
--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -254,7 +254,7 @@ ifapi_path_type_p(const char *path, const char *type)
     end_pos = (int)(end - path);
 
     /* Check sub-string and following delimiter. */
-    if (strlen(path) - pos > 3 &&
+    if (strlen(path) - pos >= 3 &&
             strncasecmp(type, &path[pos], strlen(type)) == 0 && end &&
             strncmp(IFAPI_FILE_DELIM, &path[end_pos], 1) == 0)
         return true;


### PR DESCRIPTION
The type of the path "/nv/" was not determined correctly as an NV path.
It did work e.g. for "/nv" and "/nv/..." but not for "/nv/".
So Fapi_List could not be called with path "/nv/".

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>