### PR TITLE
FAPI: Improve integration tests.

### DIFF
--- a/test/data/fapi/policy/pol_pcr16_read.json
+++ b/test/data/fapi/policy/pol_pcr16_read.json
@@ -4,7 +4,7 @@
     "policy":[
         {
             "type":"POLICYPCR",
-            "currentPCRs":[ 15 ]
+            "currentPCRs":[ 16 ]
         }
     ]
 }

--- a/test/integration/fapi-duplicate.int.c
+++ b/test/integration/fapi-duplicate.int.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <assert.h>
 #include <string.h>
 
 #include "tss2_fapi.h"
@@ -86,8 +85,8 @@ test_fapi_duplicate(FAPI_CONTEXT *context)
 
     r = Fapi_ExportKey(context, "HS/SRK/myCryptKey", NULL, &json_string_pub_key);
     goto_if_error(r, "Error Fapi_CreateKey", error);
-    assert(json_string_pub_key != NULL);
-    assert(strlen(json_string_pub_key) > ASSERT_SIZE);
+    ASSERT(json_string_pub_key != NULL);
+    ASSERT(strlen(json_string_pub_key) > ASSERT_SIZE);
 
     r = Fapi_Import(context, "ext/myNewParent", json_string_pub_key);
     goto_if_error(r, "Error Fapi_Import", error);
@@ -99,11 +98,13 @@ test_fapi_duplicate(FAPI_CONTEXT *context)
     r = Fapi_ExportKey(context, "HS/SRK/myCryptKey/myCryptKey2",
                        "ext/myNewParent", &json_duplicate);
     goto_if_error(r, "Error Fapi_CreateKey", error);
-    assert(json_duplicate != NULL);
-    assert(strlen(json_duplicate) > ASSERT_SIZE);
+    ASSERT(json_duplicate != NULL);
+    ASSERT(strlen(json_duplicate) > ASSERT_SIZE);
 
-    fprintf(stderr, "\nExport Data:\n%s\n", json_duplicate);
+    LOG_INFO("\nTEST_JSON\nExport Data:\n%s\nEND_JSON", json_duplicate);
+    char *duplicate_check[] = { "duplicate" };
 
+    CHECK_JSON_FIELDS(json_duplicate, duplicate_check, "", error);
     r = Fapi_Import(context, "importedKey", json_duplicate);
     goto_if_error(r, "Error Fapi_Import", error);
 

--- a/test/integration/fapi-export-policy.int.c
+++ b/test/integration/fapi-export-policy.int.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 #include <json-c/json.h>
 #include <json-c/json_util.h>
 
@@ -78,10 +77,12 @@ check_policy(char *policy, policy_digests *digests) {
 
         digest_str = json_object_get_string(jso_digest);
         if (strlen(digest_str) == 40) {
+            LOG_INFO("Digest SHA1: %s", digest_str);
             if (strcmp(digest_str, digests->sha1) == 0) {
                 check_sha1 = true;
             }
         } else if  (strlen(digest_str) == 64) {
+            LOG_INFO("Digest SHA256: %s", digest_str);
             if (strcmp(digest_str, digests->sha256) == 0) {
                 check_sha256 = true;
             }
@@ -211,8 +212,8 @@ test_fapi_export_policy(FAPI_CONTEXT *context)
           .sha1 = "85a1caea8de54502bb6c49ff0024bf71ae35a9c5",
           .sha256 = "86a562755e2d7074498bf9e20ee9dbee3fe65ed4989163c110d79a5f1e4eff4e" },
         { .path = "/policy/pol_pcr16_read",
-          .sha1 = "88fec58ec736d09dacc5696f494e0e68aa4c5357",
-          .sha256 = "7e247a603cd1052cabc095741b8ee2f7458aabeee960b8ec97d7f090171a039a" },
+          .sha1 = "eab0d71ae6088009cbd0b50729fde69eb453649c",
+          .sha256 = "bff2d58e9813f97cefc14f72ad8133bc7092d652b7c877959254af140c841f36" },
         { .path = "/policy/pol_pcr8_0",
           .sha1 = "3f90626b723c354255dffad8d3df57189af033f4",
           .sha256 = "54bca6a506bfcc7e957a29ee4b5b514b9bd9ea0570efc6b9a8d5c3a7562dbbc8" },
@@ -242,8 +243,8 @@ test_fapi_export_policy(FAPI_CONTEXT *context)
         policy = NULL;
         r = Fapi_ExportPolicy(context, policies[i].path, &policy);
         goto_if_error(r, "Error Fapi_ExportPolicy", error);
-        assert(policy != NULL);
-        assert(strlen(policy) > ASSERT_SIZE);
+        ASSERT(policy != NULL);
+        ASSERT(strlen(policy) > ASSERT_SIZE);
         if (!check_policy(policy, &policies[i])) {
             goto error;
         }

--- a/test/integration/fapi-ext-public-key.int.c
+++ b/test/integration/fapi-ext-public-key.int.c
@@ -17,7 +17,6 @@
 #include <stddef.h>
 #include <string.h>
 #include <inttypes.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -215,17 +214,18 @@ test_fapi_ext_public_key(FAPI_CONTEXT *context)
 
     r = Fapi_GetCertificate(context, "/ext/myExtPubKey", &cert2);
     goto_if_error(r, "Error Fapi_SetCertificate", error);
-    assert(cert2 != NULL);
-    assert(strlen(cert2) > ASSERT_SIZE);
+    ASSERT(cert2 != NULL);
+    ASSERT(strlen(cert2) > ASSERT_SIZE);
 
     if (strcmp(cert, cert2) != 0) {
         goto_if_error(r, "Different certificates", error);
     }
 
     r = Fapi_List(context, "", &path_list);
+    LOG_INFO("Pathlist: %s", path_list);
     goto_if_error(r, "Error Fapi_List", error);
-    assert(path_list != NULL);
-    assert(strlen(path_list) > ASSERT_SIZE);
+    ASSERT(path_list != NULL);
+    ASSERT(strcmp(path_list, "/ext/myExtPubKey") == 0);
 
     /* Test VerfiyQuote in non TPM mode. */
     r = Fapi_Import(context, "/ext/myExtPubKey", pubkey_pem);

--- a/test/integration/fapi-get-esys-blobs.int.c
+++ b/test/integration/fapi-get-esys-blobs.int.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <stdlib.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 #include "tss2_esys.h"
@@ -106,7 +105,7 @@ test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
     r = Fapi_GetEsysBlob(context,nvPath, &type,
                          &data, &data_size);
     goto_if_error(r, "Error Fapi_GetEsysBlob", error);
-    assert(data != NULL);
+    ASSERT(data != NULL);
 
     if (type != FAPI_ESYSBLOB_DESERIALIZE) {
         LOG_ERROR("Invalid type");
@@ -128,7 +127,7 @@ test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
     r = Fapi_GetEsysBlob(context, "HS/SRK/mySignKey", &type,
                          &data, &data_size);
     goto_if_error(r, "Error Fapi_GetEsysBlob", error);
-    assert(data != NULL);
+    ASSERT(data != NULL);
 
     if (type != FAPI_ESYSBLOB_CONTEXTLOAD) {
         LOG_ERROR("Invalid type");
@@ -193,7 +192,7 @@ test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
     r = Fapi_GetEsysBlob(context, "HS/SRK", &type,
                          &data, &data_size);
     goto_if_error(r, "Error Fapi_GetEsysBlob", error);
-    assert(data != NULL);
+    ASSERT(data != NULL);
 
     if (type != FAPI_ESYSBLOB_DESERIALIZE) {
         LOG_ERROR("Invalid type");

--- a/test/integration/fapi-get-random.int.c
+++ b/test/integration/fapi-get-random.int.c
@@ -9,9 +9,9 @@
 #endif
 
 #include <stdlib.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
+#include "test-fapi.h"
 
 #define LOGMODULE test
 #include "util/log.h"
@@ -62,14 +62,14 @@ test_fapi_get_random(FAPI_CONTEXT *context)
         r = Fapi_GetRandom_Finish(context, &randomBytes);
     } while (r == TSS2_FAPI_RC_TRY_AGAIN);
     goto_if_error(r, "Error Fapi_GetRandom_Finish", error);
-    assert(randomBytes != NULL);
+    ASSERT(randomBytes != NULL);
 
     Fapi_Free(randomBytes);
 
     randomBytes = NULL;
     r = Fapi_GetRandom(context, bytesRequested, &randomBytes);
     goto_if_error(r, "Error Fapi_GetRandom", error);
-    assert(randomBytes != NULL);
+    ASSERT(randomBytes != NULL);
 
     Fapi_Free(randomBytes);
 

--- a/test/integration/fapi-info.int.c
+++ b/test/integration/fapi-info.int.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <stdlib.h>
-#include <assert.h>
 #include <string.h>
 
 #include "tss2_fapi.h"
@@ -39,10 +38,16 @@ test_fapi_info(FAPI_CONTEXT *context)
 
     r = Fapi_GetInfo(context, &info);
     goto_if_error(r, "Error Fapi_Provision", error);
-    assert(info != NULL);
-    assert(strlen(info) > ASSERT_SIZE);
+    ASSERT(info != NULL);
+    ASSERT(strlen(info) > ASSERT_SIZE);
 
     LOG_INFO("%s", info);
+
+    char *fields_config[] =  { "fapi_config" };
+    CHECK_JSON_FIELDS(info, fields_config, "", error);
+
+    char *fields_info[] =  { "capabilities" };
+    CHECK_JSON_FIELDS(info, fields_info, "", error);
 
     SAFE_FREE(info);
     return EXIT_SUCCESS;

--- a/test/integration/fapi-key-change-auth.int.c
+++ b/test/integration/fapi-key-change-auth.int.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -38,8 +37,8 @@ auth_callback(
 
     char *profile_path;
 
-    assert(description != NULL);
-    assert(userData != NULL);
+    ASSERT(description != NULL);
+    ASSERT(userData != NULL);
 
     if (!objectPath) {
         return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
@@ -49,13 +48,16 @@ auth_callback(
     if (size == -1)
         return TSS2_FAPI_RC_MEMORY;
 
-    assert(strlen(objectPath) == strlen(profile_path));
+    ASSERT(strlen(objectPath) == strlen(profile_path));
     free(profile_path);
-    assert(strlen(userData) == strlen((char*)USER_DATA));
-    assert(strlen(description) == strlen(DESCRIPTION));
+    ASSERT(strlen(userData) == strlen((char*)USER_DATA));
+    ASSERT(strlen(description) == strlen(DESCRIPTION));
 
     *auth = PASSWORD;
     return TSS2_RC_SUCCESS;
+
+ error:
+    exit(EXIT_FAILURE);
 }
 
 
@@ -119,11 +121,11 @@ test_fapi_key_change_auth(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Provision", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     Fapi_Free(publicKey);
 

--- a/test/integration/fapi-key-create-ckda-sign.int.c
+++ b/test/integration/fapi-key-create-ckda-sign.int.c
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -102,11 +101,11 @@ test_fapi_key_create_ckda_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-key-create-policies-sign.int.c
+++ b/test/integration/fapi-key-create-policies-sign.int.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -172,11 +171,11 @@ test_fapi_key_create_policies_sign(FAPI_CONTEXT *context)
     }
 #endif /* TEST_POLICY_PHYSICAL_PRESENCE */
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_Delete(context, "/HS/SRK/mySignKey");
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 
 #include "tss2_fapi.h"
@@ -188,11 +187,12 @@ test_fapi_key_create_policy_authorize_nv(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature);
-    assert(publicKey);
-    assert(certificate);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature);
+    ASSERT(publicKey);
+    ASSERT(certificate);
+
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_Delete(context, policy_authorize_nv);
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -154,9 +153,10 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, NULL);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    LOG_INFO("PublicKey: %s", publicKey);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
 
     /* Cleanup */
     r = Fapi_Delete(context, "/");

--- a/test/integration/fapi-key-create-policy-nv-counter-sign.int.c
+++ b/test/integration/fapi-key-create-policy-nv-counter-sign.int.c
@@ -13,7 +13,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 #include <string.h>
 
 #include "tss2_fapi.h"
@@ -113,11 +112,11 @@ test_fapi_key_create_policy_nv_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_Delete(context, nvPathOrdinary);
     goto_if_error(r, "Error Fapi_NV_Undefine", error);

--- a/test/integration/fapi-key-create-policy-or-sign.int.c
+++ b/test/integration/fapi-key-create-policy-or-sign.int.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -155,11 +154,11 @@ test_fapi_key_create_policy_or_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-key-create-policy-secret-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-secret-nv-sign.int.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 
 #include "tss2_fapi.h"
@@ -167,9 +166,9 @@ test_fapi_key_create_policy_secret_nv_sign(FAPI_CONTEXT *context)
     if (r == TSS2_RC_SUCCESS)
         goto error;
 
-    assert(signature == NULL);
-    assert(publicKey == NULL);
-    assert(certificate == NULL);
+    ASSERT(signature == NULL);
+    ASSERT(publicKey == NULL);
+    ASSERT(certificate == NULL);
 
     r = Fapi_SetAuthCB(context, auth_callback, "");
     goto_if_error(r, "Error SetPolicyAuthCallback", error);
@@ -181,11 +180,12 @@ test_fapi_key_create_policy_secret_nv_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
+
 
     r = Fapi_Delete(context, nv_path_auth_object);
     goto_if_error(r, "Error Fapi_NV_Undefine", error);

--- a/test/integration/fapi-key-create-policy-signed.int.c
+++ b/test/integration/fapi-key-create-policy-signed.int.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
@@ -283,16 +282,16 @@ test_fapi_key_create_policy_signed(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_List(context, "/", &pathList);
     goto_if_error(r, "Error Fapi_List", error);
-    assert(pathList != NULL);
-    assert(strlen(pathList) > ASSERT_SIZE);
+    ASSERT(pathList != NULL);
+    ASSERT(strlen(pathList) > ASSERT_SIZE);
 
     fprintf(stderr, "\n%s\n", pathList);
 

--- a/test/integration/fapi-key-create-sign-password-provision.int.c
+++ b/test/integration/fapi-key-create-sign-password-provision.int.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <stdlib.h>
-#include <assert.h>
 #include <string.h>
 
 #include "tss2_fapi.h"
@@ -158,10 +157,10 @@ test_fapi_key_create_sign_password_provision(FAPI_CONTEXT *context)
                          &publicsize,
                          &privateblob, &privatesize, &policy);
     goto_if_error(r, "Error Fapi_GetTpmBlobs", error);
-    assert(publicblob != NULL);
-    assert(privateblob != NULL);
-    assert(policy != NULL);
-    assert(strlen(policy) > ASSERT_SIZE);
+    ASSERT(publicblob != NULL);
+    ASSERT(privateblob != NULL);
+    ASSERT(policy != NULL);
+    ASSERT(strlen(policy) > ASSERT_SIZE);
 
     r = Fapi_SetCertificate(context, "HS/SRK/mySignKey", cert);
     goto_if_error(r, "Error Fapi_SetCertificate", error);
@@ -170,16 +169,18 @@ test_fapi_key_create_sign_password_provision(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    LOG_INFO("Public key: %s", publicKey);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    LOG_INFO("Certificate: %s", certificate);
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
     r = Fapi_List(context, "/", &path_list);
     goto_if_error(r, "Error Fapi_Delete", error);
-    assert(path_list != NULL);
-    assert(strlen(path_list) > ASSERT_SIZE);
+    ASSERT(path_list != NULL);
+    ASSERT(strlen(path_list) > ASSERT_SIZE);
 
     fprintf(stderr, "\nPathList:\n%s\n", path_list);
 

--- a/test/integration/fapi-key-create-sign-policy-provision.int.c
+++ b/test/integration/fapi-key-create-sign-policy-provision.int.c
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -125,10 +124,10 @@ test_fapi_key_create_sign_policy_provision(FAPI_CONTEXT *context)
                          &publicsize,
                          &privateblob, &privatesize, &policy);
     goto_if_error(r, "Error Fapi_GetTpmBlobs", error);
-    assert(publicblob != NULL);
-    assert(privateblob != NULL);
-    assert(policy != NULL);
-    assert(strlen(policy) == 0);
+    ASSERT(publicblob != NULL);
+    ASSERT(privateblob != NULL);
+    ASSERT(policy != NULL);
+    ASSERT(strlen(policy) == 0);
 
     r = Fapi_SetCertificate(context, "HS/SRK/mySignKey", cert);
     goto_if_error(r, "Error Fapi_SetCertificate", error);
@@ -138,16 +137,16 @@ test_fapi_key_create_sign_policy_provision(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, &signature, &signatureSize,
                   &publicKey, &certificate);
     goto_if_error(r, "Error Fapi_Sign", error);
-    assert(signature != NULL);
-    assert(publicKey != NULL);
-    assert(certificate != NULL);
-    assert(strlen(publicKey) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strlen(publicKey) > ASSERT_SIZE);
+    ASSERT(strlen(certificate) > ASSERT_SIZE);
 
     r = Fapi_List(context, "/", &path_list);
     goto_if_error(r, "Error Fapi_Delete", error);
-    assert(path_list != NULL);
-    assert(strlen(path_list) > ASSERT_SIZE);
+    ASSERT(path_list != NULL);
+    ASSERT(strlen(path_list) > ASSERT_SIZE);
 
     LOG_INFO("\nPathList:\n%s\n", path_list);
 

--- a/test/integration/fapi-nv-extend.int.c
+++ b/test/integration/fapi-nv-extend.int.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -87,9 +86,14 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
 
     r = Fapi_NvRead(context, nvPathExtend, &data_dest, &dest_size, &log);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(log != NULL);
-    assert(strlen(log) > ASSERT_SIZE);
+    ASSERT(data_dest != NULL);
+    ASSERT(log != NULL);
+    LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
+    char *fields_log1[] =  { "0", "digests", "0", "digest" };
+    CHECK_JSON_FIELDS(log, fields_log1,
+                      "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
+                      error);
+    ASSERT(strlen(log) > ASSERT_SIZE);
 
     fprintf(stderr, "\nLog:\n%s\n", log);
     SAFE_FREE(data_dest);
@@ -102,9 +106,14 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
     log = NULL;
     r = Fapi_NvRead(context, nvPathExtend, &data_dest, &dest_size, &log);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(log != NULL);
-    assert(strlen(log) > ASSERT_SIZE);
+    ASSERT(data_dest != NULL);
+    ASSERT(log != NULL);
+    ASSERT(strlen(log) > ASSERT_SIZE);
+    LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
+    char *fields_log2[] =  { "1", "digests", "0", "digest" };
+    CHECK_JSON_FIELDS(log, fields_log2,
+                      "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
+                      error);
 
     fprintf(stderr, "\nLog:\n%s\n", log);
 

--- a/test/integration/fapi-nv-ordinary.int.c
+++ b/test/integration/fapi-nv-ordinary.int.c
@@ -13,7 +13,6 @@
 #include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -55,10 +54,10 @@ action_callback(
 {
     (void)(userData);
 
-    assert(objectPath != NULL);
-    assert(action != NULL);
+    ASSERT(objectPath != NULL);
+    ASSERT(action != NULL);
 
-    assert(strlen(userData) == strlen((char*)USER_DATA));
+    ASSERT(strlen(userData) == strlen((char*)USER_DATA));
 
     if (strcmp(objectPath, "/nv/Owner/myNV") != 0) {
         return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
@@ -69,6 +68,9 @@ action_callback(
         return TSS2_FAPI_RC_GENERAL_FAILURE;
     }
     return TSS2_RC_SUCCESS;
+
+ error:
+    exit(EXIT_FAILURE);
 }
 
 static char *
@@ -169,9 +171,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
 
     r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(logData != NULL);
-    assert(strlen(logData) == 0);
+    ASSERT(data_dest != NULL);
+    ASSERT(logData != NULL);
+    ASSERT(strlen(logData) == 0);
 
     if (dest_size != NV_SIZE ||
         memcmp(data_src, data_dest, dest_size) != 0) {
@@ -195,8 +197,8 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     r = Fapi_PcrRead(context, 8, &pcr_digest,
                      &pcr_digest_size, &pcrLog);
     goto_if_error(r, "Error Fapi_PcrRead", error);
-    assert(pcr_digest != NULL);
-    assert(pcrLog != NULL);
+    ASSERT(pcr_digest != NULL);
+    ASSERT(pcrLog != NULL);
 
     if (memcmp(&pcr_digest[0], &zero_digest, pcr_digest_size) != 0) {
         SAFE_FREE(pcr_digest);
@@ -223,9 +225,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
         logData = NULL;
         r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
         goto_if_error(r, "Error Fapi_NvRead", error);
-        assert(data_dest != NULL);
-        assert(logData != NULL);
-        assert(strlen(logData) == 0);
+        ASSERT(data_dest != NULL);
+        ASSERT(logData != NULL);
+        ASSERT(strlen(logData) == 0);
 
         if (dest_size != NV_SIZE ||
             memcmp(data_src, data_dest, dest_size) != 0) {
@@ -250,9 +252,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     logData = NULL;
     r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(logData != NULL);
-    assert(strlen(logData) == 0);
+    ASSERT(data_dest != NULL);
+    ASSERT(logData != NULL);
+    ASSERT(strlen(logData) == 0);
 
     if (dest_size != NV_SIZE ||
         memcmp(data_src, data_dest, dest_size) != 0) {
@@ -283,9 +285,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     logData = NULL;
     r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(logData != NULL);
-    assert(strlen(logData) == 0);
+    ASSERT(data_dest != NULL);
+    ASSERT(logData != NULL);
+    ASSERT(strlen(logData) == 0);
 
     if (dest_size != NV_SIZE ||
         memcmp(data_src, data_dest, dest_size) != 0) {
@@ -308,7 +310,7 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
 
     r = Fapi_GetDescription(context, nvPathOrdinary, &description2);
     goto_if_error(r, "Error Fapi_GetDescription", error);
-    assert(description2 != NULL);
+    ASSERT(description2 != NULL);
 
     if (strcmp(description1, description2) != 0) {
         goto_if_error(r, "Different descriptions", error);
@@ -321,9 +323,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     logData = NULL;
     r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(logData != NULL);
-    assert(strlen(logData) == 0);
+    ASSERT(data_dest != NULL);
+    ASSERT(logData != NULL);
+    ASSERT(strlen(logData) == 0);
 
     if (dest_size != NV_SIZE ||
         memcmp(data_src, data_dest, dest_size) != 0) {
@@ -351,9 +353,9 @@ test_fapi_nv_ordinary(FAPI_CONTEXT *context)
     logData = NULL;
     r = Fapi_NvRead(context, nvPathOrdinary, &data_dest, &dest_size, &logData);
     goto_if_error(r, "Error Fapi_NvRead", error);
-    assert(data_dest != NULL);
-    assert(logData != NULL);
-    assert(strlen(logData) == 0);
+    ASSERT(data_dest != NULL);
+    ASSERT(logData != NULL);
+    ASSERT(strlen(logData) == 0);
 
     if (dest_size != NV_SIZE ||
         memcmp(data_src, data_dest, dest_size) != 0) {

--- a/test/integration/fapi-nv-written-policy.int.c
+++ b/test/integration/fapi-nv-written-policy.int.c
@@ -13,9 +13,9 @@
 #include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
+#include "test-fapi.h"
 
 #define LOGMODULE test
 #include "util/log.h"
@@ -101,7 +101,7 @@ test_fapi_nv_written_policy(FAPI_CONTEXT *context)
 
     r = Fapi_GetAppData(context, nvPathOrdinary, &appDataOut, &appDataOutSize);
     goto_if_error(r, "Error Fapi_GetAppData", error);
-    assert(appDataOut != NULL);
+    ASSERT(appDataOut != NULL);
 
     if (APP_DATA_SIZE != appDataOutSize ||
             memcmp(appDataOut, &appDataIn[0], appDataOutSize) != 0) {

--- a/test/integration/fapi-pcr-test.int.c
+++ b/test/integration/fapi-pcr-test.int.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -180,9 +179,9 @@ test_fapi_pcr_test(FAPI_CONTEXT *context)
     r = Fapi_PcrRead(context, 16, &pcr_digest,
                      &pcr_digest_size, &log);
     goto_if_error(r, "Error Fapi_PcrRead", error);
-    assert(pcr_digest != NULL);
-    assert(log != NULL);
-    assert(strlen(log) > ASSERT_SIZE);
+    ASSERT(pcr_digest != NULL);
+    ASSERT(log != NULL);
+    ASSERT(strlen(log) > ASSERT_SIZE);
 
     for (i = 0; i < ( sizeof(log_exp) / sizeof(log_exp[0]) ); i++)
         if (strcmp(log_exp[i], log) == 0)
@@ -191,8 +190,8 @@ test_fapi_pcr_test(FAPI_CONTEXT *context)
         LOG_ERROR("Log mismatch. Received: %s", log);
         goto error;
     }
-
-    fprintf(stderr, "\n\Event Log:\n%s\n", log);
+    CHECK_JSON_LIST(log_exp, log, error);
+    fprintf(stderr, "\nEvent Log:\n%s\n", log);
 
     SAFE_FREE(pcr_digest);
     SAFE_FREE(log);
@@ -204,9 +203,11 @@ test_fapi_pcr_test(FAPI_CONTEXT *context)
     r = Fapi_PcrRead(context, 16, &pcr_digest,
                      &pcr_digest_size, &log);
     goto_if_error(r, "Error Fapi_PcrRead", error);
-    assert(pcr_digest != NULL);
-    assert(log != NULL);
-    assert(strlen(log) > ASSERT_SIZE);
+    ASSERT(pcr_digest != NULL);
+    ASSERT(log != NULL);
+    ASSERT(strlen(log) > ASSERT_SIZE);
+    LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
+
 
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-platform-certificates.int.c
+++ b/test/integration/fapi-platform-certificates.int.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <stdlib.h>
-#include <assert.h>
 
 #include "tss2_esys.h"
 #include "tss2_fapi.h"
@@ -147,8 +146,8 @@ test_fapi_platform_certificates(FAPI_CONTEXT *context)
     if (r == TSS2_FAPI_RC_NO_CERT)
         goto skip;
     goto_if_error(r, "Error Fapi_GetPlatformCertificates", error);
-    assert(certs != NULL);
-    assert(certsSize == nv_size);
+    ASSERT(certs != NULL);
+    ASSERT(certsSize == nv_size);
 
     Fapi_Free(certs);
 

--- a/test/integration/fapi-quote-destructive.int.c
+++ b/test/integration/fapi-quote-destructive.int.c
@@ -13,7 +13,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tss2_fapi.h"
 
@@ -92,13 +91,13 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
                    &signature, &signatureSize,
                    &pcrEventLog, &certificate);
     goto_if_error(r, "Error Fapi_Quote", error);
-    assert(quoteInfo != NULL);
-    assert(signature != NULL);
-    assert(pcrEventLog != NULL);
-    assert(certificate != NULL);
-    assert(strlen(quoteInfo) > ASSERT_SIZE);
-    assert(strlen(pcrEventLog) > ASSERT_SIZE);
-    assert(strlen(certificate) > ASSERT_SIZE);
+    ASSERT(quoteInfo != NULL);
+    ASSERT(signature != NULL);
+    ASSERT(pcrEventLog != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strlen(quoteInfo) > ASSERT_SIZE);
+    ASSERT(strlen(pcrEventLog) > ASSERT_SIZE);
+    ASSERT(strlen(certificate) > ASSERT_SIZE);
 
     LOG_INFO("\npcrEventLog: %s\n", pcrEventLog);
 
@@ -109,8 +108,8 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
 
     r = Fapi_List(context, "/", &pathlist);
     goto_if_error(r, "Pathlist", error);
-    assert(pathlist != NULL);
-    assert(strlen(pathlist) > ASSERT_SIZE);
+    ASSERT(pathlist != NULL);
+    ASSERT(strlen(pathlist) > ASSERT_SIZE);
 
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);

--- a/test/integration/fapi-unseal.int.c
+++ b/test/integration/fapi-unseal.int.c
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tss2_esys.h"
 #include "tss2_fapi.h"
@@ -65,7 +64,7 @@ test_fapi_unseal(FAPI_CONTEXT *context)
     r = Fapi_Unseal(context, "/HS/SRK/mySealObject", &result,
                     &resultSize);
     goto_if_error(r, "Error Fapi_CreateSeal", error);
-    assert(result != NULL);
+    ASSERT(result != NULL);
 
     if (resultSize != digest.size ||
             memcmp(result, &digest.buffer[0], resultSize) != 0) {
@@ -86,7 +85,7 @@ test_fapi_unseal(FAPI_CONTEXT *context)
     r = Fapi_Unseal(context, "/HS/SRK/myRandomSealObject", &result,
                     &resultSize);
     goto_if_error(r, "Error Fapi_CreateSeal", error);
-    assert(result != NULL);
+    ASSERT(result != NULL);
 
     LOGBLOB_INFO(result, resultSize, "Unsealed random data");
 

--- a/test/integration/test-fapi.h
+++ b/test/integration/test-fapi.h
@@ -5,12 +5,121 @@
  *
  * All rights reserved.
  ***********************************************************************/
+#include <assert.h>
+#include <json-c/json.h>
+#include <json-c/json_util.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include "tss2_fapi.h"
 
 #define EXIT_SKIP 77
 #define EXIT_ERROR 99
 
 #define ASSERT_SIZE 10 /* sanity check value for string outputs of Fapi commands  */
+
+
+#define ASSERT(EXPR)                          \
+    if (!(EXPR)) { \
+        LOG_ERROR("Failed assertion: " #EXPR);              \
+        goto error; \
+    }
+
+/*
+ * Based on a list of keys (FIELD_LIST) a json sub object of the
+ * json object represented by JSON_STRING will be determined.
+ * If an json array is part of the list of sub objects an element
+ * of the array can be selected by a value from '0' to '9'.
+ * If SUBSTRING is "" the check is ok if the sub object was found.
+ * Otherwise it will be checked whether SUBSTRING does occur
+ * in the string representing the sub object.
+ */
+#define CHECK_JSON_FIELDS(JSON_STRING, FIELD_LIST, SUBSTRING, LABEL)    \
+   { \
+        json_object *jso = NULL; \
+        json_object *jso1 = NULL; \
+        json_object *jso2 = NULL; \
+        size_t i, n; \
+        n = sizeof(FIELD_LIST) / sizeof(FIELD_LIST[0]); \
+        jso = json_tokener_parse(JSON_STRING); \
+        if (!jso) { \
+            LOG_ERROR("Invalid JSON"); \
+            goto error; \
+        } \
+        jso1 = jso; \
+        for (i = 0; i < n; i++) { \
+            if (strlen(FIELD_LIST[i]) == 1 && \
+                FIELD_LIST[i][0] >= '0' && FIELD_LIST[i][0] <= '9') { \
+                jso2 = json_object_array_get_idx(jso1, FIELD_LIST[i][0]  - '0'); \
+                ASSERT(jso2); \
+            } \
+            else if (!jso1 || !json_object_object_get_ex(jso1, FIELD_LIST[i],  &jso2)) { \
+                json_object_put(jso); \
+                LOG_ERROR("%s not found.", FIELD_LIST[i]); \
+                goto error; \
+            } \
+            jso1 = jso2; \
+        } \
+        if (strlen(SUBSTRING) > 0 && !strstr( json_object_get_string(jso1), SUBSTRING)) { \
+            json_object_put(jso); \
+            LOG_ERROR("Sub string %s not found.", SUBSTRING); \
+            goto error; \
+        } \
+        json_object_put(jso); \
+    }
+
+/* It will be checked whether two json objects are equal. */
+#define CHECK_JSON(JSON1, JSON2, LABEL) \
+        { \
+            json_object *jso1 = NULL; \
+            json_object *jso2 = NULL; \
+            jso1 = json_tokener_parse(JSON1) ; \
+            ASSERT(jso1) ; \
+            if (!jso1) { \
+                LOG_ERROR("Invalid JSON") ;\
+                goto LABEL ;\
+            }                                        \
+            jso2 = json_tokener_parse(JSON2) ;\
+            ASSERT(jso2) ;\
+            if (!jso2) { \
+                LOG_ERROR("Invalid JSON") ;\
+                goto LABEL ;\
+            }                                        \
+            if (!cmp_jso(jso1, jso2)) { \
+                json_object_put(jso1) ; \
+                json_object_put(jso2) ; \
+                goto LABEL; \
+            } \
+            json_object_put(jso1); \
+            json_object_put(jso2); \
+        }
+
+/* It will be checked whether a json object is included in a list
+   of json objects. */
+#define CHECK_JSON_LIST(LIST, JSO_STRING, LABEL) \
+    { \
+        size_t i, n; \
+        n = sizeof(LIST) / sizeof(LIST[0]); \
+        json_object *jso1 = json_tokener_parse(JSO_STRING); \
+        ASSERT(jso1); \
+        json_object *jso2 = NULL; \
+        for (i = 0; i < n; i++) { \
+             jso2 = json_tokener_parse(LIST[i]); \
+             ASSERT(jso2); \
+             if (cmp_jso(jso1, jso2)) { \
+                break; \
+             } \
+             json_object_put(jso2); \
+        } \
+        if (i >=  n) { \
+            json_object_put(jso1); \
+            json_object_put(jso2); \
+            LOG_ERROR("Mismatch" ); \
+            goto LABEL; \
+        } \
+       json_object_put(jso1); \
+       json_object_put(jso2); \
+    }
 
 #define goto_error_if_not_failed(rc,msg,label)                          \
     if (rc == TSS2_RC_SUCCESS) {                                        \
@@ -24,6 +133,13 @@ extern char *fapi_profile;
 
 TSS2_RC
 pcr_reset(FAPI_CONTEXT *context, UINT32 pcr);
+
+bool cmp_strtokens(char* string1, char *string2, char *delimiter);
+
+char * normalize_string(const char *string);
+
+bool cmp_jso(json_object *jso1, json_object *jso2);
+
 /*
  * This is the prototype for all integration tests in the tpm2-tss
  * project. Integration tests are intended to exercise the combined


### PR DESCRIPTION
* The asserts which are activated by --enable-debug are replaced with ASSERT, which
  is always active, to ensure that for FAPI integration tests the asserts are
  always fulfilled.

* For JSON encoded results, if possible, the complete JSON value will be checked.
  If parts of the JSON object are variable only selected sub fields will be
  checked.

* The result of Fapi_List will be compared with an expected list of objects for
  typical use cases.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>