### PR TITLE
FAPI: Several backport fixes for 2.4.x

### DIFF
--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -44,28 +44,24 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
     return_if_null(out, "out is NULL", TSS2_FAPI_RC_BAD_REFERENCE);
     return_if_null(jso, "jso is NULL", TSS2_FAPI_RC_BAD_REFERENCE);
 
+    memset(out, 0, sizeof(IFAPI_CONFIG));
+
     /* Deserialize the JSON object) */
     json_object *jso2;
     TSS2_RC r;
     LOG_TRACE("call");
 
-    if (!ifapi_get_sub_object(jso, "profile_dir", &jso2)) {
-        out->profile_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "profile_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->profile_dir);
         return_if_error(r, "BAD VALUE");
     }
 
-    if (!ifapi_get_sub_object(jso, "user_dir", &jso2)) {
-        out->user_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "user_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->user_dir);
         return_if_error(r, "BAD VALUE");
     }
 
-    if (!ifapi_get_sub_object(jso, "system_dir", &jso2)) {
-        out->keystore_dir = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "system_dir", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->keystore_dir);
         return_if_error(r, "BAD VALUE");
     }
@@ -98,9 +94,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
     r = ifapi_json_TPML_PCR_SELECTION_deserialize(jso2, &out->system_pcrs);
     return_if_error(r, "BAD VALUE");
 
-    if (!ifapi_get_sub_object(jso, "ek_cert_file", &jso2)) {
-        out->ek_cert_file = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "ek_cert_file", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->ek_cert_file);
         return_if_error(r, "BAD VALUE");
     }
@@ -120,9 +114,7 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
         out->ek_fingerprint.hashAlg = 0;
     }
 
-    if (!ifapi_get_sub_object(jso, "intel_cert_service", &jso2)) {
-        out->intel_cert_service = NULL;
-    } else {
+    if (ifapi_get_sub_object(jso, "intel_cert_service", &jso2)) {
         r = ifapi_json_char_deserialize(jso2, &out->intel_cert_service);
         return_if_error(r, "BAD VALUE");
     }

--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -71,7 +71,8 @@ ifapi_json_IFAPI_CONFIG_deserialize(json_object *jso, IFAPI_CONFIG *out)
     }
 
     if (!ifapi_get_sub_object(jso, "log_dir", &jso2)) {
-        out->log_dir = DEFAULT_LOG_DIR;
+        out->log_dir = strdup(DEFAULT_LOG_DIR);
+        return_if_null(jso, "Out of memory.", TSS2_FAPI_RC_MEMORY);
     } else {
         r = ifapi_json_char_deserialize(jso2, &out->log_dir);
         return_if_error(r, "BAD VALUE");

--- a/src/tss2-fapi/ifapi_get_intl_cert.c
+++ b/src/tss2-fapi/ifapi_get_intl_cert.c
@@ -306,9 +306,10 @@ ifapi_get_intl_ek_certificate(FAPI_CONTEXT *context, TPM2B_PUBLIC *ek_public,
 {
     int rc = 1;
     unsigned char *hash = hash_ek_public(ek_public);
-    char *cert_ptr;
+    char *cert_ptr = NULL;
     char *cert_start = NULL, *cert_bin = NULL;
     char *b64 = base64_encode(hash);
+    *cert_buffer = NULL;
 
     if (!b64) {
         LOG_ERROR("base64_encode returned null");
@@ -375,6 +376,8 @@ out:
     if (rc == 0) {
         return TSS2_RC_SUCCESS;
     } else {
+        SAFE_FREE(cert_bin);
+        SAFE_FREE(cert_ptr);
         LOG_ERROR("Get INTEL EK certificate.");
         return TSS2_FAPI_RC_NO_CERT;
     }

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -1182,7 +1182,9 @@ ifapi_exec_auth_policy(
     }
 cleanup:
     SAFE_FREE(names);
-    cleanup_policy_list(current_policy->policy_list);
+    /* Check whether cleanup was executed. */
+    if (fapi_ctx->policy.policyutil_stack)
+        cleanup_policy_list(current_policy->policy_list);
     return r;
 }
 

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -169,24 +169,26 @@ ifapi_profiles_initialize_finish(
     free(buffer);
     if (jso == NULL) {
         LOG_ERROR("Failed to parse profile %s", profiles->filenames[profiles->profiles_idx]);
-        return TSS2_FAPI_RC_BAD_VALUE;
+        r = TSS2_FAPI_RC_BAD_VALUE;
+        goto error;
     }
 
     r = ifapi_profile_json_deserialize(jso,
             &profiles->profiles[profiles->profiles_idx].profile);
     json_object_put(jso);
-    return_if_error2(r, "Parsing profile %s failed",
-                     profiles->filenames[profiles->profiles_idx]);
+    goto_if_error2(r, "Parsing profile %s failed", error,
+                   profiles->filenames[profiles->profiles_idx]);
 
     r = ifapi_profile_checkpcrs(&profiles->profiles[profiles->profiles_idx].profile.pcr_selection);
-    return_if_error2(r, "Malformed profile pcr selection for profile %s",
-                     profiles->filenames[profiles->profiles_idx]);
+    goto_if_error2(r, "Malformed profile pcr selection for profile %s", error,
+                   profiles->filenames[profiles->profiles_idx]);
 
     profiles->profiles_idx += 1;
 
     if (profiles->profiles_idx < profiles->num_profiles) {
         r = ifapi_io_read_async(io, profiles->filenames[profiles->profiles_idx]);
-        return_if_error2(r, "Reading profile %s", profiles->filenames[profiles->profiles_idx]);
+        goto_if_error2(r, "Reading profile %s", error,
+                       profiles->filenames[profiles->profiles_idx]);
 
         return TSS2_FAPI_RC_TRY_AGAIN;
     }
@@ -201,7 +203,8 @@ ifapi_profiles_initialize_finish(
     if (i == profiles->num_profiles) {
         LOG_ERROR("Default profile %s not in the list of loaded profiles",
                   profiles->default_name);
-        return TSS2_FAPI_RC_BAD_VALUE;
+        r = TSS2_FAPI_RC_BAD_VALUE;
+        goto error;
     }
 
     for (i = 0; i < profiles->num_profiles; i++) {
@@ -210,6 +213,14 @@ ifapi_profiles_initialize_finish(
     SAFE_FREE(profiles->filenames);
 
     return TSS2_RC_SUCCESS;
+
+ error:
+    for (i = 0; i < profiles->num_profiles; i++) {
+        SAFE_FREE(profiles->filenames[i]);
+    }
+    SAFE_FREE(profiles->filenames);
+    ifapi_profiles_finalize(profiles);
+    return r;
 }
 
 /** Return the profile data for a given profile name.
@@ -333,6 +344,7 @@ ifapi_profile_json_deserialize(
     };
 
     LOG_TRACE("call");
+    memset(out, 0, sizeof(IFAPI_PROFILE));
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
     if (!ifapi_get_sub_object(jso, "type", &jso2)) {


### PR DESCRIPTION
* Fix error cleanup for key loading and policy execution.
* Fix initialization of default log_dir.
* Fix cleanup in several error cases.
* initialise 'out' parameter in ifapi_json_IFAPI_CONFIG_deserialize

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
