### PR TITLE
configure.ac: fix compatibility with autoconf 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,7 +285,7 @@ AC_ARG_ENABLE([integration],
         [build and execute integration tests])],,
     [enable_integration=no])
 AS_IF([test "x$enable_integration" = "xyes"],
-     AS_IF([test "$HOSTOS" = "Linux"],
+     [AS_IF([test "$HOSTOS" = "Linux"],
            [ERROR_IF_NO_PROG([ss])],
            [ERROR_IF_NO_PROG([sockstat])])
        ERROR_IF_NO_PROG([echo])
@@ -335,7 +335,7 @@ AS_IF([test "x$enable_integration" = "xyes"],
              [AC_MSG_ERROR([No simulator executable found in PATH for testing TCTI.])])
        AC_SUBST([INTEGRATION_TCTI], [$integration_tcti])
        AC_SUBST([INTEGRATION_ARGS], [$integration_args])
-       AC_SUBST([ENABLE_INTEGRATION], [$enable_integration]))
+       AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 #
 # sanitizer compiler flags


### PR DESCRIPTION
With autoconf 2.70, not quoting the second argument to one of the AS_IF
macro expansions leads to generation of invalid shell code affecting the
first nested ERROR_IF_NO_PROG expansion.

The invalid shell code leads to an error resembling:
```
  ./configure: line 18826: syntax error near unexpected token `newline'
  ./configure: line 18826: `    '''
```
Fix the issue by quoting the second argument to the affected AS_IF,
similar to the quoting found elsewhere in configure.ac.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>