### PR TITLE
Enable lower maxlog levels

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -2019,8 +2019,7 @@ ifapi_verify_ek_cert(
                    "Failed to initialize X509 context.", cleanup);
     }
     if (1 != X509_verify_cert(ctx)) {
-        int rc = X509_STORE_CTX_get_error(ctx);
-        LOG_ERROR("%s", X509_verify_cert_error_string(rc));
+        LOG_ERROR("%s", X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
                    "Failed to verify intermediate certificate", cleanup);
     }
@@ -2042,8 +2041,7 @@ ifapi_verify_ek_cert(
     }
     /* Verify the EK certificate. */
     if (1 != X509_verify_cert(ctx)) {
-        int rc = X509_STORE_CTX_get_error(ctx);
-        LOG_ERROR("%s", X509_verify_cert_error_string(rc));
+        LOG_ERROR("%s", X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
                    "Failed to verify EK certificate", cleanup);
     }

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -38,6 +38,7 @@ static void
 copy_policy_digest(TPML_DIGEST_VALUES *dest, TPML_DIGEST_VALUES *src,
                    size_t digest_idx, size_t hash_size, char *txt)
 {
+    (void)(txt); /* If max log-leve < debug, this param is unused */
     memcpy(&dest->digests[digest_idx].digest, &src->digests[digest_idx].digest,
            hash_size);
     dest->digests[digest_idx].hashAlg = src->digests[digest_idx].hashAlg;
@@ -57,6 +58,8 @@ static void
 log_policy_digest(TPML_DIGEST_VALUES *dest, size_t digest_idx, size_t hash_size,
                   char *txt)
 {
+    (void)(dest);(void)(digest_idx);(void)(hash_size);(void)(txt);
+    /* If max log-leve < debug, this param is unused */
     LOGBLOB_DEBUG((uint8_t *)&dest->digests[digest_idx].digest, hash_size,
                   "Digest %s", txt);
 }

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -112,7 +112,6 @@ TSS2_RC tcti_control_command (
     uint32_t *resp_code, void *resp_sdu, size_t *resp_sdu_len)
 {
     TSS2_TCTI_SWTPM_CONTEXT *tcti_swtpm = tcti_swtpm_context_cast(tctiContext);
-    UINT32 rsp = 0;
     TSS2_RC rc = TSS2_RC_SUCCESS;
     int ret;
     uint32_t response_code;
@@ -220,7 +219,7 @@ TSS2_RC tcti_control_command (
     }
 
     if (response_code != 0) {
-        LOG_ERROR ("Control command failed with error: %" PRIu32, rsp);
+        LOG_ERROR ("Control command failed with error: %" PRIu32, response_code);
         rc = TSS2_TCTI_RC_IO_ERROR;
         goto out;
     }


### PR DESCRIPTION
This patch fixed the setting of maxloglevel during configure wrt unused variables throughout the stack.

No clue how far this needs to be backported