### PR TITLE
Avoid compiler warnings/errors in the unit test suite when building with GCC 11

### DIFF
--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -326,7 +326,7 @@ tpm2b_unmarshal_buffer_null (void **state)
 void
 tpm2b_unmarshal_dest_null (void **state)
 {
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     TSS2_RC rc;
 
     rc = Tss2_MU_TPM2B_DIGEST_Unmarshal (buffer, sizeof (buffer), NULL, NULL);

--- a/test/unit/TPMS-marshal.c
+++ b/test/unit/TPMS-marshal.c
@@ -317,7 +317,7 @@ tpms_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
 {
     TPMS_ALG_PROPERTY alg = {0};
     TPMS_CAPABILITY_DATA cap = {0};
-    uint8_t buffer[sizeof(alg) + sizeof(cap) + 1] = { 0 };
+    uint8_t buffer[sizeof(alg) + sizeof(cap) + 3] = { 0 };
     TPMS_ALG_PROPERTY *ptr;
     TPMS_CAPABILITY_DATA *ptr2;
     size_t offset = 3;

--- a/test/unit/UINT16-marshal.c
+++ b/test/unit/UINT16-marshal.c
@@ -171,7 +171,7 @@ UINT16_unmarshal_buffer_null (void **state)
 void
 UINT16_unmarshal_dest_null (void **state)
 {
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     TSS2_RC rc;
 
     rc = Tss2_MU_UINT16_Unmarshal (buffer, sizeof (buffer), NULL, NULL);
@@ -186,7 +186,7 @@ void
 UINT16_unmarshal_buffer_size_lt_offset (void **state)
 {
     UINT16   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
@@ -204,7 +204,7 @@ void
 UINT16_unmarshal_buffer_size_lt_dest (void **state)
 {
     UINT16   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer);
     TSS2_RC rc;
 

--- a/test/unit/UINT32-marshal.c
+++ b/test/unit/UINT32-marshal.c
@@ -172,7 +172,7 @@ UINT32_unmarshal_buffer_null (void **state)
 void
 UINT32_unmarshal_dest_null (void **state)
 {
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     TSS2_RC rc;
 
     rc = Tss2_MU_UINT32_Unmarshal (buffer, sizeof (buffer), NULL, NULL);
@@ -187,7 +187,7 @@ void
 UINT32_unmarshal_buffer_size_lt_offset (void **state)
 {
     UINT32   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
@@ -205,7 +205,7 @@ void
 UINT32_unmarshal_buffer_size_lt_dest (void **state)
 {
     UINT32   dest = 0;
-    uint8_t buffer [3];
+    uint8_t buffer [3] = { 0 };
     size_t  offset = sizeof (buffer);
     TSS2_RC rc;
 

--- a/test/unit/UINT64-marshal.c
+++ b/test/unit/UINT64-marshal.c
@@ -172,7 +172,7 @@ UINT64_unmarshal_buffer_null (void **state)
 void
 UINT64_unmarshal_dest_null (void **state)
 {
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     TSS2_RC rc;
 
     rc = Tss2_MU_UINT64_Unmarshal (buffer, sizeof (buffer), NULL, NULL);
@@ -187,7 +187,7 @@ void
 UINT64_unmarshal_buffer_size_lt_offset (void **state)
 {
     UINT64   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
@@ -205,7 +205,7 @@ void
 UINT64_unmarshal_buffer_size_lt_dest (void **state)
 {
     UINT64   dest = 0;
-    uint8_t buffer [3];
+    uint8_t buffer [3] = { 0 };
     size_t  offset = sizeof (buffer);
     TSS2_RC rc;
 

--- a/test/unit/UINT8-marshal.c
+++ b/test/unit/UINT8-marshal.c
@@ -167,7 +167,7 @@ UINT8_unmarshal_buffer_null (void **state)
 void
 UINT8_unmarshal_dest_null (void **state)
 {
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     TSS2_RC rc;
 
     rc = Tss2_MU_UINT8_Unmarshal (buffer, sizeof (buffer), NULL, NULL);
@@ -181,7 +181,7 @@ UINT8_unmarshal_dest_null (void **state)
 void
 UINT8_unmarshal_dest_null_offset_valid (void **state)
 {
-    uint8_t buffer [2];
+    uint8_t buffer [2] = { 0 };
     size_t  offset = 1;
     TSS2_RC rc;
 
@@ -199,7 +199,7 @@ void
 UINT8_unmarshal_buffer_size_lt_offset (void **state)
 {
     UINT8   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
@@ -217,7 +217,7 @@ void
 UINT8_unmarshal_buffer_size_lt_dest (void **state)
 {
     UINT8   dest = 0;
-    uint8_t buffer [1];
+    uint8_t buffer [1] = { 0 };
     size_t  offset = sizeof (buffer);
     TSS2_RC rc;
 


### PR DESCRIPTION
GCC 11 tightens static checks, leading to additional compiler warnings that are treated as errors due to `-Werror`.

<s>Since `-Werror` is enabled in release builds as well, it would be good to get these changes into the pending 3.1.0 release as well.</s> `-Werror` is [disabled](https://github.com/tpm2-software/tpm2-tss/blob/2bae50a3551cd8b0123ef609ea973678339df5ae/configure.ac#L435-L436) for releases, so this shouldn't directly affect the upcoming 3.1.0 release.