### PR TITLE
ci/cirrus: drop IGNORE_OSVERSION and set to 12-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,8 @@ task:
     ibmtpm_name: ibmtpm1637
   freebsd_instance:
     matrix:
-      image_family: freebsd-12-1-snap
+      image_family: freebsd-12-2
   install_script:
-    - export IGNORE_OSVERSION=yes
     - pkg update -f
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive


### PR DESCRIPTION
Rather than ignoring an error, set to the newest stable FreeBSD cirrus
version of 12-2. This seems to avoid the package/kernel mismatch errors.

Signed-off-by: William Roberts <william.c.roberts@intel.com>