### PR TITLE
FAPI: Fix potential memory corruption in Fapi_Import 2.4.x

### DIFF
--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -493,7 +493,7 @@ Fapi_Import_Finish(
 
 error_cleanup:
     SAFE_FREE(command->private);
-    if (newObject) {
+    if (newObject && newObject->objectType == IFAPI_KEY_OBJ) {
         /* Private buffer was already freed. */
         newObject->misc.key.private.buffer = NULL;
         ifapi_cleanup_ifapi_object(newObject);


### PR DESCRIPTION
An illegal free was executed for non key objects in Fapi_Import.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>