### PR TITLE
FAPI: Fix state handling in policy execution (3.0.x).

### DIFF
--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -203,6 +203,7 @@ ifapi_get_object_name(
     }
 
 cleanup:
+    context->io_state = IO_INIT;
     ifapi_cleanup_ifapi_object(&object);
     return r;
 }
@@ -271,6 +272,7 @@ ifapi_get_nv_public(
     }
 
 cleanup:
+    context->io_state = IO_INIT;
     ifapi_cleanup_ifapi_object(&object);
     return r;
 }

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -794,6 +794,7 @@ execute_policy_authorize_nv(
         r = Esys_PolicyAuthorizeNV_Finish(esys_ctx);
         return_try_again(r);
         goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", cleanup);
+        current_policy->state = POLICY_EXECUTE_INIT;
         break;
 
     statecasedefault(current_policy->state);
@@ -891,6 +892,7 @@ execute_policy_secret(
                                      NULL);
         return_try_again(r);
         goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", error_cleanup);
+        current_policy->state = POLICY_EXECUTE_INIT;
         break;
 
     statecasedefault(current_policy->state);
@@ -1438,6 +1440,7 @@ execute_policy_action(
         /* Execute the callback and try it again if the callback is not finished. */
         r = cb->cbaction(policy->action, cb->cbaction_userdata);
         try_again_or_error(r, "Execute policy action callback.");
+        current_policy->state = POLICY_EXECUTE_INIT;
         return r;
 
     statecasedefault(current_policy->state);


### PR DESCRIPTION
In some policy execution functions the policy state was not initialized
correctly after successful policy execution.
The policies "secret", "authorize_nv", and "action" were affected.

Fixes Issue #1937.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>