### PR TITLE
FAPI: Improve checks for file access.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -643,7 +643,8 @@ test_unit_fapi_io_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
                             -Wl,--wrap=read \
                             -Wl,--wrap=write \
                             -Wl,--wrap=fileno \
-                            -Wl,--wrap=fclose
+                            -Wl,--wrap=fclose \
+                            -Wl,--wrap=stat
 test_unit_fapi_io_SOURCES = test/unit/fapi-io.c \
                             src/tss2-fapi/ifapi_json_deserialize.c \
                             src/tss2-fapi/ifapi_json_serialize.c \

--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -13,6 +13,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <json-c/json_util.h>
 #include <json-c/json_tokener.h>
 
@@ -41,6 +43,19 @@ FILE mock_stream; /**< stream will be used to activate wrapper.*/
 /*
  * Wrapper functions for file system io.
  */
+
+int
+ __real_stat(const char *pathname, struct stat *statbuf, ...);
+
+int
+ __wrap_stat(const char *pathname, struct stat *statbuf, ...)
+{
+    if (strcmp(pathname, "tss_unit_dummyf")) {
+        return __real_stat(pathname, statbuf);
+    }
+    statbuf->st_mode = R_OK;
+    return 0;
+}
 
 FILE *
 __real_fopen(const char *pathname, const char* mode, ...);


### PR DESCRIPTION
* Before trying to open a file for reading it will be checked whether the file is
  a directory and wheter read access is possible.
* The return codes for fseek, ftell, and fopen will be checked in all cases.
* Fixes  #1978

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>