### PR TITLE
 ESYS: Fix binding of ESYS_TR_RH_NULL (Fixes #1993)

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -197,6 +197,8 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-create-primary-ecc-hmac.int \
     test/integration/esys-create-primary-hmac.int \
     test/integration/esys-create-session-auth-bound.int \
+    test/integration/esys-create-session-null-bind-tpm-key.int \
+    test/integration/esys-create-session-null-bind-no-tpm-key.int \
     test/integration/esys-create-session-auth-ecc.int \
     test/integration/esys-create-session-auth.int \
     test/integration/esys-create-session-auth-long.int \
@@ -1006,6 +1008,25 @@ test_integration_esys_create_session_auth_bound_int_SOURCES = \
     $(ESYS_SRC_UTIL_CRYPTO_SRC) \
     test/integration/esys-create-session-auth.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_create_session_null_bind_tpm_key_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTEST_AES_ENCRYPTION -DTEST_NULL_BIND_TPMKEY $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_integration_esys_create_session_null_bind_tpm_key_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_create_session_null_bind_tpm_key_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_integration_esys_create_session_null_bind_tpm_key_int_SOURCES = \
+    $(ESYS_SRC_UTIL_CRYPTO_SRC) \
+    test/integration/esys-create-session-auth.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_create_session_null_bind_no_tpm_key_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTEST_AES_ENCRYPTION -DTEST_NULL_BIND_NO_TPM_KEY $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_integration_esys_create_session_null_bind_no_tpm_key_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_create_session_null_bind_no_tpm_key_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_integration_esys_create_session_null_bind_no_tpm_key_int_SOURCES = \
+    $(ESYS_SRC_UTIL_CRYPTO_SRC) \
+    test/integration/esys-create-session-auth.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
 
 test_integration_esys_create_session_auth_ecc_int_CFLAGS  = $(TESTS_CFLAGS) \
     -DTEST_AES_ENCRYPTION -DTEST_ECC $(TSS2_ESYS_CFLAGS_CRYPTO)


### PR DESCRIPTION
* If ESYS_TR_RH_NULL was used as bind parameter for Esys_StartAuthSession the wrong HMAC
   was computed, because the session was not treated as unbound session.
   It will be checked whether no tpm key is passed and ESYS_TR_RH_NULL is used as bind
   parameter to skip KDF computation of the session key.
* Integration tests to check bind with ESYS_TR_RH_NULL was added,
    
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>