### PR TITLE
tcti: fix windows build

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -287,8 +287,8 @@ tcti_mssim_get_poll_handles (
         *handles = tcti_mssim->tpm_sock;
 #else
         handles->fd = tcti_mssim->tpm_sock;
-#endif
         handles->events = POLLIN | POLLOUT;
+#endif
     }
 
     return TSS2_RC_SUCCESS;


### PR DESCRIPTION
Windows build failes with
error : member reference base type 'TSS2_TCTI_POLL_HANDLE'
(aka 'void *') is not a structure error.

https://ci.appveyor.com/project/tstruk/tpm2-tss/build/job/rshu41fripqevvoi#L717
Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>