### PR TITLE
configure: use git version over hardcode in init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # All rights reserved.
 
 AC_INIT([tpm2-tss],
-        [3.1.0],
+        [m4_esyscmd_s([git describe --tags --always --dirty])],
         [https://github.com/tpm2-software/tpm2-tss/issues],
         [],
         [https://github.com/tpm2-software/tpm2-tss])


### PR DESCRIPTION
Bumping the version manually in configure.ac is a recipe for disaster. It doesn't take into account the git tree state. Rather use git describe output. The only thing this really changes is you have to build from release tarball or git, you cant use the zip snapshot feature of github.
-----
Currently master will produce a version of 3.1.0-rc0, even though its 27
commits ahead of the tag at this moment and contain local uncommited
changed.

git describe --tags --always --dirty
3.1.0-rc0-27-gc6b77ca306dc-dirty

So we have three scenarios to consider:
release: version
rc: version + -rc<N>
dev: verions + anything tacked on (thats not just -rc<N>)

Release and dev versions stay the same, since nothing in their version
information is changing.

In the development scenario, pkg-config will consider something like:
3.2.0-rc0-28-g1299b2d85053 > 3.2.0
So this works as expected.

pkg-config --modversion tss2-sys
3.2.0-rc1-abcdef
pkg-config --exists --print-errors "tss2-sys > 3.2.0"

But it's even smarter, it knows git describe output and can verify that
patch 28 is greater than patch 27

pkg-config --exists --print-errors "tss2-sys > 3.2.0-rc0-29"
Requested 'tss2-sys > 3.2.0-rc0-29' but version of tss2-sys is 3.2.0-rc0-28-g1299b2d85053

The package VERSION was never exported in the source code, so their
should be no suprises there either.

Signed-off-by: William Roberts <william.c.roberts@intel.com>