### PR TITLE
CI: Add m4 to package list for cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ task:
   install_script:
     - pkg update -f
     - pkg upgrade -y
-    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive
+    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive m4
     - pkg install -y automake openssl json-c cmocka uthash wget curl git
     - wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
     - shasum -a256 $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327


### PR DESCRIPTION
A newer m4 version was needed by autom4te.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>