### PR TITLE
FAPI: Fix check overwriting of files in Fapi_Import.     

### DIFF
--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -634,7 +634,7 @@ Fapi_Import_Finish(
 
 error_cleanup:
     SAFE_FREE(command->private);
-    if (newObject) {
+    if (newObject && newObject->objectType == IFAPI_KEY_OBJ) {
         /* Private buffer was already freed. */
         newObject->misc.key.private.buffer = NULL;
         ifapi_cleanup_ifapi_object(newObject);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1295,14 +1295,12 @@ ifapi_keystore_search_nv_obj(
   *
   * The passed relative path will be expanded for user store and system store.
   *
-  *  Keys objects, NV objects, and hierarchies can be written.
-  *
   * @param[in] keystore The key directories and default profile.
   * @param[in] io  The input/output context being used for file I/O.
   * @param[in] path The relative path of the object. For keys the path will
-  *           expanded if possible.
+  *            expanded if possible.
   * @retval TSS2_RC_SUCCESS if the object does not exist.
-  * @retval TSS2_FAPI_RC_PATH_ALREADY_EXISTS if the file in objects exists.
+  * @retval TSS2_FAPI_RC_PATH_ALREADY_EXISTS if the file exists in the keystore.
   * @retval TSS2_FAPI_RC_MEMORY: if memory could not be allocated to hold the output data.
   */
 TSS2_RC

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -304,3 +304,37 @@ ifapi_policy_store_store_finish(
 
     return TSS2_RC_SUCCESS;
 }
+
+ /** Check whether policy already exists.
+  *
+  * @param[in] pstore The key directories and default profile.
+  * @param[in] io  The input/output context being used for file I/O.
+  * @param[in] path The relative path of the policy.
+  * @retval TSS2_RC_SUCCESS if the object does not exist.
+  * @retval TSS2_FAPI_RC_PATH_ALREADY_EXISTS if the policy file exists.
+  * @retval TSS2_FAPI_RC_MEMORY: if memory could not be allocated to hold the output data.
+  */
+TSS2_RC
+ifapi_policystore_check_overwrite(
+    IFAPI_POLICY_STORE *pstore,
+    IFAPI_IO *io,
+    const char *path)
+{
+    TSS2_RC r;
+    char *abs_path = NULL;
+    (void)io; /* Used to simplify future extensions */
+
+    /* Convert relative path to absolute path in keystore */
+    r = policy_rel_path_to_abs_path(pstore, path, &abs_path);
+    goto_if_error2(r, "Object %s not found.", cleanup, path);
+
+    if (ifapi_io_path_exists(abs_path)) {
+        goto_error(r, TSS2_FAPI_RC_PATH_ALREADY_EXISTS,
+                   "Object %s already exists.", cleanup, path);
+    }
+    r = TSS2_RC_SUCCESS;
+
+cleanup:
+    SAFE_FREE(abs_path);
+    return r;
+}

--- a/src/tss2-fapi/ifapi_policy_store.h
+++ b/src/tss2-fapi/ifapi_policy_store.h
@@ -52,4 +52,10 @@ ifapi_policy_store_store_finish(
     IFAPI_POLICY_STORE *pstore,
     IFAPI_IO *io);
 
+TSS2_RC
+ifapi_policystore_check_overwrite(
+    IFAPI_POLICY_STORE *pstore,
+    IFAPI_IO *io,
+    const char *path);
+
 #endif /* IFAPI_POLICY_STORE_H */

--- a/test/integration/fapi-ext-public-key.int.c
+++ b/test/integration/fapi-ext-public-key.int.c
@@ -227,6 +227,9 @@ test_fapi_ext_public_key(FAPI_CONTEXT *context)
     ASSERT(path_list != NULL);
     ASSERT(strcmp(path_list, "/ext/myExtPubKey") == 0);
 
+    r = Fapi_Delete(context, "/ext/myExtPubKey");
+    goto_if_error(r, "Error Fapi_Delete", error);
+
     /* Test VerfiyQuote in non TPM mode. */
     r = Fapi_Import(context, "/ext/myExtPubKey", pubkey_pem);
     goto_if_error(r, "Error Fapi_Import", error);

--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -329,6 +329,9 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     }
     json_policy[policy_size] = '\0';
 
+    r = Fapi_Delete(context, policy_pcr_read);
+    goto_if_error(r, "Error Fapi_Delete", error);
+
     r = Fapi_Import(context, policy_pcr_read, json_policy);
     goto_if_error(r, "Error Fapi_Import", error);
 


### PR DESCRIPTION
* If files to be imported exist in the keystore or in the policy store the
  error FAPI_RC_PATH_ALREADY_EXISTS will be returned.
  Fixes #2028.

* It should not be possible to overwrite file with Fapi_Import. If the
  files already exist in keystore or policy store they will be deleted before
  the execution of Fapi_Import.

* A potential memory corruption in Fapi_Import was fixed.
 
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>