### PR TITLE
configure: make tss user and FAPI directory creation non-fatal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -691,14 +691,14 @@ EXTRA_DIST += dist/tpm-udev.rules
 install-dirs:
 if HOSTOS_LINUX
 if SYSD_SYSUSERS
-	systemd-sysusers
+	systemd-sysusers || echo "*** WARNING *** Failed to create the tss user and group"
 else
-	$(call make_tss_user_and_group)
+	$(call make_tss_user_and_group) || echo "*** WARNING *** Failed to create the tss user and group"
 endif
 if SYSD_TMPFILES
-	systemd-tmpfiles --create
+	systemd-tmpfiles --create || echo "*** WARNING *** Failed to create the FAPI directories with the correct permissions"
 else
-	$(call make_fapi_dirs) && $(call set_fapi_permissions)
+	-$(call make_fapi_dirs) && $(call set_fapi_permissions) || echo "*** WARNING *** Failed to create the FAPI directories with the correct permissions"
 endif
 	$(call check_fapi_dirs)
 endif


### PR DESCRIPTION
PR #2019 made the installation routine abort with an error if the `tss` user or the FAPI directories cannot be created.

However, these actions are expected to fail if the installation is not run as root, e.g.  for distribution packaging using `DESTDIR`. In this case, the failure leads to a potentially incomplete installation, additionally suppressing the exit status of make might hide actual build failures.

Furthermore, `systemd-sysusers` and `systemd-tmpfiles` are run on every system start, so a failure is not a huge problem since it will be fixed by the next reboot. Print a noisy warning to inform the user that something is potentially wrong, but continue with the installation.