### PR TITLE
FAPI: Fix invalid check of read access rights.

### DIFF
--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -57,11 +57,6 @@ ifapi_io_read_async(
         return TSS2_FAPI_RC_IO_ERROR;
     }
 
-    /* Check read access. */
-    if (!(statbuf.st_mode & R_OK)) {
-        LOG_ERROR("Can't read \"%s\".", filename);
-        return TSS2_FAPI_RC_IO_ERROR;
-    }
     if (io->char_rbuffer) {
         LOG_ERROR("rbuffer still in use; maybe use of old API.");
         return TSS2_FAPI_RC_IO_ERROR;
@@ -75,7 +70,7 @@ ifapi_io_read_async(
 
     io->stream = fopen(filename, "rt");
     if (io->stream == NULL) {
-        LOG_ERROR("File \"%s\" not found.", filename);
+        LOG_ERROR("Open file \"%s\": %s", filename, strerror(errno));
         return TSS2_FAPI_RC_IO_ERROR;
     }
 
@@ -101,7 +96,7 @@ ifapi_io_read_async(
 
     io->stream = fopen(filename, "rt");
     if (io->stream == NULL) {
-        LOG_ERROR("Could not open  \"%s\".", filename);
+        LOG_ERROR("Open file \"%s\": %s", filename, strerror(errno));
         return TSS2_FAPI_RC_IO_ERROR;
     }
     io->char_rbuffer = malloc (length + 1);
@@ -225,7 +220,8 @@ ifapi_io_write_async(
     io->stream = fopen(filename, "wt");
     if (io->stream == NULL) {
         goto_error(r, TSS2_FAPI_RC_IO_ERROR,
-                   "Could not open file \"%s\" for writing.", error, filename);
+                   "Open file \"%s\" for writing: %s", error, filename,
+                   strerror(errno));
     }
     /* Locking the file. Lock will be release upon close */
     if (lockf(fileno(io->stream), F_TLOCK, 0) == -1 && errno == EAGAIN) {

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -609,6 +609,7 @@ ifapi_keystore_load_async(
 
     /* Prepare read operation */
     r = ifapi_io_read_async(io, abs_path);
+    goto_if_error2(r, "Read object %s", error_cleanup, path);
     SAFE_FREE(abs_path);
     return r;
 


### PR DESCRIPTION
* The check could be removed. Errors will be handled by fopen.
* The error messages related to fopen were improved.
* One leak related to file opening was fixed: If access to the file to
  be loaded was not possible the computed path string was not freed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>