### PR TITLE
log: add support for logging to a file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,13 @@ AX_VALGRIND_CHECK
 
 gl_LD_VERSION_SCRIPT
 
+AC_ARG_ENABLE([log-file],
+            [AS_HELP_STRING([--disable-log-file],
+                            [write logging to stderr only])],,
+            [enable_log_file=yes])
+AS_IF([test "x$enable_log_file" != xno],
+	[AC_DEFINE([LOG_FILE_ENABLED],[1], [Support for writing to a log file is enabled])])
+
 AC_ARG_WITH([maxloglevel],
             [AS_HELP_STRING([--with-maxloglevel={none,error,warning,info,debug,trace}],
                             [sets the maximum log level (default is trace)])],,

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -6,7 +6,7 @@ disable the overhead code and reduce overall code size.
 # Runtime log level
 
 At runtime, the log level is determined by an environment variable. The default
-log level is WARNING. The level can be changed by setting the TSS2_LOG
+log level is WARNING. The level can be changed by setting the `TSS2_LOG`
 environment variable.
 
 Possible levels are: NONE, ERROR, WARNING, INFO, DEBUG, TRACE
@@ -15,6 +15,16 @@ The level can be set for all module using the `all` module name or individually
 per module. The environment variable is evaluated left to right.
 
 Example: `TSS2_LOG=all+ERROR,marshal+TRACE,tcti+DEBUG`
+
+# Log file
+
+By default, logs are written to standard error (`stderr`). If the environment
+variable `TSS2_LOGFILE` is set, the TSS will log to the file at the given path
+instead. If the file does not yet exist, it will be created. Otherwise, the TSS
+will append to it.
+
+The special value `stderr` will result in default behavior while `stdout` and
+`-` will have the TSS write to standard output.
 
 # Implementation
 


### PR DESCRIPTION
Add support for logging to a file specified via the env variable `TSS2_LOGFILE`. Log file support can be disabled via the configure flag `--disable-log-file.`

Creates the log file if it does not exist, appends to it otherwise. Prints to stderr if the file cannot be opened.

Examples:
   * `TSS2_LOGFILE=tpm2-tss.log ./test/integration/esys-get-random.int`
   * `TSS2_LOGFILE=stderr ./test/integration/esys-get-random.int`
   * `TSS2_LOGFILE=stdout ./test/integration/esys-get-random.int`
   * `TSS2_LOGFILE=- ./test/integration/esys-get-random.int`

Signed-off-by: Johannes Holland <johannes.holland@infineon.com>