### PR TITLE
fix issues with MAYBE_UNUSED

### DIFF
--- a/src/tss2-esys/esys_crypto_mbed.c
+++ b/src/tss2-esys/esys_crypto_mbed.c
@@ -444,7 +444,7 @@ iesys_cryptmbed_hmac_abort(IESYS_CRYPTO_CONTEXT_BLOB ** context)
  * @param[om] buf_size Number of bytes to write to buffer.
  */
 static int get_random(void* context, unsigned char * buffer, size_t buf_size) {
-    (void)context;
+    UNUSED(context);
 
     int r = 0; //success in terms of mbedtls
 

--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -423,7 +423,7 @@ Fapi_ChangeAuth_Finish(
 
         statecase(context->state, ENTITY_CHANGE_AUTH_WRITE)
             /* Finish writing the object to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -190,8 +190,7 @@ Fapi_CreateNv_Async(
     return_if_error(r, "Initialize NV_CreateNv");
 
     /* First check whether an existing object would be overwritten */
-    r = ifapi_keystore_check_overwrite(&context->keystore, &context->io,
-                                       path);
+    r = ifapi_keystore_check_overwrite(&context->keystore, path);
     return_if_error2(r, "Check overwrite %s", path);
 
     /* Copy parameters to context for use during _Finish. */
@@ -467,7 +466,7 @@ Fapi_CreateNv_Finish(
 
         statecase(context->state, NV_CREATE_WRITE)
             /* Finish writing the NV object to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -234,7 +234,7 @@ Fapi_Import_Async(
             goto_if_error(r, "Serialize policy", cleanup_error);
 
             /* Check whether an existing object would be overwritten */
-            r = ifapi_policystore_check_overwrite(&context->pstore, &context->io,
+            r = ifapi_policystore_check_overwrite(&context->pstore,
                                                   command->out_path);
             goto_if_error_reset_state(r, "Check overwrite %s", cleanup_error,
                                       command->out_path);
@@ -257,8 +257,8 @@ Fapi_Import_Async(
             switch (object->objectType) {
             case IFAPI_EXT_PUB_KEY_OBJ:
                 /* Check whether an existing object would be overwritten */
-                r = ifapi_keystore_check_overwrite(&context->keystore, &context->io,
-                                                   command->out_path);
+                r = ifapi_keystore_check_overwrite(&context->keystore,
+                        command->out_path);
                 goto_if_error_reset_state(r, "Check overwrite %s", cleanup_error,
                                           command->out_path);
 
@@ -436,7 +436,7 @@ Fapi_Import_Finish(
             goto_if_error_reset_state(r, "Load", error_cleanup);
 
             /* Check whether object already exists in key store. */
-            r = ifapi_keystore_check_overwrite(&context->keystore, &context->io,
+            r = ifapi_keystore_check_overwrite(&context->keystore,
                                                command->out_path);
             goto_if_error_reset_state(r, "Check overwrite %s", error_cleanup,
                                       command->out_path);
@@ -451,7 +451,7 @@ Fapi_Import_Finish(
 
         statecase(context->state, IMPORT_WRITE);
             /* Finish writing the key to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 
@@ -496,7 +496,7 @@ Fapi_Import_Finish(
             break;
 
         statecase(context->state, IMPORT_KEY_WRITE);
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 
@@ -588,7 +588,7 @@ Fapi_Import_Finish(
             goto_if_error(r, "Prepare serialization", error_cleanup);
 
             /* Check whether an existing object would be overwritten */
-            r = ifapi_keystore_check_overwrite(&context->keystore, &context->io,
+            r = ifapi_keystore_check_overwrite(&context->keystore,
                                                command->out_path);
             goto_if_error_reset_state(r, "Check overwrite %s", error_cleanup,
                                       command->out_path);
@@ -605,7 +605,7 @@ Fapi_Import_Finish(
 
         statecase(context->state, IMPORT_KEY_WRITE_OBJECT);
             /* Finish writing the object to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_NvExtend.c
+++ b/src/tss2-fapi/api/Fapi_NvExtend.c
@@ -277,7 +277,7 @@ Fapi_NvExtend_Finish(
     switch (context->state) {
     statecase(context->state, NV_EXTEND_READ)
         /* First check whether the file in object store can be updated. */
-        r = ifapi_keystore_check_writeable(&context->keystore, &context->io, command->nvPath);
+        r = ifapi_keystore_check_writeable(&context->keystore, command->nvPath);
         goto_if_error_reset_state(r, "Check whether update object store is possible.", error_cleanup);
 
         r = ifapi_keystore_load_finish(&context->keystore, &context->io, object);
@@ -446,7 +446,7 @@ Fapi_NvExtend_Finish(
 
     statecase(context->state, NV_EXTEND_WRITE)
         /* Finish writing the NV object to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
         fallthrough;

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -236,7 +236,7 @@ Fapi_NvIncrement_Finish(
     switch (context->state) {
     statecase(context->state, NV_INCREMENT_READ)
         /* First check whether the file in object store can be updated. */
-        r = ifapi_keystore_check_writeable(&context->keystore, &context->io, command->nvPath);
+        r = ifapi_keystore_check_writeable(&context->keystore, command->nvPath);
         goto_if_error_reset_state(r, "Check whether update object store is possible.", error_cleanup);
 
         r = ifapi_keystore_load_finish(&context->keystore, &context->io, object);
@@ -325,7 +325,7 @@ Fapi_NvIncrement_Finish(
 
     statecase(context->state, NV_INCREMENT_WRITE)
         /* Finish writing the NV object to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
         fallthrough;

--- a/src/tss2-fapi/api/Fapi_NvSetBits.c
+++ b/src/tss2-fapi/api/Fapi_NvSetBits.c
@@ -244,7 +244,7 @@ Fapi_NvSetBits_Finish(
     switch (context->state) {
     statecase(context->state, NV_SET_BITS_READ)
         /* First check whether the file in object store can be updated. */
-        r = ifapi_keystore_check_writeable(&context->keystore, &context->io, command->nvPath);
+        r = ifapi_keystore_check_writeable(&context->keystore, command->nvPath);
         goto_if_error_reset_state(r, "Check whether update object store is possible.", error_cleanup);
 
         r = ifapi_keystore_load_finish(&context->keystore, &context->io, object);
@@ -334,7 +334,7 @@ Fapi_NvSetBits_Finish(
 
     statecase(context->state, NV_SET_BITS_WRITE)
         /* Finish writing the NV object to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_NvWrite.c
+++ b/src/tss2-fapi/api/Fapi_NvWrite.c
@@ -253,7 +253,7 @@ Fapi_NvWrite_Finish(
     switch (context->state) {
     statecase(context->state, NV_WRITE_READ);
         /* First check whether the file in object store can be updated. */
-        r = ifapi_keystore_check_writeable(&context->keystore, &context->io, command->nvPath);
+        r = ifapi_keystore_check_writeable(&context->keystore, command->nvPath);
         goto_if_error_reset_state(r, "Check whether update object store is possible.", error_cleanup);
 
         /* Write to the NV index. */
@@ -279,7 +279,7 @@ Fapi_NvWrite_Finish(
 
     statecase(context->state, NV_WRITE_WRITE);
         /* Finish writing the NV object to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -852,7 +852,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_EK_WRITE);
             /* Finish writing the EK to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 
@@ -997,7 +997,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_SRK_WRITE);
             /* Finish writing the SRK to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 
@@ -1129,7 +1129,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_WRITE_LOCKOUT);
             /* Finish writing the lockout hierarchy to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 
@@ -1198,7 +1198,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_WRITE_EH);
             /* Finish writing the endorsement hierarchy to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 
@@ -1269,7 +1269,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_WRITE_SH);
             /* The onwer hierarchy object will be written to key store. */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 
@@ -1293,7 +1293,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_WRITE_NULL);
             /* The null hierarchy object will be written to key store. */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 
@@ -1377,7 +1377,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
         statecase(context->state, PROVISION_WRITE_HIERARCHY);
             /* Finish writing the hierarchy to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             goto_if_error_reset_state(r, "write_finish failed", error_cleanup);
 

--- a/src/tss2-fapi/api/Fapi_SetAppData.c
+++ b/src/tss2-fapi/api/Fapi_SetAppData.c
@@ -262,7 +262,7 @@ Fapi_SetAppData_Finish(
 
         statecase(context->state, APP_DATA_SET_WRITE);
             /* Finish writing of object */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
             ifapi_cleanup_ifapi_object(object);

--- a/src/tss2-fapi/api/Fapi_SetCertificate.c
+++ b/src/tss2-fapi/api/Fapi_SetCertificate.c
@@ -248,7 +248,7 @@ Fapi_SetCertificate_Finish(
 
         statecase(context->state, KEY_SET_CERTIFICATE_WRITE)
             /* Finish writing the object to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_SetDescription.c
+++ b/src/tss2-fapi/api/Fapi_SetDescription.c
@@ -221,7 +221,7 @@ Fapi_SetDescription_Finish(
             fallthrough;
 
         statecase(context->state, PATH_SET_DESCRIPTION_WRITE);
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/api/Fapi_WriteAuthorizeNV.c
+++ b/src/tss2-fapi/api/Fapi_WriteAuthorizeNV.c
@@ -240,8 +240,7 @@ Fapi_WriteAuthorizeNv_Finish(
     switch (context->state) {
         statecase(context->state, WRITE_AUTHORIZE_NV_READ_NV)
             /* First check whether the file in object store can be updated. */
-            r = ifapi_keystore_check_writeable(&context->keystore, &context->io,
-                    nvCmd->nvPath);
+            r = ifapi_keystore_check_writeable(&context->keystore, nvCmd->nvPath);
             goto_if_error_reset_state(r,
                     "Check whether update object store is possible.", error_cleanup);
 
@@ -309,7 +308,7 @@ Fapi_WriteAuthorizeNv_Finish(
 
         statecase(context->state, WRITE_AUTHORIZE_NV_WRITE_OBJCECT)
             /* Finish writing the NV object to the key store */
-            r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+            r = ifapi_keystore_store_finish(&context->io);
             return_try_again(r);
             return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -2333,7 +2333,7 @@ ifapi_nv_write(
 
     statecase(context->nv_cmd.nv_write_state, NV2_WRITE_WRITE);
         /* Finish writing the NV object to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
 
@@ -3176,8 +3176,7 @@ ifapi_key_create_prepare(
     return_if_error(r, "Initialize Key_Create");
 
     /* First check whether an existing object would be overwritten */
-    r = ifapi_keystore_check_overwrite(&context->keystore, &context->io,
-                                       keyPath);
+    r = ifapi_keystore_check_overwrite(&context->keystore, keyPath);
     return_if_error2(r, "Check overwrite %s", keyPath);
 
     context->srk_handle = 0;
@@ -3546,7 +3545,7 @@ ifapi_key_create(
 
     statecase(context->cmd.Key_Create.state, KEY_CREATE_WRITE);
         /* Finish writing the key to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
 
@@ -4699,7 +4698,7 @@ ifapi_create_primary(
 
     statecase(context->cmd.Key_Create.state, KEY_CREATE_PRIMARY_WRITE);
         /* Finish writing the key to the key store */
-        r = ifapi_keystore_store_finish(&context->keystore, &context->io);
+        r = ifapi_keystore_store_finish(&context->io);
         return_try_again(r);
         return_if_error_reset_state(r, "write_finish failed");
 

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -787,7 +787,6 @@ cleanup:
  *
  * This function needs to be called repeatedly until it does not return TSS2_FAPI_RC_TRY_AGAIN.
  *
- * @param[in] keystore The key directories and default profile.
  * @param[in,out] io The input/output context being used for file I/O.
  * @retval TSS2_RC_SUCCESS: if the function call was a success.
  * @retval TSS2_FAPI_RC_IO_ERROR: if an I/O error was encountered; such as the file was not found.
@@ -796,7 +795,6 @@ cleanup:
  */
 TSS2_RC
 ifapi_keystore_store_finish(
-    IFAPI_KEYSTORE *keystore MAYBE_UNUSED,
     IFAPI_IO *io)
 {
     TSS2_RC r;
@@ -1290,7 +1288,6 @@ ifapi_keystore_search_nv_obj(
   * The passed relative path will be expanded for user store and system store.
   *
   * @param[in] keystore The key directories and default profile.
-  * @param[in] io  The input/output context being used for file I/O.
   * @param[in] path The relative path of the object. For keys the path will
   *            expanded if possible.
   * @retval TSS2_RC_SUCCESS if the object does not exist.
@@ -1300,7 +1297,6 @@ ifapi_keystore_search_nv_obj(
 TSS2_RC
 ifapi_keystore_check_overwrite(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io MAYBE_UNUSED,
     const char *path)
 {
     TSS2_RC r;
@@ -1345,7 +1341,6 @@ cleanup:
  *  Keys objects, NV objects, and hierarchies can be written.
  *
  * @param[in] keystore The key directories and default profile.
- * @param[in] io  The input/output context being used for file I/O.
  * @param[in] path The relative path of the object. For keys the path will
  *           expanded if possible.
  * @retval TSS2_RC_SUCCESS if the object does not exist.
@@ -1364,7 +1359,6 @@ cleanup:
 TSS2_RC
 ifapi_keystore_check_writeable(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io MAYBE_UNUSED,
     const char *path)
 {
     TSS2_RC r;

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -188,7 +188,6 @@ ifapi_keystore_store_async(
 
 TSS2_RC
 ifapi_keystore_store_finish(
-    IFAPI_KEYSTORE *keystore,
     IFAPI_IO *io);
 
 TSS2_RC
@@ -225,13 +224,11 @@ ifapi_keystore_search_nv_obj(
 TSS2_RC
 ifapi_keystore_check_overwrite(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io,
     const char *path);
 
 TSS2_RC
 ifapi_keystore_check_writeable(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io,
     const char *path);
 
 TSS2_RC

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -648,7 +648,6 @@ cleanup:
  */
 TSS2_RC
 ifapi_calculate_policy_physical_presence(
-    TPMS_POLICYPHYSICALPRESENCE *policy MAYBE_UNUSED,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
 {
@@ -667,7 +666,6 @@ ifapi_calculate_policy_physical_presence(
  *
  * The policy will be updated with the function ifapi_calculate_simple_policy()
  *
- * @param[in] policy The policy auth value.
  * @param[in,out] current_digest The digest list which has to be updated.
  * @param[in] current_hash_alg The hash algorithm used for the policy computation.
  *
@@ -680,7 +678,6 @@ ifapi_calculate_policy_physical_presence(
  */
 TSS2_RC
 ifapi_calculate_policy_auth_value(
-    TPMS_POLICYAUTHVALUE *policy MAYBE_UNUSED,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
 {
@@ -699,7 +696,6 @@ ifapi_calculate_policy_auth_value(
  *
  * The policy will be updated with the function ifapi_calculate_simple_policy()
  *
- * @param[in] policy The policy password.
  * @param[in,out] current_digest The digest list which has to be updated.
  * @param[in] current_hash_alg The hash algorithm used for the policy computation.
  *
@@ -712,12 +708,10 @@ ifapi_calculate_policy_auth_value(
  */
 TSS2_RC
 ifapi_calculate_policy_password(
-    TPMS_POLICYPASSWORD *policy,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    (void)policy;
 
     LOG_DEBUG("call");
 
@@ -1326,20 +1320,17 @@ ifapi_calculate_policy(
 
         case POLICYPHYSICALPRESENCE:
             r = ifapi_calculate_policy_physical_presence(
-                    &policy->elements[i].element.PolicyPhysicalPresence,
                     &policy->elements[i].policyDigests, hash_alg);
             return_if_error(r, "Compute policy physical presence");
             break;
 
         case POLICYAUTHVALUE:
-            r = ifapi_calculate_policy_auth_value(&policy->elements[i].element.PolicyAuthValue,
-                                                  &policy->elements[i].policyDigests, hash_alg);
+            r = ifapi_calculate_policy_auth_value(&policy->elements[i].policyDigests, hash_alg);
             return_if_error(r, "Compute policy auth value");
             break;
 
         case POLICYPASSWORD:
-            r = ifapi_calculate_policy_password(&policy->elements[i].element.PolicyPassword,
-                                                &policy->elements[i].policyDigests, hash_alg);
+            r = ifapi_calculate_policy_password(&policy->elements[i].policyDigests, hash_alg);
             return_if_error(r, "Compute policy password");
             break;
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -813,8 +813,6 @@ cleanup:
  * @param[in,out] policy The policy which defines the object whose secret
  *                is needed for policy execution.
  *                The policy digest will be added to the policy.
- * @param[in]     current_hash_alg The hash algorithm wich will be used for
- *                policy computation.
  * @param[in,out] current_policy The policy context which stores the state
  *                of the policy execution.
  * @retval TSS2_RC_SUCCESS on success.
@@ -846,7 +844,6 @@ static TSS2_RC
 execute_policy_secret(
     ESYS_CONTEXT *esys_ctx,
     TPMS_POLICYSECRET *policy,
-    TPMI_ALG_HASH hash_alg MAYBE_UNUSED,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
@@ -962,7 +959,6 @@ execute_policy_counter_timer(
  *
  * @param[in,out] *esys_ctx The ESAPI context which is needed to execute the
  *                policy command.
- * @param[in,out] policy The policy indicating that physical presence is needed.
  * @param[in,out] current_policy The policy context which stores the state
  *                of the policy execution.
  * @retval TSS2_RC_SUCCESS on success.
@@ -975,7 +971,6 @@ execute_policy_counter_timer(
 static TSS2_RC
 execute_policy_physical_presence(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYPHYSICALPRESENCE *policy MAYBE_UNUSED,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
@@ -1011,7 +1006,6 @@ execute_policy_physical_presence(
 
  * @param[in,out] *esys_ctx The ESAPI context which is needed to execute the
  *                policy command.
- * @param[in,out] policy The policy indicating that a auth value is needed.
  * @param[in,out] current_policy The policy context which stores the state
  *                of the policy execution.
  * @retval TSS2_RC_SUCCESS on success.
@@ -1024,7 +1018,6 @@ execute_policy_physical_presence(
 static TSS2_RC
 execute_policy_auth_value(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYAUTHVALUE *policy MAYBE_UNUSED,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
@@ -1061,7 +1054,6 @@ execute_policy_auth_value(
  *
  * @param[in,out] *esys_ctx The ESAPI context which is needed to execute the
  *                policy command.
- * @param[in,out] policy The policy indicating that a auth value is needed.
  * @param[in,out] current_policy The policy context which stores the state
  *                of the policy execution.
  * @retval TSS2_RC_SUCCESS on success.
@@ -1074,7 +1066,6 @@ execute_policy_auth_value(
 static TSS2_RC
 execute_policy_password(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYPASSWORD *policy MAYBE_UNUSED,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
@@ -1489,7 +1480,6 @@ execute_policy_element(
     case POLICYSECRET:
         r = execute_policy_secret(esys_ctx,
                                   &policy->element.PolicySecret,
-                                  hash_alg,
                                   current_policy);
         try_again_or_error_goto(r, "Execute policy authorize", error);
         break;
@@ -1501,7 +1491,6 @@ execute_policy_element(
         break;
     case POLICYAUTHVALUE:
         r = execute_policy_auth_value(esys_ctx,
-                                      &policy->element.PolicyAuthValue,
                                       current_policy);
         try_again_or_error_goto(r, "Execute policy auth value", error);
         break;
@@ -1575,13 +1564,11 @@ execute_policy_element(
         break;
     case POLICYPHYSICALPRESENCE:
         r = execute_policy_physical_presence(esys_ctx,
-                                             &policy->element.PolicyPhysicalPresence,
                                              current_policy);
         try_again_or_error_goto(r, "Execute policy physical presence", error);
             break;
     case POLICYPASSWORD:
         r = execute_policy_password(esys_ctx,
-                                    &policy->element.PolicyPassword,
                                     current_policy);
         try_again_or_error_goto(r, "Execute policy password", error);
         break;

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -308,7 +308,6 @@ ifapi_policy_store_store_finish(
  /** Check whether policy already exists.
   *
   * @param[in] pstore The key directories and default profile.
-  * @param[in] io  The input/output context being used for file I/O.
   * @param[in] path The relative path of the policy.
   * @retval TSS2_RC_SUCCESS if the object does not exist.
   * @retval TSS2_FAPI_RC_PATH_ALREADY_EXISTS if the policy file exists.
@@ -317,12 +316,10 @@ ifapi_policy_store_store_finish(
 TSS2_RC
 ifapi_policystore_check_overwrite(
     IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io,
     const char *path)
 {
     TSS2_RC r;
     char *abs_path = NULL;
-    (void)io; /* Used to simplify future extensions */
 
     /* Convert relative path to absolute path in keystore */
     r = policy_rel_path_to_abs_path(pstore, path, &abs_path);

--- a/src/tss2-fapi/ifapi_policy_store.h
+++ b/src/tss2-fapi/ifapi_policy_store.h
@@ -55,7 +55,6 @@ ifapi_policy_store_store_finish(
 TSS2_RC
 ifapi_policystore_check_overwrite(
     IFAPI_POLICY_STORE *pstore,
-    IFAPI_IO *io,
     const char *path);
 
 #endif /* IFAPI_POLICY_STORE_H */

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -149,9 +149,10 @@ TPMS_PCR_UNMARSHAL(TPMS_TAGGED_PCR_SELECT, \
 #define TPMS_MARSHAL_0(type) \
 TSS2_RC Tss2_MU_##type##_Marshal(type const *src, \
                                  uint8_t buffer[] MAYBE_UNUSED, \
-                                 size_t buffer_size MAYBE_UNUSED, \
+                                 size_t buffer_size, \
                                  size_t *offset MAYBE_UNUSED) \
 { \
+    UNUSED(buffer_size); \
     if (!src) { \
         LOG_WARNING("src param is NULL"); \
         return TSS2_MU_RC_BAD_REFERENCE; \

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -148,11 +148,13 @@ TPMS_PCR_UNMARSHAL(TPMS_TAGGED_PCR_SELECT, \
 
 #define TPMS_MARSHAL_0(type) \
 TSS2_RC Tss2_MU_##type##_Marshal(type const *src, \
-                                 uint8_t buffer[] MAYBE_UNUSED, \
+                                 uint8_t buffer[], \
                                  size_t buffer_size, \
-                                 size_t *offset MAYBE_UNUSED) \
+                                 size_t *offset) \
 { \
+    UNUSED(buffer); \
     UNUSED(buffer_size); \
+    UNUSED(offset); \
     if (!src) { \
         LOG_WARNING("src param is NULL"); \
         return TSS2_MU_RC_BAD_REFERENCE; \

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -169,9 +169,9 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, \
 TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
                                    size_t *offset, type *dest) \
 { \
-    (void)(buffer); \
-    (void)(buffer_size); \
-    (void)(offset); \
+    UNUSED(buffer); \
+    UNUSED(buffer_size); \
+    UNUSED(offset); \
 \
     if (!dest) { \
         LOG_WARNING("src param is NULL"); \

--- a/src/util/aux_util.h
+++ b/src/util/aux_util.h
@@ -33,7 +33,7 @@ extern "C" {
  * MAYBE_UNUSED macro should be used to mark variables used only
  * for assertions i.e. in debug mode, and/or for logging, which
  * might be compiled out. This shuldn't trigger 'unused variable'
- * or 'variable assigned, but not used' waraings when debug and
+ * or 'variable assigned, but not used' warnings when debug and
  * logging is disabled on configure time, but should trigger
  * warnings for variables that are not used for neither.
  */

--- a/src/util/aux_util.h
+++ b/src/util/aux_util.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #define UNUSED(x) (void)(x)
-#if (MAXLOGLEVEL == LOGL_NONE) || defined(NDEBUG)
+#if (MAXLOGLEVEL == LOGL_NONE)
 /* Note:
  * MAYBE_UNUSED macro should be used to mark variables used only
  * for assertions i.e. in debug mode, and/or for logging, which

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -255,7 +255,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                                   TPMA_SESSION_AUDIT);
     goto_if_error(r, "Error Esys_TRSess_SetAttributes", error);
 
-#if TEST_BOUND_SESSION
+#if defined(TEST_BOUND_SESSION)
     r = Esys_StartAuthSession(esys_context,
                               primaryHandle_AuthSession,
                               primaryHandle_AuthSession,
@@ -263,7 +263,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                               NULL,
                               sessionType, &symmetric, authHash, &session);
 #else
-#if TEST_NULL_BIND_TPMKEY
+#if defined(TEST_NULL_BIND_TPMKEY)
      r = Esys_StartAuthSession(esys_context,
                               primaryHandle_AuthSession,
                               ESYS_TR_RH_NULL,
@@ -271,7 +271,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                               NULL,
                               sessionType, &symmetric, authHash, &session);
 #else
-#if TEST_NULL_BIND_NO_TPM_KEY
+#if defined(TEST_NULL_BIND_NO_TPM_KEY)
      r = Esys_StartAuthSession(esys_context,
                                ESYS_TR_NONE,
                                ESYS_TR_RH_NULL,

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -53,7 +53,9 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
     ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
-    ESYS_TR primaryHandle_AuthSession MAYBE_UNUSED = ESYS_TR_NONE;
+#if defined(TEST_ECC) || !defined(TEST_NULL_BIND_NO_TPM_KEY)
+    ESYS_TR primaryHandle_AuthSession = ESYS_TR_NONE;
+#endif
     ESYS_TR session = ESYS_TR_NONE;
     ESYS_TR outerSession = ESYS_TR_NONE;
 
@@ -219,7 +221,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
 
     r = Esys_TR_SetAuth(esys_context, primaryHandle_AuthSession, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
-#else
+#elif defined(TEST_BOUND_SESSION) || !defined(TEST_NULL_BIND_NO_TPM_KEY)
     primaryHandle_AuthSession = primaryHandle;
 #endif /* TEST_ECC */
 

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -262,16 +262,14 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                               outerSession, ESYS_TR_NONE, ESYS_TR_NONE,
                               NULL,
                               sessionType, &symmetric, authHash, &session);
-#else
-#if defined(TEST_NULL_BIND_TPMKEY)
+#elif defined(TEST_NULL_BIND_TPMKEY)
      r = Esys_StartAuthSession(esys_context,
                               primaryHandle_AuthSession,
                               ESYS_TR_RH_NULL,
                               outerSession, ESYS_TR_NONE, ESYS_TR_NONE,
                               NULL,
                               sessionType, &symmetric, authHash, &session);
-#else
-#if defined(TEST_NULL_BIND_NO_TPM_KEY)
+#elif defined(TEST_NULL_BIND_NO_TPM_KEY)
      r = Esys_StartAuthSession(esys_context,
                                ESYS_TR_NONE,
                                ESYS_TR_RH_NULL,
@@ -285,8 +283,6 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
                                outerSession, ESYS_TR_NONE, ESYS_TR_NONE,
                                NULL,
                                sessionType, &symmetric, authHash, &session);
-#endif
-#endif
 #endif
 
      Esys_FlushContext(esys_context, outerSession);


### PR DESCRIPTION
Corrects:
- src/util/aux_util: drop NDEBUG from  MAYBE_UNUSED_MACRO
- test: conditionally include primaryHandle_AuthSession
- test: simplify conditional compilation expression
- test: fix preprocessor if statements
- fapi: remove UNUSED variables
- tpms-types.c: mark param as UNUSED not MAYBE_UNUSED
