### PR TITLE
configure: improve make install on systems without systemd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -588,8 +588,8 @@ define make_parent_dir
 endef
 
 define make_tss_user_and_group
-    (id -g tss || groupadd -r tss) && \
-    (id -u tss || useradd -r -g tss tss)
+    (id -g tss 2>/dev/null || groupadd -r tss) && \
+    (id -u tss 2>/dev/null || useradd -r -g tss tss)
 endef
 
 define make_tss_dir
@@ -608,17 +608,17 @@ define make_fapi_dirs
 endef
 
 define set_fapi_permissions
-    ($(call set_tss_permissions,$(DESTDIR)$(runstatedir)/tpm2-tss)
-    ($(call set_tss_permissions,$(DESTDIR)$(localstatedir)/lib/tpm2-tss)
+    ($(call set_tss_permissions,$(DESTDIR)$(runstatedir)/tpm2-tss))
+    ($(call set_tss_permissions,$(DESTDIR)$(localstatedir)/lib/tpm2-tss))
 endef
 
 define check_dir
-    if [ ! -d "$1" ]; then echo "*** WARNING *** Directory $1 could not be created"; fi
+    if [ ! -d "$1" ]; then echo "WARNING Directory $1 could not be created"; fi
 endef
 
 define check_fapi_dirs
-    $(call check_dir,$(DESTDIR)$(runstatedir)/tpm2-tss/eventlog/)
-    $(call check_dir,$(DESTDIR)$(localstatedir)/lib/tpm2-tss/system/keystore/)
+    ($(call check_dir,$(DESTDIR)$(runstatedir)/tpm2-tss/eventlog/))
+    ($(call check_dir,$(DESTDIR)$(localstatedir)/lib/tpm2-tss/system/keystore/))
 endef
 
 ### Man Pages
@@ -665,9 +665,22 @@ EXTRA_DIST += dist/tpm-udev.rules
 
 install-dirs:
 if HOSTOS_LINUX
-	(systemd-sysusers && systemd-tmpfiles --create) || \
-	($(call make_tss_user_and_group) && $(call make_fapi_dirs) && ($call set_fapi_permissions)) || true
-	$(call check_fapi_dirs)
+if SYSD_SYSUSERS
+	@echo "systemd-sysusers $(DESTDIR)$(sysconfdir)/sysusers.d/tpm2-tss.conf"
+	@systemd-sysusers $(DESTDIR)$(sysconfdir)/sysusers.d/tpm2-tss.conf || echo "WARNING Failed to create the tss user and group"
+else
+	@echo "call make_tss_user_and_group"
+	@$(call make_tss_user_and_group) || echo "WARNING Failed to create the tss user and group"
+endif
+if SYSD_TMPFILES
+	@echo "systemd-tmpfiles --create $(DESTDIR)$(sysconfdir)/tmpfiles.d/tpm2-tss-fapi.conf"
+	@systemd-tmpfiles --create $(DESTDIR)$(sysconfdir)/tmpfiles.d/tpm2-tss-fapi.conf|| echo "WARNING Failed to create the FAPI directories with the correct permissions"
+else
+	@echo "(call make_fapi_dirs) && (call set_fapi_permissions)"
+	@-$(call make_fapi_dirs) && $(call set_fapi_permissions) || echo "WARNING Failed to create the FAPI directories with the correct permissions"
+endif
+	@echo "call check_fapi_dirs"
+	@$(call check_fapi_dirs)
 endif
 
 install-data-hook: install-dirs

--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,21 @@ AC_ARG_ENABLE([weakcrypto],
 AS_IF([test "x$enable_weakcrypto" = "xyes"],
 	AC_DEFINE([DISABLE_WEAK_CRYPTO],[1],[DISABLE WEAK CRYPTO ALGORITHMS]))
 
+# Check for systemd helper tools used by make install
+AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
+AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
+AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
+AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+# Check all tools used by make install
+AS_IF([test "$HOSTOS" = "Linux"],
+      [ERROR_IF_NO_PROG([groupadd])
+       ERROR_IF_NO_PROG([useradd])
+       ERROR_IF_NO_PROG([id])
+       ERROR_IF_NO_PROG([chown])
+       ERROR_IF_NO_PROG([chmod])
+       ERROR_IF_NO_PROG([mkdir])
+       ERROR_IF_NO_PROG([setfacl])])
+
 AC_SUBST([PATH])
 
 dnl --------- Doxy Gen -----------------------


### PR DESCRIPTION
install-data-hook uses systemd helpers for creating users and tmpfiles,
but on systems where there is no systemd or not all the helpers are
installed it needs to fall back to the old methods.
This should improve the make install step on some old systems
like ubuntu 16.04.
This is a squash of multiple commits from master backported to 3.0.x branch
https://github.com/tpm2-software/tpm2-tss/pull/2019
https://github.com/tpm2-software/tpm2-tss/pull/2022
https://github.com/tpm2-software/tpm2-tss/pull/2026

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>