### PR TITLE
tcti-device: 'partial' may be used uninitialized

### DIFF
--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -412,6 +412,7 @@ Tss2_Tcti_Device_Init (
     tcti_common->state = TCTI_STATE_TRANSMIT;
     memset (&tcti_common->header, 0, sizeof (tcti_common->header));
     tcti_common->locality = 3;
+    tcti_common->partial = false;
 
     if (conf == NULL) {
         LOG_TRACE ("No TCTI device file specified");


### PR DESCRIPTION
If partial read is not supported then tcti_common->partial will be used
uninitialized in tcti_device_receive().

Signed-off-by: Jeffrey Ferreira <jeffpferreira@gmail.com>