### PR TITLE
sys: esys: EncryptDecrypt change mode type

### DIFF
--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -286,8 +286,8 @@ Both the synchronous and asynchronous API are exposed through a single library: 
  * ESAPI function to invoke the TPM2_EncryptDecrypt command
  * either as a one-call or in an asynchronous manner.
  \{
- \fn TSS2_RC Esys_EncryptDecrypt_Async(ESYS_CONTEXT *esysContext, ESYS_TR keyHandle, ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3, TPMI_YES_NO decrypt, TPMI_ALG_SYM_MODE mode, const TPM2B_IV *ivIn, const TPM2B_MAX_BUFFER *inData)
- \fn TSS2_RC Esys_EncryptDecrypt(ESYS_CONTEXT *esysContext, ESYS_TR keyHandle, ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3, TPMI_YES_NO decrypt, TPMI_ALG_SYM_MODE mode, const TPM2B_IV *ivIn, const TPM2B_MAX_BUFFER *inData, TPM2B_MAX_BUFFER **outData, TPM2B_IV **ivOut)
+ \fn TSS2_RC Esys_EncryptDecrypt_Async(ESYS_CONTEXT *esysContext, ESYS_TR keyHandle, ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3, TPMI_YES_NO decrypt, TPMI_ALG_CIPHER_MODE mode, const TPM2B_IV *ivIn, const TPM2B_MAX_BUFFER *inData)
+ \fn TSS2_RC Esys_EncryptDecrypt(ESYS_CONTEXT *esysContext, ESYS_TR keyHandle, ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3, TPMI_YES_NO decrypt, TPMI_ALG_CIPHER_MODE mode, const TPM2B_IV *ivIn, const TPM2B_MAX_BUFFER *inData, TPM2B_MAX_BUFFER **outData, TPM2B_IV **ivOut)
  \fn TSS2_RC Esys_EncryptDecrypt_Finish(ESYS_CONTEXT *esysContext, TPM2B_MAX_BUFFER **outData, TPM2B_IV **ivOut)
  \}
  \defgroup Esys_EventSequenceComplete The ESAPI function for the TPM2_EventSequenceComplete command.
@@ -2647,6 +2647,8 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
         json_object **jso)
 \fn TSS2_RC ifapi_json_TPMI_ALG_SYM_MODE_serialize(const TPMI_ALG_SYM_MODE in,
                                        json_object **jso)
+\fn TSS2_RC ifapi_json_TPMI_ALG_CIPHER_MODE_serialize(const TPMI_ALG_CIPHER_MODE in,
+                                       json_object **jso)
 \fn TSS2_RC ifapi_json_TPMI_ALG_SYM_OBJECT_serialize(const TPMI_ALG_SYM_OBJECT in,
         json_object **jso)
 \fn TSS2_RC ifapi_json_TPMI_ECC_CURVE_serialize(const TPMI_ECC_CURVE in, json_object **jso)
@@ -2901,6 +2903,8 @@ and are marked according to the PC Client Profile Revision 01.03 v22:
         TPMI_ALG_SIG_SCHEME *out)
 \fn TSS2_RC ifapi_json_TPMI_ALG_SYM_MODE_deserialize(json_object *jso,
         TPMI_ALG_SYM_MODE *out)
+\fn TSS2_RC ifapi_json_TPMI_ALG_CIPHER_MODE_deserialize(json_object *jso,
+        TPMI_ALG_CIPHER_MODE *out)
 \fn TSS2_RC ifapi_json_TPMI_ALG_SYM_OBJECT_deserialize(json_object *jso,
         TPMI_ALG_SYM_OBJECT *out)
 \fn TSS2_RC ifapi_json_TPMI_ALG_SYM_deserialize(json_object *jso, TPMI_ALG_SYM *out)

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -916,7 +916,7 @@ Esys_EncryptDecrypt(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER **outData,
@@ -930,7 +930,7 @@ Esys_EncryptDecrypt_Async(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData);
 
@@ -951,7 +951,7 @@ Esys_EncryptDecrypt2(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     TPM2B_MAX_BUFFER **outData,
     TPM2B_IV **ivOut);
@@ -965,7 +965,7 @@ Esys_EncryptDecrypt2_Async(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn);
 
 TSS2_RC

--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -587,7 +587,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData);
 
@@ -601,7 +601,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt(
     TPMI_DH_OBJECT keyHandle,
     TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER *outData,
@@ -613,7 +613,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare(
     TPMI_DH_OBJECT keyHandle,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn);
 
 TSS2_RC Tss2_Sys_EncryptDecrypt2_Complete(
@@ -627,7 +627,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2(
     TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut,

--- a/src/tss2-esys/api/Esys_EncryptDecrypt.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt.c
@@ -74,7 +74,7 @@ Esys_EncryptDecrypt(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER **outData,
@@ -156,7 +156,7 @@ Esys_EncryptDecrypt_Async(
     ESYS_TR shandle2,
     ESYS_TR shandle3,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData)
 {

--- a/src/tss2-esys/api/Esys_EncryptDecrypt2.c
+++ b/src/tss2-esys/api/Esys_EncryptDecrypt2.c
@@ -72,7 +72,7 @@ Esys_EncryptDecrypt2(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     TPM2B_MAX_BUFFER **outData,
     TPM2B_IV **ivOut)
@@ -151,7 +151,7 @@ Esys_EncryptDecrypt2_Async(
     ESYS_TR shandle3,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn)
 {
     TSS2_RC r;

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -410,7 +410,7 @@ ifapi_profile_json_deserialize(
         LOG_ERROR("Field \"sym_mode\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;
     }
-    r = ifapi_json_TPMI_ALG_SYM_MODE_deserialize(jso2, &out->sym_mode);
+    r = ifapi_json_TPMI_ALG_CIPHER_MODE_deserialize(jso2, &out->sym_mode);
     return_if_error(r, "Bad value for field \"sym_mode\".");
 
     if (!ifapi_get_sub_object(jso, "sym_parameters", &jso2)) {

--- a/src/tss2-fapi/ifapi_profiles.h
+++ b/src/tss2-fapi/ifapi_profiles.h
@@ -21,7 +21,7 @@ typedef struct IFAPI_PROFILE {
     TPMT_SIG_SCHEME                  ecc_signing_scheme;    /**< Signing scheme for the ECC key. */
     TPMT_SIG_SCHEME                  rsa_signing_scheme;    /**< Signing scheme for the RSA key. */
     TPMT_RSA_DECRYPT                 rsa_decrypt_scheme;    /**< Decrypt scheme for the RSA key. */
-    TPMI_ALG_SYM_MODE                          sym_mode;    /**< Mode for symmectric encryption. */
+    TPMI_ALG_CIPHER_MODE                       sym_mode;    /**< Mode for symmectric encryption. */
     TPMT_SYM_DEF_OBJECT                  sym_parameters;    /**< Parameters for symmectric encryption. */
     UINT16                               sym_block_size;    /**< Block size for symmectric encryption. */
     TPML_PCR_SELECTION                    pcr_selection;    /**< Parameters for symmectric encryption. */

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -1315,6 +1315,21 @@ ifapi_json_TPMI_ALG_SYM_MODE_deserialize(json_object *jso,
         TPM2_ALG_CTR, TPM2_ALG_OFB, TPM2_ALG_CBC, TPM2_ALG_CFB, TPM2_ALG_ECB, TPM2_ALG_NULL);
 }
 
+/** Deserialize a TPMI_ALG_CIPHER_MODE json object.
+ *
+ * @param[in]  jso the json object to be deserialized.
+ * @param[out] out the deserialzed binary object.
+ * @retval TSS2_RC_SUCCESS if the function call was a success.
+ * @retval TSS2_FAPI_RC_BAD_VALUE if the json object can't be deserialized.
+ */
+TSS2_RC
+ifapi_json_TPMI_ALG_CIPHER_MODE_deserialize(json_object *jso,
+        TPMI_ALG_CIPHER_MODE *out)
+{
+    SUBTYPE_FILTER(TPMI_ALG_CIPHER_MODE, TPM2_ALG_ID,
+        TPM2_ALG_CTR, TPM2_ALG_OFB, TPM2_ALG_CBC, TPM2_ALG_CFB, TPM2_ALG_ECB, TPM2_ALG_NULL);
+}
+
 /** Deserialize a TPMI_ALG_KDF json object.
  *
  * @param[in]  jso the json object to be deserialized.

--- a/src/tss2-fapi/tpm_json_deserialize.h
+++ b/src/tss2-fapi/tpm_json_deserialize.h
@@ -88,6 +88,10 @@ ifapi_json_TPMI_ALG_SYM_OBJECT_deserialize(json_object *jso,
         TPMI_ALG_SYM_OBJECT *out);
 
 TSS2_RC
+ifapi_json_TPMI_ALG_CIPHER_MODE_deserialize(json_object *jso,
+        TPMI_ALG_CIPHER_MODE *out);
+
+TSS2_RC
 ifapi_json_TPMI_ALG_SYM_MODE_deserialize(json_object *jso,
         TPMI_ALG_SYM_MODE *out);
 

--- a/src/tss2-fapi/tpm_json_serialize.c
+++ b/src/tss2-fapi/tpm_json_serialize.c
@@ -1088,6 +1088,23 @@ ifapi_json_TPMI_ALG_SYM_MODE_serialize(const TPMI_ALG_SYM_MODE in,
     return ifapi_json_TPM2_ALG_ID_serialize(in, jso);
 }
 
+/** Serialize TPMI_ALG_CIPHER_MODE to json.
+ *
+ * @param[in] in variable to be serialized.
+ * @param[out] jso pointer to the json object.
+ * @retval TSS2_FAPI_RC_BAD_VALUE if an invalid value was passed into
+ *         the function.
+ * @retval TSS2_FAPI_RC_MEMORY if not enough memory can be allocated.
+ */
+TSS2_RC
+ifapi_json_TPMI_ALG_CIPHER_MODE_serialize(const TPMI_ALG_CIPHER_MODE in,
+                                          json_object **jso)
+{
+    CHECK_IN_LIST(TPMI_ALG_CIPHER_MODE, in, TPM2_ALG_CTR, TPM2_ALG_OFB,
+        TPM2_ALG_CBC, TPM2_ALG_CFB, TPM2_ALG_ECB, TPM2_ALG_NULL);
+    return ifapi_json_TPM2_ALG_ID_serialize(in, jso);
+}
+
 /** Serialize TPMI_ALG_KDF to json.
  *
  * @param[in] in variable to be serialized.

--- a/src/tss2-fapi/tpm_json_serialize.h
+++ b/src/tss2-fapi/tpm_json_serialize.h
@@ -93,6 +93,10 @@ ifapi_json_TPMI_ALG_SYM_MODE_serialize(const TPMI_ALG_SYM_MODE in,
                                        json_object **jso);
 
 TSS2_RC
+ifapi_json_TPMI_ALG_CIPHER_MODE_serialize(const TPMI_ALG_CIPHER_MODE in,
+                                          json_object **jso);
+
+TSS2_RC
 ifapi_json_TPMI_ALG_KDF_serialize(const TPMI_ALG_KDF in, json_object **jso);
 
 TSS2_RC

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt.c
@@ -16,7 +16,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData)
 {
@@ -118,7 +118,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt(
     TPMI_DH_OBJECT keyHandle,
     TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER *outData,

--- a/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
+++ b/src/tss2-sys/api/Tss2_Sys_EncryptDecrypt2.c
@@ -17,7 +17,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare (
     TPMI_DH_OBJECT keyHandle,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
@@ -124,7 +124,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2 (
     TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
-    TPMI_ALG_SYM_MODE mode,
+    TPMI_ALG_CIPHER_MODE mode,
     const TPM2B_IV *ivIn,
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut,

--- a/test/integration/esys-encrypt-decrypt.int.c
+++ b/test/integration/esys-encrypt-decrypt.int.c
@@ -232,7 +232,7 @@ test_esys_encrypt_decrypt(ESYS_CONTEXT * esys_context)
     ESYS_TR keyHandle_handle = loadedKeyHandle;
     TPMI_YES_NO decrypt = TPM2_YES;
     TPMI_YES_NO encrypt = TPM2_NO;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = {
         .size = 16,
         .buffer = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16}

--- a/test/integration/sys-util.c
+++ b/test/integration/sys-util.c
@@ -249,7 +249,7 @@ tpm_encrypt_decrypt_cfb (
     TPM2B_MAX_BUFFER *data_in,
     TPM2B_MAX_BUFFER *data_out)
 {
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV iv_in = TPM2B_IV_INIT;
     TPM2B_IV iv_out = TPM2B_IV_INIT;
 
@@ -306,7 +306,7 @@ tpm_encrypt_decrypt_2_cfb (
     TPM2B_MAX_BUFFER *data_in,
     TPM2B_MAX_BUFFER *data_out)
 {
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV iv_in = TPM2B_IV_INIT;
     TPM2B_IV iv_out = TPM2B_IV_INIT;
 

--- a/test/unit/esys-resubmissions.c
+++ b/test/unit/esys-resubmissions.c
@@ -793,7 +793,7 @@ test_EncryptDecrypt(void **state)
 
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPM2B_MAX_BUFFER *outData;
@@ -821,7 +821,7 @@ test_EncryptDecrypt2(void **state)
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER *outData;
     TPM2B_IV *ivOut;

--- a/test/unit/esys-tcti-rcs.c
+++ b/test/unit/esys-tcti-rcs.c
@@ -744,7 +744,7 @@ test_EncryptDecrypt(void **state)
 
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPM2B_MAX_BUFFER *outData;
@@ -770,7 +770,7 @@ test_EncryptDecrypt2(void **state)
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER *outData;
     TPM2B_IV *ivOut;

--- a/test/unit/esys-tpm-rcs.c
+++ b/test/unit/esys-tpm-rcs.c
@@ -724,7 +724,7 @@ test_EncryptDecrypt(void **state)
 
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPM2B_MAX_BUFFER *outData;
@@ -750,7 +750,7 @@ test_EncryptDecrypt2(void **state)
     ESYS_TR keyHandle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER inData = DUMMY_2B_DATA(.buffer);
     TPMI_YES_NO decrypt = 0;
-    TPMI_ALG_SYM_MODE mode = TPM2_ALG_NULL;
+    TPMI_ALG_CIPHER_MODE mode = TPM2_ALG_NULL;
     TPM2B_IV ivIn = DUMMY_2B_DATA16(.buffer);
     TPM2B_MAX_BUFFER *outData;
     TPM2B_IV *ivOut;


### PR DESCRIPTION
Update EncryptDecrypt and EncryptDecrypt2 function definitions
and change the mode type from TPMI_ALG_SYM_MODE to TPMI_ALG_CIPHER_MODE.
to make it complient with the TPM2.0 1.59 specification.
These types are the same (UINT16) so there is no impact to existing code.