### PR TITLE
Add tct-libtpms

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,5 +23,5 @@ task:
     - rm -fr $ibmtpm_name $ibmtpm_name.tar.gz
   script:
     ./bootstrap &&
-    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-mssim=yes --disable-dependency-tracking &&
+    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-libtpms=no --enable-tcti-mssim=yes --disable-dependency-tracking &&
     gmake -j distcheck || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,17 @@
 extraction:
   cpp:
     prepare:
-      packages: "autoconf-archive"
+      packages:
+      - autoconf-archive
+      - libssl-dev
+    after_prepare:
+    - cd "$LGTM_WORKSPACE"
+    - mkdir installdir
+    - git clone https://github.com/stefanberger/libtpms.git
+    - cd libtpms
+    - ./bootstrap.sh
+    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr"
+    - make install
+    - export PKG_CONFIG_PATH="$LGTM_WORKSPACE/installdir/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
+    - export LD_LIBRARY_PATH="$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"
+    - export C_INCLUDE_PATH="$LGTM_WORKSPACE/installdir/usr/include/";

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -105,6 +105,9 @@ endif
 if ENABLE_TCTI_SWTPM
 TESTS_UNIT += test/unit/tcti-swtpm
 endif
+if ENABLE_TCTI_LIBTPMS
+TESTS_UNIT += test/unit/tcti-libtpms
+endif
 if ENABLE_TCTI_DEVICE
 TESTS_UNIT += test/unit/tcti-device
 endif
@@ -420,6 +423,17 @@ test_unit_tcti_swtpm_LDFLAGS = -Wl,--wrap=connect,--wrap=read,--wrap=select,--wr
 test_unit_tcti_swtpm_SOURCES = test/unit/tcti-swtpm.c \
     src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-swtpm.c src/tss2-tcti/tcti-swtpm.h
+endif
+
+if ENABLE_TCTI_LIBTPMS
+test_unit_tcti_libtpms_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_libtpms_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil) $(LIBADD_DL)
+test_unit_tcti_libtpms_LDFLAGS = -Wl,--wrap=dlopen,--wrap=dlclose,--wrap=dlsym \
+    -Wl,--wrap=open,--wrap=close,--wrap=mmap,--wrap=mremap,--wrap=munmap \
+    -Wl,--wrap=lseek,--wrap=posix_fallocate,--wrap=truncate
+test_unit_tcti_libtpms_SOURCES = test/unit/tcti-libtpms.c \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-libtpms.c src/tss2-tcti/tcti-libtpms.h
 endif
 
 if ENABLE_TCTI_PCAP

--- a/Makefile.am
+++ b/Makefile.am
@@ -352,6 +352,24 @@ src_tss2_tcti_libtss2_tcti_pcap_la_SOURCES  = \
     src/tss2-tcti/tcti-pcap.c
 endif # ENABLE_TCTI_PCAP
 
+# tcti libtpms library
+if ENABLE_TCTI_LIBTPMS
+libtss2_tcti_libtpms = src/tss2-tcti/libtss2-tcti-libtpms.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_libtpms.h
+lib_LTLIBRARIES += $(libtss2_tcti_libtpms)
+pkgconfig_DATA += lib/tss2-tcti-libtpms.pc
+EXTRA_DIST += lib/tss2-tcti-libtpms.map
+
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_libtpms_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-libtpms.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_libtpms_la_LIBADD   = $(libtss2_tctildr) $(libutil)
+src_tss2_tcti_libtss2_tcti_libtpms_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-libtpms.c \
+    src/tss2-tcti/tcti-libtpms.h
+endif # ENABLE_TCTI_LIBTPMS
+
 # tcti library for sub-process commands
 if ENABLE_TCTI_CMD
 libtss2_tcti_cmd = src/tss2-tcti/libtss2-tcti-cmd.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -340,7 +340,7 @@ libtss2_tcti_pcap = src/tss2-tcti/libtss2-tcti-pcap.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_pcap.h
 lib_LTLIBRARIES += $(libtss2_tcti_pcap)
 pkgconfig_DATA += lib/tss2-tcti-pcap.pc
-EXTRA_DIST += lib/tss2-tcti-pcap.map # joho TODO enable tcti-pcap for Win (.def, visual studio files
+EXTRA_DIST += lib/tss2-tcti-pcap.map
 
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_tcti_libtss2_tcti_pcap_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-pcap.map

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-libtpms.pc lib/tss2-tcti-pcap.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -206,6 +206,15 @@ AC_ARG_ENABLE([tcti-pcap],
                             [don't build the tcti-pcap module])],,
             [enable_tcti_pcap=yes])
 AM_CONDITIONAL([ENABLE_TCTI_PCAP], [test "x$enable_tcti_pcap" != xno])
+
+AC_ARG_ENABLE([tcti-libtpms],
+            [AS_HELP_STRING([--disable-tcti-libtpms],
+                            [don't build the tcti-libtpms module])],
+            [AS_IF([test "x$enable_tcti_libtpms" = "xyes"],
+                   [AC_CHECK_HEADER(libtpms/tpm_library.h, [], [AC_MSG_ERROR([library libtpms missing])])])],
+            [AC_CHECK_HEADER(libtpms/tpm_library.h, [enable_tcti_libtpms=yes],
+                                                    [AC_MSG_WARN([library libtpms missing])])])
+AM_CONDITIONAL([ENABLE_TCTI_LIBTPMS], [test "x$enable_tcti_libtpms" != xno])
 
 AC_ARG_ENABLE([tcti-cmd],
             [AS_HELP_STRING([--disable-tcti-cmd],

--- a/include/tss2/tss2_tcti_libtpms.h
+++ b/include/tss2/tss2_tcti_libtpms.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ * All rights reserved.
+ */
+#ifndef TSS2_TCTI_LIBTPMS_H
+#define TSS2_TCTI_LIBTPMS_H
+
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Libtpms_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_LIBTPMS_H */

--- a/lib/tss2-tcti-libtpms.def
+++ b/lib/tss2-tcti-libtpms.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-libtpms
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Libtpms_Init

--- a/lib/tss2-tcti-libtpms.map
+++ b/lib/tss2-tcti-libtpms.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Libtpms_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-libtpms.pc.in
+++ b/lib/tss2-tcti-libtpms.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-libtpms
+Description: TCTI library for communicating with the libtpms library.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -ltss2-tcti-libtpms -L${libdir}

--- a/man/Tss2_Tcti_Libtpms_Init.3.in
+++ b/man/Tss2_Tcti_Libtpms_Init.3.in
@@ -1,0 +1,113 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH Tss2_Tcti_Libtpms_Init 3 "FEBRUARY 2021" "TPM2 Software Stack"
+.SH NAME
+Tss2_Tcti_Libtpms_Init \- Initialization function for the libtpms TPM simulator TCTI library.
+.SH SYNOPSIS
+.B #include <tcti/tcti_libtpms.h>
+.sp
+.BI "TSS2_RC Tss2_Tcti_Libtpms_Init (TSS2_TCTI_CONTEXT " "*tctiContext" ", size_t " "*contextSize" ", const char " "*conf" ");"
+.sp
+The
+.BR  Tss2_Tcti_Libtpms_Init ()
+function initializes a TCTI context used to communicate with the libtpms TPM2
+simulator.
+.SH DESCRIPTION
+.BR Tss2_Tcti_Libtpms_Init ()
+attempts to dynamically load the libtpms library and initialize a caller allocated
+.I tcti_context
+of size
+.I size
+\&. Since the
+.I tcti_context
+must be a caller allocated buffer, the caller needs to know the buffer size
+required by the TCTI library. The minimum size of this context can be
+discovered by providing
+.BR NULL
+for the
+.I tcti_context
+and a non-
+.BR NULL
+.I size
+parameter. The initialization function will then populate the
+.I size
+parameter with the minimum size of the
+.I tcti_context
+buffer. The caller must then allocate a buffer of this size (or larger) and
+call
+.B Tss2_Tcti_Libtpms_Init ()
+again providing the newly allocated
+.I tcti_context
+and the size of this context in the
+.I size
+parameter. This pattern is common to all TCTI initialization functions. We
+provide an example of this pattern using the
+.BR Tss2_Tcti_Libtpms_Init ()
+function in the section titled
+.B EXAMPLE.
+.sp
+The
+.I conf
+parameter can be used to specify the path to a state file (or NULL for none).
+.sp
+Once initialized, the TCTI context returned exposes the Trusted Computing
+Group (TCG) defined API for the lowest level communication with the TPM.
+Using this API the caller can exchange (send / receive) TPM2 command and
+response buffers with the libtpms TPM simulator. In nearly all cases however,
+the caller will initialize a context using this function before passing the
+context to a higher level API like the System API (SAPI), and then never touch
+it again.
+.sp
+For a more thorough discussion of the TCTI API see the \*(lqTSS System Level
+API and TPM Command Transmission Interface Specification\*(rq as published by
+the TCG:
+\%https://trustedcomputinggroup.org/tss-system-level-api-tpm-command-transmission-interface-specification/
+.SH RETURN VALUE
+A successful call to
+.BR Tss2_Tcti_Libtpms_Init ()
+will return
+.B TSS2_RC_SUCCESS.
+An unsuccessful call will produce a response code described in section
+.B ERRORS.
+.SH ERRORS
+.B TSS2_TCTI_RC_BAD_VALUE
+is returned if both the
+.I tcti_context
+and the
+.I size
+parameters are NULL.
+.SH EXAMPLE
+.sp
+TCTI initialization fragment:
+.sp
+.nf
+#include <inttypes.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <tcti/tcti_libtpms.h>
+
+TSS2_RC rc;
+TSS2_TCTI_CONTEXT *tcti_context;
+size_t size;
+
+rc = Tss2_Tcti_Libtpms_Init (NULL, &size, NULL);
+if (rc != TSS2_RC_SUCCESS) {
+    fprintf (stderr, "Failed to get allocation size for libtpms TCTI "
+             " context: 0x%" PRIx32 "\n", rc);
+    exit (EXIT_FAILURE);
+}
+tcti_context = calloc (1, size);
+if (tcti_context == NULL) {
+    fprintf (stderr, "Allocation for TCTI context failed: %s\n",
+             strerror (errno));
+    exit (EXIT_FAILURE);
+}
+rc = Tss2_Tcti_Libtpms_Init (&tcti_context, &size, "tpm2-state.bin");
+if (rc != TSS2_RC_SUCCESS) {
+    fprintf (stderr, "Failed to initialize libtpms TCTI context: "
+             "0x%" PRIx32 "\n", rc);
+    free (tcti_context);
+    exit (EXIT_FAILURE);
+}
+.fi

--- a/man/tss2-tcti-libtpms.7.in
+++ b/man/tss2-tcti-libtpms.7.in
@@ -1,0 +1,14 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-LIBTPMS 7 "FEBRUARY 2021" "TPM2 Software Stack"
+.SH NAME
+tcti-libtpms \- TPM simulator library TCTI library
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for interaction with the
+TPM2 simulator library libtpms.
+.SH DESCRIPTION
+tcti-libtpms is a library that abstracts the details of the API exposed
+by the libtpms library implementing the TPM2 reference implementation. The
+interface exposed by this library is defined in the \*(lqTSS System Level API
+and TPM Command Transmission Interface Specification\*(rq specification.

--- a/src/tss2-tcti/tcti-libtpms.c
+++ b/src/tss2-tcti/tcti-libtpms.c
@@ -1,0 +1,855 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2019, Fraunhofer SIT, Infineon Technologies AG, Intel Corporation
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <netinet/in.h>
+#include "tss2_tcti_libtpms.h"
+
+#include "tcti-libtpms.h"
+#include "tcti-common.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+/*
+ * libtpms API calls need to be wrapped. We set the current active TCTI module
+ * for this thread. This is needed because libtpms may call callbacks and these
+ * need to know which TCTI context they have to operate on.
+ *
+ * This macro assumes that int ret is declared. Jumps to fail_label on error. In
+ * this case, rc contains the respective error code.
+ */
+#define LIBTPMS_API_CALL(fail_label, tcti_libtpms, function, ...) \
+    current_tcti_libtpms = tcti_libtpms; \
+    ret = tcti_libtpms->function(__VA_ARGS__); \
+    if (ret != TPM_SUCCESS) { \
+        LOG_ERROR("libtpms function " #function "() failed with return code 0x%" PRIx32, ret); \
+        rc = TSS2_TCTI_RC_GENERAL_FAILURE; \
+        goto fail_label; \
+    } \
+    current_tcti_libtpms = NULL;
+
+static __thread TSS2_TCTI_LIBTPMS_CONTEXT *current_tcti_libtpms = NULL;
+
+/*
+ * Map the state file for this context into memory and allocate disk space. The
+ * file descriptor is closed again. Once this context reaches the end of its
+ * lifetime, the memory must be unmapped and the file must be truncated to its
+ * real size (rather than the allocated size).
+ */
+static TSS2_RC
+tcti_libtpms_map_state_file(TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms)
+{
+    TSS2_RC rc;
+    int ret;
+    int state_fd = -1;
+    ssize_t file_len = 0;
+
+    /* if no/empty state path, skip */
+    if (tcti_libtpms->state_path == NULL) {
+        LOG_DEBUG("No state path. Skip mapping state file.");
+        return TPM2_RC_SUCCESS;
+    }
+    LOG_DEBUG("Mapping state file: %s", tcti_libtpms->state_path);
+
+    tcti_libtpms->state_mmap_len = STATE_MMAP_CHUNK_LEN;
+
+    /* open file */
+    state_fd = open(tcti_libtpms->state_path, O_RDWR | O_CREAT, 0644);
+    if(state_fd == -1){
+        LOG_ERROR("open failed on file %s: %s",
+                    tcti_libtpms->state_path,
+                    strerror(errno));
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* get file size (to detect if state does already exist). */
+    file_len = lseek(state_fd, 0L, SEEK_END);
+    if(file_len < 0){
+        LOG_ERROR("lseek failed on file %s: %s",
+                    tcti_libtpms->state_path,
+                    strerror(errno));
+        rc = TSS2_TCTI_RC_IO_ERROR;
+        goto cleanup_fd;
+    }
+    tcti_libtpms->state_mmap_len = (file_len / STATE_MMAP_CHUNK_LEN + 1) * STATE_MMAP_CHUNK_LEN;
+
+    /* allocate disk space */
+    ret = posix_fallocate(state_fd, 0, tcti_libtpms->state_mmap_len);
+    if (ret != 0) {
+        LOG_ERROR("fallocate failed on file %s: %d",tcti_libtpms->state_path, ret);
+        rc = TSS2_TCTI_RC_IO_ERROR;
+        goto cleanup_fd;
+    }
+
+
+    /* map memory (either backed by file or not) */
+    tcti_libtpms->state_mmap = mmap(NULL,
+                                    tcti_libtpms->state_mmap_len,
+                                    PROT_READ | PROT_WRITE,
+                                    MAP_SHARED,
+                                    state_fd,
+                                    0);
+    if (tcti_libtpms->state_mmap == MAP_FAILED){
+        tcti_libtpms->state_mmap_len = 0;
+        LOG_ERROR("mmap failed on file %s: %s",
+                  tcti_libtpms->state_path,
+                  strerror(errno));
+        rc = TSS2_TCTI_RC_IO_ERROR;
+        goto cleanup_fd;
+    }
+
+    tcti_libtpms->state_len = file_len;
+
+    rc = TPM2_RC_SUCCESS;
+
+cleanup_fd:
+    if (state_fd != -1) {
+        /* file can always be closed, this does not unmap the region */
+        close(state_fd);
+    }
+
+    return rc;
+}
+
+/*
+ * If the mapped memory for the state file does not suffice, reallocate.
+ */
+static TSS2_RC
+tcti_libtpms_ensure_state_len(
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms,
+    size_t state_len)
+{
+    int ret;
+    char *new_state_mmap;
+    size_t new_state_mmap_len;
+    int state_fd;
+
+    if (state_len > tcti_libtpms->state_mmap_len)
+    {
+        new_state_mmap_len = (state_len / STATE_MMAP_CHUNK_LEN + 1) * STATE_MMAP_CHUNK_LEN;
+        LOG_DEBUG("Mapped memory region is too small: %zu > %zu. Reallocating to %zu...",
+                  state_len,
+                  tcti_libtpms->state_mmap_len,
+                  new_state_mmap_len);
+        new_state_mmap = mremap(tcti_libtpms->state_mmap,
+                                tcti_libtpms->state_mmap_len,
+                                new_state_mmap_len,
+                                MREMAP_MAYMOVE);
+        if (new_state_mmap == MAP_FAILED) {
+            LOG_ERROR("mremap failed on file %s: %s",
+                      tcti_libtpms->state_path,
+                      strerror(errno));
+            return TSS2_TCTI_RC_IO_ERROR;
+        }
+        tcti_libtpms->state_mmap = new_state_mmap;
+        tcti_libtpms->state_mmap_len = new_state_mmap_len;
+
+        LOG_DEBUG("Successfully mapped state file to %zu bytes.",
+                  tcti_libtpms->state_mmap_len);
+
+        /* allocate more disk space */
+        if (tcti_libtpms->state_path) {
+            state_fd = open(tcti_libtpms->state_path, O_RDWR | O_CREAT, 0644);
+            if(state_fd == -1){
+                LOG_ERROR("open failed on file %s: %s",
+                        tcti_libtpms->state_path,
+                        strerror(errno));
+                return TSS2_TCTI_RC_IO_ERROR;
+            }
+
+            ret = posix_fallocate(state_fd, 0, tcti_libtpms->state_mmap_len);
+            if (ret != 0) {
+                LOG_ERROR("fallocate failed on file %s: %d",tcti_libtpms->state_path, ret);
+                close(state_fd);
+                return TSS2_TCTI_RC_IO_ERROR;
+            }
+
+            close(state_fd);
+        }
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+/*
+ * Retrieve libtpms state and save it to the state file.
+ */
+static TSS2_RC
+tcti_libtpms_store_state(TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms)
+{
+    TSS2_RC rc;
+    int ret;
+    unsigned char *permanent_buf, *volatile_buf;
+    uint32_t permanent_buf_len, volatile_buf_len;
+    uint32_t permanent_buf_len_be, volatile_buf_len_be;
+    size_t offset = 0;
+    size_t size;
+
+    /* if no state file, skip loading */
+    if (tcti_libtpms->state_path == NULL) {
+        LOG_DEBUG("No state file. Skip storing state file.");
+        return TPM2_RC_SUCCESS;
+    }
+    LOG_DEBUG("Storing state to file: %s", tcti_libtpms->state_path);
+
+    /* get states */
+    LIBTPMS_API_CALL(fail,
+                     tcti_libtpms,
+                     TPMLIB_GetState,
+                     TPMLIB_STATE_PERMANENT,
+                     &permanent_buf,
+                     &permanent_buf_len);
+    LIBTPMS_API_CALL(cleanup_permanent,
+                     tcti_libtpms,
+                     TPMLIB_GetState,
+                     TPMLIB_STATE_VOLATILE,
+                     &volatile_buf,
+                     &volatile_buf_len);
+
+    /* check if enough memory is allocated first */
+    size = sizeof(uint32_t) + permanent_buf_len + sizeof(uint32_t) + volatile_buf_len;
+    rc = tcti_libtpms_ensure_state_len(tcti_libtpms, size);
+    if (rc != TSS2_RC_SUCCESS) {
+        goto cleanup_volatile;
+    }
+
+    /* write permanent buffer length (big endian) */
+    size = sizeof(permanent_buf_len_be);
+    permanent_buf_len_be = htonl(permanent_buf_len);
+    memcpy(tcti_libtpms->state_mmap + offset,
+           &permanent_buf_len_be,
+           size);
+    offset += size;
+
+    /* write permanent buffer */
+    size = permanent_buf_len;
+    memcpy(tcti_libtpms->state_mmap + offset,
+           permanent_buf,
+           size);
+    offset += size;
+
+    /* write volatile buffer length (big endian) */
+    size = sizeof(volatile_buf_len_be);
+    volatile_buf_len_be = htonl(volatile_buf_len);
+    memcpy(tcti_libtpms->state_mmap + offset,
+           &volatile_buf_len_be,
+           size);
+    offset += size;
+
+    /* write volatile buffer */
+    size = volatile_buf_len;
+    memcpy(tcti_libtpms->state_mmap + offset,
+           volatile_buf,
+           size);
+    offset += size;
+
+    tcti_libtpms->state_len = offset;
+
+    rc = TPM2_RC_SUCCESS;
+
+cleanup_volatile:
+    free(volatile_buf);
+
+cleanup_permanent:
+    free(permanent_buf);
+
+fail:
+    return rc;
+}
+
+/*
+ * Load the libtpms state from the mapped memory (state file). This has to be
+ * called after TPMLIB_ChooseTPMVersion and before TPMLIB_MainInit.
+ */
+static TSS2_RC
+tcti_libtpms_load_state(TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms)
+{
+    TSS2_RC rc;
+    int ret;
+    unsigned char *permanent_buf, *volatile_buf;
+    uint32_t permanent_buf_len, volatile_buf_len;
+    size_t offset = 0;
+
+    /* if no/empty state file, skip loading */
+    if (tcti_libtpms->state_path == NULL || tcti_libtpms->state_len == 0) {
+        LOG_DEBUG("No/empty state file found. Skip loading state file.");
+        return TPM2_RC_SUCCESS;
+    }
+    LOG_DEBUG("Loading from state file: %s", tcti_libtpms->state_path);
+
+    tcti_libtpms->state_len = 0;
+
+    /* permanent buffer length (big endian) */
+    memcpy(&permanent_buf_len, tcti_libtpms->state_mmap, sizeof(permanent_buf_len));
+    permanent_buf_len = ntohl(permanent_buf_len);
+    offset += sizeof(permanent_buf_len);
+
+    /* permanent buffer */
+    permanent_buf = (unsigned char *) tcti_libtpms->state_mmap + offset;
+    offset += permanent_buf_len;
+
+    /* volatile buffer length (big endian) */
+    memcpy(&volatile_buf_len, tcti_libtpms->state_mmap + offset, sizeof(volatile_buf_len));
+    volatile_buf_len = ntohl(volatile_buf_len);
+    offset += sizeof(volatile_buf_len);
+
+    /* volatile buffer */
+    volatile_buf = (unsigned char *) tcti_libtpms->state_mmap + offset;
+    offset += volatile_buf_len;
+
+    LIBTPMS_API_CALL(fail, tcti_libtpms, TPMLIB_SetState, TPMLIB_STATE_PERMANENT,
+                                                          permanent_buf,
+                                                          permanent_buf_len);
+    LIBTPMS_API_CALL(fail, tcti_libtpms, TPMLIB_SetState, TPMLIB_STATE_VOLATILE,
+                                                          volatile_buf,
+                                                          volatile_buf_len);
+
+    tcti_libtpms->state_len = offset;
+
+    rc = TPM2_RC_SUCCESS;
+
+fail:
+    return rc;
+}
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the mssim TCTI context. If passed a NULL context the function
+ * returns a NULL ptr. The function doesn't check magic number anymore
+ * It should checked by the appropriate tcti_common_checks.
+ */
+static TSS2_TCTI_LIBTPMS_CONTEXT*
+tcti_libtpms_context_cast(TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx == NULL)
+        return NULL;
+
+    return (TSS2_TCTI_LIBTPMS_CONTEXT*) tcti_ctx;
+}
+
+/*
+ * This function down-casts the libtpms TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+static TSS2_TCTI_COMMON_CONTEXT*
+tcti_libtpms_down_cast(TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms)
+{
+    if (tcti_libtpms == NULL) {
+        return NULL;
+    }
+    return &tcti_libtpms->common;
+}
+
+/*
+ * Transmits and gets the response. The response buffer was allocated by
+ * libtpms, is referenced by the libtpms TCTI context and needs to be freed once
+ * it is not needed anymore (i.e. at the end of tcti_libtpms_receive()).
+ */
+TSS2_RC
+tcti_libtpms_transmit(
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t size,
+    const uint8_t *cmd_buf)
+{
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = tcti_libtpms_context_cast(tcti_ctx);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_libtpms_down_cast(tcti_libtpms);
+    tpm_header_t header;
+    TSS2_RC rc;
+    TPM_RESULT ret;
+
+    rc = tcti_common_transmit_checks(tcti_common, cmd_buf, TCTI_LIBTPMS_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    rc = header_unmarshal(cmd_buf, &header);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    if (header.size != size) {
+        LOG_ERROR("Buffer size parameter: %zu, and TPM2 command header size "
+                  "field: %" PRIu32 " disagree.", size, header.size);
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    LOGBLOB_DEBUG(cmd_buf, size, "Sending command with TPM_CC 0x%" PRIx32, header.size);
+    LIBTPMS_API_CALL(fail, tcti_libtpms, TPMLIB_Process, &tcti_libtpms->response_buffer,
+                                                         (uint32_t *) &tcti_libtpms->response_len,
+                                                         (uint32_t *) &tcti_libtpms->response_buffer_len,
+                                                         (uint8_t *) cmd_buf,
+                                                         size);
+    rc = tcti_libtpms_store_state(tcti_libtpms);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Failed to store state file");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+
+    return TSS2_RC_SUCCESS;
+
+fail:
+    return TSS2_TCTI_RC_IO_ERROR;
+}
+
+TSS2_RC
+tcti_libtpms_cancel(
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    (void) (tctiContext);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_libtpms_set_locality(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality)
+{
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = tcti_libtpms_context_cast(tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_libtpms_down_cast(tcti_libtpms);
+    TSS2_RC rc;
+
+    rc = tcti_common_set_locality_checks(tcti_common, TCTI_LIBTPMS_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    tcti_common->locality = locality;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_libtpms_get_poll_handles(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    (void)(tctiContext);
+    (void)(handles);
+    (void)(num_handles);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+void
+tcti_libtpms_finalize(
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    int ret;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = tcti_libtpms_context_cast(tctiContext);
+
+    if (tcti_libtpms == NULL) {
+        return;
+    }
+
+    tcti_libtpms->TPMLIB_Terminate();
+
+    /* close libtpms library handle */
+    dlclose(tcti_libtpms->libtpms);
+
+    if (tcti_libtpms->state_mmap != NULL) {
+        /* unmap memory (may be backed by a state file) */
+        munmap(tcti_libtpms->state_mmap, tcti_libtpms->state_mmap_len);
+    }
+
+    if (tcti_libtpms->state_path != NULL) {
+        /* truncate state file to its real size */
+        ret = truncate(tcti_libtpms->state_path, tcti_libtpms->state_len);
+        if (ret != 0) {
+            LOG_WARNING("truncate failed on file %s: %s",
+                        tcti_libtpms->state_path,
+                        strerror(errno));
+        }
+    }
+
+    if (tcti_libtpms->state_path != NULL) {
+        free(tcti_libtpms->state_path);
+    }
+
+    if (tcti_libtpms->response_buffer) {
+        free(tcti_libtpms->response_buffer);
+    }
+}
+
+TSS2_RC
+tcti_libtpms_receive(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    unsigned char *response_buffer,
+    int32_t timeout)
+{
+#ifdef TEST_FAPI_ASYNC
+    /* Used for simulating a timeout. */
+    static int wait = 0;
+#endif
+
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = tcti_libtpms_context_cast(tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_libtpms_down_cast(tcti_libtpms);
+    TSS2_RC rc;
+
+    rc = tcti_common_receive_checks(tcti_common, response_size, TCTI_LIBTPMS_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    if (timeout != TSS2_TCTI_TIMEOUT_BLOCK) {
+        LOG_TRACE("Asynchronous I/O not actually implemented.");
+#ifdef TEST_FAPI_ASYNC
+        if (wait < 1) {
+            LOG_TRACE("Simulating Async by requesting another invocation.");
+            wait += 1;
+            return TSS2_TCTI_RC_TRY_AGAIN;
+        } else {
+            LOG_TRACE("Sending the actual result.");
+            wait = 0;
+        }
+#endif /* TEST_FAPI_ASYNC */
+    }
+
+    if (response_buffer == NULL) {
+        *response_size = tcti_libtpms->response_len;
+        return TSS2_RC_SUCCESS;
+    }
+
+    if (*response_size < tcti_libtpms->response_len) {
+        *response_size = tcti_libtpms->response_len;
+        return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+    }
+    *response_size = tcti_libtpms->response_len;
+
+    memcpy(response_buffer, tcti_libtpms->response_buffer, tcti_libtpms->response_len);
+
+    LOGBLOB_DEBUG(response_buffer, *response_size, "Response received:");
+
+    free(tcti_libtpms->response_buffer);
+    tcti_libtpms->response_buffer = NULL;
+    tcti_libtpms->response_buffer_len = 0;
+    tcti_libtpms->response_len = 0;
+
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+
+    return TSS2_RC_SUCCESS;
+}
+
+static void
+tcti_libtpms_init_context_data(TSS2_TCTI_COMMON_CONTEXT *tcti_common)
+{
+    TSS2_TCTI_MAGIC (tcti_common) = TCTI_LIBTPMS_MAGIC;
+    TSS2_TCTI_VERSION (tcti_common) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tcti_common) = tcti_libtpms_transmit;
+    TSS2_TCTI_RECEIVE (tcti_common) = tcti_libtpms_receive;
+    TSS2_TCTI_FINALIZE (tcti_common) = tcti_libtpms_finalize;
+    TSS2_TCTI_CANCEL (tcti_common) = tcti_libtpms_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tcti_common) = tcti_libtpms_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_libtpms_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tcti_common) = tcti_make_sticky_not_implemented;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    memset(&tcti_common->header, 0, sizeof(tcti_common->header));
+}
+
+TSS2_RC
+tcti_libtpms_dl(TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms)
+{
+    const char *names[] = {"libtpms.so", "libtpms.so.0"};
+
+    for (size_t i = 0; i < ARRAY_LEN(names); i++) {
+        tcti_libtpms->libtpms = dlopen(names[i], RTLD_LAZY | RTLD_LOCAL);
+        if (tcti_libtpms->libtpms != NULL) {
+            break;
+        }
+    }
+    if (tcti_libtpms->libtpms == NULL) {
+        LOG_ERROR("Could not load libtpms library: %s", dlerror());
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    tcti_libtpms->TPMLIB_ChooseTPMVersion = dlsym(tcti_libtpms->libtpms, "TPMLIB_ChooseTPMVersion");
+    if (tcti_libtpms->TPMLIB_ChooseTPMVersion == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_ChooseTPMVersion(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_RegisterCallbacks = dlsym(tcti_libtpms->libtpms, "TPMLIB_RegisterCallbacks");
+    if (tcti_libtpms->TPMLIB_RegisterCallbacks == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_RegisterCallbacks(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_GetState = dlsym(tcti_libtpms->libtpms, "TPMLIB_GetState");
+    if (tcti_libtpms->TPMLIB_GetState == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_GetState(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_MainInit = dlsym(tcti_libtpms->libtpms, "TPMLIB_MainInit");
+    if (tcti_libtpms->TPMLIB_MainInit == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_MainInit(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_Process = dlsym(tcti_libtpms->libtpms, "TPMLIB_Process");
+    if (tcti_libtpms->TPMLIB_Process == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_Process(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_SetState = dlsym(tcti_libtpms->libtpms, "TPMLIB_SetState");
+    if (tcti_libtpms->TPMLIB_SetState == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_SetState(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    tcti_libtpms->TPMLIB_Terminate = dlsym(tcti_libtpms->libtpms, "TPMLIB_Terminate");
+    if (tcti_libtpms->TPMLIB_Terminate == NULL) {
+        LOG_ERROR("Could not resolve libtpms symbol TPMLIB_Terminate(): %s", dlerror());
+        goto cleanup_dl;
+    }
+
+    return TPM2_RC_SUCCESS;
+
+cleanup_dl:
+    dlclose(tcti_libtpms->libtpms);
+    return TSS2_TCTI_RC_GENERAL_FAILURE;
+}
+
+/****************** libtpms callbacks ******************
+ * Override the libtpms callbacks. This is needed to implement localities and to
+ * prevent the NVChip file from being created. The other callbacks are
+ * implemented as per advice from the libtpms man pages and/or as a placeholder
+ * for future features.
+ *
+ * Using tcti_libtpms_get_current_tcti(), one can retrieve the currently active
+ * libtpms TCTI instance.
+ */
+
+TPM_RESULT
+tcti_libtpms_cb_nvram_init(void)
+{
+    LOG_TRACE("tcti-libtpms callback nvram_init() called.");
+
+    return TPM_SUCCESS;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_nvram_loaddata(
+    unsigned char **data,
+    uint32_t *length,
+    uint32_t tpm_number,
+    const char *name)
+{
+    LOG_TRACE("tcti-libtpms callback nvram_loaddata() called: "
+              "data=0x%" PRIxPTR ", "
+              "length=0x%" PRIxPTR ", "
+              "tpm_number=%" PRIu32 ", "
+              "name=%s",
+               (uintptr_t) data, (uintptr_t) length, tpm_number, name);
+
+    return TPM_RETRY;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_nvram_storedata(
+    const unsigned char *data,
+    uint32_t length,
+    uint32_t tpm_number,
+    const char *name)
+{
+    LOG_TRACE("tcti-libtpms callback nvram_storedata() called: "
+              "data=0x%" PRIxPTR ", "
+              "length=%" PRIu32 ", "
+              "tpm_number=%" PRIu32 ", "
+              "name=%s",
+               (uintptr_t) data, length, tpm_number, name);
+
+    return TPM_SUCCESS;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_nvram_deletename(
+    uint32_t tpm_number,
+    const char *name,
+    TPM_BOOL must_exist)
+{
+    LOG_TRACE("tcti-libtpms callback nvram_deletename() called: "
+              "tpm_number=%" PRIu32 ", "
+              "name=%s, "
+              "must_exist=%d",
+               tpm_number, name, must_exist);
+
+    LOG_ERROR("Not implemented");
+
+    return TPM_FAIL;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_io_init(void)
+{
+    LOG_TRACE("tcti-libtpms callback io_init() called.");
+
+    return TPM_SUCCESS;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_io_getlocality(
+    TPM_MODIFIER_INDICATOR *locality_modifer,
+    uint32_t tpm_number)
+{
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common;
+
+    LOG_TRACE("tcti-libtpms callback io_getlocality() called: "
+              "locality_modifer=0x%" PRIxPTR ", "
+              "tpm_number=%" PRIu32,
+               (uintptr_t) locality_modifer, tpm_number);
+
+    if (locality_modifer == NULL) {
+        return TPM_FAIL;
+    }
+
+    if (current_tcti_libtpms == NULL) {
+        LOG_ERROR("No TCTI registered as currently active before libtpms API call.");
+        return TPM_FAIL;
+    }
+    tcti_common = tcti_libtpms_down_cast(current_tcti_libtpms);
+    *locality_modifer = tcti_common->locality;
+
+    return TPM_SUCCESS;
+}
+
+TPM_RESULT
+tcti_libtpms_cb_io_getphysicalpresence(
+    TPM_BOOL *physical_presence,
+    uint32_t tpm_number)
+{
+    LOG_TRACE("tcti-libtpms callback io_getphysicalpresence() called: "
+              "physical_presence=0x%" PRIxPTR ", "
+              "tpm_number=%" PRIu32,
+               (uintptr_t) physical_presence, tpm_number);
+
+    LOG_ERROR("Not implemented");
+
+    return TPM_FAIL;
+}
+/*************** end: libtpms callbacks ****************/
+
+TSS2_RC
+Tss2_Tcti_Libtpms_Init(
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf)
+{
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*)tctiContext;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_libtpms_down_cast(tcti_libtpms);
+    TSS2_RC rc;
+    TPM_RESULT ret;
+    (void)(conf);
+
+    LOG_TRACE("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
+               (uintptr_t)tctiContext, (uintptr_t)size, conf);
+    if (size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    if (tctiContext == NULL) {
+        *size = sizeof(TSS2_TCTI_LIBTPMS_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    tcti_libtpms_init_context_data(tcti_common);
+
+    rc = tcti_libtpms_set_locality(tctiContext, 0);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_WARNING ("Could not set locality: 0x%" PRIx32, rc);
+        return rc;
+    }
+
+    rc = tcti_libtpms_dl(tcti_libtpms);
+    if (rc != TPM2_RC_SUCCESS) {
+        return rc;
+    }
+    LOG_TRACE("Successfully loaded libtpms and resolved symbols.");
+
+    /* copy state path given in conf */
+    if (conf == NULL || strlen(conf) == 0) {
+        tcti_libtpms->state_path = NULL;
+    } else {
+        tcti_libtpms->state_path = strdup(conf);
+        if (tcti_libtpms->state_path == NULL) {
+            LOG_ERROR("Out of memory.");
+            rc = TSS2_TCTI_RC_MEMORY;
+            goto cleanup_dl;
+        }
+    }
+
+    rc = tcti_libtpms_map_state_file(tcti_libtpms);
+    if (rc != TPM2_RC_SUCCESS) {
+        LOG_ERROR("Could not create and map state file.");
+        goto cleanup_state_path;
+    }
+    LOG_TRACE("Successfully opened memory-mapped libtpms state file: %s",
+                tcti_libtpms->state_path);
+
+    struct libtpms_callbacks callbacks = {
+        .sizeOfStruct               = sizeof(struct libtpms_callbacks),
+        .tpm_nvram_init             = tcti_libtpms_cb_nvram_init,
+        .tpm_nvram_loaddata         = tcti_libtpms_cb_nvram_loaddata,
+        .tpm_nvram_storedata        = tcti_libtpms_cb_nvram_storedata,
+        .tpm_nvram_deletename       = tcti_libtpms_cb_nvram_deletename,
+        .tpm_io_init                = tcti_libtpms_cb_io_init,
+        .tpm_io_getlocality         = tcti_libtpms_cb_io_getlocality,
+        .tpm_io_getphysicalpresence = tcti_libtpms_cb_io_getphysicalpresence
+    };
+    LIBTPMS_API_CALL(cleanup_state_mmap, tcti_libtpms, TPMLIB_ChooseTPMVersion, TPMLIB_TPM_VERSION_2);
+    LIBTPMS_API_CALL(cleanup_state_mmap, tcti_libtpms, TPMLIB_RegisterCallbacks, &callbacks);
+    rc = tcti_libtpms_load_state(tcti_libtpms);
+    if (rc != TPM2_RC_SUCCESS) {
+        goto cleanup_state_mmap;
+    }
+    LIBTPMS_API_CALL(cleanup_state_mmap, tcti_libtpms, TPMLIB_MainInit);
+
+    tcti_libtpms->response_buffer = NULL;
+    tcti_libtpms->response_buffer_len = 0;
+    tcti_libtpms->response_len = 0;
+
+    return TSS2_RC_SUCCESS;
+
+cleanup_state_mmap:
+    if (tcti_libtpms->state_path != NULL) {
+        munmap(tcti_libtpms->state_mmap, tcti_libtpms->state_mmap_len);
+    }
+
+cleanup_state_path:
+    if (tcti_libtpms->state_path != NULL) {
+        free(tcti_libtpms->state_path);
+    }
+
+cleanup_dl:
+    dlclose(tcti_libtpms->libtpms);
+
+    return rc;
+}
+
+/* public info structure */
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-libtpms",
+    .description = "TCTI module for communication with the libtpms library.",
+    .config_help = "Path to the state file. NULL for no state file.",
+    .init = Tss2_Tcti_Libtpms_Init,
+};
+
+const TSS2_TCTI_INFO *
+Tss2_Tcti_Info(void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-libtpms.h
+++ b/src/tss2-tcti/tcti-libtpms.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2019, Fraunhofer SIT, Infineon Technologies AG, Intel Corporation
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifndef TCTI_LIBTPMS_H
+#define TCTI_LIBTPMS_H
+
+#include <limits.h>
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#include <libtpms/tpm_library.h>
+#include <libtpms/tpm_error.h>
+
+#include "tcti-common.h"
+#include "util/io.h"
+
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
+#define TCTI_LIBTPMS_MAGIC 0x49E299A554504D32ULL
+
+#define STATE_MMAP_CHUNK_LEN 2048
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    void *libtpms;
+    TPM_RESULT (*TPMLIB_ChooseTPMVersion)(TPMLIB_TPMVersion);
+    TPM_RESULT (*TPMLIB_RegisterCallbacks)(struct libtpms_callbacks *);
+    TPM_RESULT (*TPMLIB_GetState)(enum TPMLIB_StateType, unsigned char **, uint32_t *);
+    TPM_RESULT (*TPMLIB_MainInit)(void);
+    TPM_RESULT (*TPMLIB_Process)(unsigned char **, uint32_t *, uint32_t *, unsigned char *, uint32_t);
+    TPM_RESULT (*TPMLIB_SetState)(enum TPMLIB_StateType, const unsigned char *, uint32_t);
+    void (*TPMLIB_Terminate)(void);
+    uint8_t *response_buffer;
+    size_t response_buffer_len;
+    size_t response_len;
+    char *state_path;
+    char *state_mmap;
+    size_t state_mmap_len;
+    size_t state_len;
+} TSS2_TCTI_LIBTPMS_CONTEXT;
+
+#endif /* TCTI_LIBTPMS_H */

--- a/test/integration/sys-nv-policy-locality.int.c
+++ b/test/integration/sys-nv-policy-locality.int.c
@@ -217,6 +217,9 @@ nv_write_test (TSS2_SYS_CONTEXT *sys_ctx)
     {
         LOG_INFO ("%s: writing NV from locality %" PRIu8, __func__, locality);
         rc = Tss2_Tcti_SetLocality (tcti_ctx, locality);
+        if (rc == TSS2_TCTI_RC_NOT_IMPLEMENTED) {
+            return 77;
+        }
         return_if_error (rc, "Tss2_Tcti_SetLocality");
 
         rc = nv_write (sys_ctx);

--- a/test/unit/tcti-libtpms.c
+++ b/test/unit/tcti-libtpms.c
@@ -17,6 +17,7 @@
 
 #include <setjmp.h>
 #include <cmocka.h>
+#include <unistd.h>
 
 #include "tss2_tcti.h"
 #include "tss2_tcti_libtpms.h"
@@ -32,6 +33,9 @@
 #define STATEFILE_FD       0xAABB
 #define STATEFILE_MMAP     mmap_buf
 #define STATEFILE_MMAP_NEW mmap_buf_new
+
+#define STATEFILE_PATH_REAL0 "statefile0.bin"
+#define STATEFILE_PATH_REAL1 "statefile1.bin"
 
 /* loaded state */
 #define S1_PERMANENT_BUF_LITERAL "aaaaaaaa"
@@ -176,15 +180,21 @@ void *__wrap_dlsym(void *handle, const char *symbol)
     check_expected_ptr(symbol);
     return mock_type(void *);
 }
+void *__real_mmap (void *addr, size_t len, int prot, int flags, int fd, off_t offset);
 void *__wrap_mmap (void *addr, size_t len, int prot, int flags, int fd, off_t offset)
 {
-    check_expected_ptr(addr);
-    check_expected(len);
-    check_expected(prot);
-    check_expected(flags);
-    check_expected(fd);
-    check_expected(offset);
-    return mock_type(void *);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected_ptr(addr);
+        check_expected(len);
+        check_expected(prot);
+        check_expected(flags);
+        check_expected(fd);
+        check_expected(offset);
+        return mock_type(void *);
+    } else {
+        return __real_mmap(addr, len, prot, flags, fd, offset);
+    }
 }
 void *__wrap_mremap(void *old_address, size_t old_size, size_t new_size, int flags)
 {
@@ -199,11 +209,17 @@ void *__wrap_mremap(void *old_address, size_t old_size, size_t new_size, int fla
     }
     return new_address;
 }
+int __real_munmap(void *addr, size_t len);
 int __wrap_munmap(void *addr, size_t len)
 {
-    check_expected_ptr(addr);
-    check_expected(len);
-    return mock_type(int);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected_ptr(addr);
+        check_expected(len);
+        return mock_type(int);
+    } else {
+        return __real_munmap(addr, len);
+    }
 }
 int __real_open(const char *pathname, int flags, ...);
 int __wrap_open(const char *pathname, int flags, mode_t mode)
@@ -213,36 +229,66 @@ int __wrap_open(const char *pathname, int flags, mode_t mode)
         check_expected(flags);
         check_expected(mode);
         return mock_type(int);
+    } else if (strncmp(pathname, STATEFILE_PATH_REAL0, strlen(STATEFILE_PATH_REAL0)) == 0 \
+            || strncmp(pathname, STATEFILE_PATH_REAL1, strlen(STATEFILE_PATH_REAL1)) == 0) {
+        check_expected_ptr(pathname);
+        check_expected(flags);
+        check_expected(mode);
+        return __real_open(pathname, flags, mode);
     } else {
         /* only mock opening of state files as the open() syscall is needed
            for code coverage reports as well */
         return __real_open(pathname, flags, mode);
     }
 }
+off_t __real_lseek(int fd, off_t offset, int whence);
 off_t __wrap_lseek(int fd, off_t offset, int whence)
 {
-    check_expected(fd);
-    check_expected(offset);
-    check_expected(whence);
-    return mock_type(off_t);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected(fd);
+        check_expected(offset);
+        check_expected(whence);
+        return mock_type(off_t);
+    } else {
+        return __real_lseek(fd, offset, whence);
+    }
 }
+int __real_posix_fallocate(int fd, off_t offset, off_t len);
 int __wrap_posix_fallocate(int fd, off_t offset, off_t len)
 {
-    check_expected(fd);
-    check_expected(offset);
-    check_expected(len);
-    return mock_type(int);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected(fd);
+        check_expected(offset);
+        check_expected(len);
+        return mock_type(int);
+    } else {
+        return __real_posix_fallocate(fd, offset, len);
+    }
 }
+int __real_truncate(const char *path, off_t length);
 int __wrap_truncate(const char *path, off_t length)
 {
-    check_expected_ptr(path);
-    check_expected(length);
-    return mock_type(int);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected_ptr(path);
+        check_expected(length);
+        return mock_type(int);
+    } else {
+        return __real_truncate(path, length);
+    }
 }
+int __real_close(int fd);
 int __wrap_close(int fd)
 {
-    check_expected(fd);
-    return mock_type(int);
+    int wrap = mock_type(int);
+    if (wrap) {
+        check_expected(fd);
+        return mock_type(int);
+    } else {
+        return __real_close(fd);
+    }
 }
 
 /* When passed all NULL values, we expect TSS2_TCTI_RC_BAD_VALUE. */
@@ -448,10 +494,12 @@ tcti_libtpms_init_state_lseek_fail_test(void **state)
     expect_value(__wrap_lseek, fd, STATEFILE_FD);
     expect_value(__wrap_lseek, offset, 0L);
     expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, 1); /* wrap = true */
     will_return(__wrap_lseek, -1);
 
     /* cleanup */
     expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 1); /* wrap = true */
     will_return(__wrap_close, 0);
 
     expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
@@ -516,16 +564,19 @@ tcti_libtpms_init_state_posix_fallocate_fail_test(void **state)
     expect_value(__wrap_lseek, fd, STATEFILE_FD);
     expect_value(__wrap_lseek, offset, 0L);
     expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, 1); /* wrap = true */
     will_return(__wrap_lseek, S1_STATE_LEN);
 
     /* fail to posix_fallocate */
     expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
     expect_value(__wrap_posix_fallocate, offset, 0);
     expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_posix_fallocate, 1); /* wrap = true */
     will_return(__wrap_posix_fallocate, -1);
 
     /* cleanup */
     expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 1); /* wrap = true */
     will_return(__wrap_close, 0);
 
     expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
@@ -590,11 +641,13 @@ tcti_libtpms_init_state_mmap_fail_test(void **state)
     expect_value(__wrap_lseek, fd, STATEFILE_FD);
     expect_value(__wrap_lseek, offset, 0L);
     expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, 1); /* wrap = true */
     will_return(__wrap_lseek, S1_STATE_LEN);
 
     expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
     expect_value(__wrap_posix_fallocate, offset, 0);
     expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_posix_fallocate, 1); /* wrap = true */
     will_return(__wrap_posix_fallocate, 0);
 
     /* fail to mmap */
@@ -604,10 +657,12 @@ tcti_libtpms_init_state_mmap_fail_test(void **state)
     expect_value(__wrap_mmap, flags, MAP_SHARED);
     expect_value(__wrap_mmap, fd, STATEFILE_FD);
     expect_value(__wrap_mmap, offset, 0);
+    will_return(__wrap_mmap, 1); /* wrap = true */
     will_return(__wrap_mmap, MAP_FAILED);
 
     /* cleanup */
     expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 1); /* wrap = true */
     will_return(__wrap_close, 0);
 
     expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
@@ -683,11 +738,13 @@ tcti_libtpms_init_from_conf(const char *conf)
         expect_value(__wrap_lseek, fd, STATEFILE_FD);
         expect_value(__wrap_lseek, offset, 0L);
         expect_value(__wrap_lseek, whence, SEEK_END);
+        will_return(__wrap_lseek, 1); /* wrap = true */
         will_return(__wrap_lseek, S1_STATE_LEN);
 
         expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
         expect_value(__wrap_posix_fallocate, offset, 0);
         expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+        will_return(__wrap_posix_fallocate, 1); /* wrap = true */
         will_return(__wrap_posix_fallocate, 0);
 
         expect_value(__wrap_mmap, addr, NULL);
@@ -696,9 +753,11 @@ tcti_libtpms_init_from_conf(const char *conf)
         expect_value(__wrap_mmap, flags, MAP_SHARED);
         expect_value(__wrap_mmap, fd, STATEFILE_FD);
         expect_value(__wrap_mmap, offset, 0);
+        will_return(__wrap_mmap, 1); /* wrap = true */
         will_return(__wrap_mmap, STATEFILE_MMAP);
 
         expect_value(__wrap_close, fd, STATEFILE_FD);
+        will_return(__wrap_close, 1); /* wrap = true */
         will_return(__wrap_close, 0);
 
         expect_value(TPMLIB_SetState, st, TPMLIB_STATE_PERMANENT);
@@ -728,6 +787,97 @@ tcti_libtpms_init_from_conf(const char *conf)
         assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN);
         assert_int_equal(tcti_libtpms->state_len, S1_STATE_LEN);
         assert_memory_equal(tcti_libtpms->state_mmap, S1_STATE, S1_STATE_LEN);
+    } else {
+        assert_ptr_equal(tcti_libtpms->state_path, NULL);
+        assert_ptr_equal(tcti_libtpms->state_mmap, NULL);
+        assert_int_equal(tcti_libtpms->state_mmap_len, 0);
+        assert_int_equal(tcti_libtpms->state_len, 0);
+    }
+
+    return ctx;
+}
+/*
+ * This is a utility function used by other tests to setup a 2nd TCTI context.
+ * It effectively wraps the init / allocate / init pattern as well as priming
+ * the mock functions necessary for a the successful call to
+ * 'Tss2_Tcti_Libtpms_Init'.
+ */
+static TSS2_TCTI_CONTEXT*
+tcti_libtpms_init_from_conf_real(const char *conf)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms;
+
+    memcpy(mmap_buf, S2_STATE, S2_STATE_LEN);
+
+    fprintf(stderr, "%s: before first init\n", __func__);
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+    tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+
+    fprintf(stderr, "%s: before second_init\n", __func__);
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    if (conf != NULL) {
+        expect_string(__wrap_open, pathname, conf);
+        expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+        expect_value(__wrap_open, mode, 0644);
+        /* __wrap_open delegates to __real_open based on filename */
+
+        will_return(__wrap_lseek, 0); /* wrap = false, delegate to __real_lseek */
+        will_return(__wrap_posix_fallocate, 0); /* wrap = false, delegate to __real_posix_fallocate */
+        will_return(__wrap_mmap, 0); /* wrap = false, delegate to __real_mmap */
+        will_return(__wrap_close, 0); /* wrap = false, delegate to __real_close */
+
+        /* statefile does not exist already, do not load any state */
+    }
+
+    expect_value(TPMLIB_ChooseTPMVersion, ver, TPMLIB_TPM_VERSION_2);
+    will_return(TPMLIB_ChooseTPMVersion, 0);
+    will_return(TPMLIB_RegisterCallbacks, 0);
+    will_return(TPMLIB_MainInit, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, conf);
+    fprintf(stderr, "%s: after second init\n", __func__);
+    assert_int_equal(ret, TSS2_RC_SUCCESS);
+
+    if (conf != NULL) {
+        assert_string_equal(tcti_libtpms->state_path, conf);
+        assert_int_equal(tcti_libtpms->state_len, 0);
     } else {
         assert_ptr_equal(tcti_libtpms->state_path, NULL);
         assert_ptr_equal(tcti_libtpms->state_mmap, NULL);
@@ -874,9 +1024,11 @@ tcti_libtpms_remap_state_success_test(void **state)
     expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
     expect_value(__wrap_posix_fallocate, offset, 0);
     expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_posix_fallocate, 1); /* wrap = true */
     will_return(__wrap_posix_fallocate, 0);
 
     expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 1); /* wrap = true */
     will_return(__wrap_close, 0);
 
     rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
@@ -972,10 +1124,12 @@ tcti_libtpms_remap_state_posix_fallocate_fail_test(void **state)
     expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
     expect_value(__wrap_posix_fallocate, offset, 0);
     expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_posix_fallocate, 1); /* wrap = true */
     will_return(__wrap_posix_fallocate, -5);
 
     /* cleanup */
     expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 1); /* wrap = true */
     will_return(__wrap_close, 0);
 
     rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
@@ -1036,6 +1190,212 @@ tcti_libtpms_no_statefile_success_test(void **state)
     assert_int_equal(tcti_libtpms->state_len, 0);
 }
 
+static void
+tcti_libtpms_two_states_no_statefiles_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT **ctxs = (TSS2_TCTI_CONTEXT **) *state;
+    TSS2_TCTI_LIBTPMS_CONTEXT **tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT**) ctxs;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common[2];
+    TSS2_RC rc;
+    unsigned char cmd_aa[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0xaa, 0xaa};
+    unsigned char rsp_aa[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0xaa, 0xaa, 0xaa, 0xaa};
+    unsigned char rsp_aa_out[sizeof(rsp_aa)];
+    size_t rsp_aa_len_out = sizeof(rsp_aa);
+    unsigned char cmd_bb[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0xbb, 0xbb};
+    unsigned char rsp_bb[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0xbb, 0xbb, 0xbb, 0xbb};
+    unsigned char rsp_bb_out[sizeof(rsp_bb)];
+    size_t rsp_bb_len_out = sizeof(rsp_bb);
+
+    tcti_common[0] = tcti_common_context_cast(ctxs[0]);
+    tcti_common[1] = tcti_common_context_cast(ctxs[1]);
+
+    /* ===== transmit on instance 0 ===== */
+    expect_value(TPMLIB_Process, cmd, cmd_aa);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd_aa));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp_aa);
+    will_return(TPMLIB_Process, sizeof(rsp_aa));
+    will_return(TPMLIB_Process, 0);
+
+    rc = Tss2_Tcti_Transmit(ctxs[0], sizeof(cmd_aa), cmd_aa);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(tcti_libtpms[0]->response_buffer, rsp_aa, sizeof(rsp_aa));
+    assert_int_equal(tcti_libtpms[0]->response_buffer_len, sizeof(rsp_aa));
+    assert_int_equal(tcti_libtpms[0]->response_len, sizeof(rsp_aa));
+
+    /* expect no state */
+    assert_null(tcti_libtpms[0]->state_path);
+    assert_null(tcti_libtpms[0]->state_mmap);
+    assert_int_equal(tcti_libtpms[0]->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms[0]->state_len, 0);
+
+    /* ===== transmit on instance 1 ===== */
+    expect_value(TPMLIB_Process, cmd, cmd_bb);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd_bb));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp_bb);
+    will_return(TPMLIB_Process, sizeof(rsp_bb));
+    will_return(TPMLIB_Process, 0);
+
+    rc = Tss2_Tcti_Transmit(ctxs[1], sizeof(cmd_bb), cmd_bb);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(tcti_libtpms[1]->response_buffer, rsp_bb, sizeof(rsp_bb));
+    assert_int_equal(tcti_libtpms[1]->response_buffer_len, sizeof(rsp_bb));
+    assert_int_equal(tcti_libtpms[1]->response_len, sizeof(rsp_bb));
+
+    /* expect no state */
+    assert_null(tcti_libtpms[1]->state_path);
+    assert_null(tcti_libtpms[1]->state_mmap);
+    assert_int_equal(tcti_libtpms[1]->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms[1]->state_len, 0);
+
+    /* ===== receive on instance 0 ===== */
+    rc = Tss2_Tcti_Receive(ctxs[0], &rsp_aa_len_out, rsp_aa_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(rsp_aa_out, rsp_aa, rsp_aa_len_out);
+    assert_int_equal(rsp_aa_len_out, sizeof(rsp_aa));
+    assert_int_equal(tcti_common[0]->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms[0]->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms[0]->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms[0]->response_len, 0);
+
+    /* expect no state */
+    assert_null(tcti_libtpms[0]->state_path);
+    assert_null(tcti_libtpms[0]->state_mmap);
+    assert_int_equal(tcti_libtpms[0]->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms[0]->state_len, 0);
+
+    /* ===== receive on instance 1 ===== */
+    rc = Tss2_Tcti_Receive(ctxs[1], &rsp_bb_len_out, rsp_bb_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(rsp_bb_out, rsp_bb, rsp_bb_len_out);
+    assert_int_equal(rsp_bb_len_out, sizeof(rsp_bb));
+    assert_int_equal(tcti_common[1]->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms[1]->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms[1]->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms[1]->response_len, 0);
+
+    /* expect no state */
+    assert_null(tcti_libtpms[1]->state_path);
+    assert_null(tcti_libtpms[1]->state_mmap);
+    assert_int_equal(tcti_libtpms[1]->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms[1]->state_len, 0);
+}
+
+static void
+tcti_libtpms_two_states_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT **ctxs = (TSS2_TCTI_CONTEXT **) *state;
+    TSS2_TCTI_LIBTPMS_CONTEXT **tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT**) ctxs;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common[2];
+    TSS2_RC rc;
+    unsigned char cmd_aa[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0xaa, 0xaa};
+    unsigned char rsp_aa[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0xaa, 0xaa, 0xaa, 0xaa};
+    unsigned char rsp_aa_out[sizeof(rsp_aa)];
+    size_t rsp_aa_len_out = sizeof(rsp_aa);
+    unsigned char cmd_bb[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0xbb, 0xbb};
+    unsigned char rsp_bb[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0xbb, 0xbb, 0xbb, 0xbb};
+    unsigned char rsp_bb_out[sizeof(rsp_bb)];
+    size_t rsp_bb_len_out = sizeof(rsp_bb);
+
+    tcti_common[0] = tcti_common_context_cast(ctxs[0]);
+    tcti_common[1] = tcti_common_context_cast(ctxs[1]);
+
+    /* ===== transmit on instance 0 ===== */
+    expect_value(TPMLIB_Process, cmd, cmd_aa);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd_aa));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp_aa);
+    will_return(TPMLIB_Process, sizeof(rsp_aa));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S1_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S1_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S1_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S1_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    rc = Tss2_Tcti_Transmit(ctxs[0], sizeof(cmd_aa), cmd_aa);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(tcti_libtpms[0]->response_buffer, rsp_aa, sizeof(rsp_aa));
+    assert_int_equal(tcti_libtpms[0]->response_buffer_len, sizeof(rsp_aa));
+    assert_int_equal(tcti_libtpms[0]->response_len, sizeof(rsp_aa));
+
+    assert_string_equal(tcti_libtpms[0]->state_path, STATEFILE_PATH_REAL0);
+    assert_int_equal(tcti_libtpms[0]->state_len, S1_STATE_LEN);
+    assert_memory_equal(tcti_libtpms[0]->state_mmap, S1_STATE, S1_STATE_LEN);
+
+    /* ===== transmit on instance 1 ===== */
+    expect_value(TPMLIB_Process, cmd, cmd_bb);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd_bb));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp_bb);
+    will_return(TPMLIB_Process, sizeof(rsp_bb));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S2_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S2_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S2_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S2_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    rc = Tss2_Tcti_Transmit(ctxs[1], sizeof(cmd_bb), cmd_bb);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(tcti_libtpms[1]->response_buffer, rsp_bb, sizeof(rsp_bb));
+    assert_int_equal(tcti_libtpms[1]->response_buffer_len, sizeof(rsp_bb));
+    assert_int_equal(tcti_libtpms[1]->response_len, sizeof(rsp_bb));
+
+    assert_string_equal(tcti_libtpms[1]->state_path, STATEFILE_PATH_REAL1);
+    assert_int_equal(tcti_libtpms[1]->state_len, S2_STATE_LEN);
+    assert_memory_equal(tcti_libtpms[1]->state_mmap, S2_STATE, S2_STATE_LEN);
+
+    /* ===== receive on instance 0 ===== */
+    rc = Tss2_Tcti_Receive(ctxs[0], &rsp_aa_len_out, rsp_aa_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(rsp_aa_out, rsp_aa, rsp_aa_len_out);
+    assert_int_equal(rsp_aa_len_out, sizeof(rsp_aa));
+    assert_int_equal(tcti_common[0]->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms[0]->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms[0]->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms[0]->response_len, 0);
+
+    assert_string_equal(tcti_libtpms[0]->state_path, STATEFILE_PATH_REAL0);
+    assert_int_equal(tcti_libtpms[0]->state_len, S1_STATE_LEN);
+    assert_memory_equal(tcti_libtpms[0]->state_mmap, S1_STATE, S1_STATE_LEN);
+
+    /* ===== receive on instance 1 ===== */
+    rc = Tss2_Tcti_Receive(ctxs[1], &rsp_bb_len_out, rsp_bb_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(rsp_bb_out, rsp_bb, rsp_bb_len_out);
+    assert_int_equal(rsp_bb_len_out, sizeof(rsp_bb));
+    assert_int_equal(tcti_common[1]->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms[1]->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms[1]->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms[1]->response_len, 0);
+
+    assert_string_equal(tcti_libtpms[1]->state_path, STATEFILE_PATH_REAL1);
+    assert_int_equal(tcti_libtpms[1]->state_len, S2_STATE_LEN);
+    assert_memory_equal(tcti_libtpms[1]->state_mmap, S2_STATE, S2_STATE_LEN);
+}
+
 /*
  * This is a utility function to setup the "default" TCTI context.
  */
@@ -1056,6 +1416,53 @@ tcti_libtpms_setup_no_statefile(void **state)
     fprintf(stderr, "%s: before tcti_libtpms_init_from_conf\n", __func__);
     *state = tcti_libtpms_init_from_conf(NULL);
     fprintf(stderr, "%s: done\n", __func__);
+    return 0;
+}
+/*
+ * This is a utility function to setup two "default" TCTI contexts.
+ */
+static int
+tcti_libtpms_setup_two_states_no_statefiles(void **state)
+{
+    TSS2_TCTI_CONTEXT **ctxs = malloc(sizeof(void *) * 2);
+    fprintf(stderr, "%s: before tcti_libtpms_init_from_conf\n", __func__);
+    ctxs[0] = tcti_libtpms_init_from_conf_real(NULL);
+    ctxs[1] = tcti_libtpms_init_from_conf_real(NULL);
+    fprintf(stderr, "%s: done\n", __func__);
+
+    *state = ctxs;
+    return 0;
+}
+/*
+ * This is a utility function to setup two "default" TCTI contexts.
+ */
+static int
+tcti_libtpms_setup_two_states(void **state)
+{
+    int ret;
+    TSS2_TCTI_CONTEXT **ctxs = malloc(sizeof(void *) * 2);
+    assert_non_null(ctxs);
+
+    /* delete state files if they exist already */
+    ret = unlink(STATEFILE_PATH_REAL0);
+    if (ret < 0 && errno != ENOENT) {
+        LOG_ERROR("Failed to delete statefile " STATEFILE_PATH_REAL0 ": %s",
+                  strerror(errno));
+        assert_int_equal(ret, 0);
+    }
+    ret = unlink(STATEFILE_PATH_REAL1);
+    if (ret < 0 && errno != ENOENT) {
+        LOG_ERROR("Failed to delete statefile " STATEFILE_PATH_REAL1 ": %s",
+                  strerror(errno));
+        assert_int_equal(ret, 0);
+    }
+
+    fprintf(stderr, "%s: before tcti_libtpms_init_from_conf\n", __func__);
+    ctxs[0] = tcti_libtpms_init_from_conf_real(STATEFILE_PATH_REAL0);
+    ctxs[1] = tcti_libtpms_init_from_conf_real(STATEFILE_PATH_REAL1);
+    fprintf(stderr, "%s: done\n", __func__);
+
+    *state = ctxs;
     return 0;
 }
 /*
@@ -1090,11 +1497,13 @@ tcti_libtpms_teardown_s1(void **state)
     if (tcti_libtpms->state_mmap != NULL) {
         expect_value(__wrap_munmap, addr, tcti_libtpms->state_mmap);
         expect_value(__wrap_munmap, len, tcti_libtpms->state_mmap_len);
+        will_return(__wrap_munmap, 1); /* wrap = true */
         will_return(__wrap_munmap, 0);
     }
 
     expect_string(__wrap_truncate, path, STATEFILE_PATH);
     expect_value(__wrap_truncate, length, S1_STATE_LEN);
+    will_return(__wrap_truncate, 1); /* wrap = true */
     will_return(__wrap_truncate, 0);
 
     Tss2_Tcti_Finalize(ctx);
@@ -1115,10 +1524,12 @@ tcti_libtpms_teardown_s2(void **state)
 
     expect_value(__wrap_munmap, addr, STATEFILE_MMAP);
     expect_value(__wrap_munmap, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_munmap, 1); /* wrap = true */
     will_return(__wrap_munmap, 0);
 
     expect_string(__wrap_truncate, path, STATEFILE_PATH);
     expect_value(__wrap_truncate, length, S2_STATE_LEN);
+    will_return(__wrap_truncate, 1); /* wrap = true */
     will_return(__wrap_truncate, 0);
 
     Tss2_Tcti_Finalize(ctx);
@@ -1139,14 +1550,61 @@ tcti_libtpms_teardown_s3(void **state)
 
     expect_value(__wrap_munmap, addr, STATEFILE_MMAP_NEW);
     expect_value(__wrap_munmap, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_munmap, 1); /* wrap = true */
     will_return(__wrap_munmap, 0);
 
     expect_string(__wrap_truncate, path, STATEFILE_PATH);
     expect_value(__wrap_truncate, length, S3_STATE_LEN);
+    will_return(__wrap_truncate, 1); /* wrap = true */
     will_return(__wrap_truncate, 0);
 
     Tss2_Tcti_Finalize(ctx);
     free(ctx);
+    return 0;
+}
+/*
+ * This is a utility function to teardown two TCTI contexts allocated by the
+ * tcti_libtpms_setup function.
+ */
+static int
+tcti_libtpms_teardown_two_states(void **state)
+{
+    int ret;
+    TSS2_TCTI_CONTEXT **ctxs = (TSS2_TCTI_CONTEXT**) *state;
+    TSS2_TCTI_LIBTPMS_CONTEXT **tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT**) ctxs;
+    *state = *ctxs;
+
+    /* for both tcti instances */
+    for (int i = 0; i < 2; i++) {
+        expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+        will_return(__wrap_dlclose, 0);
+
+        if (tcti_libtpms[i]->state_mmap != NULL) {
+            will_return(__wrap_munmap, 0); /* wrap = false, delegate to __real_munmap */
+        }
+
+        if (tcti_libtpms[i]->state_path != NULL) {
+            will_return(__wrap_truncate, 0); /* wrap = false, delegate to __real_truncate */
+        }
+
+        Tss2_Tcti_Finalize(ctxs[i]);
+
+        free(ctxs[i]);
+    }
+    free(ctxs);
+
+    /* try to delete state files */
+    ret = unlink(STATEFILE_PATH_REAL0);
+    if (ret < 0) {
+        LOG_WARNING("Failed to delete statefile " STATEFILE_PATH_REAL0 ": %s",
+                    strerror(errno));
+    }
+    ret = unlink(STATEFILE_PATH_REAL1);
+    if (ret < 0) {
+        LOG_WARNING("Failed to delete statefile " STATEFILE_PATH_REAL1 ": %s",
+                    strerror(errno));
+    }
+
     return 0;
 }
 
@@ -1183,6 +1641,12 @@ main(int   argc,
         cmocka_unit_test_setup_teardown(tcti_libtpms_remap_state_posix_fallocate_fail_test,
                                         tcti_libtpms_setup,
                                         tcti_libtpms_teardown_s1),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_two_states_no_statefiles_success_test,
+                                        tcti_libtpms_setup_two_states_no_statefiles,
+                                        tcti_libtpms_teardown_two_states),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_two_states_success_test,
+                                        tcti_libtpms_setup_two_states,
+                                        tcti_libtpms_teardown_two_states),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unit/tcti-libtpms.c
+++ b/test/unit/tcti-libtpms.c
@@ -1,0 +1,1188 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/***********************************************************************;
+ * Copyright (c) 2015 - 2018, Intel Corporation
+ * All rights reserved.
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_libtpms.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-libtpms.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+
+#define LIBTPMS_DL_HANDLE  0x12345678
+#define STATEFILE_PATH     "statefile.bin"
+#define STATEFILE_FD       0xAABB
+#define STATEFILE_MMAP     mmap_buf
+#define STATEFILE_MMAP_NEW mmap_buf_new
+
+/* loaded state */
+#define S1_PERMANENT_BUF_LITERAL "aaaaaaaa"
+#define S1_PERMANENT_BUF_LEN     8
+#define S1_VOLATILE_BUF_LITERAL  "bbbbb"
+#define S1_VOLATILE_BUF_LEN      5
+#define S1_STATE                 "\0\0\0\x08" S1_PERMANENT_BUF_LITERAL "\0\0\0\x05" S1_VOLATILE_BUF_LITERAL
+#define S1_STATE_LEN             (sizeof(uint32_t) + S1_PERMANENT_BUF_LEN + sizeof(uint32_t) + S1_VOLATILE_BUF_LEN)
+
+/* next state */
+#define S2_PERMANENT_BUF_LITERAL "xxxxxxxxxxxxx"
+#define S2_PERMANENT_BUF_LEN     13
+#define S2_VOLATILE_BUF_LITERAL  "yyyyyyy"
+#define S2_VOLATILE_BUF_LEN      7
+#define S2_STATE                 "\0\0\0\x0D" S2_PERMANENT_BUF_LITERAL "\0\0\0\x07" S2_VOLATILE_BUF_LITERAL
+#define S2_STATE_LEN             (sizeof(uint32_t) + S2_PERMANENT_BUF_LEN + sizeof(uint32_t) + S2_VOLATILE_BUF_LEN)
+
+/* big state */
+#define S3_PERMANENT_BUF_LITERAL "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" \
+                                 "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss"
+#define S3_PERMANENT_BUF_LEN     1200
+#define S3_VOLATILE_BUF_LITERAL  "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" \
+                                 "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
+#define S3_VOLATILE_BUF_LEN      1100
+#define S3_STATE                 "\0\0\x04\xB0" S3_PERMANENT_BUF_LITERAL "\0\0\04\x4C" S3_VOLATILE_BUF_LITERAL
+#define S3_STATE_LEN             (sizeof(uint32_t) + S3_PERMANENT_BUF_LEN + sizeof(uint32_t) + S3_VOLATILE_BUF_LEN)
+
+char mmap_buf[STATE_MMAP_CHUNK_LEN] = {0};
+char mmap_buf_new[2400] = {0};
+
+struct libtpms_callbacks global_callbacks;
+
+/* mock libtpms API */
+TPM_RESULT TPMLIB_ChooseTPMVersion(TPMLIB_TPMVersion ver)
+{
+    check_expected(ver);
+    return mock_type(int);
+}
+TPM_RESULT TPMLIB_RegisterCallbacks(struct libtpms_callbacks *callbacks)
+{
+    global_callbacks.sizeOfStruct = callbacks->sizeOfStruct;
+    global_callbacks.tpm_nvram_init = callbacks->tpm_nvram_init;
+    global_callbacks.tpm_nvram_loaddata = callbacks->tpm_nvram_loaddata;
+    global_callbacks.tpm_nvram_storedata = callbacks->tpm_nvram_storedata;
+    global_callbacks.tpm_nvram_deletename = callbacks->tpm_nvram_deletename;
+    global_callbacks.tpm_io_init = callbacks->tpm_io_init;
+    global_callbacks.tpm_io_getlocality = callbacks->tpm_io_getlocality;
+    global_callbacks.tpm_io_getphysicalpresence = callbacks->tpm_io_getphysicalpresence;
+    return mock_type(int);
+}
+TPM_RESULT TPMLIB_GetState(enum TPMLIB_StateType st, unsigned char **buf, uint32_t *buf_len)
+{
+    check_expected(st);
+    unsigned char *buf_out = mock_type(unsigned char *);
+    *buf_len = mock_type(uint32_t);
+    *buf = malloc(*buf_len);
+    assert_non_null(*buf);
+    memcpy(*buf, buf_out, *buf_len);
+    return mock_type(int);
+}
+TPM_RESULT TPMLIB_MainInit(void)
+{
+    uint32_t ret;
+    ret = global_callbacks.tpm_nvram_init();
+    assert_int_equal(ret, 0);
+    ret = global_callbacks.tpm_io_init();
+    assert_int_equal(ret, 0);
+    ret = global_callbacks.tpm_nvram_loaddata((unsigned char **) 1,
+                                               (uint32_t *) 2,
+                                               3,
+                                               "4");
+    assert_int_equal(ret, TPM_RETRY);
+    return mock_type(int);
+}
+TPM_RESULT TPMLIB_Process(unsigned char **resp_buf, uint32_t *resp_len, uint32_t *resp_buf_len, unsigned char *cmd, uint32_t cmd_len)
+{
+    uint32_t locality;
+    uint32_t ret;
+    check_expected_ptr(cmd);
+    check_expected(cmd_len);
+    ret = global_callbacks.tpm_io_getlocality(&locality, 0);
+    assert_int_equal(ret, 0);
+    check_expected(locality);
+
+    ret = global_callbacks.tpm_nvram_storedata((unsigned char *) 1, 2, 3, "4");
+    assert_int_equal(ret, TPM_SUCCESS);
+
+    unsigned char *buf_out = mock_type(unsigned char *);
+    *resp_buf_len = *resp_len = mock_type(uint32_t);
+    *resp_buf = malloc(*resp_len);
+    assert_non_null(*resp_buf);
+    memcpy(*resp_buf, buf_out, *resp_len);
+    return mock_type(int);
+}
+TPM_RESULT TPMLIB_SetState(enum TPMLIB_StateType st, const unsigned char *buf, uint32_t buf_len)
+{
+    check_expected_ptr(st);
+    check_expected_ptr(buf);
+    check_expected_ptr(buf_len);
+    return mock_type(int);
+}
+void TPMLIB_Terminate(void)
+{
+}
+
+void *__wrap_dlopen(const char *filename, int flags)
+{
+    LOG_TRACE("Called with filename %s and flags %x", filename, flags);
+    check_expected_ptr(filename);
+    check_expected(flags);
+    return mock_type(void *);
+}
+int __wrap_dlclose(void *handle)
+{
+    LOG_TRACE("Called with handle %p", handle);
+    check_expected_ptr(handle);
+    return mock_type(int);
+}
+void *__wrap_dlsym(void *handle, const char *symbol)
+{
+    LOG_TRACE("Called with handle %p and symbol %s", handle, symbol);
+    check_expected_ptr(handle);
+    check_expected_ptr(symbol);
+    return mock_type(void *);
+}
+void *__wrap_mmap (void *addr, size_t len, int prot, int flags, int fd, off_t offset)
+{
+    check_expected_ptr(addr);
+    check_expected(len);
+    check_expected(prot);
+    check_expected(flags);
+    check_expected(fd);
+    check_expected(offset);
+    return mock_type(void *);
+}
+void *__wrap_mremap(void *old_address, size_t old_size, size_t new_size, int flags)
+{
+    void *new_address;
+    check_expected_ptr(old_address);
+    check_expected(old_size);
+    check_expected(new_size);
+    check_expected(flags);
+    new_address = mock_type(void *);
+    if (new_address != MAP_FAILED) {
+        memcpy(new_address, old_address, old_size);
+    }
+    return new_address;
+}
+int __wrap_munmap(void *addr, size_t len)
+{
+    check_expected_ptr(addr);
+    check_expected(len);
+    return mock_type(int);
+}
+int __real_open(const char *pathname, int flags, ...);
+int __wrap_open(const char *pathname, int flags, mode_t mode)
+{
+    if (strncmp(pathname, STATEFILE_PATH, strlen(STATEFILE_PATH)) == 0) {
+        check_expected_ptr(pathname);
+        check_expected(flags);
+        check_expected(mode);
+        return mock_type(int);
+    } else {
+        /* only mock opening of state files as the open() syscall is needed
+           for code coverage reports as well */
+        return __real_open(pathname, flags, mode);
+    }
+}
+off_t __wrap_lseek(int fd, off_t offset, int whence)
+{
+    check_expected(fd);
+    check_expected(offset);
+    check_expected(whence);
+    return mock_type(off_t);
+}
+int __wrap_posix_fallocate(int fd, off_t offset, off_t len)
+{
+    check_expected(fd);
+    check_expected(offset);
+    check_expected(len);
+    return mock_type(int);
+}
+int __wrap_truncate(const char *path, off_t length)
+{
+    check_expected_ptr(path);
+    check_expected(length);
+    return mock_type(int);
+}
+int __wrap_close(int fd)
+{
+    check_expected(fd);
+    return mock_type(int);
+}
+
+/* When passed all NULL values, we expect TSS2_TCTI_RC_BAD_VALUE. */
+static void
+tcti_libtpms_init_all_null_test(void **state)
+{
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_Libtpms_Init(NULL, NULL, NULL);
+    assert_int_equal(rc, TSS2_TCTI_RC_BAD_VALUE);
+}
+
+/* When dlopen fails for library names we expect TSS2_TCTI_RC_GENERAL_FAILURE. */
+static void
+tcti_libtpms_init_dlopen_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtpms.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, NULL);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, NULL);
+    assert_int_equal(ret, TSS2_TCTI_RC_GENERAL_FAILURE);
+
+    free(ctx);
+}
+
+/* When dlsym fails for any libtpms symbol, we expect TSS2_TCTI_RC_GENERAL_FAILURE. */
+static void
+tcti_libtpms_init_dlsym_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    const char *syms[] = {
+        "TPMLIB_ChooseTPMVersion",
+        "TPMLIB_RegisterCallbacks",
+        "TPMLIB_GetState",
+        "TPMLIB_MainInit",
+        "TPMLIB_Process",
+        "TPMLIB_SetState",
+        "TPMLIB_Terminate",
+    };
+
+    /* test for every symbol syms[i] */
+    for (size_t i = 0; i < ARRAY_LEN(syms); i++) {
+        ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+        assert_true(ret == TSS2_RC_SUCCESS);
+        ctx = calloc(1, tcti_size);
+        assert_non_null(ctx);
+
+        expect_string(__wrap_dlopen, filename, "libtpms.so");
+        expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+        will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+        /* successfully load all symbols up to (excluding) index i */
+        for (size_t j = 0; j < i; j++) {
+            expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+            expect_string(__wrap_dlsym, symbol, syms[j]);
+            will_return(__wrap_dlsym, (void *) 1);
+        }
+
+        /* fail to load sym at index i */
+        expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+        expect_string(__wrap_dlsym, symbol, syms[i]);
+        will_return(__wrap_dlsym, NULL);
+
+        /* cleanup */
+        expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+        will_return(__wrap_dlclose, 0);
+
+        ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, NULL);
+        assert_int_equal(ret, TSS2_TCTI_RC_GENERAL_FAILURE);
+
+        free(ctx);
+    }
+}
+
+/* When open fails to open the state file, we expect TSS2_TCTI_RC_IO_ERROR. */
+static void
+tcti_libtpms_init_state_open_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    /* fail open */
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, -1);
+
+    /* cleanup */
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, STATEFILE_PATH);
+    assert_int_equal(ret, TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+
+/* When lseek fails on the state file, we expect TSS2_TCTI_RC_IO_ERROR. */
+static void
+tcti_libtpms_init_state_lseek_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, STATEFILE_FD);
+
+    /* fail to lseek */
+    expect_value(__wrap_lseek, fd, STATEFILE_FD);
+    expect_value(__wrap_lseek, offset, 0L);
+    expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, -1);
+
+    /* cleanup */
+    expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 0);
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, STATEFILE_PATH);
+    assert_int_equal(ret, TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+
+/* When posix_fallocate fails on the state file, we expect TSS2_TCTI_RC_IO_ERROR. */
+static void
+tcti_libtpms_init_state_posix_fallocate_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, STATEFILE_FD);
+
+    expect_value(__wrap_lseek, fd, STATEFILE_FD);
+    expect_value(__wrap_lseek, offset, 0L);
+    expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, S1_STATE_LEN);
+
+    /* fail to posix_fallocate */
+    expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
+    expect_value(__wrap_posix_fallocate, offset, 0);
+    expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_posix_fallocate, -1);
+
+    /* cleanup */
+    expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 0);
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, STATEFILE_PATH);
+    assert_int_equal(ret, TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+
+/* When mmap fails on the state file, we expect TSS2_TCTI_RC_IO_ERROR. */
+static void
+tcti_libtpms_init_state_mmap_fail_test(void **state)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, STATEFILE_FD);
+
+    expect_value(__wrap_lseek, fd, STATEFILE_FD);
+    expect_value(__wrap_lseek, offset, 0L);
+    expect_value(__wrap_lseek, whence, SEEK_END);
+    will_return(__wrap_lseek, S1_STATE_LEN);
+
+    expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
+    expect_value(__wrap_posix_fallocate, offset, 0);
+    expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_posix_fallocate, 0);
+
+    /* fail to mmap */
+    expect_value(__wrap_mmap, addr, NULL);
+    expect_value(__wrap_mmap, len, STATE_MMAP_CHUNK_LEN);
+    expect_value(__wrap_mmap, prot, PROT_READ | PROT_WRITE);
+    expect_value(__wrap_mmap, flags, MAP_SHARED);
+    expect_value(__wrap_mmap, fd, STATEFILE_FD);
+    expect_value(__wrap_mmap, offset, 0);
+    will_return(__wrap_mmap, MAP_FAILED);
+
+    /* cleanup */
+    expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 0);
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, STATEFILE_PATH);
+    assert_int_equal(ret, TSS2_TCTI_RC_IO_ERROR);
+
+    free(ctx);
+}
+
+/*
+ * This is a utility function used by other tests to setup a TCTI context. It
+ * effectively wraps the init / allocate / init pattern as well as priming the
+ * mock functions necessary for a the successful call to
+ * 'Tss2_Tcti_Libtpms_Init'.
+ */
+static TSS2_TCTI_CONTEXT*
+tcti_libtpms_init_from_conf(const char *conf)
+{
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms;
+
+    memcpy(mmap_buf, S1_STATE, S1_STATE_LEN);
+
+    fprintf(stderr, "%s: before first init\n", __func__);
+    ret = Tss2_Tcti_Libtpms_Init(NULL, &tcti_size, NULL);
+    assert_true(ret == TSS2_RC_SUCCESS);
+    ctx = calloc(1, tcti_size);
+    assert_non_null(ctx);
+
+    fprintf(stderr, "%s: before second_init\n", __func__);
+    expect_string(__wrap_dlopen, filename, "libtpms.so");
+    expect_value(__wrap_dlopen, flags, RTLD_LAZY | RTLD_LOCAL);
+    will_return(__wrap_dlopen, LIBTPMS_DL_HANDLE);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_ChooseTPMVersion");
+    will_return(__wrap_dlsym, &TPMLIB_ChooseTPMVersion);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_RegisterCallbacks");
+    will_return(__wrap_dlsym, &TPMLIB_RegisterCallbacks);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_GetState");
+    will_return(__wrap_dlsym, &TPMLIB_GetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_MainInit");
+    will_return(__wrap_dlsym, &TPMLIB_MainInit);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Process");
+    will_return(__wrap_dlsym, &TPMLIB_Process);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_SetState");
+    will_return(__wrap_dlsym, &TPMLIB_SetState);
+
+    expect_value(__wrap_dlsym, handle, LIBTPMS_DL_HANDLE);
+    expect_string(__wrap_dlsym, symbol, "TPMLIB_Terminate");
+    will_return(__wrap_dlsym, &TPMLIB_Terminate);
+
+    if (conf != NULL) {
+        expect_string(__wrap_open, pathname, STATEFILE_PATH);
+        expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+        expect_value(__wrap_open, mode, 0644);
+        will_return(__wrap_open, STATEFILE_FD);
+
+        expect_value(__wrap_lseek, fd, STATEFILE_FD);
+        expect_value(__wrap_lseek, offset, 0L);
+        expect_value(__wrap_lseek, whence, SEEK_END);
+        will_return(__wrap_lseek, S1_STATE_LEN);
+
+        expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
+        expect_value(__wrap_posix_fallocate, offset, 0);
+        expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN);
+        will_return(__wrap_posix_fallocate, 0);
+
+        expect_value(__wrap_mmap, addr, NULL);
+        expect_value(__wrap_mmap, len, STATE_MMAP_CHUNK_LEN);
+        expect_value(__wrap_mmap, prot, PROT_READ | PROT_WRITE);
+        expect_value(__wrap_mmap, flags, MAP_SHARED);
+        expect_value(__wrap_mmap, fd, STATEFILE_FD);
+        expect_value(__wrap_mmap, offset, 0);
+        will_return(__wrap_mmap, STATEFILE_MMAP);
+
+        expect_value(__wrap_close, fd, STATEFILE_FD);
+        will_return(__wrap_close, 0);
+
+        expect_value(TPMLIB_SetState, st, TPMLIB_STATE_PERMANENT);
+        expect_value(TPMLIB_SetState, buf, STATEFILE_MMAP + sizeof(uint32_t));
+        expect_value(TPMLIB_SetState, buf_len, S1_PERMANENT_BUF_LEN);
+        will_return(TPMLIB_SetState, 0);
+
+        expect_value(TPMLIB_SetState, st, TPMLIB_STATE_VOLATILE);
+        expect_value(TPMLIB_SetState, buf, STATEFILE_MMAP + sizeof(uint32_t) + S1_PERMANENT_BUF_LEN + sizeof(uint32_t));
+        expect_value(TPMLIB_SetState, buf_len, S1_VOLATILE_BUF_LEN);
+        will_return(TPMLIB_SetState, 0);
+    }
+
+    expect_value(TPMLIB_ChooseTPMVersion, ver, TPMLIB_TPM_VERSION_2);
+    will_return(TPMLIB_ChooseTPMVersion, 0);
+    will_return(TPMLIB_RegisterCallbacks, 0);
+    will_return(TPMLIB_MainInit, 0);
+
+    ret = Tss2_Tcti_Libtpms_Init(ctx, &tcti_size, conf);
+    fprintf(stderr, "%s: after second init\n", __func__);
+    assert_int_equal(ret, TSS2_RC_SUCCESS);
+
+    tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    if (conf != NULL) {
+        assert_string_equal(tcti_libtpms->state_path, STATEFILE_PATH);
+        assert_ptr_equal(tcti_libtpms->state_mmap, STATEFILE_MMAP);
+        assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN);
+        assert_int_equal(tcti_libtpms->state_len, S1_STATE_LEN);
+        assert_memory_equal(tcti_libtpms->state_mmap, S1_STATE, S1_STATE_LEN);
+    } else {
+        assert_ptr_equal(tcti_libtpms->state_path, NULL);
+        assert_ptr_equal(tcti_libtpms->state_mmap, NULL);
+        assert_int_equal(tcti_libtpms->state_mmap_len, 0);
+        assert_int_equal(tcti_libtpms->state_len, 0);
+    }
+
+    return ctx;
+}
+
+static void
+tcti_libtpms_locality_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+
+    rc = Tss2_Tcti_SetLocality(ctx, 4);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 4); /* expect locality 4 */
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 123);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TSS2_TCTI_RC_IO_ERROR);
+}
+
+static void
+tcti_libtpms_transmit_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S2_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S2_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S2_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S2_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(tcti_libtpms->response_buffer, rsp, sizeof(rsp));
+    assert_int_equal(tcti_libtpms->response_buffer_len, sizeof(rsp));
+    assert_int_equal(tcti_libtpms->response_len, sizeof(rsp));
+
+    assert_string_equal(tcti_libtpms->state_path, STATEFILE_PATH);
+    assert_ptr_equal(tcti_libtpms->state_mmap, STATEFILE_MMAP);
+    assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN);
+    assert_int_equal(tcti_libtpms->state_len, S2_STATE_LEN);
+    assert_memory_equal(tcti_libtpms->state_mmap, S2_STATE, S2_STATE_LEN);
+}
+
+static void
+tcti_libtpms_receive_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast(ctx);
+    TSS2_RC rc;
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+    unsigned char rsp_out[sizeof(rsp)];
+    size_t rsp_len_out = 0;
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+    tcti_libtpms->response_buffer = malloc(sizeof(rsp));
+    assert_non_null(tcti_libtpms->response_buffer);
+    memcpy(tcti_libtpms->response_buffer, rsp, sizeof(rsp));
+    tcti_libtpms->response_buffer_len = sizeof(rsp);
+    tcti_libtpms->response_len = sizeof(rsp);
+
+    /* response get size */
+    rc = Tss2_Tcti_Receive(ctx, &rsp_len_out, NULL, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+    assert_int_equal(rsp_len_out, sizeof(rsp));
+    assert_int_equal(tcti_common->state, TCTI_STATE_RECEIVE);
+
+    /* get response */
+    rc = Tss2_Tcti_Receive(ctx, &rsp_len_out, rsp_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+    assert_memory_equal(rsp_out, rsp, rsp_len_out);
+    assert_int_equal(rsp_len_out, sizeof(rsp));
+    assert_int_equal(tcti_common->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms->response_len, 0);
+}
+
+static void
+tcti_libtpms_remap_state_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    expect_value(__wrap_mremap, old_address, STATEFILE_MMAP);
+    expect_value(__wrap_mremap, old_size, STATE_MMAP_CHUNK_LEN);
+    expect_value(__wrap_mremap, new_size, STATE_MMAP_CHUNK_LEN * 2);
+    expect_value(__wrap_mremap, flags, MREMAP_MAYMOVE);
+    will_return(__wrap_mremap, STATEFILE_MMAP_NEW);
+
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, STATEFILE_FD);
+
+    expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
+    expect_value(__wrap_posix_fallocate, offset, 0);
+    expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_posix_fallocate, 0);
+
+    expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 0);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_string_equal(tcti_libtpms->state_path, STATEFILE_PATH);
+    assert_ptr_equal(tcti_libtpms->state_mmap, STATEFILE_MMAP_NEW);
+    assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN * 2);
+    assert_int_equal(tcti_libtpms->state_len, S3_STATE_LEN);
+    assert_memory_equal(tcti_libtpms->state_mmap, S3_STATE, S3_STATE_LEN);
+}
+
+/* Have mremap fail during state remap (transmit), expect TSS2_TCTI_RC_IO_ERROR */
+static void
+tcti_libtpms_remap_state_mremap_fail_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    expect_value(__wrap_mremap, old_address, STATEFILE_MMAP);
+    expect_value(__wrap_mremap, old_size, STATE_MMAP_CHUNK_LEN);
+    expect_value(__wrap_mremap, new_size, STATE_MMAP_CHUNK_LEN * 2);
+    expect_value(__wrap_mremap, flags, MREMAP_MAYMOVE);
+    will_return(__wrap_mremap, MAP_FAILED);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TSS2_TCTI_RC_IO_ERROR);
+
+    /* reallocating memory (and thus storing) failed for S3, we're still at S1 */
+    assert_string_equal(tcti_libtpms->state_path, STATEFILE_PATH);
+    assert_ptr_equal(tcti_libtpms->state_mmap, STATEFILE_MMAP);
+    assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN);
+    assert_int_equal(tcti_libtpms->state_len, S1_STATE_LEN);
+    assert_memory_equal(tcti_libtpms->state_mmap, S1_STATE, S1_STATE_LEN);
+}
+
+/* Have open fail during state remap (transmit), expect TSS2_TCTI_RC_IO_ERROR */
+static void
+tcti_libtpms_remap_state_posix_fallocate_fail_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 0);
+
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_PERMANENT);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_PERMANENT_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+    expect_value(TPMLIB_GetState, st, TPMLIB_STATE_VOLATILE);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LITERAL);
+    will_return(TPMLIB_GetState, S3_VOLATILE_BUF_LEN);
+    will_return(TPMLIB_GetState, 0);
+
+    expect_value(__wrap_mremap, old_address, STATEFILE_MMAP);
+    expect_value(__wrap_mremap, old_size, STATE_MMAP_CHUNK_LEN);
+    expect_value(__wrap_mremap, new_size, STATE_MMAP_CHUNK_LEN * 2);
+    expect_value(__wrap_mremap, flags, MREMAP_MAYMOVE);
+    will_return(__wrap_mremap, STATEFILE_MMAP_NEW);
+
+    expect_string(__wrap_open, pathname, STATEFILE_PATH);
+    expect_value(__wrap_open, flags, O_RDWR | O_CREAT);
+    expect_value(__wrap_open, mode, 0644);
+    will_return(__wrap_open, STATEFILE_FD);
+
+    expect_value(__wrap_posix_fallocate, fd, STATEFILE_FD);
+    expect_value(__wrap_posix_fallocate, offset, 0);
+    expect_value(__wrap_posix_fallocate, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_posix_fallocate, -5);
+
+    /* cleanup */
+    expect_value(__wrap_close, fd, STATEFILE_FD);
+    will_return(__wrap_close, 0);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TSS2_TCTI_RC_IO_ERROR);
+
+    /* storing failed for S3, but we could allocate more memory, still S1 */
+    assert_string_equal(tcti_libtpms->state_path, STATEFILE_PATH);
+    assert_ptr_equal(tcti_libtpms->state_mmap, STATEFILE_MMAP_NEW);
+    assert_int_equal(tcti_libtpms->state_mmap_len, STATE_MMAP_CHUNK_LEN * 2);
+    assert_int_equal(tcti_libtpms->state_len, S1_STATE_LEN);
+    assert_memory_equal(tcti_libtpms->state_mmap, S1_STATE, S1_STATE_LEN);
+}
+
+/* Have open fail during state remap (transmit), expect TSS2_TCTI_RC_IO_ERROR */
+static void
+tcti_libtpms_no_statefile_success_test(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_common_context_cast(ctx);
+    TSS2_RC rc;
+    unsigned char cmd[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00};
+    unsigned char rsp[] = {0x80, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00};
+    unsigned char rsp_out[sizeof(rsp)];
+    size_t rsp_len_out = sizeof(rsp);
+
+    expect_value(TPMLIB_Process, cmd, cmd);
+    expect_value(TPMLIB_Process, cmd_len, sizeof(cmd));
+    expect_value(TPMLIB_Process, locality, 0);
+    will_return(TPMLIB_Process, rsp);
+    will_return(TPMLIB_Process, sizeof(rsp));
+    will_return(TPMLIB_Process, 0);
+
+    rc = Tss2_Tcti_Transmit(ctx, sizeof(cmd), cmd);
+    assert_int_equal(rc, TPM2_RC_SUCCESS);
+
+    /* expect no state */
+    assert_ptr_equal(tcti_libtpms->state_path, NULL);
+    assert_ptr_equal(tcti_libtpms->state_mmap, NULL);
+    assert_int_equal(tcti_libtpms->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms->state_len, 0);
+
+    rc = Tss2_Tcti_Receive(ctx, &rsp_len_out, rsp_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    assert_memory_equal(rsp_out, rsp, rsp_len_out);
+    assert_int_equal(rsp_len_out, sizeof(rsp));
+    assert_int_equal(tcti_common->state, TCTI_STATE_TRANSMIT);
+
+    assert_ptr_equal(tcti_libtpms->response_buffer, NULL);
+    assert_int_equal(tcti_libtpms->response_buffer_len, 0);
+    assert_int_equal(tcti_libtpms->response_len, 0);
+
+    /* expect no state */
+    assert_ptr_equal(tcti_libtpms->state_path, NULL);
+    assert_ptr_equal(tcti_libtpms->state_mmap, NULL);
+    assert_int_equal(tcti_libtpms->state_mmap_len, 0);
+    assert_int_equal(tcti_libtpms->state_len, 0);
+}
+
+/*
+ * This is a utility function to setup the "default" TCTI context.
+ */
+static int
+tcti_libtpms_setup(void **state)
+{
+    fprintf(stderr, "%s: before tcti_libtpms_init_from_conf\n", __func__);
+    *state = tcti_libtpms_init_from_conf(STATEFILE_PATH);
+    fprintf(stderr, "%s: done\n", __func__);
+    return 0;
+}
+/*
+ * This is a utility function to setup the "default" TCTI context.
+ */
+static int
+tcti_libtpms_setup_no_statefile(void **state)
+{
+    fprintf(stderr, "%s: before tcti_libtpms_init_from_conf\n", __func__);
+    *state = tcti_libtpms_init_from_conf(NULL);
+    fprintf(stderr, "%s: done\n", __func__);
+    return 0;
+}
+/*
+ * This is a utility function to teardown a TCTI context allocated by the
+ * tcti_libtpms_setup function. Will expect no state file.
+ */
+static int
+tcti_libtpms_teardown_no_statefile(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*) *state;
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    Tss2_Tcti_Finalize(ctx);
+    free(ctx);
+    return 0;
+}
+/*
+ * This is a utility function to teardown a TCTI context allocated by the
+ * tcti_libtpms_setup function. Will expect libtpms state 1.
+ */
+static int
+tcti_libtpms_teardown_s1(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*) *state;
+    TSS2_TCTI_LIBTPMS_CONTEXT *tcti_libtpms = (TSS2_TCTI_LIBTPMS_CONTEXT*) ctx;
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    if (tcti_libtpms->state_mmap != NULL) {
+        expect_value(__wrap_munmap, addr, tcti_libtpms->state_mmap);
+        expect_value(__wrap_munmap, len, tcti_libtpms->state_mmap_len);
+        will_return(__wrap_munmap, 0);
+    }
+
+    expect_string(__wrap_truncate, path, STATEFILE_PATH);
+    expect_value(__wrap_truncate, length, S1_STATE_LEN);
+    will_return(__wrap_truncate, 0);
+
+    Tss2_Tcti_Finalize(ctx);
+    free(ctx);
+    return 0;
+}
+/*
+ * This is a utility function to teardown a TCTI context allocated by the
+ * tcti_libtpms_setup function. Will expect libtpms state 2.
+ */
+static int
+tcti_libtpms_teardown_s2(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*) *state;
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    expect_value(__wrap_munmap, addr, STATEFILE_MMAP);
+    expect_value(__wrap_munmap, len, STATE_MMAP_CHUNK_LEN);
+    will_return(__wrap_munmap, 0);
+
+    expect_string(__wrap_truncate, path, STATEFILE_PATH);
+    expect_value(__wrap_truncate, length, S2_STATE_LEN);
+    will_return(__wrap_truncate, 0);
+
+    Tss2_Tcti_Finalize(ctx);
+    free(ctx);
+    return 0;
+}
+/*
+ * This is a utility function to teardown a TCTI context allocated by the
+ * tcti_libtpms_setup function. Will expect libtpms state 3.
+ */
+static int
+tcti_libtpms_teardown_s3(void **state)
+{
+    TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*) *state;
+
+    expect_value(__wrap_dlclose, handle, LIBTPMS_DL_HANDLE);
+    will_return(__wrap_dlclose, 0);
+
+    expect_value(__wrap_munmap, addr, STATEFILE_MMAP_NEW);
+    expect_value(__wrap_munmap, len, STATE_MMAP_CHUNK_LEN * 2);
+    will_return(__wrap_munmap, 0);
+
+    expect_string(__wrap_truncate, path, STATEFILE_PATH);
+    expect_value(__wrap_truncate, length, S3_STATE_LEN);
+    will_return(__wrap_truncate, 0);
+
+    Tss2_Tcti_Finalize(ctx);
+    free(ctx);
+    return 0;
+}
+
+int
+main(int   argc,
+     char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(tcti_libtpms_init_all_null_test),
+        cmocka_unit_test(tcti_libtpms_init_dlopen_fail_test),
+        cmocka_unit_test(tcti_libtpms_init_dlsym_fail_test),
+        cmocka_unit_test(tcti_libtpms_init_state_open_fail_test),
+        cmocka_unit_test(tcti_libtpms_init_state_lseek_fail_test),
+        cmocka_unit_test(tcti_libtpms_init_state_posix_fallocate_fail_test),
+        cmocka_unit_test(tcti_libtpms_init_state_mmap_fail_test),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_no_statefile_success_test,
+                                        tcti_libtpms_setup_no_statefile,
+                                        tcti_libtpms_teardown_no_statefile),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_receive_success_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s1),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_locality_success_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s1),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_transmit_success_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s2),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_remap_state_success_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s3),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_remap_state_mremap_fail_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s1),
+        cmocka_unit_test_setup_teardown(tcti_libtpms_remap_state_posix_fallocate_fail_test,
+                                        tcti_libtpms_setup,
+                                        tcti_libtpms_teardown_s1),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Add `tcti-libtpms`. As of now, localities and pollhandles are not implemented. While the TPM state is unique to the tcti context, it cannot be shared across processes.