### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@ $ sudo apt -y install \
   doxygen \
   libjson-c-dev \
   libini-config-dev \
-  libcurl-dev
+  libcurl4-openssl-dev
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 


### PR DESCRIPTION
I met an error when I deploy the libs using the previous version “lib-dev” on ubuntu 18.04, I corrected the error when I changed it to "libcurl4-openssl-dev". Thus, I think it would be better after changing the dependencies.