### PR TITLE
marshal: remove double define

### DIFF
--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -21,20 +21,6 @@ extern "C" {
 #endif
 
 TSS2_RC
-Tss2_MU_BYTE_Marshal(
-    BYTE           src,
-    uint8_t         buffer[],
-    size_t          buffer_size,
-    size_t         *offset);
-
-TSS2_RC
-Tss2_MU_BYTE_Unmarshal(
-    uint8_t const   buffer[],
-    size_t          buffer_size,
-    size_t         *offset,
-    BYTE           *dest);
-
-TSS2_RC
 Tss2_MU_INT8_Marshal(
     INT8            src,
     uint8_t         buffer[],


### PR DESCRIPTION
Remove double define from API header `tss2/tss2_mu.h`.

They are also defined here:
https://github.com/tpm2-software/tpm2-tss/blob/27d3bd8295a58d5788cf4ea220f614603d5c2fee/include/tss2/tss2_mu.h#L1998-L2010