### PR TITLE
esys_crypto: remove redundant blk size param

### DIFF
--- a/src/tss2-esys/esys_crypto_mbed.c
+++ b/src/tss2-esys/esys_crypto_mbed.c
@@ -808,11 +808,10 @@ cleanup:
  * @param[in] key_bits Key size in bits.
  * @param[in] tpm_mode Block cipher mode of opertion in TSS2 notation (CFB).
  *            For parameter encryption only CFB can be used.
- * @param[in] blk_len Length Block length of AES.
  * @param[in,out] buffer Data to be encrypted. The encrypted date will be stored
  *                in this buffer.
  * @param[in] buffer_size size of data to be encrypted.
- * @param[in] iv The initialization vector. The size is equal to blk_len.
+ * @param[in] iv The initialization vector.
  * @retval TSS2_RC_SUCCESS on success, or TSS2_ESYS_RC_BAD_VALUE and
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters,
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
@@ -822,14 +821,10 @@ iesys_cryptmbed_sym_aes_encrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_sym_alg,
                                 TPMI_AES_KEY_BITS key_bits,
                                 TPM2_ALG_ID tpm_mode,
-                                size_t blk_len,
                                 uint8_t * buffer,
                                 size_t buffer_size,
                                 uint8_t * iv)
 {
-    /* Parameter blk_len needed for other crypto libraries */
-    (void)blk_len;
-
     TSS2_RC r = TSS2_RC_SUCCESS;
     mbedtls_aes_context aes_ctx;
 
@@ -868,11 +863,10 @@ cleanup:
  * @param[in] key_bits Key size in bits.
  * @param[in] tpm_mode Block cipher mode of opertion in TSS2 notation (CFB).
  *            For parameter encryption only CFB can be used.
- * @param[in] blk_len Length Block length of AES.
  * @param[in,out] buffer Data to be decrypted. The decrypted date will be stored
  *                in this buffer.
  * @param[in] buffer_size size of data to be encrypted.
- * @param[in] iv The initialization vector. The size is equal to blk_len.
+ * @param[in] iv The initialization vector.
  * @retval TSS2_RC_SUCCESS on success, or TSS2_ESYS_RC_BAD_VALUE and
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters,
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
@@ -882,14 +876,10 @@ iesys_cryptmbed_sym_aes_decrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_sym_alg,
                                 TPMI_AES_KEY_BITS key_bits,
                                 TPM2_ALG_ID tpm_mode,
-                                size_t blk_len,
                                 uint8_t * buffer,
                                 size_t buffer_size,
                                 uint8_t * iv)
 {
-    /* Parameter blk_len needed for other crypto libraries */
-    (void)blk_len;
-
     TSS2_RC r = TSS2_RC_SUCCESS;
     mbedtls_aes_context aes_ctx;
 

--- a/src/tss2-esys/esys_crypto_mbed.h
+++ b/src/tss2-esys/esys_crypto_mbed.h
@@ -104,7 +104,6 @@ TSS2_RC iesys_cryptmbed_sym_aes_encrypt(
     TPM2_ALG_ID tpm_sym_alg,
     TPMI_AES_KEY_BITS key_bits,
     TPM2_ALG_ID tpm_mode,
-    size_t blk_len,
     uint8_t *dst,
     size_t dst_size,
     uint8_t *iv);
@@ -114,7 +113,6 @@ TSS2_RC iesys_cryptmbed_sym_aes_decrypt(
     TPM2_ALG_ID tpm_sym_alg,
     TPMI_AES_KEY_BITS key_bits,
     TPM2_ALG_ID tpm_mode,
-    size_t blk_len,
     uint8_t *dst,
     size_t dst_size,
     uint8_t *iv);

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -948,11 +948,10 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC *key,
  * @param[in] key_bits Key size in bits.
  * @param[in] tpm_mode Block cipher mode of opertion in TSS2 notation (CFB).
  *            For parameter encryption only CFB can be used.
- * @param[in] blk_len Length Block length of AES.
  * @param[in,out] buffer Data to be encrypted. The encrypted date will be stored
  *                in this buffer.
  * @param[in] buffer_size size of data to be encrypted.
- * @param[in] iv The initialization vector. The size is equal to blk_len.
+ * @param[in] iv The initialization vector.
  * @retval TSS2_RC_SUCCESS on success, or TSS2_ESYS_RC_BAD_VALUE and
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters,
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
@@ -962,7 +961,6 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_sym_alg,
                                 TPMI_AES_KEY_BITS key_bits,
                                 TPM2_ALG_ID tpm_mode,
-                                size_t blk_len,
                                 uint8_t * buffer,
                                 size_t buffer_size,
                                 uint8_t * iv)
@@ -977,9 +975,6 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t * key,
     }
 
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS AES input");
-
-    /* Parameter blk_len needed for other crypto libraries */
-    (void)blk_len;
 
     if (key_bits == 128 && tpm_mode == TPM2_ALG_CFB)
         cipher_alg = EVP_aes_128_cfb();
@@ -1033,11 +1028,10 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t * key,
  * @param[in] key_bits Key size in bits.
  * @param[in] tpm_mode Block cipher mode of opertion in TSS2 notation (CFB).
  *            For parameter encryption only CFB can be used.
- * @param[in] blk_len Length Block length of AES.
  * @param[in,out] buffer Data to be decrypted. The decrypted date will be stored
  *                in this buffer.
  * @param[in] buffer_size size of data to be encrypted.
- * @param[in] iv The initialization vector. The size is equal to blk_len.
+ * @param[in] iv The initialization vector.
  * @retval TSS2_RC_SUCCESS on success, or TSS2_ESYS_RC_BAD_VALUE and
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters,
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
@@ -1047,7 +1041,6 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_sym_alg,
                                 TPMI_AES_KEY_BITS key_bits,
                                 TPM2_ALG_ID tpm_mode,
-                                size_t blk_len,
                                 uint8_t * buffer,
                                 size_t buffer_size,
                                 uint8_t * iv)
@@ -1056,9 +1049,6 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t * key,
     const EVP_CIPHER *cipher_alg = NULL;
     EVP_CIPHER_CTX *ctx = NULL;
     int cipher_len = 0;
-
-    /* Parameter blk_len needed for other crypto libraries */
-    (void)blk_len;
 
     if (key == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Bad reference");

--- a/src/tss2-esys/esys_crypto_ossl.h
+++ b/src/tss2-esys/esys_crypto_ossl.h
@@ -105,7 +105,6 @@ TSS2_RC iesys_cryptossl_sym_aes_encrypt(
     TPM2_ALG_ID tpm_sym_alg,
     TPMI_AES_KEY_BITS key_bits,
     TPM2_ALG_ID tpm_mode,
-    size_t blk_len,
     uint8_t *dst,
     size_t dst_size,
     uint8_t *iv);
@@ -115,7 +114,6 @@ TSS2_RC iesys_cryptossl_sym_aes_decrypt(
     TPM2_ALG_ID tpm_sym_alg,
     TPMI_AES_KEY_BITS key_bits,
     TPM2_ALG_ID tpm_mode,
-    size_t blk_len,
     uint8_t *dst,
     size_t dst_size,
     uint8_t *iv);

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -735,7 +735,6 @@ iesys_encrypt_param(ESYS_CONTEXT * esys_context,
                                                  symDef->algorithm,
                                                  symDef->keyBits.aes,
                                                  symDef->mode.aes,
-                                                 AES_BLOCK_SIZE_IN_BYTES,
                                                  &encrypt_buffer[0], paramSize,
                                                  &symKey[aes_off]);
                 return_if_error(r, "AES encryption not possible");
@@ -835,7 +834,6 @@ iesys_decrypt_param(ESYS_CONTEXT * esys_context)
                                      symDef->algorithm,
                                      symDef->keyBits.aes,
                                      symDef->mode.aes,
-                                     AES_BLOCK_SIZE_IN_BYTES,
                                      &plaintext[0], p2BSize,
                                      &symKey[aes_off]);
         return_if_error(r, "Decryption error");

--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -209,34 +209,34 @@ check_aes_encrypt(void **state)
     uint8_t buffer[5] = { 1, 2, 3, 4, 5 };
     size_t size = 5;
 
-    rc = iesys_crypto_sym_aes_encrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_encrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 192, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], 0, 256, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_encrypt(&key[0], 0, 256, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, 0, 16,
+    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, 0,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 999, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 999, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_decrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_decrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_sym_aes_decrypt(&key[0], 0, 192, TPM2_ALG_CFB, 16,
+    rc = iesys_crypto_sym_aes_decrypt(&key[0], 0, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 }


### PR DESCRIPTION
AES block size is const.
Remove redundant blk_size param from enc() and dec() functions.