### PR TITLE
cherry-pick: marshal: remove double define

### DIFF
--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -21,20 +21,6 @@ extern "C" {
 #endif
 
 TSS2_RC
-Tss2_MU_BYTE_Marshal(
-    BYTE           src,
-    uint8_t         buffer[],
-    size_t          buffer_size,
-    size_t         *offset);
-
-TSS2_RC
-Tss2_MU_BYTE_Unmarshal(
-    uint8_t const   buffer[],
-    size_t          buffer_size,
-    size_t         *offset,
-    BYTE           *dest);
-
-TSS2_RC
 Tss2_MU_INT8_Marshal(
     INT8            src,
     uint8_t         buffer[],


### PR DESCRIPTION
It would be good to get this commit into 3.0.x as the double BYTE marshal functions doesn't work well with python cffi.
