### PR TITLE
FAPI:  Fix error clean-up for file reading and certificate searching and unit tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,7 @@ task:
     matrix:
       image_family: freebsd-12-1-snap
   install_script:
+    - export IGNORE_OSVERSION=yes
     - pkg update -f
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -129,7 +129,12 @@ TESTS_UNIT += \
 endif ESYS
 if FAPI
 TESTS_UNIT += \
-    test/unit/fapi-json
+    test/unit/fapi-json \
+    test/unit/fapi-helpers \
+    test/unit/fapi-io \
+    test/unit/fapi-profiles \
+    test/unit/fapi-config \
+    test/unit/fapi-get-intl-cert
 endif FAPI
 endif #UNIT
 
@@ -607,6 +612,105 @@ test_unit_fapi_json_SOURCES = test/unit/fapi-json.c \
                               src/tss2-fapi/ifapi_policy_json_serialize.c \
                               src/tss2-fapi/tpm_json_deserialize.c \
                               src/tss2-fapi/tpm_json_serialize.c
+
+test_unit_fapi_helpers_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_fapi_helpers_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_fapi_helpers_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
+                                 -Wl,--wrap=ifapi_crypto_hash_update \
+                                 -Wl,--wrap=ifapi_crypto_hash_finish
+test_unit_fapi_helpers_SOURCES = test/unit/fapi-helpers.c \
+                                 src/tss2-fapi/ifapi_json_deserialize.c \
+                                 src/tss2-fapi/ifapi_json_serialize.c \
+                                 src/tss2-fapi/ifapi_policy_json_deserialize.c \
+                                 src/tss2-fapi/ifapi_policy_json_serialize.c \
+                                 src/tss2-fapi/tpm_json_deserialize.c \
+                                 src/tss2-fapi/tpm_json_serialize.c \
+                                 src/tss2-fapi/fapi_crypto.c \
+                                 src/tss2-fapi/ifapi_eventlog.c \
+                                 src/tss2-fapi/ifapi_helpers.c \
+                                 src/tss2-fapi/ifapi_keystore.c  \
+                                 src/tss2-fapi/ifapi_io.c
+
+test_unit_fapi_io_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_fapi_io_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_fapi_io_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
+                            -Wl,--wrap=fopen \
+                            -Wl,--wrap=lockf \
+                            -Wl,--wrap=fseek \
+                            -Wl,--wrap=ftell \
+                            -Wl,--wrap=fcntl \
+                            -Wl,--wrap=malloc \
+                            -Wl,--wrap=read \
+                            -Wl,--wrap=write \
+                            -Wl,--wrap=fileno \
+                            -Wl,--wrap=fclose
+test_unit_fapi_io_SOURCES = test/unit/fapi-io.c \
+                            src/tss2-fapi/ifapi_json_deserialize.c \
+                            src/tss2-fapi/ifapi_json_serialize.c \
+                            src/tss2-fapi/ifapi_policy_json_deserialize.c \
+                            src/tss2-fapi/ifapi_policy_json_serialize.c \
+                            src/tss2-fapi/tpm_json_deserialize.c \
+                            src/tss2-fapi/tpm_json_serialize.c \
+                            src/tss2-fapi/fapi_crypto.c \
+                            src/tss2-fapi/ifapi_eventlog.c \
+                            src/tss2-fapi/ifapi_helpers.c \
+                            src/tss2-fapi/ifapi_keystore.c  \
+                            src/tss2-fapi/ifapi_io.c
+
+test_unit_fapi_profiles_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_fapi_profiles_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_fapi_profiles_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
+                                  -Wl,--wrap=ifapi_io_read_finish
+test_unit_fapi_profiles_SOURCES = test/unit/fapi-profiles.c \
+                                  src/tss2-fapi/ifapi_profiles.c \
+                                  src/tss2-fapi/ifapi_json_deserialize.c \
+                                  src/tss2-fapi/ifapi_json_serialize.c \
+                                  src/tss2-fapi/ifapi_policy_json_deserialize.c \
+                                  src/tss2-fapi/ifapi_policy_json_serialize.c \
+                                  src/tss2-fapi/tpm_json_deserialize.c \
+                                  src/tss2-fapi/tpm_json_serialize.c \
+                                  src/tss2-fapi/fapi_crypto.c \
+                                  src/tss2-fapi/ifapi_eventlog.c \
+                                  src/tss2-fapi/ifapi_helpers.c \
+                                  src/tss2-fapi/ifapi_keystore.c  \
+                                  src/tss2-fapi/ifapi_io.c
+
+test_unit_fapi_config_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_fapi_config_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_fapi_config_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
+                                  -Wl,--wrap=ifapi_io_read_finish
+test_unit_fapi_config_SOURCES = test/unit/fapi-config.c \
+                                  src/tss2-fapi/ifapi_config.c \
+                                  src/tss2-fapi/ifapi_json_deserialize.c \
+                                  src/tss2-fapi/ifapi_json_serialize.c \
+                                  src/tss2-fapi/ifapi_policy_json_deserialize.c \
+                                  src/tss2-fapi/ifapi_policy_json_serialize.c \
+                                  src/tss2-fapi/tpm_json_deserialize.c \
+                                  src/tss2-fapi/tpm_json_serialize.c \
+                                  src/tss2-fapi/fapi_crypto.c \
+                                  src/tss2-fapi/ifapi_eventlog.c \
+                                  src/tss2-fapi/ifapi_helpers.c \
+                                  src/tss2-fapi/ifapi_keystore.c  \
+                                  src/tss2-fapi/ifapi_io.c
+
+test_unit_fapi_get_intl_cert_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_fapi_get_intl_cert_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
+test_unit_fapi_get_intl_cert_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
+                                       -Wl,--wrap=ifapi_get_curl_buffer \
+                                       -Wl,--wrap=SHA256_Update
+test_unit_fapi_get_intl_cert_SOURCES = test/unit/fapi-get-intl-cert.c \
+	                                   src/tss2-fapi/ifapi_get_intl_cert.c \
+                                       src/tss2-fapi/ifapi_json_deserialize.c \
+                                       src/tss2-fapi/ifapi_json_serialize.c \
+                                       src/tss2-fapi/ifapi_policy_json_deserialize.c \
+                                       src/tss2-fapi/ifapi_policy_json_serialize.c \
+                                       src/tss2-fapi/tpm_json_deserialize.c \
+                                       src/tss2-fapi/tpm_json_serialize.c \
+                                       src/tss2-fapi/fapi_crypto.c \
+                                       src/tss2-fapi/ifapi_eventlog.c \
+                                       src/tss2-fapi/ifapi_helpers.c \
+                                       src/tss2-fapi/ifapi_keystore.c  \
+                                       src/tss2-fapi/ifapi_io.c
 
 endif # FAPI
 endif # UNIT

--- a/src/tss2-fapi/ifapi_get_intl_cert.c
+++ b/src/tss2-fapi/ifapi_get_intl_cert.c
@@ -306,9 +306,10 @@ ifapi_get_intl_ek_certificate(FAPI_CONTEXT *context, TPM2B_PUBLIC *ek_public,
 {
     int rc = 1;
     unsigned char *hash = hash_ek_public(ek_public);
-    char *cert_ptr;
+    char *cert_ptr = NULL;
     char *cert_start = NULL, *cert_bin = NULL;
     char *b64 = base64_encode(hash);
+    *cert_buffer = NULL;
 
     if (!b64) {
         LOG_ERROR("base64_encode returned null");
@@ -375,6 +376,8 @@ out:
     if (rc == 0) {
         return TSS2_RC_SUCCESS;
     } else {
+        SAFE_FREE(cert_bin);
+        SAFE_FREE(cert_ptr);
         LOG_ERROR("Get INTEL EK certificate.");
         return TSS2_FAPI_RC_NO_CERT;
     }

--- a/src/tss2-fapi/ifapi_get_intl_cert.c
+++ b/src/tss2-fapi/ifapi_get_intl_cert.c
@@ -194,7 +194,7 @@ base64_encode(const unsigned char* buffer)
 static char *
 base64_decode(unsigned char* buffer, size_t len, size_t *new_len)
 {
-    size_t i, unescape_len, r;
+    size_t i, unescape_len = 0, r;
     char *binary_data = NULL, *unescaped_string = NULL;
 
     LOG_INFO("Decoding the base64 encoded cert into binary form");

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -169,24 +169,26 @@ ifapi_profiles_initialize_finish(
     free(buffer);
     if (jso == NULL) {
         LOG_ERROR("Failed to parse profile %s", profiles->filenames[profiles->profiles_idx]);
-        return TSS2_FAPI_RC_BAD_VALUE;
+        r = TSS2_FAPI_RC_BAD_VALUE;
+        goto error;
     }
 
     r = ifapi_profile_json_deserialize(jso,
             &profiles->profiles[profiles->profiles_idx].profile);
     json_object_put(jso);
-    return_if_error2(r, "Parsing profile %s failed",
-                     profiles->filenames[profiles->profiles_idx]);
+    goto_if_error2(r, "Parsing profile %s failed", error,
+                   profiles->filenames[profiles->profiles_idx]);
 
     r = ifapi_profile_checkpcrs(&profiles->profiles[profiles->profiles_idx].profile.pcr_selection);
-    return_if_error2(r, "Malformed profile pcr selection for profile %s",
-                     profiles->filenames[profiles->profiles_idx]);
+    goto_if_error2(r, "Malformed profile pcr selection for profile %s", error,
+                   profiles->filenames[profiles->profiles_idx]);
 
     profiles->profiles_idx += 1;
 
     if (profiles->profiles_idx < profiles->num_profiles) {
         r = ifapi_io_read_async(io, profiles->filenames[profiles->profiles_idx]);
-        return_if_error2(r, "Reading profile %s", profiles->filenames[profiles->profiles_idx]);
+        goto_if_error2(r, "Reading profile %s", error,
+                       profiles->filenames[profiles->profiles_idx]);
 
         return TSS2_FAPI_RC_TRY_AGAIN;
     }
@@ -201,7 +203,8 @@ ifapi_profiles_initialize_finish(
     if (i == profiles->num_profiles) {
         LOG_ERROR("Default profile %s not in the list of loaded profiles",
                   profiles->default_name);
-        return TSS2_FAPI_RC_BAD_VALUE;
+        r = TSS2_FAPI_RC_BAD_VALUE;
+        goto error;
     }
 
     for (i = 0; i < profiles->num_profiles; i++) {
@@ -210,6 +213,14 @@ ifapi_profiles_initialize_finish(
     SAFE_FREE(profiles->filenames);
 
     return TSS2_RC_SUCCESS;
+
+ error:
+    for (i = 0; i < profiles->num_profiles; i++) {
+        SAFE_FREE(profiles->filenames[i]);
+    }
+    SAFE_FREE(profiles->filenames);
+    ifapi_profiles_finalize(profiles);
+    return r;
 }
 
 /** Return the profile data for a given profile name.
@@ -336,6 +347,7 @@ ifapi_profile_json_deserialize(
     };
 
     LOG_TRACE("call");
+    memset(out, 0, sizeof(IFAPI_PROFILE));
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {

--- a/test/unit/fapi-config.c
+++ b/test/unit/fapi-config.c
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <json-c/json_object.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include "ifapi_io.h"
+#include "ifapi_config.h"
+#include "util/aux_util.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+/*
+ * The unit tests will test deserialization of FAPI config files. It will be
+ * checked whether the correct return codes are returned if optional and
+ * mandatory fields are removed from the configuration.
+ */
+
+/* Config file which will be used for the test. */
+char *wrap_config_file;
+/* JSON field which will be removed for the test. */
+char *wrap_remove_field;
+
+json_object *
+read_json(char *file_name)
+{
+    FILE *stream = NULL;
+    long file_size;
+    char *json_string = NULL;
+    json_object *jso = NULL;
+    char file[1024];
+
+    if (snprintf(&file[0], 1023, TOP_SOURCEDIR "/%s", file_name) < 0)
+        return NULL;
+
+    stream = fopen(file, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", file);
+        return NULL;
+    }
+    fseek(stream, 0L, SEEK_END);
+    file_size = ftell(stream);
+    fclose(stream);
+    json_string = malloc(file_size + 1);
+    stream = fopen(file, "r");
+    ssize_t ret = read(fileno(stream), json_string, file_size);
+    if (ret != file_size) {
+        LOG_ERROR("IO error %s.",file);
+        return NULL;
+    }
+    json_string[file_size] = '\0';
+    jso = json_tokener_parse(json_string);
+    SAFE_FREE(json_string);
+    return jso;
+}
+
+/*
+ * Wrappers for reading the JSON profile.
+ */
+TSS2_RC
+__wrap_ifapi_io_read_finish(
+    struct IFAPI_IO *io,
+    uint8_t **buffer,
+    size_t *length, ...);
+
+TSS2_RC
+__wrap_ifapi_io_read_finish(
+    struct IFAPI_IO *io,
+    uint8_t **buffer,
+    size_t *length, ...)
+{
+    json_object *jso = NULL;
+    const char *jso_string = NULL;
+
+    jso = read_json(wrap_config_file);
+    assert_ptr_not_equal(jso, NULL);
+    json_object_object_del(jso, wrap_remove_field);
+    jso_string = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PRETTY);
+    assert_ptr_not_equal(jso_string, NULL);
+    *buffer = (uint8_t *)strdup(jso_string);
+    *length = strlen(jso_string);
+    json_object_put(jso);
+    assert_ptr_not_equal(*buffer, NULL);
+    return TSS2_RC_SUCCESS;
+}
+
+/* Function to remove the field and check the initialization of the configuration. */
+void check_remove_field(char *file, char* fname, TSS2_RC rc)
+{
+    IFAPI_IO io;
+    IFAPI_CONFIG config;
+    TSS2_RC r;
+
+    wrap_config_file = file;
+    wrap_remove_field = fname;
+    r = ifapi_config_initialize_finish(&io, &config);
+    assert_int_equal(r, rc);
+    if (r == TSS2_RC_SUCCESS) {
+        SAFE_FREE(config.profile_dir);
+        SAFE_FREE(config.user_dir);
+        SAFE_FREE(config.keystore_dir);
+        SAFE_FREE(config.profile_name);
+        SAFE_FREE(config.tcti);
+        SAFE_FREE(config.log_dir);
+        SAFE_FREE(config.ek_cert_file);
+        SAFE_FREE(config.intel_cert_service)
+            }
+}
+
+/* Function to remove the field and check the initialization of the configuration. */
+static void
+check_config_json_remove_field_allowed(void **state) {
+    check_remove_field("dist/fapi-config.json.in", "log_dir", TSS2_RC_SUCCESS);
+}
+
+/* Check removing of the mandatory fields. */
+static void
+check_config_json_remove_field_not_allowed(void **state) {
+    check_remove_field("dist/fapi-config.json.in", "profile_dir", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("dist/fapi-config.json.in", "system_dir", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("dist/fapi-config.json.in", "user_dir", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("dist/fapi-config.json.in", "profile_name", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("dist/fapi-config.json.in", "tcti", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("dist/fapi-config.json.in", "system_pcrs", TSS2_FAPI_RC_BAD_VALUE);
+}
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(check_config_json_remove_field_allowed),
+        cmocka_unit_test(check_config_json_remove_field_not_allowed),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/fapi-get-intl-cert.c
+++ b/test/unit/fapi-get-intl-cert.c
@@ -1,0 +1,245 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+#include <openssl/sha.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_fapi.h"
+#include "fapi_int.h"
+#include "ifapi_get_intl_cert.h"
+
+#include "util/aux_util.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+/*
+ * The unit tests will simulate error codes which can be returned by the
+ * functions which are used to retrieve the INTEL certificates.
+ */
+
+/* Mock data for the certificate buffer. and the public data of the EK  */
+
+char* valid_json_cert = "{ \"certificate\": \"ZG15Cg==\" }"; /**< dmy base64 encoded */
+char* invalid_json_cert1 = "{ \"certificate\": 1 }";
+char* invalid_json_cert2 = "{ }";
+char* mock_json_cert;
+
+TPM2B_PUBLIC eccPublic = {
+    .size = 0,
+    .publicArea = {
+        .type = TPM2_ALG_ECC,
+        .nameAlg = TPM2_ALG_SHA256,
+        .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                             TPMA_OBJECT_RESTRICTED |
+                             TPMA_OBJECT_SIGN_ENCRYPT |
+                             TPMA_OBJECT_FIXEDTPM |
+                             TPMA_OBJECT_FIXEDPARENT |
+                             TPMA_OBJECT_SENSITIVEDATAORIGIN),
+        .authPolicy = {
+            .size = 0,
+        },
+        .parameters.eccDetail = {
+            .symmetric = {
+                .algorithm = TPM2_ALG_NULL,
+                .keyBits.aes = 128,
+                .mode.aes = TPM2_ALG_CFB,
+            },
+            .scheme = {
+                .scheme = TPM2_ALG_ECDSA,
+                .details = {
+                    .ecdsa = {.hashAlg  = TPM2_ALG_SHA256}},
+            },
+            .curveID = TPM2_ECC_NIST_P256,
+            .kdf = {
+                .scheme = TPM2_ALG_NULL,
+                .details = {}}
+        },
+        .unique.ecc = {
+            .x = {.size = 2, .buffer = { 1, 2 }},
+            .y = {.size = 2, .buffer = { 3, 4 }},
+        },
+    },
+};
+
+TPM2B_PUBLIC rsaPublic = {
+        .size = 0,
+        .publicArea = {
+            .type = TPM2_ALG_RSA,
+            .nameAlg = TPM2_ALG_SHA1,
+            .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                                 TPMA_OBJECT_SIGN_ENCRYPT  |
+                                 TPMA_OBJECT_FIXEDTPM |
+                                 TPMA_OBJECT_FIXEDPARENT |
+                                 TPMA_OBJECT_SENSITIVEDATAORIGIN),
+            .authPolicy = {
+                 .size = 0,
+             },
+            .parameters.rsaDetail = {
+                 .symmetric = {
+                     .algorithm = TPM2_ALG_NULL,
+                     .keyBits.aes = 128,
+                     .mode.aes = TPM2_ALG_CFB},
+                 .scheme = {
+                      .scheme = TPM2_ALG_RSAPSS,
+                      .details = {
+                          .rsapss = { .hashAlg = TPM2_ALG_SHA1 }
+                      }
+                  },
+                 .keyBits = 2048,
+                 .exponent = 0,
+             },
+            .unique.rsa = {
+                 .size = 2,
+                 .buffer = { 1, 2 },
+             },
+        },
+    };
+
+/*
+ * Wrapper function for reading the certificate buffer.
+ */
+int
+__real_ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
+                             size_t *buffer_size);
+
+int
+__wrap_ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
+                          size_t *buffer_size)
+{
+    (void)url;
+    *buffer = (unsigned char *)strdup(mock_json_cert);      ;
+    *buffer_size = strlen(mock_json_cert) + 1;
+    return 0;
+}
+
+/*
+ * Wrapper function for updating the hash of EK public data.
+ */
+size_t wrap_SHA256_update_test = 0;
+
+int
+__real_SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
+
+int
+__wrap_SHA256_Update(SHA256_CTX *c, const void *data, size_t len)
+{
+    if (!wrap_SHA256_update_test) {
+        return __real_SHA256_Update(c, data, len);
+    } else if (wrap_SHA256_update_test == 1) {
+        wrap_SHA256_update_test = 0;
+        return mock_type(int);
+    } else {
+        wrap_SHA256_update_test--;
+        return __real_SHA256_Update(c, data, len);
+    }
+}
+
+static int
+setup (void **state)
+{
+    *state = calloc(1, sizeof(FAPI_CONTEXT));  //Fapi_Initialize
+    return 0;
+}
+
+static int
+teardown (void **state)
+{
+    SAFE_FREE(*state);
+    return 0;
+
+}
+
+/*
+ * Check receiving of valid JSON data for the certificate.
+ */
+static void
+check_get_intl_cert_ok(void **state) {
+    FAPI_CONTEXT *ctx = *state;
+    unsigned char *cert_buf = NULL;
+    size_t cert_size;
+    TSS2_RC r;
+
+    mock_json_cert = valid_json_cert;
+    r = ifapi_get_intl_ek_certificate(ctx, &eccPublic, &cert_buf, &cert_size);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    SAFE_FREE(cert_buf);
+
+    r = ifapi_get_intl_ek_certificate(ctx, &rsaPublic, &cert_buf, &cert_size);
+    SAFE_FREE(cert_buf);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+}
+
+/*
+ * Check receiving of invalid JSON data for the certificate.
+ */
+static void
+check_get_intl_cert_invalid_json(void **state) {
+    FAPI_CONTEXT *ctx = *state;
+    unsigned char *cert_buf = NULL;
+    size_t cert_size;
+    TSS2_RC r;
+    mock_json_cert = invalid_json_cert1;
+    r = ifapi_get_intl_ek_certificate(ctx, &eccPublic, &cert_buf, &cert_size);
+    assert_int_equal(r, TSS2_FAPI_RC_NO_CERT);
+
+    mock_json_cert = invalid_json_cert2;
+    r = ifapi_get_intl_ek_certificate(ctx, &rsaPublic, &cert_buf, &cert_size);
+    assert_int_equal(r, TSS2_FAPI_RC_NO_CERT);
+}
+
+/*
+ * Simulate error during hash update for the EK public data.
+ */
+static void
+check_get_intl_cert_sha_error(void **state) {
+    FAPI_CONTEXT *ctx = *state;
+    unsigned char *cert_buf = NULL;
+    size_t cert_size;
+    TSS2_RC r;
+    will_return_always(__wrap_SHA256_Update, 0);
+    mock_json_cert = valid_json_cert;
+    wrap_SHA256_update_test = 1;
+    r = ifapi_get_intl_ek_certificate(ctx, &eccPublic, &cert_buf, &cert_size);
+    assert_int_equal(r,TSS2_FAPI_RC_NO_CERT);
+
+    wrap_SHA256_update_test = 1;
+    r = ifapi_get_intl_ek_certificate(ctx, &rsaPublic, &cert_buf, &cert_size);
+    assert_int_equal(r,TSS2_FAPI_RC_NO_CERT);
+
+    wrap_SHA256_update_test = 2;
+    r = ifapi_get_intl_ek_certificate(ctx, &eccPublic, &cert_buf, &cert_size);
+    assert_int_equal(r,TSS2_FAPI_RC_NO_CERT);
+
+    wrap_SHA256_update_test = 2;
+    r = ifapi_get_intl_ek_certificate(ctx, &rsaPublic, &cert_buf, &cert_size);
+    assert_int_equal(r,TSS2_FAPI_RC_NO_CERT);
+
+}
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(check_get_intl_cert_ok, setup, teardown),
+        cmocka_unit_test_setup_teardown(check_get_intl_cert_invalid_json, setup, teardown),
+        cmocka_unit_test_setup_teardown(check_get_intl_cert_sha_error, setup, teardown),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/fapi-helpers.c
+++ b/test/unit/fapi-helpers.c
@@ -1,0 +1,342 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_fapi.h"
+#include "tpm_json_serialize.h"
+#include "ifapi_eventlog.h"
+#include "tpm_json_deserialize.h"
+#include "ifapi_json_serialize.h"
+#include "ifapi_json_deserialize.h"
+#include "ifapi_helpers.h"
+#include "fapi_crypto.h"
+
+#include "util/aux_util.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+/*
+ * The unit tests will be used to test cases of the FAPI helper
+ * functions which were not covered by the integration tests.
+ */
+
+/* Global variables to trigger wrapper functions. If set to false the
+ * real function will be called. */
+bool wrap_activate_crypto_hash_update = false;
+bool wrap_activate_crypto_hash_finish = false;
+
+
+/*
+ * Wrappers for crypto functions.
+ */
+TSS2_RC
+__real_ifapi_crypto_hash_update(IFAPI_CRYPTO_CONTEXT_BLOB *context,
+                                const uint8_t *buffer, size_t size, ...);
+
+TSS2_RC
+__wrap_ifapi_crypto_hash_update(IFAPI_CRYPTO_CONTEXT_BLOB *context,
+                                const uint8_t *buffer, size_t size, ...)
+{
+    if (wrap_activate_crypto_hash_update)
+        return mock_type(int);
+    else
+        return __real_ifapi_crypto_hash_update(context, buffer, size);
+}
+
+TSS2_RC
+__real_ifapi_crypto_hash_finish(IFAPI_CRYPTO_CONTEXT_BLOB **context,
+                                const uint8_t *digest, size_t size, ...);
+
+TSS2_RC
+__wrap_ifapi_crypto_hash_finish(IFAPI_CRYPTO_CONTEXT_BLOB **context,
+                                const uint8_t *digest, size_t size, ...)
+{
+    if (wrap_activate_crypto_hash_finish)
+        return mock_type(int);
+    else
+        return __real_ifapi_crypto_hash_finish(context, digest, size);
+}
+
+/*
+ * Check all cases to determine the first index of an NV path.
+ */
+static void
+check_get_nv_start_index2(char *path, TPM2_HANDLE exp_start_idx, TSS2_RC exp_r)
+{
+    TSS2_RC r;
+    TPM2_HANDLE nv_index;
+
+    r = ifapi_get_nv_start_index(path, &nv_index);
+    assert_int_equal(r, exp_r);
+    if (r == TPM2_RC_SUCCESS) {
+        assert_int_equal(nv_index, exp_start_idx);
+    }
+}
+
+static void
+check_get_nv_start_index(void **state)
+{
+    check_get_nv_start_index2("/nv/wrong_path", 0, TSS2_FAPI_RC_BAD_PATH);
+    check_get_nv_start_index2("/nv/TPM", 0x01000000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Owner", 0x01800000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Endorsement_Certificate", 0x01c00000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Platform_Certificate", 0x01c08000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Component_OEM", 0x01c10000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/TPM_OEM", 0x01c20000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Platform_OEM", 0x01c30000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/PC-Client", 0x01c40000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Server", 0x01c50000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Virtualized_Platform", 0x01c60000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/MPWG", 0x01c70000, TSS2_RC_SUCCESS);
+    check_get_nv_start_index2("/nv/Embedded", 0x01c80000, TSS2_RC_SUCCESS);
+}
+
+/*
+ * Test all cases which check whether a given NV index is valid for a certain path.
+ */
+static void
+check_check_nv_index2(char *path, TPM2_HANDLE nv_index, TSS2_RC exp_r)
+{
+    TSS2_RC r;
+
+    r = ifapi_check_nv_index(path, nv_index);
+    assert_int_equal(r, exp_r);
+}
+
+static void
+check_check_nv_index(void **state)
+{
+    check_check_nv_index2("/nv/TPM", 0x01000000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/TPM", 0x013fffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/TPM", 0xffffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/TPM", 0x1400000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform", 0x01400000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform", 0x017fffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform", 0x13fffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform", 0x1800000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Owner", 0x01800000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Owner", 0x01bfffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Owner", 0x17fffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Owner", 0x1c00000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Endorsement_Certificate", 0x01c00000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Endorsement_Certificate", 0x01c07fff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Endorsement_Certificate", 0x1bfffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Endorsement_Certificate", 0x1c08000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform_Certificate", 0x01c08000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform_Certificate", 0x01c0ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform_Certificate", 0x1c07fff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform_Certificate", 0x1c10000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Component_OEM", 0x01c10000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Component_OEM", 0x01c1ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Component_OEM", 0x1c0ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Component_OEM", 0x1c20000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/TPM_OEM", 0x01c20000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/TPM_OEM", 0x01c2ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/TPM_OEM", 0x1c1ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/TPM_OEM", 0x1c30000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform_OEM", 0x01c30000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform_OEM", 0x01c3ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Platform_OEM", 0x1c2ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Platform_OEM", 0x1c40000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/PC-Client", 0x01c40000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/PC-Client", 0x01c4ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/PC-Client", 0x1c3ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/PC-Client", 0x1c50000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Server", 0x01c50000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Server", 0x01c5ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Server", 0x1c4ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Server", 0x1c60000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Virtualized_Platform", 0x01c60000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Virtualized_Platform", 0x01c6ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Virtualized_Platform", 0x1c5ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Virtualized_Platform", 0x1c70000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/MPWG", 0x01c70000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/MPWG", 0x01c7ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/MPWG", 0x1c6ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/MPWG", 0x1c80000, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Embedded", 0x01c80000, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Embedded", 0x01c8ffff, TSS2_RC_SUCCESS);
+    check_check_nv_index2("/nv/Embedded", 0x1c7ffff, TSS2_FAPI_RC_BAD_VALUE);
+    check_check_nv_index2("/nv/Embedded", 0x1c90000, TSS2_FAPI_RC_BAD_VALUE);
+}
+
+/*
+ * Check comparison of TPMU_PUBLIC_ID structures with the selectors
+ * TPM2_ALG_KEYEDHASH and TPM2_ALG_SYMCIPHER.
+ */
+static void
+check_cmp_TPMU_PUBLIC_ID2(
+    TPMT_PUBLIC *pid1,
+    TPMT_PUBLIC *pid2,
+    bool exp_r)
+{
+    bool r;
+    r = ifapi_TPMT_PUBLIC_cmp(pid1, pid2);
+    if (exp_r)
+        assert_true(r);
+    else
+        assert_false(r);
+}
+
+static void
+check_cmp_TPMU_PUBLIC_ID(void **state) {
+    TPM2B_DIGEST digest1 = {
+        .size = 10,
+        .buffer = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }
+    };
+    TPM2B_DIGEST digest2 = {
+        .size = 10,
+        .buffer = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
+    };
+    TPMT_PUBLIC keyed_hash1;
+    TPMT_PUBLIC sym1;
+    TPMT_PUBLIC keyed_hash2;
+    TPMT_PUBLIC sym2;
+
+    keyed_hash1.type = TPM2_ALG_KEYEDHASH;
+    keyed_hash1.unique.keyedHash = digest1;
+    sym1.type = TPM2_ALG_SYMCIPHER;
+    sym1.unique.sym = digest1;
+    keyed_hash2.type = TPM2_ALG_KEYEDHASH;
+    keyed_hash2.unique.keyedHash = digest2;
+    sym2.type = TPM2_ALG_SYMCIPHER;
+    sym2.unique.sym = digest2;
+
+    check_cmp_TPMU_PUBLIC_ID2(&keyed_hash1, &sym1, false);
+    check_cmp_TPMU_PUBLIC_ID2(&keyed_hash1, &keyed_hash1, true);
+    check_cmp_TPMU_PUBLIC_ID2(&keyed_hash1, &keyed_hash2, false);
+    check_cmp_TPMU_PUBLIC_ID2(&sym1, &sym1, true);
+    check_cmp_TPMU_PUBLIC_ID2(&sym1, &sym2, false);
+}
+
+TPMT_PUBLIC in_public = {
+    .type = TPM2_ALG_ECC,
+    .nameAlg = TPM2_ALG_SHA256,
+    .objectAttributes = (TPMA_OBJECT_USERWITHAUTH |
+                         TPMA_OBJECT_RESTRICTED |
+                         TPMA_OBJECT_SIGN_ENCRYPT |
+                         TPMA_OBJECT_FIXEDTPM |
+                         TPMA_OBJECT_FIXEDPARENT |
+                         TPMA_OBJECT_SENSITIVEDATAORIGIN),
+    .authPolicy = {
+        .size = 0,
+    },
+    .parameters.eccDetail = {
+        .symmetric = {
+            .algorithm = TPM2_ALG_NULL,
+            .keyBits.aes = 128,
+            .mode.aes = TPM2_ALG_CFB,
+        },
+        .scheme = {
+            .scheme = TPM2_ALG_ECDSA,
+            .details = {.ecdsa =
+                        {.hashAlg = TPM2_ALG_SHA1}
+            }
+        },
+        .curveID = TPM2_ECC_NIST_P256,
+        .kdf = {.scheme =
+                TPM2_ALG_NULL,.details = {}
+        }
+    },
+    .unique.ecc = {
+        .x = {.size = 0,.buffer = {}},
+        .y = {.size = 0,.buffer = {}}
+    },
+};
+
+/*
+ * Check error cases of the function ifapi_get_name.
+ */
+static void
+check_get_name(void **state) {
+    TPMT_PUBLIC public = { 0 };
+    TPM2B_NAME name;
+    TSS2_RC r;
+
+    public.nameAlg = TPM2_ALG_SHA256;
+    r = ifapi_get_name(&public, &name);
+    assert_int_equal(r, TSS2_MU_RC_BAD_VALUE);
+
+    wrap_activate_crypto_hash_update = true;
+    will_return(__wrap_ifapi_crypto_hash_update, TSS2_FAPI_RC_GENERAL_FAILURE);
+
+     r = ifapi_get_name(&in_public, &name);
+    assert_int_equal(r, TSS2_FAPI_RC_GENERAL_FAILURE);
+    wrap_activate_crypto_hash_update = false;
+
+    wrap_activate_crypto_hash_finish = true;
+    will_return(__wrap_ifapi_crypto_hash_finish, TSS2_FAPI_RC_GENERAL_FAILURE);
+
+    r = ifapi_get_name(&in_public, &name);
+    assert_int_equal(r, TSS2_FAPI_RC_GENERAL_FAILURE);
+    wrap_activate_crypto_hash_finish = false;
+}
+
+/*
+ * Check valid return and out parameters of the function
+ * ifapi_get_profile_sig_scheme.
+ */
+static void
+check_get_profile_sig_scheme(void **stat) {
+    IFAPI_PROFILE profile;
+    TPMT_SIG_SCHEME sig_scheme;
+    TPMT_PUBLIC tpm_public;
+    TSS2_RC r;
+    TPMT_SIG_SCHEME ecc_scheme = { .scheme = TPM2_ALG_ECDSA,
+                                   .details.ecdsa = TPM2_ALG_SHA1 };
+    TPMT_SIG_SCHEME rsa_scheme = { .scheme = TPM2_ALG_RSAPSS,
+                                   .details.rsapss = TPM2_ALG_SHA1 };
+    TPMI_ALG_HASH hash_alg;
+
+    profile.rsa_signing_scheme = rsa_scheme;
+    profile.ecc_signing_scheme = ecc_scheme;
+
+    tpm_public.type = TPM2_ALG_RSA;
+    r = ifapi_get_profile_sig_scheme(&profile, &tpm_public, &sig_scheme);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    assert_true(sig_scheme.scheme == TPM2_ALG_RSAPSS);
+    hash_alg = sig_scheme.details.rsapss.hashAlg;
+    assert_true(hash_alg== TPM2_ALG_SHA1);
+
+    tpm_public.type = TPM2_ALG_ECC;
+    r = ifapi_get_profile_sig_scheme(&profile, &tpm_public, &sig_scheme);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    assert_true(sig_scheme.scheme == TPM2_ALG_ECDSA);
+    hash_alg = sig_scheme.details.ecdsa.hashAlg;
+    assert_true(hash_alg== TPM2_ALG_SHA1);
+
+    tpm_public.type = TPM2_ALG_NULL;
+    r = ifapi_get_profile_sig_scheme(&profile, &tpm_public, &sig_scheme);
+    assert_int_equal(r, TSS2_FAPI_RC_BAD_VALUE);
+}
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(check_get_nv_start_index),
+        cmocka_unit_test(check_check_nv_index),
+        cmocka_unit_test(check_cmp_TPMU_PUBLIC_ID),
+        cmocka_unit_test(check_get_name),
+        cmocka_unit_test(check_get_profile_sig_scheme),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -1,0 +1,366 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include "ifapi_io.h"
+#include "util/aux_util.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+/*
+ * The unit tests will simulate error codes which can be returned by the
+ * system calls for file system IO.
+ */
+
+/* Global variables to trigger wrapper functions. If set to false the
+ * real function will be called. */
+bool wrap_fcntl_test = false;
+bool wrap_malloc_test = false;
+bool wrap_read_test = false;
+FILE mock_stream; /**< stream will be used to activate wrapper.*/
+
+/*
+ * Wrapper functions for file system io.
+ */
+
+FILE *
+__real_fopen(const char *pathname, const char* mode, ...);
+FILE *
+__wrap_fopen(const char *pathname, const char* mode, ...)
+{
+    if (strcmp(pathname, "tss_unit_dummyf")) {
+        return __real_fopen(pathname, mode);
+    }
+    return mock_ptr_type(FILE*);
+}
+
+int
+__real_lockf(int fd, int cmd, off_t len, ...);
+int
+__wrap_lockf(int fd, int cmd, off_t len, ...)
+{
+    errno = EAGAIN;
+    return mock_type(int);
+}
+
+int
+__real_fclose(FILE *stream, ...);
+
+int
+__wrap_fclose(FILE *stream, ...)
+{
+    if (stream != &mock_stream) {
+        return __real_fclose(stream);
+    }
+    return mock_type(int);
+}
+
+int
+__real_fseek(FILE *stream, long offset, int whence, ...);
+
+int
+__wrap_fseek(FILE *stream, long offset, int whence, ...)
+{
+    if (stream != &mock_stream) {
+        return __real_fseek(stream, offset, whence);
+    }
+    return mock_type(int);
+}
+
+long
+__real_ftell(FILE *stream, ...);
+
+long
+__wrap_ftell(FILE *stream, ...)
+{
+    if (stream != &mock_stream) {
+        return __real_ftell(stream);
+    }
+    return mock_type(int);
+}
+
+int
+__real_fcntl(int fd, int cmd, ...);
+
+int
+__wrap_fcntl(int fd, int cmd, ...)
+{
+    if (wrap_fcntl_test)
+        return mock_type(int);
+    else
+        return __real_fcntl(fd, cmd);
+}
+
+void *
+__real_malloc(size_t size, ...);
+
+void *
+__wrap_malloc(size_t size, ...)
+{
+    if (wrap_malloc_test) {
+        return mock_ptr_type (void*);
+    } else {
+        return __real_malloc(size);
+    }
+}
+
+int
+__real_fileno(FILE *stream, ...);
+
+int
+__wrap_fileno(FILE *stream, ...)
+{
+    if (stream != &mock_stream) {
+        return __real_fileno(stream);
+    }
+    return 1;
+}
+
+ssize_t
+__real_read(int fd, void *buf, size_t count);
+
+ssize_t
+__wrap_read(int fd, void *buf, size_t count, ...) {
+    if (!wrap_read_test) {
+        return __real_read(fd, buf, count);
+    }
+
+    return mock_type(ssize_t);
+}
+
+/*
+ * The return codes for error cases which can be occur in the
+ * function: ifapi_io_read_async will be checked.
+ */
+static void
+check_io_read_async(void **state) {
+    IFAPI_IO io;
+    TSS2_RC r;
+    char *dmy_buf = "dummy";
+
+    memset(&io, 0, sizeof(IFAPI_IO));
+    io.char_rbuffer = &dmy_buf[0];
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    io.char_rbuffer = NULL;
+    will_return(__wrap_fopen, NULL);
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    will_return(__wrap_fopen, NULL);
+    io.char_buffer = "dummy";
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_lockf, -1);
+    will_return_always(__wrap_fclose, 0);
+    errno = EAGAIN;
+    io.char_buffer = NULL;
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_lockf, 0);
+    will_return(__wrap_fseek, 0);
+    will_return(__wrap_ftell, 1);
+    will_return(__wrap_malloc, NULL);
+    errno = 0;
+    io.char_buffer = NULL;
+    wrap_malloc_test = true;
+
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_MEMORY);
+
+    wrap_malloc_test = false;
+
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_lockf, 0);
+    will_return(__wrap_fseek, 0);
+    will_return(__wrap_ftell, 1);
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_fcntl, -1);
+
+    errno = 0;
+    io.char_buffer = NULL;
+    wrap_fcntl_test = true;
+    r = ifapi_io_read_async(&io, "tss_unit_dummyf");
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+    wrap_fcntl_test = false;
+}
+
+/*
+ * The return codes for error cases which can be occur in the
+ * function: ifapi_io_read_finish will be checked.
+ */
+static void
+check_io_read_finish(void **state) {
+    IFAPI_IO io;
+    TSS2_RC r;
+    uint8_t *buffer[10];
+    char io_char_buffer[10];
+    size_t count = 10;
+
+    memset(&io, 0, sizeof(IFAPI_IO));
+    wrap_read_test = true;
+    will_return(__wrap_read, -1);
+    // will_return_always(__wrap_fileno, 1);
+    will_return_always(__wrap_fclose, 0);
+    io.char_buffer = &io_char_buffer[0];
+    io.buffer_length = 10;
+    io.stream = &mock_stream;
+    errno = EAGAIN;
+    r = ifapi_io_read_finish(&io, &buffer[0], &count);
+    assert_int_equal(r, TSS2_FAPI_RC_TRY_AGAIN);
+
+    will_return(__wrap_read, -1);
+    errno = 0;
+    r = ifapi_io_read_finish(&io, &buffer[0], &count);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    will_return(__wrap_read, 8);
+    errno = 0;
+    r = ifapi_io_read_finish(&io, &buffer[0], &count);
+    assert_int_equal(r, TSS2_FAPI_RC_TRY_AGAIN);
+
+    will_return(__wrap_read, 10);
+    errno = 0;
+    r = ifapi_io_read_finish(&io, &buffer[0], &count);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+
+    will_return(__wrap_read, 10);
+    errno = 0;
+    r = ifapi_io_read_finish(&io, NULL, &count);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+
+    wrap_read_test = false;
+}
+
+/*
+ * The return codes for error cases which can be occur in the
+ * function: ifapi_io_write_async will be checked.
+ */
+static void
+check_io_write_async(void **state) {
+    IFAPI_IO io;
+    TSS2_RC r;
+    uint8_t buffer[5]  = { 1, 2, 3, 4, 5 };
+    char *char_buffer = "dummy";
+
+    will_return_always(__wrap_fclose, 0);
+    // will_return_always(__wrap_fileno, 1);
+
+    memset(&io, 0, sizeof(IFAPI_IO));
+
+    io.char_rbuffer = &char_buffer[0];
+    r = ifapi_io_write_async(&io, "tss_unit_dummyf", NULL, 0);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    io.char_rbuffer = NULL;
+    will_return(__wrap_malloc, NULL);
+    wrap_malloc_test = true;
+
+    r = ifapi_io_write_async(&io, "tss_unit_dummyf", NULL, 0);
+    assert_int_equal(r, TSS2_FAPI_RC_MEMORY);
+
+    wrap_malloc_test = false;
+
+    will_return(__wrap_fopen, NULL);
+    r = ifapi_io_write_async(&io, "tss_unit_dummyf", &buffer[0], 5);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_lockf, -1);
+
+    errno = EAGAIN;
+    r = ifapi_io_write_async(&io, "tss_unit_dummyf", &buffer[0], 5);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    io.char_rbuffer = NULL;
+    will_return(__wrap_fopen, &mock_stream);
+    will_return(__wrap_lockf, 0);
+    wrap_fcntl_test = true;
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_fcntl, -1);
+    errno = 0;
+    r = ifapi_io_write_async(&io, "tss_unit_dummyf", &buffer[0], 5);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+    wrap_fcntl_test = false;
+}
+
+bool wrap_write_test = false;
+
+ssize_t
+__real_write(int fd, void *buf, size_t count);
+
+ssize_t
+__wrap_write(int fd, void *buf, size_t count, ...) {
+    if (!wrap_write_test) {
+        return __real_read(fd, buf, count);
+    }
+
+    return mock_type(ssize_t);
+}
+
+/*
+ * The return codes for error cases which can be occur in the
+ * function: ifapi_io_write_finish will be checked.
+ */
+static void
+check_io_write_finish(void **state) {
+    IFAPI_IO io;
+    TSS2_RC r;
+    //uint8_t buffer[5]  = { 1, 2, 3, 4, 5 };
+
+    memset(&io, 0, sizeof(IFAPI_IO));
+    // will_return_always(__wrap_fileno, 1);
+    will_return_always(__wrap_fclose, 0);
+
+    wrap_write_test = true;
+    io.stream = &mock_stream;
+    will_return(__wrap_write, -1);
+    errno = EAGAIN;
+    r = ifapi_io_write_finish(&io);
+    assert_int_equal(r, TSS2_FAPI_RC_TRY_AGAIN);
+
+    errno = 0;
+    will_return(__wrap_write, -1);
+    r = ifapi_io_write_finish(&io);
+    assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
+
+    wrap_write_test = false;
+}
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(check_io_read_async),
+        cmocka_unit_test(check_io_read_finish),
+        cmocka_unit_test(check_io_write_async),
+        cmocka_unit_test(check_io_write_finish),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/fapi-profiles.c
+++ b/test/unit/fapi-profiles.c
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <json-c/json_object.h>
+#include <json-c/json_util.h>
+#include <json-c/json_tokener.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include "ifapi_io.h"
+#include "ifapi_profiles.h"
+#include "util/aux_util.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+/*
+ * The unit tests will test deserialization of FAPI profiles. It will be
+ * checked whether the correct return codes are returned if optional and
+ * mandatory fields are removed from the profile.
+ */
+
+/* Profile file which will be used for the test. */
+char *wrap_profile_file;
+/* JSON field which will be removed for the test. */
+char *wrap_remove_field;
+
+json_object *
+read_json(char *file_name)
+{
+    FILE *stream = NULL;
+    long file_size;
+    char *json_string = NULL;
+    json_object *jso = NULL;
+    char file[1024];
+
+    if (snprintf(&file[0], 1023, TOP_SOURCEDIR "/%s", file_name) < 0)
+        return NULL;
+
+    stream = fopen(file, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", file);
+        return NULL;
+    }
+    fseek(stream, 0L, SEEK_END);
+    file_size = ftell(stream);
+    fclose(stream);
+    json_string = malloc(file_size + 1);
+    stream = fopen(file, "r");
+    ssize_t ret = read(fileno(stream), json_string, file_size);
+    if (ret != file_size) {
+        LOG_ERROR("IO error %s.",file);
+        return NULL;
+    }
+    json_string[file_size] = '\0';
+    jso = json_tokener_parse(json_string);
+    SAFE_FREE(json_string);
+    return jso;
+}
+
+/*
+ * Wrappers for reading the JSON profile.
+ */
+TSS2_RC
+__wrap_ifapi_io_read_finish(
+    struct IFAPI_IO *io,
+    uint8_t **buffer,
+    size_t *length, ...);
+
+TSS2_RC
+__wrap_ifapi_io_read_finish(
+    struct IFAPI_IO *io,
+    uint8_t **buffer,
+    size_t *length, ...)
+{
+    json_object *jso = NULL;
+    const char *jso_string = NULL;
+
+    jso = read_json(wrap_profile_file);
+    assert_ptr_not_equal(jso, NULL);
+    json_object_object_del(jso, wrap_remove_field);
+    jso_string = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PRETTY);
+    assert_ptr_not_equal(jso_string, NULL);
+    *buffer = (uint8_t *)strdup(jso_string);
+    json_object_put(jso);
+    assert_ptr_not_equal(*buffer, NULL);
+    return TSS2_RC_SUCCESS;
+}
+
+/* Function to remove the field and check the profile initialization. */
+void check_remove_field(char *file, char* fname, TSS2_RC rc)
+    {
+        IFAPI_IO io;
+        IFAPI_PROFILES profiles;
+        TSS2_RC r;
+
+        profiles.num_profiles = 1;
+        profiles.profiles_idx = 0;
+        profiles.default_name = strdup("dmy_name");
+        profiles.filenames = calloc(1 ,sizeof(profiles.filenames[0]));
+        assert_ptr_not_equal(profiles.filenames, NULL);
+        profiles.profiles = calloc(profiles.num_profiles, sizeof(profiles.profiles[0]));
+        profiles.profiles[0].name = strdup("dmy_name");
+        assert_ptr_not_equal(profiles.profiles[0].name, NULL);
+        profiles.filenames[0] = strdup("dmy_name");
+        assert_ptr_not_equal( profiles.filenames[0], NULL);
+        wrap_profile_file = file;
+        wrap_remove_field = fname;
+        r = ifapi_profiles_initialize_finish(&profiles, &io);
+        assert_int_equal(r, rc);
+        ifapi_profiles_finalize(&profiles);
+    }
+
+/* Check removing the optional fields. */
+static void
+check_profile_json_remove_field_allowed(void **state) {
+    check_remove_field("test/data/fapi/P_RSA.json", "srk_description", TSS2_RC_SUCCESS);
+    check_remove_field("test/data/fapi/P_RSA.json", "ekk_description", TSS2_RC_SUCCESS);
+}
+
+/* Check removing of the mandatory fields. */
+static void
+check_profile_json_remove_field_not_allowed(void **state) {
+    check_remove_field("test/data/fapi/P_ECC.json", "type", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_ECC.json", "curveID", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "keyBits", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "exponent", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "nameAlg", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "pcr_selection", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "pcr_selection", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "sym_block_size", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "sym_parameters", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "sym_mode", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "ek_template", TSS2_FAPI_RC_BAD_VALUE);
+    check_remove_field("test/data/fapi/P_RSA.json", "srk_template", TSS2_FAPI_RC_BAD_VALUE);
+}
+
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(check_profile_json_remove_field_allowed),
+        cmocka_unit_test(check_profile_json_remove_field_not_allowed),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
* Fix clean-up in several error cases which could occur in file reading and
  retrieving certificates.
* Unit tests were added for profile and config reading, for FAPI io, for FAPI helper
  functions, and retrieving the INTEL certificates.
*The  update in cirrus ci was fixed.


Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>