### PR TITLE
tcti: add read eagain handling for freeBSD

### DIFF
--- a/src/util/io.h
+++ b/src/util/io.h
@@ -33,6 +33,13 @@ typedef SSIZE_T ssize_t;
         __ret = exp; \
     } while (__ret == SOCKET_ERROR && WSAGetLastError() == WSAEINTR); \
     dest = __ret; }
+#elif defined (__FreeBSD__)
+#define TEMP_RETRY(dest, exp) \
+{   int __ret; \
+    do { \
+        __ret = exp; \
+    } while ((__ret == SOCKET_ERROR) && (errno == EINTR || errno == EAGAIN)); \
+    dest =__ret; }
 #else
 #define TEMP_RETRY(dest, exp) \
 {   int __ret; \


### PR DESCRIPTION
The random build failures on Cirrus CI seems to be related
to IO errno 35: Resource temporarily unavailable error.
https://cirrus-ci.com/task/5455668787281920?command=main#L2013

Handling for retries is done in select() on Linux,
but on FreeBSD select() returns immediately.
Need to add read() retry handling for FreeBSD specifically.

Fixes: #2002
Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>