### PR TITLE
util: mark variables as unused

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -796,10 +796,12 @@ cleanup:
  */
 TSS2_RC
 ifapi_keystore_store_finish(
-    IFAPI_KEYSTORE *keystore MAYBE_UNUSED,
+    IFAPI_KEYSTORE *keystore,
     IFAPI_IO *io)
 {
     TSS2_RC r;
+
+    UNUSED(keystore);
 
     /* Finish writing the object */
     r = ifapi_io_write_finish(io);
@@ -1300,13 +1302,14 @@ ifapi_keystore_search_nv_obj(
 TSS2_RC
 ifapi_keystore_check_overwrite(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io MAYBE_UNUSED,
+    IFAPI_IO *io,
     const char *path)
 {
     TSS2_RC r;
     char *directory = NULL;
     char *file = NULL;
 
+    UNUSED(io);
     /* Expand relative path */
     r = expand_path(keystore, path, &directory);
     goto_if_error(r, "Expand path", cleanup);
@@ -1364,13 +1367,14 @@ cleanup:
 TSS2_RC
 ifapi_keystore_check_writeable(
     IFAPI_KEYSTORE *keystore,
-    IFAPI_IO *io MAYBE_UNUSED,
+    IFAPI_IO *io,
     const char *path)
 {
     TSS2_RC r;
     char *directory = NULL;
     char *file = NULL;
 
+    UNUSED(io);
     /* Expand relative path */
     r = expand_path(keystore, path, &directory);
     goto_if_error(r, "Expand path", cleanup);

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -648,13 +648,14 @@ cleanup:
  */
 TSS2_RC
 ifapi_calculate_policy_physical_presence(
-    TPMS_POLICYPHYSICALPRESENCE *policy MAYBE_UNUSED,
+    TPMS_POLICYPHYSICALPRESENCE *policy,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_DEBUG("call");
+    UNUSED(policy);
 
     r = ifapi_calculate_simple_policy(TPM2_CC_PolicyPhysicalPresence, 0,
             current_digest, current_hash_alg);
@@ -680,13 +681,14 @@ ifapi_calculate_policy_physical_presence(
  */
 TSS2_RC
 ifapi_calculate_policy_auth_value(
-    TPMS_POLICYAUTHVALUE *policy MAYBE_UNUSED,
+    TPMS_POLICYAUTHVALUE *policy,
     TPML_DIGEST_VALUES *current_digest,
     TPMI_ALG_HASH current_hash_alg)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_DEBUG("call");
+    UNUSED(policy);
 
     r = ifapi_calculate_simple_policy(TPM2_CC_PolicyAuthValue, 0,
             current_digest, current_hash_alg);

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -846,12 +846,13 @@ static TSS2_RC
 execute_policy_secret(
     ESYS_CONTEXT *esys_ctx,
     TPMS_POLICYSECRET *policy,
-    TPMI_ALG_HASH hash_alg MAYBE_UNUSED,
+    TPMI_ALG_HASH hash_alg,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_DEBUG("call");
+    UNUSED(hash_alg);
 
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)
@@ -975,12 +976,13 @@ execute_policy_counter_timer(
 static TSS2_RC
 execute_policy_physical_presence(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYPHYSICALPRESENCE *policy MAYBE_UNUSED,
+    TPMS_POLICYPHYSICALPRESENCE *policy,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_TRACE("call");
+    UNUSED(policy);
 
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)
@@ -1024,12 +1026,13 @@ execute_policy_physical_presence(
 static TSS2_RC
 execute_policy_auth_value(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYAUTHVALUE *policy MAYBE_UNUSED,
+    TPMS_POLICYAUTHVALUE *policy,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_TRACE("call");
+    UNUSED(policy);
 
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)
@@ -1074,12 +1077,13 @@ execute_policy_auth_value(
 static TSS2_RC
 execute_policy_password(
     ESYS_CONTEXT *esys_ctx,
-    TPMS_POLICYPASSWORD *policy MAYBE_UNUSED,
+    TPMS_POLICYPASSWORD *policy,
     IFAPI_POLICY_EXEC_CTX *current_policy)
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
 
     LOG_TRACE("call");
+    UNUSED(policy);
 
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)

--- a/src/tss2-mu/tpms-types.c
+++ b/src/tss2-mu/tpms-types.c
@@ -147,11 +147,13 @@ TPMS_PCR_UNMARSHAL(TPMS_TAGGED_PCR_SELECT, \
                              dest? &dest->tag : NULL))
 
 #define TPMS_MARSHAL_0(type) \
-TSS2_RC Tss2_MU_##type##_Marshal(type const *src, \
-                                 uint8_t buffer[] MAYBE_UNUSED, \
-                                 size_t buffer_size MAYBE_UNUSED, \
-                                 size_t *offset MAYBE_UNUSED) \
+TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
+                                 size_t buffer_size, size_t *offset) \
 { \
+    UNUSED(buffer); \
+    UNUSED(buffer_size); \
+    UNUSED(offset); \
+\
     if (!src) { \
         LOG_WARNING("src param is NULL"); \
         return TSS2_MU_RC_BAD_REFERENCE; \
@@ -168,9 +170,9 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, \
 TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
                                    size_t *offset, type *dest) \
 { \
-    (void)(buffer); \
-    (void)(buffer_size); \
-    (void)(offset); \
+    UNUSED(buffer); \
+    UNUSED(buffer_size); \
+    UNUSED(offset); \
 \
     if (!dest) { \
         LOG_WARNING("src param is NULL"); \

--- a/test/integration/esys-create-session-auth.int.c
+++ b/test/integration/esys-create-session-auth.int.c
@@ -53,7 +53,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
     ESYS_TR loadedKeyHandle = ESYS_TR_NONE;
-    ESYS_TR primaryHandle_AuthSession MAYBE_UNUSED = ESYS_TR_NONE;
+    ESYS_TR primaryHandle_AuthSession = ESYS_TR_NONE;
     ESYS_TR session = ESYS_TR_NONE;
     ESYS_TR outerSession = ESYS_TR_NONE;
 
@@ -208,7 +208,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, primaryHandle, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 
-
+    primaryHandle_AuthSession = primaryHandle;
 #ifdef TEST_ECC
     r = Esys_CreatePrimary(esys_context, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
                            ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublicEcc,
@@ -220,7 +220,7 @@ test_esys_create_session_auth(ESYS_CONTEXT * esys_context)
     r = Esys_TR_SetAuth(esys_context, primaryHandle_AuthSession, &authValuePrimary);
     goto_if_error(r, "Error: TR_SetAuth", error);
 #else
-    primaryHandle_AuthSession = primaryHandle;
+    UNUSED(primaryHandle_AuthSession);
 #endif /* TEST_ECC */
 
 #if TEST_XOR_OBFUSCATION


### PR DESCRIPTION
Mark some variables are always unused.
They are not used in nether debug nor logging statements.