### PR TITLE
FAPI: Fix leak in keystore load function.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -609,6 +609,7 @@ ifapi_keystore_load_async(
 
     /* Prepare read operation */
     r = ifapi_io_read_async(io, abs_path);
+    goto_if_error2(r, "Read object %s", error_cleanup, path);
     SAFE_FREE(abs_path);
     return r;
 


### PR DESCRIPTION
If access to the file to be loaded was not possible the computed path was not freed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>