### PR TITLE
configure: improve make install on systems without systemd

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,7 @@ following sections describe them for the supported platforms.
 * doxygen
 * OpenSSL development libraries and header files
 * libcurl development libraries
+* Access Control List utility (acl)
 
 The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --enable-integration):

--- a/Makefile.am
+++ b/Makefile.am
@@ -613,8 +613,8 @@ define make_parent_dir
 endef
 
 define make_tss_user_and_group
-    (id -g tss || groupadd -r tss) && \
-    (id -u tss || useradd -r -g tss tss)
+    (id -g tss 2>/dev/null || groupadd -r tss) && \
+    (id -u tss 2>/dev/null || useradd -r -g tss tss)
 endef
 
 define make_tss_dir
@@ -633,8 +633,8 @@ define make_fapi_dirs
 endef
 
 define set_fapi_permissions
-    ($(call set_tss_permissions,$(DESTDIR)$(runstatedir)/tpm2-tss)
-    ($(call set_tss_permissions,$(DESTDIR)$(localstatedir)/lib/tpm2-tss)
+    ($(call set_tss_permissions,$(DESTDIR)$(runstatedir)/tpm2-tss))
+    ($(call set_tss_permissions,$(DESTDIR)$(localstatedir)/lib/tpm2-tss))
 endef
 
 define check_dir
@@ -642,8 +642,8 @@ define check_dir
 endef
 
 define check_fapi_dirs
-    $(call check_dir,$(DESTDIR)$(runstatedir)/tpm2-tss/eventlog/)
-    $(call check_dir,$(DESTDIR)$(localstatedir)/lib/tpm2-tss/system/keystore/)
+    ($(call check_dir,$(DESTDIR)$(runstatedir)/tpm2-tss/eventlog/))
+    ($(call check_dir,$(DESTDIR)$(localstatedir)/lib/tpm2-tss/system/keystore/))
 endef
 
 ### Man Pages
@@ -690,8 +690,16 @@ EXTRA_DIST += dist/tpm-udev.rules
 
 install-dirs:
 if HOSTOS_LINUX
-	(systemd-sysusers && systemd-tmpfiles --create) || \
-	($(call make_tss_user_and_group) && $(call make_fapi_dirs) && ($call set_fapi_permissions)) || true
+if SYSD_SYSUSERS
+	systemd-sysusers
+else
+	$(call make_tss_user_and_group)
+endif
+if SYSD_TMPFILES
+	systemd-tmpfiles --create
+else
+	$(call make_fapi_dirs) && $(call set_fapi_permissions)
+endif
 	$(call check_fapi_dirs)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -470,6 +470,15 @@ AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
 AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
 AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
 AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+# Check all tools used by make install
+AS_IF([test "$HOSTOS" = "Linux"],
+      [ERROR_IF_NO_PROG([groupadd])
+       ERROR_IF_NO_PROG([useradd])
+       ERROR_IF_NO_PROG([id])
+       ERROR_IF_NO_PROG([chown])
+       ERROR_IF_NO_PROG([chmod])
+       ERROR_IF_NO_PROG([mkdir])
+       ERROR_IF_NO_PROG([setfacl])])
 
 AC_SUBST([PATH])
 

--- a/configure.ac
+++ b/configure.ac
@@ -465,6 +465,12 @@ AS_IF([test "x$enable_self_generated_certificate" = xyes],
 AS_IF([test "x$enable_integration" = "xyes" && test "x$enable_self_generated_certificate" != "xyes" && test "x$integration_tcti" != "xdevice"],
       [AC_MSG_WARN([Running integration tests without EK certificate verification, use --enable-self-generated-certificate for full test coverage])])
 
+# Check for systemd helper tools used by make install
+AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
+AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
+AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
+AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+
 AC_SUBST([PATH])
 
 dnl --------- Doxy Gen -----------------------


### PR DESCRIPTION
install-data-hook uses systemd helpers for creating users and tmpfiles,
but on systems where there is no systemd or not all the helpers are
installed it needs to fall back to the old methods.
This should improve the make install step on some old systems
like ubuntu 16.04.

Fixes: #2016