### PR TITLE
fix of possible access outside the array.

### DIFF
--- a/src/tss2-fapi/ifapi_policy.c
+++ b/src/tss2-fapi/ifapi_policy.c
@@ -134,7 +134,7 @@ ifapi_calculate_tree(
         if (already_computed)
             break;
 
-        if (i > TPM2_NUM_PCR_BANKS) {
+        if (i >= TPM2_NUM_PCR_BANKS) {
             return_error(TSS2_FAPI_RC_BAD_VALUE, "Table overflow");
         }
         *digest_idx = i;


### PR DESCRIPTION
the specified condition will skip the value 16, which will cause a write outside the allocated memory.