### PR TITLE
CI: Add m4 to package list for cirrus ci 2.4.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
       image: freebsd-12-1-release-amd64
   install_script:
     - pkg upgrade -y
-    - pkg install -y gmake coreutils libtool pkgconf autoconf autoconf-archive
+    - pkg install -y gmake coreutils libtool pkgconf autoconf autoconf-archive m4
     - pkg install -y automake libgcrypt openssl json-c cmocka uthash wget
     - wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
     - shasum -a256 $ibmtpm_name.tar.gz | grep ^b9eef79904e276aeaed2a6b9e4021442ef4d7dfae4adde2473bef1a6a4cd10fb


### PR DESCRIPTION
A newer m4 version was needed by autom4te.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>