### PR TITLE
FAPI: Add integration test for Esys_EncryptDecrypt2.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -258,6 +258,7 @@ ESYS_TESTS_INTEGRATION_OPTIONAL = \
     test/integration/esys-createloaded-session.int \
     test/integration/esys-duplicate.int \
     test/integration/esys-encrypt-decrypt.int \
+    test/integration/esys-encrypt-decrypt2.int \
     test/integration/esys-get-time.int \
     test/integration/esys-hierarchy-control.int \
     test/integration/esys-nv-certify.int \
@@ -1058,6 +1059,14 @@ test_integration_esys_encrypt_decrypt_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_encrypt_decrypt_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_encrypt_decrypt_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_encrypt_decrypt_int_SOURCES = \
+    test/integration/esys-encrypt-decrypt.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_encrypt_decrypt2_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTEST_ENCRYPT_DECRYPT2
+test_integration_esys_encrypt_decrypt2_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_encrypt_decrypt2_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_encrypt_decrypt2_int_SOURCES = \
     test/integration/esys-encrypt-decrypt.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
 

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -242,6 +242,22 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
         .buffer = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16}
     };
 
+#ifdef TEST_ENCRYPT_DECRYPT2
+    LOG_INFO("Test Esys_EncryptDecrypt2");
+    r = Esys_EncryptDecrypt2(
+        esys_context,
+        keyHandle_handle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &inData,
+        encrypt,
+        mode,
+        &ivIn,
+        &outData,
+        &ivOut);
+#else
+    LOG_INFO("Test Esys_EncryptDecrypt");
     r = Esys_EncryptDecrypt(
         esys_context,
         keyHandle_handle,
@@ -254,6 +270,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
         &inData,
         &outData,
         &ivOut);
+#endif  /* TEST_ENCRYPT_DECRYPT2 */
 
     if ((r == TPM2_RC_COMMAND_CODE) ||
         (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
@@ -265,7 +282,20 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error: EncryptDecrypt", error);
 
-
+#ifdef TEST_ENCRYPT_DECRYPT2
+      r = Esys_EncryptDecrypt2(
+        esys_context,
+        keyHandle_handle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        outData,
+        decrypt,
+        mode,
+        &ivIn,
+        &outData2,
+        &ivOut2);
+#else
     r = Esys_EncryptDecrypt(
         esys_context,
         keyHandle_handle,
@@ -278,6 +308,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
         outData,
         &outData2,
         &ivOut2);
+#endif /* TEST_ENCRYPT_DECRYPT2 */
 
     if ((r == TPM2_RC_COMMAND_CODE) ||
         (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||


### PR DESCRIPTION
The integration test Esys_EncryptDecrypt was extended to test also
Esys_EncryptDecrypt2.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>