### PR TITLE
FAPI: use FAPI_TEST_EK_CERT_LESS with --disable-self-generated-certificate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,6 +462,8 @@ AS_IF([test "x$enable_self_generated_certificate" = xyes],
 	[AC_DEFINE([SELF_GENERATED_CERTIFICATE], [1], [Allow usage of self generated root certificate])],
 	[AS_IF([test "x$integration_tcti" != "xdevice"], [AC_DEFINE([FAPI_TEST_EK_CERT_LESS], [1], [Perform integration tests without EK certificate verification])])])
 
+AS_IF([test "x$enable_integration" = "xyes" && test "x$enable_self_generated_certificate" != "xyes" && test "x$integration_tcti" != "xdevice"],
+      [AC_MSG_WARN([Running integration tests without EK certificate verification, use --enable-self-generated-certificate for full test coverage])])
 
 AC_SUBST([PATH])
 

--- a/configure.ac
+++ b/configure.ac
@@ -458,8 +458,9 @@ AC_ARG_ENABLE([self-generated-certificate],
             [AS_HELP_STRING([--enable-self-generated-certificate],
                             [Alllow usage of self generated root certifcate])],,
             [enable_self_generated_certificate=no])
-AS_IF([test "x$enable_self_generated_certificate" == xyes],
-	[AC_DEFINE([SELF_GENERATED_CERTIFICATE],[1], [Allow usage of self generated root certifcate])])
+AS_IF([test "x$enable_self_generated_certificate" = xyes],
+	[AC_DEFINE([SELF_GENERATED_CERTIFICATE], [1], [Allow usage of self generated root certificate])],
+	[AS_IF([test "x$integration_tcti" != "xdevice"], [AC_DEFINE([FAPI_TEST_EK_CERT_LESS], [1], [Perform integration tests without EK certificate verification])])])
 
 
 AC_SUBST([PATH])

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -226,8 +226,11 @@ int init_fapi(char *profile, FAPI_CONTEXT **fapi_context)
 #endif
                     "}\n",
                     profile, tmpdir, tmpdir, tmpdir,
-                    getenv("TPM20TEST_TCTI"),
-                    getenv("FAPI_TEST_FINGERPRINT"));
+                    getenv("TPM20TEST_TCTI")
+#if !defined(FAPI_TEST_EK_CERT_LESS)
+                    , getenv("FAPI_TEST_FINGERPRINT")
+#endif
+                   );
 #elif defined(FAPI_TEST_CERTIFICATE)
     size = asprintf(&config, "{\n"
                     "     \"profile_name\": \"%s\",\n"
@@ -244,8 +247,11 @@ int init_fapi(char *profile, FAPI_CONTEXT **fapi_context)
 #endif
                     "}\n",
                     profile, tmpdir, tmpdir, tmpdir,
-                    getenv("TPM20TEST_TCTI"),
-                    getenv("FAPI_TEST_CERTIFICATE"));
+                    getenv("TPM20TEST_TCTI")
+#if !defined(FAPI_TEST_EK_CERT_LESS)
+                    , getenv("FAPI_TEST_CERTIFICATE")
+#endif
+                   );
 #elif defined(FAPI_TEST_FINGERPRINT_ECC)
     size = asprintf(&config, "{\n"
                     "     \"profile_name\": \"%s\",\n"
@@ -262,8 +268,11 @@ int init_fapi(char *profile, FAPI_CONTEXT **fapi_context)
 #endif
                     "}\n",
                     profile, tmpdir, tmpdir, tmpdir,
-                    getenv("TPM20TEST_TCTI"),
-                    getenv("FAPI_TEST_FINGERPRINT_ECC"));
+                    getenv("TPM20TEST_TCTI")
+#if !defined(FAPI_TEST_EK_CERT_LESS)
+                    , getenv("FAPI_TEST_FINGERPRINT_ECC")
+#endif
+                   );
 #elif defined(FAPI_TEST_CERTIFICATE_ECC)
     size = asprintf(&config, "{\n"
                     "     \"profile_name\": \"%s\",\n"
@@ -280,8 +289,12 @@ int init_fapi(char *profile, FAPI_CONTEXT **fapi_context)
 #endif
                     "}\n",
                     profile, tmpdir, tmpdir, tmpdir,
-                    getenv("TPM20TEST_TCTI"),
-                    getenv("FAPI_TEST_CERTIFICATE_ECC"));
+                    getenv("TPM20TEST_TCTI")
+#if defined(FAPI_TEST_EK_CERT_LESS)
+#else
+                    , getenv("FAPI_TEST_CERTIFICATE_ECC")
+#endif
+                   );
 #else /* FAPI_NONTPM */
     size = asprintf(&config, "{\n"
                     "     \"profile_name\": \"%s\",\n"


### PR DESCRIPTION
Since commit 199b4edc265b2f4758aa22ebf4ed6472a34b9a7a ("FAPI: Fix reading of the root certificate for provisioning.") it is required to specify `--enable-self-generated-certificate` in order to make the FAPI integration tests pass. This is an option that should usually not be enabled in production builds for security reasons, but still some form of integration testing might be desirable in this case to verify whether the compiled library works as expected. Use `FAPI_TEST_EK_CERT_LESS` in this case to run the tests without EK certificate validation.