### PR TITLE
TEST: Change remaining used hash algorithm from sha1 to sha256.

### DIFF
--- a/test/data/fapi/P_RSA_sh_policy.json
+++ b/test/data/fapi/P_RSA_sh_policy.json
@@ -27,12 +27,12 @@
     "sym_block_size": 16,
     "pcr_selection": [
         { "hash": "TPM2_ALG_SHA1",
-          "pcrSelect": [ 9, 15, 13 ]
-        },
-        { "hash": "TPM2_ALG_SHA256",
-          "pcrSelect": [ 8, 16, 14 ]
-        }
-    ],
+            "pcrSelect": [ ]
+          },
+          { "hash": "TPM2_ALG_SHA256",
+            "pcrSelect": [ 8, 9 , 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+          }
+      ],
     "exponent": 0,
     "keyBits": 2048,
     "session_hash_alg": "TPM2_ALG_SHA256",


### PR DESCRIPTION
One profile was left out during commit "TEST: Change used hash
algorithm from sha1 to sha256."

Fix this as well.

Maybe we can include this in 3.1.0 ?