### PR TITLE
Fix TOP_SOURCEDIR undeclared error when enable unit test checks only

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -128,6 +128,7 @@ TESTS_UNIT += \
 
 endif ESYS
 if FAPI
+TESTS_CFLAGS +=  -DTOP_SOURCEDIR"=\"$(top_srcdir)\""
 TESTS_UNIT += \
     test/unit/fapi-json \
     test/unit/fapi-helpers \


### PR DESCRIPTION
When we enable unit tests only but not integration tests there will be a ‘TOP_SOURCEDIR’ undeclared error
 
See below

#./configure --enable-unit
#make check -j1
make  test/unit/CommonPreparePrologue test/unit/CopyCommandHeader test/unit/io test/unit/key-value-parse test/unit/log test/unit/tctildr test/unit/tctildr-dl test/unit/tctildr-nodl test/unit/tctildr-tcti test/unit/tctildr-getinfo test/unit/UINT8-marshal test/unit/UINT16-marshal test/unit/UINT32-marshal test/unit/UINT64-marshal test/unit/TPMA-marshal test/unit/TPM2B-marshal test/unit/TPMS-marshal test/unit/TPML-marshal test/unit/TPMT-marshal test/unit/TPMU-marshal test/unit/sys-execute test/unit/tss2_rc test/unit/tcti-mssim test/unit/tcti-swtpm test/unit/tcti-device test/unit/tcti-pcap test/unit/tcti-cmd test/unit/esys-context-null test/unit/esys-resubmissions test/unit/esys-sequence-finish test/unit/esys-tcti-rcs test/unit/esys-tpm-rcs test/unit/esys-getpollhandles test/unit/esys-nulltcti test/unit/esys-crypto test/unit/fapi-json test/unit/fapi-helpers test/unit/fapi-io test/unit/fapi-profiles test/unit/fapi-config test/unit/fapi-get-intl-cert  test/helper/tpm_cmd_tcti_dummy     
make[1]: Entering directory '/tmp/tpm2-tss'
  CC       test/unit/CommonPreparePrologue-CommonPreparePrologue.o
  CC       src/tss2-sys/test_unit_CommonPreparePrologue-sysapi_util.o
  CCLD     test/unit/CommonPreparePrologue
  CC       test/unit/CopyCommandHeader-CopyCommandHeader.o
  CC       src/tss2-sys/test_unit_CopyCommandHeader-sysapi_util.o
  CCLD     test/unit/CopyCommandHeader
  CC       test/unit/io-io.o
  CCLD     test/unit/io
  CC       test/unit/key_value_parse-key-value-parse.o
  CCLD     test/unit/key-value-parse
  CC       test/unit/log-log.o
  CCLD     test/unit/log
  CC       test/unit/tctildr-tctildr.o
  CC       src/tss2-tcti/test_unit_tctildr-tctildr.o
  CCLD     test/unit/tctildr
  CC       test/unit/tctildr_dl-tctildr-dl.o
  CC       src/tss2-tcti/test_unit_tctildr_dl-tctildr-dl.o
  CCLD     test/unit/tctildr-dl
  CC       test/unit/tctildr_nodl-tctildr-nodl.o
  CC       src/tss2-tcti/test_unit_tctildr_nodl-tctildr-nodl.o
  CCLD     test/unit/tctildr-nodl
  CC       test/unit/tctildr_tcti-tctildr-tcti.o
  CC       src/tss2-tcti/test_unit_tctildr_tcti-tctildr.o
  CCLD     test/unit/tctildr-tcti
  CC       test/unit/tctildr_getinfo-tctildr-getinfo.o
  CC       src/tss2-tcti/test_unit_tctildr_getinfo-tctildr.o
  CCLD     test/unit/tctildr-getinfo
  CC       test/unit/UINT8_marshal-UINT8-marshal.o
  CCLD     test/unit/UINT8-marshal
  CC       test/unit/UINT16_marshal-UINT16-marshal.o
  CCLD     test/unit/UINT16-marshal
  CC       test/unit/UINT32_marshal-UINT32-marshal.o
  CCLD     test/unit/UINT32-marshal
  CC       test/unit/UINT64_marshal-UINT64-marshal.o
  CCLD     test/unit/UINT64-marshal
  CC       test/unit/TPMA_marshal-TPMA-marshal.o
  CCLD     test/unit/TPMA-marshal
  CC       test/unit/TPM2B_marshal-TPM2B-marshal.o
  CCLD     test/unit/TPM2B-marshal
  CC       test/unit/TPMS_marshal-TPMS-marshal.o
  CCLD     test/unit/TPMS-marshal
  CC       test/unit/TPML_marshal-TPML-marshal.o
  CCLD     test/unit/TPML-marshal
  CC       test/unit/TPMT_marshal-TPMT-marshal.o
  CCLD     test/unit/TPMT-marshal
  CC       test/unit/TPMU_marshal-TPMU-marshal.o
  CCLD     test/unit/TPMU-marshal
  CC       test/unit/sys_execute-sys-execute.o
  CC       src/tss2-tcti/test_unit_sys_execute-tcti-common.o
  CC       src/util/test_unit_sys_execute-log.o
  CCLD     test/unit/sys-execute
  CC       test/unit/tss2_rc-test_tss2_rc.o
  CCLD     test/unit/tss2_rc
  CC       test/unit/tcti_mssim-tcti-mssim.o
  CC       src/tss2-tcti/test_unit_tcti_mssim-tcti-common.o
  CC       src/tss2-tcti/test_unit_tcti_mssim-tcti-mssim.o
  CCLD     test/unit/tcti-mssim
  CC       test/unit/tcti_swtpm-tcti-swtpm.o
  CC       src/tss2-tcti/test_unit_tcti_swtpm-tcti-common.o
  CC       src/tss2-tcti/test_unit_tcti_swtpm-tcti-swtpm.o
  CCLD     test/unit/tcti-swtpm
  CC       test/unit/tcti_device-tcti-device.o
  CC       src/tss2-tcti/test_unit_tcti_device-tcti-common.o
  CC       src/tss2-tcti/test_unit_tcti_device-tcti-device.o
  CCLD     test/unit/tcti-device
  CC       test/unit/tcti_pcap-tcti-pcap.o
  CC       src/tss2-tcti/test_unit_tcti_pcap-tcti-common.o
  CC       src/tss2-tcti/test_unit_tcti_pcap-tcti-pcap.o
  CC       src/tss2-tcti/test_unit_tcti_pcap-tcti-pcap-builder.o
  CCLD     test/unit/tcti-pcap
  CC       test/unit/tcti_cmd-tcti-cmd.o
  CC       src/tss2-tcti/test_unit_tcti_cmd-tcti-common.o
  CC       src/tss2-tcti/test_unit_tcti_cmd-tcti-cmd.o
  CCLD     test/unit/tcti-cmd
  CC       test/unit/esys_context_null-esys-context-null.o
  CCLD     test/unit/esys-context-null
  CC       test/unit/esys_resubmissions-esys-resubmissions.o
  CC       src/tss2-esys/test_unit_esys_resubmissions-esys_iutil.o
  CC       src/tss2-esys/test_unit_esys_resubmissions-esys_crypto.o
  CC       src/tss2-esys/test_unit_esys_resubmissions-esys_crypto_ossl.o
  CCLD     test/unit/esys-resubmissions
  CC       test/unit/esys_sequence_finish-esys-sequence-finish.o
  CCLD     test/unit/esys-sequence-finish
  CC       test/unit/esys_tcti_rcs-esys-tcti-rcs.o
  CC       src/tss2-esys/test_unit_esys_tcti_rcs-esys_iutil.o
  CC       src/tss2-esys/test_unit_esys_tcti_rcs-esys_crypto.o
  CC       src/tss2-esys/test_unit_esys_tcti_rcs-esys_crypto_ossl.o
  CCLD     test/unit/esys-tcti-rcs
  CC       test/unit/esys_tpm_rcs-esys-tpm-rcs.o
  CC       src/tss2-esys/test_unit_esys_tpm_rcs-esys_iutil.o
  CC       src/tss2-esys/test_unit_esys_tpm_rcs-esys_crypto.o
  CC       src/tss2-esys/test_unit_esys_tpm_rcs-esys_crypto_ossl.o
  CCLD     test/unit/esys-tpm-rcs
  CC       test/unit/esys_getpollhandles-esys-getpollhandles.o
  CCLD     test/unit/esys-getpollhandles
  CC       test/unit/esys_nulltcti-esys-nulltcti.o
  CC       src/tss2-esys/test_unit_esys_nulltcti-esys_context.o
  CC       src/tss2-esys/test_unit_esys_nulltcti-esys_iutil.o
  CC       src/tss2-esys/test_unit_esys_nulltcti-esys_crypto.o
  CC       src/tss2-esys/test_unit_esys_nulltcti-esys_crypto_ossl.o
  CCLD     test/unit/esys-nulltcti
  CC       test/unit/esys_crypto-esys-crypto.o
  CC       src/tss2-esys/test_unit_esys_crypto-esys_context.o
  CC       src/tss2-esys/test_unit_esys_crypto-esys_iutil.o
  CC       src/tss2-tcti/test_unit_esys_crypto-tctildr.o
  CC       src/tss2-tcti/test_unit_esys_crypto-tctildr-dl.o
  CC       src/tss2-esys/test_unit_esys_crypto-esys_crypto.o
  CC       src/tss2-esys/test_unit_esys_crypto-esys_crypto_ossl.o
  CCLD     test/unit/esys-crypto
  CC       test/unit/fapi_json-fapi-json.o
  CC       src/tss2-fapi/test_unit_fapi_json-ifapi_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_json-ifapi_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_json-ifapi_policy_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_json-ifapi_policy_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_json-tpm_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_json-tpm_json_serialize.o
  CCLD     test/unit/fapi-json
  CC       test/unit/fapi_helpers-fapi-helpers.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_policy_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_policy_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-tpm_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-tpm_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-fapi_crypto.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_eventlog.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_helpers.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_keystore.o
  CC       src/tss2-fapi/test_unit_fapi_helpers-ifapi_io.o
  CCLD     test/unit/fapi-helpers
  CC       test/unit/fapi_io-fapi-io.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_policy_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_policy_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-tpm_json_deserialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-tpm_json_serialize.o
  CC       src/tss2-fapi/test_unit_fapi_io-fapi_crypto.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_eventlog.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_helpers.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_keystore.o
  CC       src/tss2-fapi/test_unit_fapi_io-ifapi_io.o
  CCLD     test/unit/fapi-io
  CC       test/unit/fapi_profiles-fapi-profiles.o
test/unit/fapi-profiles.c: In function ‘read_json’:
test/unit/fapi-profiles.c:52:34: error: ‘TOP_SOURCEDIR’ undeclared (first use in this function)
   52 |     if (snprintf(&file[0], 1023, TOP_SOURCEDIR "/%s", file_name) < 0)
      |                                  ^~~~~~~~~~~~~
test/unit/fapi-profiles.c:52:34: note: each undeclared identifier is reported only once for each function it appears in
test/unit/fapi-profiles.c:52:47: error: expected ‘)’ before string constant
   52 |     if (snprintf(&file[0], 1023, TOP_SOURCEDIR "/%s", file_name) < 0)
      |                                               ^~~~~~
      |                                               )
make[1]: *** [Makefile:25756: test/unit/fapi_profiles-fapi-profiles.o] Error 1
make[1]: Leaving directory '/tmp/tpm2-tss'
make: *** [Makefile:27396: check-am] Error 2
