### PR TITLE
FAPI: Fix reading of the root certificate for provisioning.

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -64,14 +64,14 @@ if [ "$CC" == "gcc" ]; then
 fi
 
 if [ "$SCANBUILD" == "yes" ]; then
-  scan-build --status-bugs ../configure --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+  scan-build --status-bugs ../configure --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 elif [ "$CC" == "clang" ]; then
-  ../configure --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+  ../configure --enable-unit --enable-self-generated-certificate  --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 else
   if [ "$WITH_TCTI" == "mssim" ]; then
-    ../configure --with-sanitizer=undefined,address --disable-tcti-swtpm --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+    ../configure --with-sanitizer=undefined,address --disable-tcti-swtpm --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
   else
-    ../configure --with-sanitizer=undefined,address --enable-unit --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+    ../configure --with-sanitizer=undefined,address --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
   fi
 fi
 
@@ -91,34 +91,34 @@ pushd ./config_test
 if [ "$CC" == "gcc" ]; then
   # No TCTI - expect to fail
   echo "========================== START TEST - NO TCTI =========================="
-  (../configure --disable-doxygen-doc --enable-unit --enable-integration --disable-tcti-swtpm --disable-tcti-mssim --disable-tcti-device && exit 1) || echo "failed as expected";
+  (../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --disable-tcti-swtpm --disable-tcti-mssim --disable-tcti-device && exit 1) || echo "failed as expected";
   # only device TCTI
   echo "========================== START TEST - device TCTI =========================="
-  mkdir -p ./dev/tpm0 && ../configure --disable-doxygen-doc --enable-unit --enable-integration --disable-tcti-swtpm --disable-tcti-mssim --enable-tcti-device --with-device=./dev/tpm0
+  mkdir -p ./dev/tpm0 && ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --disable-tcti-swtpm --disable-tcti-mssim --enable-tcti-device --with-device=./dev/tpm0
   make -j check TESTS="test/unit/tcti-device" && rm -rf ./dev
   # only mssim TCTI
   echo "========================== START TEST - mssim TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --disable-tcti-swtpm --enable-tcti-mssim --disable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --disable-tcti-swtpm --enable-tcti-mssim --disable-tcti-device
   make -j check TESTS="test/unit/tcti-mssim"
   # device and mssim TCTIs
   echo "========================== START TEST - mssim & device TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --disable-tcti-swtpm --enable-tcti-mssim --enable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --disable-tcti-swtpm --enable-tcti-mssim --enable-tcti-device
   make -j check TESTS="test/unit/tcti-device test/unit/tcti-mssim"
   # only swtmp TCTI
   echo "========================== START TEST - swtpm TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --enable-tcti-swtpm --disable-tcti-mssim --disable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --enable-tcti-swtpm --disable-tcti-mssim --disable-tcti-device
   make -j check TESTS="test/unit/tcti-swtpm"
   # swtmp and device TCTIs
   echo "========================== START TEST - swtpm & device TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --enable-tcti-swtpm --disable-tcti-mssim --enable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --enable-tcti-swtpm --disable-tcti-mssim --enable-tcti-device
   make -j check TESTS="test/unit/tcti-swtpm test/unit/tcti-device"
   # swtmp and mssim TCTIs
   echo "========================== START TEST - swtpm & mssim TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --enable-tcti-swtpm --enable-tcti-mssim --disable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --enable-tcti-swtpm --enable-tcti-mssim --disable-tcti-device
   make -j check TESTS="test/unit/tcti-swtpm test/unit/tcti-mssim"
   # all TCTIs
   echo "========================== START TEST - swtpm & mssim & device TCTI =========================="
-  ../configure --disable-doxygen-doc --enable-unit --enable-integration --enable-tcti-swtpm --enable-tcti-mssim --enable-tcti-device
+  ../configure --disable-doxygen-doc --enable-unit --enable-self-generated-certificate --enable-integration --enable-tcti-swtpm --enable-tcti-mssim --enable-tcti-device
   make -j check TESTS="test/unit/tcti-swtpm test/unit/tcti-mssim test/unit/tcti-device"
 fi # CC == gcc
 popd

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,5 +23,5 @@ task:
     - rm -fr $ibmtpm_name $ibmtpm_name.tar.gz
   script:
     ./bootstrap &&
-    ./configure --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-mssim=yes --disable-dependency-tracking &&
+    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-mssim=yes --disable-dependency-tracking &&
     gmake -j distcheck || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }

--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,14 @@ AC_ARG_ENABLE([weakcrypto],
 AS_IF([test "x$enable_weakcrypto" = "xyes"],
 	[AC_DEFINE([DISABLE_WEAK_CRYPTO],[1],[DISABLE WEAK CRYPTO ALGORITHMS])])
 
+AC_ARG_ENABLE([self-generated-certificate],
+            [AS_HELP_STRING([--enable-self-generated-certificate],
+                            [Alllow usage of self generated root certifcate])],,
+            [enable_self_generated_certificate=no])
+AS_IF([test "x$enable_self_generated_certificate" == xyes],
+	[AC_DEFINE([SELF_GENERATED_CERTIFICATE],[1], [Allow usage of self generated root certifcate])])
+
+
 AC_SUBST([PATH])
 
 dnl --------- Doxy Gen -----------------------

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -797,7 +797,11 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_PREPARE_READ_ROOT_CERT);
             /* Prepare reading of root certificate. */
+            root_ca_file = NULL;
+#ifdef SELF_GENERATED_CERTIFICATE
+#pragma message ( "*** Allow self generated certifcate ***" )
             root_ca_file = getenv("FAPI_TEST_ROOT_CERT");
+#endif
             if (!root_ca_file) {
                 context->state = PROVISION_EK_CHECK_CERT;
                 return TSS2_FAPI_RC_TRY_AGAIN;


### PR DESCRIPTION
* The root certificate defined by the environment variable FAPI_TEST_ROOT_CERT will
  only be used if it's allowed to use self generated root certificate with
  ./configure  --enable-self-generated-certificate

* This option is added to all integration tests which are using the TPM simulator.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>