### PR TITLE
FAPI: initialise 'out' parameter in ifapi_json_IFAPI_CONFIG_deserialize

### DIFF
--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -44,28 +44,24 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
     return_if_null(out, "out is NULL", TSS2_FAPI_RC_BAD_REFERENCE);
     return_if_null(jso, "jso is NULL", TSS2_FAPI_RC_BAD_REFERENCE);
 
+    memset(out, 0, sizeof(IFAPI_CONFIG));
+
     /* Deserialize the JSON object) */
     json_object *jso2;
     TSS2_RC r;
     LOG_TRACE("call");
 
-    if (!ifapi_get_sub_object(jso, "profile_dir", &jso2)) {
-        out->profile_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "profile_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->profile_dir);
         return_if_error(r, "Bad value for field \"profile_dir\".");
     }
 
-    if (!ifapi_get_sub_object(jso, "user_dir", &jso2)) {
-        out->user_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "user_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->user_dir);
         return_if_error(r, "Bad value for field \"user_dir\".");
     }
 
-    if (!ifapi_get_sub_object(jso, "system_dir", &jso2)) {
-        out->keystore_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "system_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->keystore_dir);
         return_if_error(r, "Bad value for field \"keystore_dir\".");
     }
@@ -98,9 +94,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->system_pcrs);
     return_if_error(r, "Bad value for field \"system_pcrs\".");
 
-    if (!ifapi_get_sub_object(jso, "ek_cert_file", &jso2)) {
-        out->ek_cert_file = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "ek_cert_file", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->ek_cert_file);
         return_if_error(r, "Bad value for field \"ek_cert_file\".");
     }
@@ -120,9 +114,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
         out->ek_fingerprint.hashAlg = 0;
     }
 
-    if (!ifapi_get_sub_object(jso, "intel_cert_service", &jso2)) {
-        out->intel_cert_service = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "intel_cert_service", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->intel_cert_service);
         return_if_error(r, "Bad value for field \"intel_cert_service\".");
     }


### PR DESCRIPTION
`out` needs to be fully initialised from the beginning because the `ifapi_json_IFAPI_CONFIG_deserialize` function [uses `return_if_error`](https://github.com/tpm2-software/tpm2-tss/blob/b211887403f646a7d09be1059a94ed943955c9b7/src/tss2-fapi/ifapi_config.c#L56), potentially leaving the struct only partly initialised when there is an error during JSON deserialisation. This causes a problem as `ifapi_config_initialize_finish` [tries to free all struct members in case of an error](https://github.com/tpm2-software/tpm2-tss/blob/b211887403f646a7d09be1059a94ed943955c9b7/src/tss2-fapi/ifapi_config.c#L260-L268). Attempting to free an uninitialised pointer can lead to a segfault crash.

This can be observed when running the [`fapi-config` unit test](https://github.com/tpm2-software/tpm2-tss/blob/master/test/unit/fapi-config.c) inside a systemd-nspawn container on Arch Linux, where the [`check_config_json_remove_field_not_allowed`](https://github.com/tpm2-software/tpm2-tss/blob/b211887403f646a7d09be1059a94ed943955c9b7/test/unit/fapi-config.c#L135) test crashes, leading to a test failure.