### PR TITLE
ESYS/FAPI: Remove warning from Esys_Finalize and Fapi_Finalize.

### DIFF
--- a/src/tss2-esys/esys_context.c
+++ b/src/tss2-esys/esys_context.c
@@ -111,7 +111,7 @@ Esys_Finalize(ESYS_CONTEXT ** esys_context)
     TSS2_TCTI_CONTEXT *tctcontext = NULL;
 
     if (esys_context == NULL || *esys_context == NULL) {
-        LOG_WARNING("Finalizing NULL context.");
+        LOG_DEBUG("Finalizing NULL context.");
         return;
     }
 

--- a/src/tss2-fapi/api/Fapi_Finalize.c
+++ b/src/tss2-fapi/api/Fapi_Finalize.c
@@ -39,7 +39,7 @@ Fapi_Finalize(
 
     /* Check for NULL parameters */
     if (!context || !*context) {
-        LOG_WARNING("Attempting to free NULL context");
+        LOG_DEBUG("Finalizing NULL context.");
         return;
     }
 


### PR DESCRIPTION
The warning if a NULL pointer was passed is deleted to allow customary
NULL passing to the functions without producing a warning.
Addresses Issue #1942.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>