### PR TITLE
Add tss2-dlopen-esys.c

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.
 
-TESTS_CFLAGS = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/src/tss2-mu \
+TESTS_CFLAGS = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/include -I$(srcdir)/src/tss2-mu \
     -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys  -I$(srcdir)/src/tss2-fapi \
     -Wno-unused-parameter -Wno-missing-field-initializers
 TESTS_LDADD = $(check_LTLIBRARIES) $(lib_LTLIBRARIES) \
@@ -87,6 +87,10 @@ TESTS_UNIT  = \
     test/unit/tctildr-nodl \
     test/unit/tctildr-tcti \
     test/unit/tctildr-getinfo \
+    test/unit/dlopen-fail \
+    test/unit/dlopen-UINT8-marshal \
+    test/unit/dlopen-TPM2B-marshal \
+    test/unit/dlopen-TPMU-marshal \
     test/unit/UINT8-marshal \
     test/unit/UINT16-marshal \
     test/unit/UINT32-marshal \
@@ -98,6 +102,7 @@ TESTS_UNIT  = \
     test/unit/TPMT-marshal \
     test/unit/TPMU-marshal \
     test/unit/sys-execute \
+    test/unit/dlopen_tss2_rc \
     test/unit/tss2_rc
 if ENABLE_TCTI_MSSIM
 TESTS_UNIT += test/unit/tcti-mssim
@@ -184,6 +189,7 @@ ESYS_TESTS_INTEGRATION_DESTRUCTIVE = \
     test/integration/esys-set-algorithm-set.int
 
 ESYS_TESTS_INTEGRATION_MANDATORY = \
+    test/integration/dlopen-esys-get-random.int \
     test/integration/esys-act-set-timeout.int \
     test/integration/esys-certify-creation.int \
     test/integration/esys-certifyX509.int \
@@ -299,6 +305,7 @@ if FAPI
 TESTS_LDADD += $(JSONC_LIBS)
 TESTS_CFLAGS +=  -DTOP_SOURCEDIR"=\"$(top_srcdir)\""
 FAPI_TESTS_INTEGRATION = \
+    test/integration/dlopen-fapi-get-random.fint \
     test/integration/fapi-check-wrong-paths.fint \
     test/integration/fapi-data-crypt.fint \
     test/integration/fapi-data-crypt-persistent.fint \
@@ -502,6 +509,31 @@ test_unit_CopyCommandHeader_LDADD = $(CMOCKA_LIBS) $(libtss2_sys) $(libtss2_mu)
 test_unit_CopyCommandHeader_SOURCES = test/unit/CopyCommandHeader.c \
     src/tss2-sys/sysapi_util.c
 
+test_unit_dlopen_fail_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_dlopen_fail_LDADD   = $(CMOCKA_LIBS)
+test_unit_dlopen_fail_LDFLAGS = -Wl,--wrap=dlopen,--wrap=dlclose,--wrap=dlsym
+test_unit_dlopen_fail_SOURCES = test/unit/dlopen-fail.c \
+    tss2-dlopen/tss2-dlopen-tctildr.c \
+    tss2-dlopen/tss2-dlopen-rc.c \
+    tss2-dlopen/tss2-dlopen-mu.c \
+    tss2-dlopen/tss2-dlopen-esys.c \
+    tss2-dlopen/tss2-dlopen-fapi.c
+
+test_unit_dlopen_UINT8_marshal_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_dlopen_UINT8_marshal_LDADD   = $(CMOCKA_LIBS) $(LIBADD_DL) $(libtss2_mu)
+test_unit_dlopen_UINT8_marshal_SOURCES = test/unit/UINT8-marshal.c \
+    tss2-dlopen/tss2-dlopen-mu.c
+
+test_unit_dlopen_TPM2B_marshal_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_dlopen_TPM2B_marshal_LDADD   = $(CMOCKA_LIBS) $(LIBADD_DL) $(libtss2_mu)
+test_unit_dlopen_TPM2B_marshal_SOURCES = test/unit/TPM2B-marshal.c \
+    tss2-dlopen/tss2-dlopen-mu.c
+
+test_unit_dlopen_TPMU_marshal_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_dlopen_TPMU_marshal_LDADD   = $(CMOCKA_LIBS) $(LIBADD_DL) $(libtss2_mu)
+test_unit_dlopen_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c \
+    tss2-dlopen/tss2-dlopen-mu.c
+
 test_unit_UINT8_marshal_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_UINT8_marshal_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu)
 
@@ -540,6 +572,11 @@ test_unit_sys_execute_SOURCES = test/unit/sys-execute.c \
 test_unit_tss2_rc_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tss2_rc_LDADD   = $(CMOCKA_LIBS) $(libtss2_rc) $(libtss2_sys)
 test_unit_tss2_rc_SOURCES = test/unit/test_tss2_rc.c
+
+test_unit_dlopen_tss2_rc_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_dlopen_tss2_rc_LDADD   = $(CMOCKA_LIBS) $(LIBADD_DL) $(libtss2_rc) $(libtss2_sys)
+test_unit_dlopen_tss2_rc_SOURCES = test/unit/test_tss2_rc.c \
+    tss2-dlopen/tss2-dlopen-rc.c
 
 if ESYS
 test_unit_esys_context_null_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(TSS2_ESYS_CFLAGS_CRYPTO)
@@ -844,6 +881,17 @@ if ESYS
 ESYS_SRC_UTIL_CRYPTO_SRC = src/tss2-esys/esys_iutil.c \
                            src/tss2-esys/esys_crypto.c \
                            $(TSS2_ESYS_SRC_CRYPTO)
+
+test_integration_dlopen_esys_get_random_int_CFLAGS  = $(TESTS_CFLAGS) \
+    -DENABLE_WARN=1
+test_integration_dlopen_esys_get_random_int_LDADD   = $(TESTS_LDADD) $(LIBADD_DL)
+test_integration_dlopen_esys_get_random_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_dlopen_esys_get_random_int_SOURCES = \
+    test/integration/esys-get-random.int.c \
+    tss2-dlopen/tss2-dlopen-esys.c \
+    tss2-dlopen/tss2-dlopen-mu.c \
+    tss2-dlopen/tss2-dlopen-tctildr.c \
+    test/integration/main-esys.c test/integration/test-esys.h
 
 test_integration_esys_act_set_timeout_int_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_esys_act_set_timeout_int_LDADD   = $(TESTS_LDADD)
@@ -1586,6 +1634,17 @@ test_integration_sys_policy_authorizeNV_int_SOURCES = test/integration/main-sys.
     test/integration/sys-policy-authorizeNV.int.c
 
 if FAPI
+test_integration_dlopen_fapi_get_random_fint_CFLAGS  = $(TESTS_CFLAGS) \
+    -DENABLE_WARN=1
+test_integration_dlopen_fapi_get_random_fint_LDADD   = $(TESTS_LDADD) $(LIBADD_DL)
+test_integration_dlopen_fapi_get_random_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_dlopen_fapi_get_random_fint_SOURCES = \
+    test/integration/fapi-get-random.int.c \
+    tss2-dlopen/tss2-dlopen-fapi.c \
+    tss2-dlopen/tss2-dlopen-esys.c \
+    tss2-dlopen/tss2-dlopen-mu.c \
+    tss2-dlopen/tss2-dlopen-tctildr.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_check_wrong_paths_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_check_wrong_paths_fint_LDADD   = $(TESTS_LDADD)

--- a/Makefile.am
+++ b/Makefile.am
@@ -219,6 +219,14 @@ EXTRA_DIST += \
     src/tss2-tcti/tss2-tcti-tbs.vcxproj.filters \
     tpm2-tss.sln
 
+# tss2-dlopen wrappers
+EXTRA_DIST += \
+    tss2-dlopen/tss2-dlopen-rc.c \
+    tss2-dlopen/tss2-dlopen-tctildr.c \
+    tss2-dlopen/tss2-dlopen-mu.c \
+    tss2-dlopen/tss2-dlopen-esys.c \
+    tss2-dlopen/tss2-dlopen-fapi.c
+
 # Generate the AUTHORS file from git log
 AUTHORS :
 	$(AM_V_GEN)git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \

--- a/test/unit/dlopen-fail.c
+++ b/test/unit/dlopen-fail.c
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <dlfcn.h>
+
+#include "tss2_tctildr.h"
+#include "tss2_rc.h"
+#include "tss2_mu.h"
+#include "tss2_esys.h"
+#include "tss2_fapi.h"
+
+
+#define DLOPEN_HANDLE ((void *)0xaaffffee)
+
+void *__wrap_dlopen(const char *filename, int flags)
+{
+    return mock_type (void *);
+}
+
+void *__wrap_dlsym(void *handle, const char *symbol)
+{
+    if (handle != DLOPEN_HANDLE) {
+        fprintf(stderr, "dlsym called with weird handle %p\n", handle);
+        exit(99);
+    }
+    return mock_type (void *);
+}
+
+static void test_tctildr(void **state)
+{
+    TSS2_RC r;
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_TctiLdr_Initialize_Ex(NULL, NULL, NULL);
+    assert_int_equal(r, TSS2_TCTI_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_TctiLdr_Initialize(NULL, NULL);
+    assert_int_equal(r, TSS2_TCTI_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_TctiLdr_GetInfo(NULL, NULL);
+    assert_int_equal(r, TSS2_TCTI_RC_NOT_IMPLEMENTED);
+}
+
+static void test_mu(void **state)
+{
+    TSS2_RC r;
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_UINT8_Marshal(0, NULL, 0, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_UINT8_Unmarshal(NULL, 0, NULL, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_TPM2B_DIGEST_Marshal(NULL, NULL, 0, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_TPM2B_DIGEST_Unmarshal(NULL, 0, NULL, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_TPMU_HA_Marshal(NULL, 0, NULL, 0, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_MU_TPMU_HA_Unmarshal(NULL, 0, NULL, 0, NULL);
+    assert_int_equal(r, TSS2_BASE_RC_NOT_IMPLEMENTED);
+}
+
+static void test_rc(void **state)
+{
+    const char *r;
+    TSS2_RC_HANDLER h;
+
+    will_return(__wrap_dlopen, NULL);
+    r = Tss2_RC_Decode(0);
+    assert_string_equal(r, "libtss2-rc.so.0 not found.");
+
+    will_return(__wrap_dlopen, NULL);
+    h = Tss2_RC_SetHandler(0, NULL, NULL);
+    assert_null(h);
+}
+
+static void test_esys(void **state)
+{
+    TSS2_RC r;
+
+    will_return(__wrap_dlopen, NULL);
+    r = Esys_Initialize(NULL, NULL, NULL);
+    assert_int_equal(r, TSS2_ESYS_RC_NOT_IMPLEMENTED);
+}
+
+static void test_fapi(void **state)
+{
+    TSS2_RC r;
+
+    will_return(__wrap_dlopen, NULL);
+    r = Fapi_Initialize(NULL, NULL);
+    assert_int_equal(r, TSS2_FAPI_RC_NOT_IMPLEMENTED);
+
+    will_return(__wrap_dlopen, NULL);
+    r = Fapi_Initialize_Async(NULL, NULL);
+    assert_int_equal(r, TSS2_FAPI_RC_NOT_IMPLEMENTED);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (test_tctildr),
+        cmocka_unit_test (test_rc),
+        cmocka_unit_test (test_mu),
+        cmocka_unit_test (test_esys),
+        cmocka_unit_test (test_fapi)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tss2-dlopen/tss2-dlopen-esys.c
+++ b/tss2-dlopen/tss2-dlopen-esys.c
@@ -1,0 +1,2208 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2021, Fraunhofer SIT
+ * All rights reserved.
+ *******************************************************************************/
+
+/**
+ * The purpose of this file is to copy it into your project and
+ * include it during compilation if you don't want to link against
+ * libtss2-esys at compile time.
+ * It will attempt to load libtss2-esys.so during runtime.
+ * It will either work similarly to directly linking to libtss2-esys.so
+ * at compile-time or return a NOT_IMPLEMENTED error.
+ *
+ * For new versions of this file, please check:
+ * http://github.com/tpm2-software/tpm2-tss/tss2-dlopen
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <tss2/tss2_esys.h>
+
+#define str(s) xstr(s)
+#define xstr(s) #s
+
+#ifdef ENABLE_WARN
+#define WARN(str, ...) do { fprintf(stderr, "WARNING: " str "\n", ## __VA_ARGS__); } while (0)
+#else /* ENABLE_WARN */
+#define WARN(...) do { } while (0)
+#endif /* ENABLE_WARN */
+
+#define LIB "libtss2-esys.so.0"
+static void *dlhandle = NULL;
+
+static TSS2_RC
+init_dlhandle(void)
+{
+    if (dlhandle)
+        return TSS2_RC_SUCCESS;
+    dlhandle = dlopen(LIB, RTLD_NOW | RTLD_LOCAL);
+    if (!dlhandle) {
+        WARN("Library " LIB " not found: %s.", dlerror());
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED;
+    }
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+Esys_Initialize(
+    ESYS_CONTEXT **esys_context,
+    TSS2_TCTI_CONTEXT *tcti,
+    TSS2_ABI_VERSION *abiVersion)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (ESYS_CONTEXT **esys_context, TSS2_TCTI_CONTEXT *tcti, TSS2_ABI_VERSION *abiVersion) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Esys_Initialize");
+    if (!sym) {
+        WARN("Function Esys_Initialize not found.");
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(esys_context, tcti, abiVersion);
+}
+
+void
+Esys_Finalize(ESYS_CONTEXT **ctx)
+{
+    if (!ctx || !*ctx)
+        return;
+    static TSS2_RC (*sym) (ESYS_CONTEXT **ctx) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Esys_Finalize");
+    if (!sym) {
+        WARN("Function Esys_Finalize not found.");
+        return;
+    }
+    sym(ctx);
+}
+
+void
+Esys_Free(void *__ptr)
+{
+    if (!__ptr)
+        return;
+    static TSS2_RC (*sym) (void *__ptr) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Esys_Free");
+    if (!sym) {
+        WARN("Function Esys_Free not found.");
+        return;
+    }
+    sym(__ptr);
+}
+
+#define MAKE_ESYS_0(fun) \
+TSS2_RC fun (ESYS_CONTEXT *ctx) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx); \
+}
+
+#define MAKE_ESYS_1(fun, type1,parm1) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1); \
+}
+
+#define MAKE_ESYS_2(fun, type1,parm1, type2,parm2) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2); \
+}
+
+#define MAKE_ESYS_3(fun, type1,parm1, type2,parm2, type3,parm3) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3); \
+}
+
+#define MAKE_ESYS_4(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3, type4) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4); \
+}
+
+#define MAKE_ESYS_5(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5); \
+}
+
+#define MAKE_ESYS_6(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6); \
+}
+
+#define MAKE_ESYS_7(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7); \
+}
+
+#define MAKE_ESYS_8(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7, type8,parm8) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8) { \
+    static TSS2_RC (*sym) (ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8); \
+}
+
+#define MAKE_ESYS_9(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                         type9,parm9) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9) { \
+    TSS2_RC (*sym)(ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9); \
+}
+
+#define MAKE_ESYS_10(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10) { \
+    TSS2_RC (*sym)(ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10); \
+}
+
+#define MAKE_ESYS_11(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11) { \
+    TSS2_RC (*sym)(ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11); \
+}
+
+#define MAKE_ESYS_12(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11, type12,parm12) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11, type12 parm12) { \
+    TSS2_RC (*sym)(ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11, type12) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11, parm12); \
+}
+
+#define MAKE_ESYS_13(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11, type12,parm12, \
+                          type13,parm13) \
+TSS2_RC fun (ESYS_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11, type12 parm12, \
+                                type13 parm13) { \
+    TSS2_RC (*sym)(ESYS_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11, type12, type13) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_ESYS_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11, parm12, parm13); \
+}
+
+MAKE_ESYS_1(Esys_GetTcti,
+    TSS2_TCTI_CONTEXT **, tcti);
+MAKE_ESYS_2(Esys_GetPollHandles,
+    TSS2_TCTI_POLL_HANDLE **, handles,
+    size_t *, count);
+MAKE_ESYS_1(Esys_SetTimeout,
+    int32_t, timeout);
+MAKE_ESYS_3(Esys_TR_Serialize,
+    ESYS_TR, object,
+    uint8_t **, buffer,
+    size_t *, buffer_size);
+MAKE_ESYS_3(Esys_TR_Deserialize,
+    uint8_t const *, buffer,
+    size_t, buffer_size,
+    ESYS_TR *, esys_handle);
+MAKE_ESYS_4(Esys_TR_FromTPMPublic_Async,
+    TPM2_HANDLE, tpm_handle,
+    ESYS_TR, optionalSession1,
+    ESYS_TR, optionalSession2,
+    ESYS_TR, optionalSession3);
+MAKE_ESYS_1(Esys_TR_FromTPMPublic_Finish,
+    ESYS_TR *, object);
+MAKE_ESYS_5(Esys_TR_FromTPMPublic,
+    TPM2_HANDLE, tpm_handle,
+    ESYS_TR, optionalSession1,
+    ESYS_TR, optionalSession2,
+    ESYS_TR, optionalSession3,
+    ESYS_TR *, object);
+MAKE_ESYS_1(Esys_TR_Close,
+    ESYS_TR *, rsrc_handle);
+MAKE_ESYS_2(Esys_TR_SetAuth,
+    ESYS_TR, handle,
+    TPM2B_AUTH const *, authValue);
+MAKE_ESYS_2(Esys_TR_GetName,
+    ESYS_TR, handle,
+    TPM2B_NAME **, name);
+MAKE_ESYS_2(Esys_TRSess_GetAttributes,
+    ESYS_TR, session,
+    TPMA_SESSION *, flags);
+MAKE_ESYS_3(Esys_TRSess_SetAttributes,
+    ESYS_TR, session,
+    TPMA_SESSION, flags,
+    TPMA_SESSION, mask);
+MAKE_ESYS_2(Esys_TRSess_GetNonceTPM,
+    ESYS_TR, session,
+    TPM2B_NONCE **, nonceTPM);
+MAKE_ESYS_2(Esys_TR_GetTpmHandle,
+    ESYS_TR, esys_handle,
+    TPM2_HANDLE *, tpm_handle);
+MAKE_ESYS_2(Esys_TRSess_GetAuthRequired,
+    ESYS_TR, esys_handle,
+    TPMI_YES_NO *, auth_needed);
+MAKE_ESYS_1(Esys_Startup,
+    TPM2_SU, startupType);
+MAKE_ESYS_1(Esys_Startup_Async,
+    TPM2_SU, startupType);
+MAKE_ESYS_0(Esys_Startup_Finish);
+MAKE_ESYS_4(Esys_Shutdown,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_SU, shutdownType);
+MAKE_ESYS_4(Esys_Shutdown_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_SU, shutdownType);
+MAKE_ESYS_0(Esys_Shutdown_Finish);
+MAKE_ESYS_4(Esys_SelfTest,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, fullTest);
+MAKE_ESYS_4(Esys_SelfTest_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, fullTest);
+MAKE_ESYS_0(Esys_SelfTest_Finish);
+MAKE_ESYS_5(Esys_IncrementalSelfTest,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_ALG *, toTest,
+    TPML_ALG **, toDoList);
+MAKE_ESYS_4(Esys_IncrementalSelfTest_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_ALG *, toTest);
+MAKE_ESYS_1(Esys_IncrementalSelfTest_Finish,
+    TPML_ALG **, toDoList);
+MAKE_ESYS_5(Esys_GetTestResult,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2_RC *, testResult);
+MAKE_ESYS_3(Esys_GetTestResult_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_2(Esys_GetTestResult_Finish,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2_RC *, testResult);
+MAKE_ESYS_10(Esys_StartAuthSession,
+    ESYS_TR, tpmKey,
+    ESYS_TR, bind,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceCaller,
+    TPM2_SE, sessionType,
+    const TPMT_SYM_DEF *, symmetric,
+    TPMI_ALG_HASH, authHash,
+    ESYS_TR *, sessionHandle);
+MAKE_ESYS_9(Esys_StartAuthSession_Async,
+    ESYS_TR, tpmKey,
+    ESYS_TR, bind,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceCaller,
+    TPM2_SE, sessionType,
+    const TPMT_SYM_DEF *, symmetric,
+    TPMI_ALG_HASH, authHash);
+MAKE_ESYS_1(Esys_StartAuthSession_Finish,
+    ESYS_TR *, sessionHandle);
+MAKE_ESYS_4(Esys_PolicyRestart,
+    ESYS_TR, sessionHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_PolicyRestart_Async,
+    ESYS_TR, sessionHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PolicyRestart_Finish);
+MAKE_ESYS_13(Esys_Create,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_PUBLIC *, inPublic,
+    const TPM2B_DATA *, outsideInfo,
+    const TPML_PCR_SELECTION *, creationPCR,
+    TPM2B_PRIVATE **, outPrivate,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_CREATION_DATA **, creationData,
+    TPM2B_DIGEST **, creationHash,
+    TPMT_TK_CREATION **, creationTicket);
+MAKE_ESYS_8(Esys_Create_Async,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_PUBLIC *, inPublic,
+    const TPM2B_DATA *, outsideInfo,
+    const TPML_PCR_SELECTION *, creationPCR);
+MAKE_ESYS_5(Esys_Create_Finish,
+    TPM2B_PRIVATE **, outPrivate,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_CREATION_DATA **, creationData,
+    TPM2B_DIGEST **, creationHash,
+    TPMT_TK_CREATION **, creationTicket);
+MAKE_ESYS_7(Esys_Load,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PRIVATE *, inPrivate,
+    const TPM2B_PUBLIC *, inPublic,
+    ESYS_TR *, objectHandle);
+MAKE_ESYS_6(Esys_Load_Async,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PRIVATE *, inPrivate,
+    const TPM2B_PUBLIC *, inPublic);
+MAKE_ESYS_1(Esys_Load_Finish,
+    ESYS_TR *, objectHandle);
+MAKE_ESYS_7(Esys_LoadExternal,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE *, inPrivate,
+    const TPM2B_PUBLIC *, inPublic,
+    ESYS_TR, hierarchy,
+    ESYS_TR *, objectHandle);
+MAKE_ESYS_6(Esys_LoadExternal_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE *, inPrivate,
+    const TPM2B_PUBLIC *, inPublic,
+    ESYS_TR, hierarchy);
+MAKE_ESYS_1(Esys_LoadExternal_Finish,
+    ESYS_TR *, objectHandle);
+MAKE_ESYS_7(Esys_ReadPublic,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_NAME **, name,
+    TPM2B_NAME **, qualifiedName);
+MAKE_ESYS_4(Esys_ReadPublic_Async,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_3(Esys_ReadPublic_Finish,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_NAME **, name,
+    TPM2B_NAME **, qualifiedName);
+MAKE_ESYS_8(Esys_ActivateCredential,
+    ESYS_TR, activateHandle,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ID_OBJECT *, credentialBlob,
+    const TPM2B_ENCRYPTED_SECRET *, secret,
+    TPM2B_DIGEST **, certInfo);
+MAKE_ESYS_7(Esys_ActivateCredential_Async,
+    ESYS_TR, activateHandle,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ID_OBJECT *, credentialBlob,
+    const TPM2B_ENCRYPTED_SECRET *, secret);
+MAKE_ESYS_1(Esys_ActivateCredential_Finish,
+    TPM2B_DIGEST **, certInfo);
+MAKE_ESYS_5(Esys_ACT_SetTimeout,
+    ESYS_TR, actHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, startTimeout);
+MAKE_ESYS_5(Esys_ACT_SetTimeout_Async,
+    ESYS_TR, actHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, startTimeout);
+MAKE_ESYS_0(Esys_ACT_SetTimeout_Finish);
+MAKE_ESYS_8(Esys_MakeCredential,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, credential,
+    const TPM2B_NAME *, objectName,
+    TPM2B_ID_OBJECT **, credentialBlob,
+    TPM2B_ENCRYPTED_SECRET **, secret);
+MAKE_ESYS_6(Esys_MakeCredential_Async,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, credential,
+    const TPM2B_NAME *, objectName);
+MAKE_ESYS_2(Esys_MakeCredential_Finish,
+    TPM2B_ID_OBJECT **, credentialBlob,
+    TPM2B_ENCRYPTED_SECRET **, secret);
+MAKE_ESYS_5(Esys_Unseal,
+    ESYS_TR, itemHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_SENSITIVE_DATA **, outData);
+MAKE_ESYS_4(Esys_Unseal_Async,
+    ESYS_TR, itemHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_1(Esys_Unseal_Finish,
+    TPM2B_SENSITIVE_DATA **, outData);
+MAKE_ESYS_7(Esys_ObjectChangeAuth,
+    ESYS_TR, objectHandle,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth,
+    TPM2B_PRIVATE **, outPrivate);
+MAKE_ESYS_6(Esys_ObjectChangeAuth_Async,
+    ESYS_TR, objectHandle,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth);
+MAKE_ESYS_1(Esys_ObjectChangeAuth_Finish,
+    TPM2B_PRIVATE **, outPrivate);
+MAKE_ESYS_9(Esys_CreateLoaded,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_TEMPLATE *, inPublic,
+    ESYS_TR *, objectHandle,
+    TPM2B_PRIVATE **, outPrivate,
+    TPM2B_PUBLIC **, outPublic);
+MAKE_ESYS_6(Esys_CreateLoaded_Async,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_TEMPLATE *, inPublic);
+MAKE_ESYS_3(Esys_CreateLoaded_Finish,
+    ESYS_TR *, objectHandle,
+    TPM2B_PRIVATE **, outPrivate,
+    TPM2B_PUBLIC **, outPublic);
+MAKE_ESYS_10(Esys_Duplicate,
+    ESYS_TR, objectHandle,
+    ESYS_TR, newParentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, encryptionKeyIn,
+    const TPMT_SYM_DEF_OBJECT *, symmetricAlg,
+    TPM2B_DATA **, encryptionKeyOut,
+    TPM2B_PRIVATE **, duplicate,
+    TPM2B_ENCRYPTED_SECRET **, outSymSeed);
+MAKE_ESYS_7(Esys_Duplicate_Async,
+    ESYS_TR, objectHandle,
+    ESYS_TR, newParentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, encryptionKeyIn,
+    const TPMT_SYM_DEF_OBJECT *, symmetricAlg);
+MAKE_ESYS_3(Esys_Duplicate_Finish,
+    TPM2B_DATA **, encryptionKeyOut,
+    TPM2B_PRIVATE **, duplicate,
+    TPM2B_ENCRYPTED_SECRET **, outSymSeed);
+MAKE_ESYS_10(Esys_Rewrap,
+    ESYS_TR, oldParent,
+    ESYS_TR, newParent,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PRIVATE *, inDuplicate,
+    const TPM2B_NAME *, name,
+    const TPM2B_ENCRYPTED_SECRET *, inSymSeed,
+    TPM2B_PRIVATE **, outDuplicate,
+    TPM2B_ENCRYPTED_SECRET **, outSymSeed);
+MAKE_ESYS_8(Esys_Rewrap_Async,
+    ESYS_TR, oldParent,
+    ESYS_TR, newParent,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PRIVATE *, inDuplicate,
+    const TPM2B_NAME *, name,
+    const TPM2B_ENCRYPTED_SECRET *, inSymSeed);
+MAKE_ESYS_2(Esys_Rewrap_Finish,
+    TPM2B_PRIVATE **, outDuplicate,
+    TPM2B_ENCRYPTED_SECRET **, outSymSeed);
+MAKE_ESYS_10(Esys_Import,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, encryptionKey,
+    const TPM2B_PUBLIC *, objectPublic,
+    const TPM2B_PRIVATE *, duplicate,
+    const TPM2B_ENCRYPTED_SECRET *, inSymSeed,
+    const TPMT_SYM_DEF_OBJECT *, symmetricAlg,
+    TPM2B_PRIVATE **, outPrivate);
+MAKE_ESYS_9(Esys_Import_Async,
+    ESYS_TR, parentHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, encryptionKey,
+    const TPM2B_PUBLIC *, objectPublic,
+    const TPM2B_PRIVATE *, duplicate,
+    const TPM2B_ENCRYPTED_SECRET *, inSymSeed,
+    const TPMT_SYM_DEF_OBJECT *, symmetricAlg);
+MAKE_ESYS_1(Esys_Import_Finish,
+    TPM2B_PRIVATE **, outPrivate);
+MAKE_ESYS_8(Esys_RSA_Encrypt,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PUBLIC_KEY_RSA *, message,
+    const TPMT_RSA_DECRYPT *, inScheme,
+    const TPM2B_DATA *, label,
+    TPM2B_PUBLIC_KEY_RSA **, outData);
+MAKE_ESYS_7(Esys_RSA_Encrypt_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PUBLIC_KEY_RSA *, message,
+    const TPMT_RSA_DECRYPT *, inScheme,
+    const TPM2B_DATA *, label);
+MAKE_ESYS_1(Esys_RSA_Encrypt_Finish,
+    TPM2B_PUBLIC_KEY_RSA **, outData);
+MAKE_ESYS_8(Esys_RSA_Decrypt,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PUBLIC_KEY_RSA *, cipherText,
+    const TPMT_RSA_DECRYPT *, inScheme,
+    const TPM2B_DATA *, label,
+    TPM2B_PUBLIC_KEY_RSA **, message);
+MAKE_ESYS_7(Esys_RSA_Decrypt_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_PUBLIC_KEY_RSA *, cipherText,
+    const TPMT_RSA_DECRYPT *, inScheme,
+    const TPM2B_DATA *, label);
+MAKE_ESYS_1(Esys_RSA_Decrypt_Finish,
+    TPM2B_PUBLIC_KEY_RSA **, message);
+MAKE_ESYS_6(Esys_ECDH_KeyGen,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_ECC_POINT **, zPoint,
+    TPM2B_ECC_POINT **, pubPoint);
+MAKE_ESYS_4(Esys_ECDH_KeyGen_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_2(Esys_ECDH_KeyGen_Finish,
+    TPM2B_ECC_POINT **, zPoint,
+    TPM2B_ECC_POINT **, pubPoint);
+MAKE_ESYS_6(Esys_ECDH_ZGen,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, inPoint,
+    TPM2B_ECC_POINT **, outPoint);
+MAKE_ESYS_5(Esys_ECDH_ZGen_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, inPoint);
+MAKE_ESYS_1(Esys_ECDH_ZGen_Finish,
+    TPM2B_ECC_POINT **, outPoint);
+MAKE_ESYS_5(Esys_ECC_Parameters,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ECC_CURVE, curveID,
+    TPMS_ALGORITHM_DETAIL_ECC **, parameters);
+MAKE_ESYS_4(Esys_ECC_Parameters_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ECC_CURVE, curveID);
+MAKE_ESYS_1(Esys_ECC_Parameters_Finish,
+    TPMS_ALGORITHM_DETAIL_ECC **, parameters);
+MAKE_ESYS_10(Esys_ZGen_2Phase,
+    ESYS_TR, keyA,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, inQsB,
+    const TPM2B_ECC_POINT *, inQeB,
+    TPMI_ECC_KEY_EXCHANGE, inScheme,
+    UINT16, counter,
+    TPM2B_ECC_POINT **, outZ1,
+    TPM2B_ECC_POINT **, outZ2);
+MAKE_ESYS_8(Esys_ZGen_2Phase_Async,
+    ESYS_TR, keyA,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, inQsB,
+    const TPM2B_ECC_POINT *, inQeB,
+    TPMI_ECC_KEY_EXCHANGE, inScheme,
+    UINT16, counter);
+MAKE_ESYS_2(Esys_ZGen_2Phase_Finish,
+    TPM2B_ECC_POINT **, outZ1,
+    TPM2B_ECC_POINT **, outZ2);
+MAKE_ESYS_10(Esys_EncryptDecrypt,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, decrypt,
+    TPMI_ALG_CIPHER_MODE, mode,
+    const TPM2B_IV *, ivIn,
+    const TPM2B_MAX_BUFFER *, inData,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2B_IV **, ivOut);
+MAKE_ESYS_8(Esys_EncryptDecrypt_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, decrypt,
+    TPMI_ALG_CIPHER_MODE, mode,
+    const TPM2B_IV *, ivIn,
+    const TPM2B_MAX_BUFFER *, inData);
+MAKE_ESYS_2(Esys_EncryptDecrypt_Finish,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2B_IV **, ivOut);
+MAKE_ESYS_10(Esys_EncryptDecrypt2,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, inData,
+    TPMI_YES_NO, decrypt,
+    TPMI_ALG_CIPHER_MODE, mode,
+    const TPM2B_IV *, ivIn,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2B_IV **, ivOut);
+MAKE_ESYS_8(Esys_EncryptDecrypt2_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, inData,
+    TPMI_YES_NO, decrypt,
+    TPMI_ALG_CIPHER_MODE, mode,
+    const TPM2B_IV *, ivIn);
+MAKE_ESYS_2(Esys_EncryptDecrypt2_Finish,
+    TPM2B_MAX_BUFFER **, outData,
+    TPM2B_IV **, ivOut);
+MAKE_ESYS_8(Esys_Hash,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, data,
+    TPMI_ALG_HASH, hashAlg,
+    ESYS_TR, hierarchy,
+    TPM2B_DIGEST **, outHash,
+    TPMT_TK_HASHCHECK **, validation);
+MAKE_ESYS_6(Esys_Hash_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, data,
+    TPMI_ALG_HASH, hashAlg,
+    ESYS_TR, hierarchy);
+MAKE_ESYS_2(Esys_Hash_Finish,
+    TPM2B_DIGEST **, outHash,
+    TPMT_TK_HASHCHECK **, validation);
+MAKE_ESYS_7(Esys_HMAC,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer,
+    TPMI_ALG_HASH, hashAlg,
+    TPM2B_DIGEST **, outHMAC);
+MAKE_ESYS_6(Esys_HMAC_Async,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer,
+    TPMI_ALG_HASH, hashAlg);
+MAKE_ESYS_1(Esys_HMAC_Finish,
+    TPM2B_DIGEST **, outHMAC);
+MAKE_ESYS_5(Esys_GetRandom,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT16, bytesRequested,
+    TPM2B_DIGEST **, randomBytes);
+MAKE_ESYS_4(Esys_GetRandom_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT16, bytesRequested);
+MAKE_ESYS_1(Esys_GetRandom_Finish,
+    TPM2B_DIGEST **, randomBytes);
+MAKE_ESYS_4(Esys_StirRandom,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_DATA *, inData);
+MAKE_ESYS_4(Esys_StirRandom_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_DATA *, inData);
+MAKE_ESYS_0(Esys_StirRandom_Finish);
+MAKE_ESYS_7(Esys_HMAC_Start,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    TPMI_ALG_HASH, hashAlg,
+    ESYS_TR *, sequenceHandle);
+MAKE_ESYS_6(Esys_HMAC_Start_Async,
+    ESYS_TR, handle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    TPMI_ALG_HASH, hashAlg);
+MAKE_ESYS_1(Esys_HMAC_Start_Finish,
+    ESYS_TR *, sequenceHandle);
+MAKE_ESYS_6(Esys_HashSequenceStart,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    TPMI_ALG_HASH, hashAlg,
+    ESYS_TR *, sequenceHandle);
+MAKE_ESYS_5(Esys_HashSequenceStart_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    TPMI_ALG_HASH, hashAlg);
+MAKE_ESYS_1(Esys_HashSequenceStart_Finish,
+    ESYS_TR *, sequenceHandle);
+MAKE_ESYS_5(Esys_SequenceUpdate,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer);
+MAKE_ESYS_5(Esys_SequenceUpdate_Async,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer);
+MAKE_ESYS_0(Esys_SequenceUpdate_Finish);
+MAKE_ESYS_8(Esys_SequenceComplete,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer,
+    ESYS_TR, hierarchy,
+    TPM2B_DIGEST **, result,
+    TPMT_TK_HASHCHECK **, validation);
+MAKE_ESYS_6(Esys_SequenceComplete_Async,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer,
+    ESYS_TR, hierarchy);
+MAKE_ESYS_2(Esys_SequenceComplete_Finish,
+    TPM2B_DIGEST **, result,
+    TPMT_TK_HASHCHECK **, validation);
+MAKE_ESYS_7(Esys_EventSequenceComplete,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer,
+    TPML_DIGEST_VALUES **, results);
+MAKE_ESYS_6(Esys_EventSequenceComplete_Async,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, sequenceHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, buffer);
+MAKE_ESYS_1(Esys_EventSequenceComplete_Finish,
+    TPML_DIGEST_VALUES **, results);
+MAKE_ESYS_9(Esys_Certify,
+    ESYS_TR, objectHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_Certify_Async,
+    ESYS_TR, objectHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme);
+MAKE_ESYS_2(Esys_Certify_Finish,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_11(Esys_CertifyCreation,
+    ESYS_TR, signHandle,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPM2B_DIGEST *, creationHash,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPMT_TK_CREATION *, creationTicket,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_9(Esys_CertifyCreation_Async,
+    ESYS_TR, signHandle,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPM2B_DIGEST *, creationHash,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPMT_TK_CREATION *, creationTicket);
+MAKE_ESYS_2(Esys_CertifyCreation_Finish,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_11(Esys_CertifyX509,
+    ESYS_TR, objectHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, reserved,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPM2B_MAX_BUFFER *, partialCertificate,
+    TPM2B_MAX_BUFFER **, addedToCertificate,
+    TPM2B_DIGEST **, tbsDigest,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_8(Esys_CertifyX509_Async,
+    ESYS_TR, objectHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, reserved,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPM2B_MAX_BUFFER *, partialCertificate);
+MAKE_ESYS_3(Esys_CertifyX509_Finish,
+    TPM2B_MAX_BUFFER **, addedToCertificate,
+    TPM2B_DIGEST **, tbsDigest,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_9(Esys_Quote,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPML_PCR_SELECTION *, PCRselect,
+    TPM2B_ATTEST **, quoted,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_Quote_Async,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPML_PCR_SELECTION *, PCRselect);
+MAKE_ESYS_2(Esys_Quote_Finish,
+    TPM2B_ATTEST **, quoted,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_10(Esys_GetSessionAuditDigest,
+    ESYS_TR, privacyAdminHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, sessionHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    TPM2B_ATTEST **, auditInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_8(Esys_GetSessionAuditDigest_Async,
+    ESYS_TR, privacyAdminHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, sessionHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme);
+MAKE_ESYS_2(Esys_GetSessionAuditDigest_Finish,
+    TPM2B_ATTEST **, auditInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_9(Esys_GetCommandAuditDigest,
+    ESYS_TR, privacyHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    TPM2B_ATTEST **, auditInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_GetCommandAuditDigest_Async,
+    ESYS_TR, privacyHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme);
+MAKE_ESYS_2(Esys_GetCommandAuditDigest_Finish,
+    TPM2B_ATTEST **, auditInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_9(Esys_GetTime,
+    ESYS_TR, privacyAdminHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    TPM2B_ATTEST **, timeInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_GetTime_Async,
+    ESYS_TR, privacyAdminHandle,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme);
+MAKE_ESYS_2(Esys_GetTime_Finish,
+    TPM2B_ATTEST **, timeInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_11(Esys_Commit,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, P1,
+    const TPM2B_SENSITIVE_DATA *, s2,
+    const TPM2B_ECC_PARAMETER *, y2,
+    TPM2B_ECC_POINT **, K,
+    TPM2B_ECC_POINT **, L,
+    TPM2B_ECC_POINT **, E,
+    UINT16 *, counter);
+MAKE_ESYS_7(Esys_Commit_Async,
+    ESYS_TR, signHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_ECC_POINT *, P1,
+    const TPM2B_SENSITIVE_DATA *, s2,
+    const TPM2B_ECC_PARAMETER *, y2);
+MAKE_ESYS_4(Esys_Commit_Finish,
+    TPM2B_ECC_POINT **, K,
+    TPM2B_ECC_POINT **, L,
+    TPM2B_ECC_POINT **, E,
+    UINT16 *, counter);
+MAKE_ESYS_6(Esys_EC_Ephemeral,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ECC_CURVE, curveID,
+    TPM2B_ECC_POINT **, Q,
+    UINT16 *, counter);
+MAKE_ESYS_4(Esys_EC_Ephemeral_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ECC_CURVE, curveID);
+MAKE_ESYS_2(Esys_EC_Ephemeral_Finish,
+    TPM2B_ECC_POINT **, Q,
+    UINT16 *, counter);
+MAKE_ESYS_7(Esys_VerifySignature,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, digest,
+    const TPMT_SIGNATURE *, signature,
+    TPMT_TK_VERIFIED **, validation);
+MAKE_ESYS_6(Esys_VerifySignature_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, digest,
+    const TPMT_SIGNATURE *, signature);
+MAKE_ESYS_1(Esys_VerifySignature_Finish,
+    TPMT_TK_VERIFIED **, validation);
+MAKE_ESYS_8(Esys_Sign,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, digest,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPMT_TK_HASHCHECK *, validation,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_Sign_Async,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, digest,
+    const TPMT_SIG_SCHEME *, inScheme,
+    const TPMT_TK_HASHCHECK *, validation);
+MAKE_ESYS_1(Esys_Sign_Finish,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_7(Esys_SetCommandCodeAuditStatus,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ALG_HASH, auditAlg,
+    const TPML_CC *, setList,
+    const TPML_CC *, clearList);
+MAKE_ESYS_7(Esys_SetCommandCodeAuditStatus_Async,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_ALG_HASH, auditAlg,
+    const TPML_CC *, setList,
+    const TPML_CC *, clearList);
+MAKE_ESYS_0(Esys_SetCommandCodeAuditStatus_Finish);
+MAKE_ESYS_5(Esys_PCR_Extend,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_DIGEST_VALUES *, digests);
+MAKE_ESYS_5(Esys_PCR_Extend_Async,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_DIGEST_VALUES *, digests);
+MAKE_ESYS_0(Esys_PCR_Extend_Finish);
+MAKE_ESYS_6(Esys_PCR_Event,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_EVENT *, eventData,
+    TPML_DIGEST_VALUES **, digests);
+MAKE_ESYS_5(Esys_PCR_Event_Async,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_EVENT *, eventData);
+MAKE_ESYS_1(Esys_PCR_Event_Finish,
+    TPML_DIGEST_VALUES **, digests);
+MAKE_ESYS_7(Esys_PCR_Read,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_PCR_SELECTION *, pcrSelectionIn,
+    UINT32 *, pcrUpdateCounter,
+    TPML_PCR_SELECTION **, pcrSelectionOut,
+    TPML_DIGEST **, pcrValues);
+MAKE_ESYS_4(Esys_PCR_Read_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_PCR_SELECTION *, pcrSelectionIn);
+MAKE_ESYS_3(Esys_PCR_Read_Finish,
+    UINT32 *, pcrUpdateCounter,
+    TPML_PCR_SELECTION **, pcrSelectionOut,
+    TPML_DIGEST **, pcrValues);
+MAKE_ESYS_9(Esys_PCR_Allocate,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_PCR_SELECTION *, pcrAllocation,
+    TPMI_YES_NO *, allocationSuccess,
+    UINT32 *, maxPCR,
+    UINT32 *, sizeNeeded,
+    UINT32 *, sizeAvailable);
+MAKE_ESYS_5(Esys_PCR_Allocate_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_PCR_SELECTION *, pcrAllocation);
+MAKE_ESYS_4(Esys_PCR_Allocate_Finish,
+    TPMI_YES_NO *, allocationSuccess,
+    UINT32 *, maxPCR,
+    UINT32 *, sizeNeeded,
+    UINT32 *, sizeAvailable);
+MAKE_ESYS_7(Esys_PCR_SetAuthPolicy,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, authPolicy,
+    TPMI_ALG_HASH, hashAlg,
+    TPMI_DH_PCR, pcrNum);
+MAKE_ESYS_7(Esys_PCR_SetAuthPolicy_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, authPolicy,
+    TPMI_ALG_HASH, hashAlg,
+    TPMI_DH_PCR, pcrNum);
+MAKE_ESYS_0(Esys_PCR_SetAuthPolicy_Finish);
+MAKE_ESYS_5(Esys_PCR_SetAuthValue,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, auth);
+MAKE_ESYS_5(Esys_PCR_SetAuthValue_Async,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, auth);
+MAKE_ESYS_0(Esys_PCR_SetAuthValue_Finish);
+MAKE_ESYS_4(Esys_PCR_Reset,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_PCR_Reset_Async,
+    ESYS_TR, pcrHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PCR_Reset_Finish);
+MAKE_ESYS_12(Esys_PolicySigned,
+    ESYS_TR, authObject,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceTPM,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    INT32, expiration,
+    const TPMT_SIGNATURE *, auth,
+    TPM2B_TIMEOUT **, timeout,
+    TPMT_TK_AUTH **, policyTicket);
+MAKE_ESYS_10(Esys_PolicySigned_Async,
+    ESYS_TR, authObject,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceTPM,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    INT32, expiration,
+    const TPMT_SIGNATURE *, auth);
+MAKE_ESYS_2(Esys_PolicySigned_Finish,
+    TPM2B_TIMEOUT **, timeout,
+    TPMT_TK_AUTH **, policyTicket);
+MAKE_ESYS_11(Esys_PolicySecret,
+    ESYS_TR, authHandle,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceTPM,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    INT32, expiration,
+    TPM2B_TIMEOUT **, timeout,
+    TPMT_TK_AUTH **, policyTicket);
+MAKE_ESYS_9(Esys_PolicySecret_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NONCE *, nonceTPM,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    INT32, expiration);
+MAKE_ESYS_2(Esys_PolicySecret_Finish,
+    TPM2B_TIMEOUT **, timeout,
+    TPMT_TK_AUTH **, policyTicket);
+MAKE_ESYS_9(Esys_PolicyTicket,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_TIMEOUT *, timeout,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    const TPM2B_NAME *, authName,
+    const TPMT_TK_AUTH *, ticket);
+MAKE_ESYS_9(Esys_PolicyTicket_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_TIMEOUT *, timeout,
+    const TPM2B_DIGEST *, cpHashA,
+    const TPM2B_NONCE *, policyRef,
+    const TPM2B_NAME *, authName,
+    const TPMT_TK_AUTH *, ticket);
+MAKE_ESYS_0(Esys_PolicyTicket_Finish);
+MAKE_ESYS_5(Esys_PolicyOR,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_DIGEST *, pHashList);
+MAKE_ESYS_5(Esys_PolicyOR_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_DIGEST *, pHashList);
+MAKE_ESYS_0(Esys_PolicyOR_Finish);
+MAKE_ESYS_6(Esys_PolicyPCR,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, pcrDigest,
+    const TPML_PCR_SELECTION *, pcrs);
+MAKE_ESYS_6(Esys_PolicyPCR_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, pcrDigest,
+    const TPML_PCR_SELECTION *, pcrs);
+MAKE_ESYS_0(Esys_PolicyPCR_Finish);
+MAKE_ESYS_5(Esys_PolicyLocality,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMA_LOCALITY, locality);
+MAKE_ESYS_5(Esys_PolicyLocality_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMA_LOCALITY, locality);
+MAKE_ESYS_0(Esys_PolicyLocality_Finish);
+MAKE_ESYS_9(Esys_PolicyNV,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_OPERAND *, operandB,
+    UINT16, offset,
+    TPM2_EO, operation);
+MAKE_ESYS_9(Esys_PolicyNV_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_OPERAND *, operandB,
+    UINT16, offset,
+    TPM2_EO, operation);
+MAKE_ESYS_0(Esys_PolicyNV_Finish);
+MAKE_ESYS_7(Esys_PolicyCounterTimer,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_OPERAND *, operandB,
+    UINT16, offset,
+    TPM2_EO, operation);
+MAKE_ESYS_7(Esys_PolicyCounterTimer_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_OPERAND *, operandB,
+    UINT16, offset,
+    TPM2_EO, operation);
+MAKE_ESYS_0(Esys_PolicyCounterTimer_Finish);
+MAKE_ESYS_5(Esys_PolicyCommandCode,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CC, code);
+MAKE_ESYS_5(Esys_PolicyCommandCode_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CC, code);
+MAKE_ESYS_0(Esys_PolicyCommandCode_Finish);
+MAKE_ESYS_4(Esys_PolicyPhysicalPresence,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_PolicyPhysicalPresence_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PolicyPhysicalPresence_Finish);
+MAKE_ESYS_5(Esys_PolicyCpHash,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, cpHashA);
+MAKE_ESYS_5(Esys_PolicyCpHash_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, cpHashA);
+MAKE_ESYS_0(Esys_PolicyCpHash_Finish);
+MAKE_ESYS_5(Esys_PolicyNameHash,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, nameHash);
+MAKE_ESYS_5(Esys_PolicyNameHash_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, nameHash);
+MAKE_ESYS_0(Esys_PolicyNameHash_Finish);
+MAKE_ESYS_7(Esys_PolicyDuplicationSelect,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NAME *, objectName,
+    const TPM2B_NAME *, newParentName,
+    TPMI_YES_NO, includeObject);
+MAKE_ESYS_7(Esys_PolicyDuplicationSelect_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_NAME *, objectName,
+    const TPM2B_NAME *, newParentName,
+    TPMI_YES_NO, includeObject);
+MAKE_ESYS_0(Esys_PolicyDuplicationSelect_Finish);
+MAKE_ESYS_8(Esys_PolicyAuthorize,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, approvedPolicy,
+    const TPM2B_NONCE *, policyRef,
+    const TPM2B_NAME *, keySign,
+    const TPMT_TK_VERIFIED *, checkTicket);
+MAKE_ESYS_8(Esys_PolicyAuthorize_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, approvedPolicy,
+    const TPM2B_NONCE *, policyRef,
+    const TPM2B_NAME *, keySign,
+    const TPMT_TK_VERIFIED *, checkTicket);
+MAKE_ESYS_0(Esys_PolicyAuthorize_Finish);
+MAKE_ESYS_4(Esys_PolicyAuthValue,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_PolicyAuthValue_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PolicyAuthValue_Finish);
+MAKE_ESYS_4(Esys_PolicyPassword,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_PolicyPassword_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PolicyPassword_Finish);
+MAKE_ESYS_5(Esys_PolicyGetDigest,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_DIGEST **, policyDigest);
+MAKE_ESYS_4(Esys_PolicyGetDigest_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_1(Esys_PolicyGetDigest_Finish,
+    TPM2B_DIGEST **, policyDigest);
+MAKE_ESYS_5(Esys_PolicyNvWritten,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, writtenSet);
+MAKE_ESYS_5(Esys_PolicyNvWritten_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, writtenSet);
+MAKE_ESYS_0(Esys_PolicyNvWritten_Finish);
+MAKE_ESYS_5(Esys_PolicyTemplate,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, templateHash);
+MAKE_ESYS_5(Esys_PolicyTemplate_Async,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, templateHash);
+MAKE_ESYS_0(Esys_PolicyTemplate_Finish);
+MAKE_ESYS_6(Esys_PolicyAuthorizeNV,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_6(Esys_PolicyAuthorizeNV_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, policySession,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_PolicyAuthorizeNV_Finish);
+MAKE_ESYS_13(Esys_CreatePrimary,
+    ESYS_TR, primaryHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_PUBLIC *, inPublic,
+    const TPM2B_DATA *, outsideInfo,
+    const TPML_PCR_SELECTION *, creationPCR,
+    ESYS_TR *, objectHandle,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_CREATION_DATA **, creationData,
+    TPM2B_DIGEST **, creationHash,
+    TPMT_TK_CREATION **, creationTicket);
+MAKE_ESYS_8(Esys_CreatePrimary_Async,
+    ESYS_TR, primaryHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_SENSITIVE_CREATE *, inSensitive,
+    const TPM2B_PUBLIC *, inPublic,
+    const TPM2B_DATA *, outsideInfo,
+    const TPML_PCR_SELECTION *, creationPCR);
+MAKE_ESYS_5(Esys_CreatePrimary_Finish,
+    ESYS_TR *, objectHandle,
+    TPM2B_PUBLIC **, outPublic,
+    TPM2B_CREATION_DATA **, creationData,
+    TPM2B_DIGEST **, creationHash,
+    TPMT_TK_CREATION **, creationTicket);
+MAKE_ESYS_6(Esys_HierarchyControl,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    ESYS_TR, enable,
+    TPMI_YES_NO, state);
+MAKE_ESYS_6(Esys_HierarchyControl_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    ESYS_TR, enable,
+    TPMI_YES_NO, state);
+MAKE_ESYS_0(Esys_HierarchyControl_Finish);
+MAKE_ESYS_6(Esys_SetPrimaryPolicy,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, authPolicy,
+    TPMI_ALG_HASH, hashAlg);
+MAKE_ESYS_6(Esys_SetPrimaryPolicy_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, authPolicy,
+    TPMI_ALG_HASH, hashAlg);
+MAKE_ESYS_0(Esys_SetPrimaryPolicy_Finish);
+MAKE_ESYS_4(Esys_ChangePPS,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_ChangePPS_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_ChangePPS_Finish);
+MAKE_ESYS_4(Esys_ChangeEPS,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_ChangeEPS_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_ChangeEPS_Finish);
+MAKE_ESYS_4(Esys_Clear,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_Clear_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_Clear_Finish);
+MAKE_ESYS_5(Esys_ClearControl,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, disable);
+MAKE_ESYS_5(Esys_ClearControl_Async,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_YES_NO, disable);
+MAKE_ESYS_0(Esys_ClearControl_Finish);
+MAKE_ESYS_5(Esys_HierarchyChangeAuth,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth);
+MAKE_ESYS_5(Esys_HierarchyChangeAuth_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth);
+MAKE_ESYS_0(Esys_HierarchyChangeAuth_Finish);
+MAKE_ESYS_4(Esys_DictionaryAttackLockReset,
+    ESYS_TR, lockHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_DictionaryAttackLockReset_Async,
+    ESYS_TR, lockHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_DictionaryAttackLockReset_Finish);
+MAKE_ESYS_7(Esys_DictionaryAttackParameters,
+    ESYS_TR, lockHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, newMaxTries,
+    UINT32, newRecoveryTime,
+    UINT32, lockoutRecovery);
+MAKE_ESYS_7(Esys_DictionaryAttackParameters_Async,
+    ESYS_TR, lockHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, newMaxTries,
+    UINT32, newRecoveryTime,
+    UINT32, lockoutRecovery);
+MAKE_ESYS_0(Esys_DictionaryAttackParameters_Finish);
+MAKE_ESYS_6(Esys_PP_Commands,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_CC *, setList,
+    const TPML_CC *, clearList);
+MAKE_ESYS_6(Esys_PP_Commands_Async,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPML_CC *, setList,
+    const TPML_CC *, clearList);
+MAKE_ESYS_0(Esys_PP_Commands_Finish);
+MAKE_ESYS_5(Esys_SetAlgorithmSet,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, algorithmSet);
+MAKE_ESYS_5(Esys_SetAlgorithmSet_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, algorithmSet);
+MAKE_ESYS_0(Esys_SetAlgorithmSet_Finish);
+MAKE_ESYS_7(Esys_FieldUpgradeStart,
+    ESYS_TR, authorization,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, fuDigest,
+    const TPMT_SIGNATURE *, manifestSignature);
+MAKE_ESYS_7(Esys_FieldUpgradeStart_Async,
+    ESYS_TR, authorization,
+    ESYS_TR, keyHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DIGEST *, fuDigest,
+    const TPMT_SIGNATURE *, manifestSignature);
+MAKE_ESYS_0(Esys_FieldUpgradeStart_Finish);
+MAKE_ESYS_6(Esys_FieldUpgradeData,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, fuData,
+    TPMT_HA **, nextDigest,
+    TPMT_HA **, firstDigest);
+MAKE_ESYS_4(Esys_FieldUpgradeData_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_BUFFER *, fuData);
+MAKE_ESYS_2(Esys_FieldUpgradeData_Finish,
+    TPMT_HA **, nextDigest,
+    TPMT_HA **, firstDigest);
+MAKE_ESYS_5(Esys_FirmwareRead,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, sequenceNumber,
+    TPM2B_MAX_BUFFER **, fuData);
+MAKE_ESYS_4(Esys_FirmwareRead_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT32, sequenceNumber);
+MAKE_ESYS_1(Esys_FirmwareRead_Finish,
+    TPM2B_MAX_BUFFER **, fuData);
+MAKE_ESYS_2(Esys_ContextSave,
+    ESYS_TR, saveHandle,
+    TPMS_CONTEXT **, context);
+MAKE_ESYS_1(Esys_ContextSave_Async,
+    ESYS_TR, saveHandle);
+MAKE_ESYS_1(Esys_ContextSave_Finish,
+    TPMS_CONTEXT **, context);
+MAKE_ESYS_2(Esys_ContextLoad,
+    const TPMS_CONTEXT *, context,
+    ESYS_TR *, loadedHandle);
+MAKE_ESYS_1(Esys_ContextLoad_Async,
+    const TPMS_CONTEXT *, context);
+MAKE_ESYS_1(Esys_ContextLoad_Finish,
+    ESYS_TR *, loadedHandle);
+MAKE_ESYS_1(Esys_FlushContext,
+    ESYS_TR, flushHandle);
+MAKE_ESYS_1(Esys_FlushContext_Async,
+    ESYS_TR, flushHandle);
+MAKE_ESYS_0(Esys_FlushContext_Finish);
+MAKE_ESYS_7(Esys_EvictControl,
+    ESYS_TR, auth,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_DH_PERSISTENT, persistentHandle,
+    ESYS_TR *, newObjectHandle);
+MAKE_ESYS_6(Esys_EvictControl_Async,
+    ESYS_TR, auth,
+    ESYS_TR, objectHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMI_DH_PERSISTENT, persistentHandle);
+MAKE_ESYS_1(Esys_EvictControl_Finish,
+    ESYS_TR *, newObjectHandle);
+MAKE_ESYS_4(Esys_ReadClock,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPMS_TIME_INFO **, currentTime);
+MAKE_ESYS_3(Esys_ReadClock_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_1(Esys_ReadClock_Finish,
+    TPMS_TIME_INFO **, currentTime);
+MAKE_ESYS_5(Esys_ClockSet,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT64, newTime);
+MAKE_ESYS_5(Esys_ClockSet_Async,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT64, newTime);
+MAKE_ESYS_0(Esys_ClockSet_Finish);
+MAKE_ESYS_5(Esys_ClockRateAdjust,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CLOCK_ADJUST, rateAdjust);
+MAKE_ESYS_5(Esys_ClockRateAdjust_Async,
+    ESYS_TR, auth,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CLOCK_ADJUST, rateAdjust);
+MAKE_ESYS_0(Esys_ClockRateAdjust_Finish);
+MAKE_ESYS_8(Esys_GetCapability,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CAP, capability,
+    UINT32, property,
+    UINT32, propertyCount,
+    TPMI_YES_NO *, moreData,
+    TPMS_CAPABILITY_DATA **, capabilityData);
+MAKE_ESYS_6(Esys_GetCapability_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2_CAP, capability,
+    UINT32, property,
+    UINT32, propertyCount);
+MAKE_ESYS_2(Esys_GetCapability_Finish,
+    TPMI_YES_NO *, moreData,
+    TPMS_CAPABILITY_DATA **, capabilityData);
+MAKE_ESYS_4(Esys_TestParms,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPMT_PUBLIC_PARMS *, parameters);
+MAKE_ESYS_4(Esys_TestParms_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPMT_PUBLIC_PARMS *, parameters);
+MAKE_ESYS_0(Esys_TestParms_Finish);
+MAKE_ESYS_7(Esys_NV_DefineSpace,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    const TPM2B_NV_PUBLIC *, publicInfo,
+    ESYS_TR *, nvHandle);
+MAKE_ESYS_6(Esys_NV_DefineSpace_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, auth,
+    const TPM2B_NV_PUBLIC *, publicInfo);
+MAKE_ESYS_1(Esys_NV_DefineSpace_Finish,
+    ESYS_TR *, nvHandle);
+MAKE_ESYS_5(Esys_NV_UndefineSpace,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_5(Esys_NV_UndefineSpace_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_UndefineSpace_Finish);
+MAKE_ESYS_5(Esys_NV_UndefineSpaceSpecial,
+    ESYS_TR, nvIndex,
+    ESYS_TR, platform,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_5(Esys_NV_UndefineSpaceSpecial_Async,
+    ESYS_TR, nvIndex,
+    ESYS_TR, platform,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_UndefineSpaceSpecial_Finish);
+MAKE_ESYS_6(Esys_NV_ReadPublic,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    TPM2B_NV_PUBLIC **, nvPublic,
+    TPM2B_NAME **, nvName);
+MAKE_ESYS_4(Esys_NV_ReadPublic_Async,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_2(Esys_NV_ReadPublic_Finish,
+    TPM2B_NV_PUBLIC **, nvPublic,
+    TPM2B_NAME **, nvName);
+MAKE_ESYS_7(Esys_NV_Write,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_NV_BUFFER *, data,
+    UINT16, offset);
+MAKE_ESYS_7(Esys_NV_Write_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_NV_BUFFER *, data,
+    UINT16, offset);
+MAKE_ESYS_0(Esys_NV_Write_Finish);
+MAKE_ESYS_5(Esys_NV_Increment,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_5(Esys_NV_Increment_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_Increment_Finish);
+MAKE_ESYS_6(Esys_NV_Extend,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_NV_BUFFER *, data);
+MAKE_ESYS_6(Esys_NV_Extend_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_MAX_NV_BUFFER *, data);
+MAKE_ESYS_0(Esys_NV_Extend_Finish);
+MAKE_ESYS_6(Esys_NV_SetBits,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT64, bits);
+MAKE_ESYS_6(Esys_NV_SetBits_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT64, bits);
+MAKE_ESYS_0(Esys_NV_SetBits_Finish);
+MAKE_ESYS_5(Esys_NV_WriteLock,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_5(Esys_NV_WriteLock_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_WriteLock_Finish);
+MAKE_ESYS_4(Esys_NV_GlobalWriteLock,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_4(Esys_NV_GlobalWriteLock_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_GlobalWriteLock_Finish);
+MAKE_ESYS_8(Esys_NV_Read,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT16, size,
+    UINT16, offset,
+    TPM2B_MAX_NV_BUFFER **, data);
+MAKE_ESYS_7(Esys_NV_Read_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    UINT16, size,
+    UINT16, offset);
+MAKE_ESYS_1(Esys_NV_Read_Finish,
+    TPM2B_MAX_NV_BUFFER **, data);
+MAKE_ESYS_5(Esys_NV_ReadLock,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_5(Esys_NV_ReadLock_Async,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3);
+MAKE_ESYS_0(Esys_NV_ReadLock_Finish);
+MAKE_ESYS_5(Esys_NV_ChangeAuth,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth);
+MAKE_ESYS_5(Esys_NV_ChangeAuth_Async,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_AUTH *, newAuth);
+MAKE_ESYS_0(Esys_NV_ChangeAuth_Finish);
+MAKE_ESYS_12(Esys_NV_Certify,
+    ESYS_TR, signHandle,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    UINT16, size,
+    UINT16, offset,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_10(Esys_NV_Certify_Async,
+    ESYS_TR, signHandle,
+    ESYS_TR, authHandle,
+    ESYS_TR, nvIndex,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, qualifyingData,
+    const TPMT_SIG_SCHEME *, inScheme,
+    UINT16, size,
+    UINT16, offset);
+MAKE_ESYS_2(Esys_NV_Certify_Finish,
+    TPM2B_ATTEST **, certifyInfo,
+    TPMT_SIGNATURE **, signature);
+MAKE_ESYS_5(Esys_Vendor_TCG_Test,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, inputData,
+    TPM2B_DATA **, outputData);
+MAKE_ESYS_4(Esys_Vendor_TCG_Test_Async,
+    ESYS_TR, shandle1,
+    ESYS_TR, shandle2,
+    ESYS_TR, shandle3,
+    const TPM2B_DATA *, inputData);
+MAKE_ESYS_1(Esys_Vendor_TCG_Test_Finish,
+    TPM2B_DATA **, outputData);
+MAKE_ESYS_1(Esys_GetSysContext,
+    TSS2_SYS_CONTEXT **, sys_context);

--- a/tss2-dlopen/tss2-dlopen-fapi.c
+++ b/tss2-dlopen/tss2-dlopen-fapi.c
@@ -1,0 +1,727 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2021, Fraunhofer SIT
+ * All rights reserved.
+ *******************************************************************************/
+
+/**
+ * The purpose of this file is to copy it into your project and
+ * include it during compilation if you don't want to link against
+ * libtss2-fapi at compile time.
+ * It will attempt to load libtss2-fapi.so during runtime.
+ * It will either work similarly to directly linking to libtss2-fapi.so
+ * at compile-time or return a NOT_IMPLEMENTED error.
+ *
+ * For new versions of this file, please check:
+ * http://github.com/tpm2-software/tpm2-tss/tss2-dlopen
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <tss2/tss2_fapi.h>
+
+#define str(s) xstr(s)
+#define xstr(s) #s
+
+#ifdef ENABLE_WARN
+#define WARN(str, ...) do { fprintf(stderr, "WARNING: " str "\n", ## __VA_ARGS__); } while (0)
+#else /* ENABLE_WARN */
+#define WARN(...) do { } while (0)
+#endif /* ENABLE_WARN */
+
+#define LIB "libtss2-fapi.so.1"
+static void *dlhandle = NULL;
+
+static TSS2_RC
+init_dlhandle(void)
+{
+    if (dlhandle)
+        return TSS2_RC_SUCCESS;
+    dlhandle = dlopen(LIB, RTLD_NOW | RTLD_LOCAL);
+    if (!dlhandle) {
+        WARN("Library " LIB " not found: %s.", dlerror());
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+    }
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+Fapi_Initialize(
+    FAPI_CONTEXT  **context,
+    char     const *uri)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (FAPI_CONTEXT **context, char const *uri) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Fapi_Initialize");
+    if (!sym) {
+        WARN("Function Fapi_Initialize not found.");
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(context, uri);
+}
+
+TSS2_RC
+Fapi_Initialize_Async(
+    FAPI_CONTEXT  **context,
+    char     const *uri)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (FAPI_CONTEXT **context, char const *uri) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Fapi_Initialize_Async");
+    if (!sym) {
+        WARN("Function Fapi_Initialize_Async not found.");
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(context, uri);
+}
+
+TSS2_RC Fapi_Initialize_Finish(
+    FAPI_CONTEXT  **context)
+{
+    static TSS2_RC (*sym) (FAPI_CONTEXT **context) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Fapi_Initialize_Finish");
+    if (!sym) {
+        WARN("Function Fapi_Initialize_Finish not found.");
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(context);
+}
+
+void
+Fapi_Finalize(FAPI_CONTEXT **ctx)
+{
+    if (!ctx || !*ctx)
+        return;
+    static TSS2_RC (*sym) (FAPI_CONTEXT **ctx) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Fapi_Finalize");
+    if (!sym) {
+        WARN("Function Fapi_Finalize not found.");
+        return;
+    }
+    sym(ctx);
+}
+
+void
+Fapi_Free(void *__ptr)
+{
+    if (!__ptr)
+        return;
+    static TSS2_RC (*sym) (void *__ptr) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Fapi_Free");
+    if (!sym) {
+        WARN("Function Fapi_Free not found.");
+        return;
+    }
+    sym(__ptr);
+}
+
+#define MAKE_FAPI_0(fun) \
+TSS2_RC fun (FAPI_CONTEXT *ctx) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx); \
+}
+
+#define MAKE_FAPI_1(fun, type1,parm1) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1); \
+}
+
+#define MAKE_FAPI_2(fun, type1,parm1, type2,parm2) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2); \
+}
+
+#define MAKE_FAPI_3(fun, type1,parm1, type2,parm2, type3,parm3) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3); \
+}
+
+#define MAKE_FAPI_4(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3, type4) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4); \
+}
+
+#define MAKE_FAPI_5(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5); \
+}
+
+#define MAKE_FAPI_6(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6); \
+}
+
+#define MAKE_FAPI_7(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7); \
+}
+
+#define MAKE_FAPI_8(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7, type8,parm8) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8) { \
+    static TSS2_RC (*sym) (FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8); \
+}
+
+#define MAKE_FAPI_9(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                         type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                         type9,parm9) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9) { \
+    TSS2_RC (*sym)(FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9); \
+}
+
+#define MAKE_FAPI_10(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10) { \
+    TSS2_RC (*sym)(FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10); \
+}
+
+#define MAKE_FAPI_11(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11) { \
+    TSS2_RC (*sym)(FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11); \
+}
+
+#define MAKE_FAPI_12(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11, type12,parm12) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11, type12 parm12) { \
+    TSS2_RC (*sym)(FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11, type12) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11, parm12); \
+}
+
+#define MAKE_FAPI_13(fun, type1,parm1, type2,parm2, type3,parm3, type4,parm4, \
+                          type5,parm5, type6,parm6, type7,parm7, type8,parm8, \
+                          type9,parm9, type10,parm10, type11,parm11, type12,parm12, \
+                          type13,parm13) \
+TSS2_RC fun (FAPI_CONTEXT *ctx, type1 parm1, type2 parm2, type3 parm3, type4 parm4, \
+                                type5 parm5, type6 parm6, type7 parm7, type8 parm8, \
+                                type9 parm9, type10 parm10, type11 parm11, type12 parm12, \
+                                type13 parm13) { \
+    TSS2_RC (*sym)(FAPI_CONTEXT *ctx, type1, type2, type3, type4, type5, type6, type7, type8, \
+                                      type9, type10, type11, type12, type13) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(fun)); \
+    if (!sym) { \
+        WARN("Function " str(fun) " not found."); \
+        return TSS2_FAPI_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(ctx, parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, \
+                    parm9, parm10, parm11, parm12, parm13); \
+}
+
+MAKE_FAPI_1(Fapi_GetTcti,
+    TSS2_TCTI_CONTEXT **, tcti);
+MAKE_FAPI_2(Fapi_GetPollHandles,
+    FAPI_POLL_HANDLE **, handles,
+    size_t *, num_handles);
+MAKE_FAPI_1(Fapi_GetInfo,
+    char **, info);
+MAKE_FAPI_0(Fapi_GetInfo_Async);
+MAKE_FAPI_1(Fapi_GetInfo_Finish,
+    char **, info);
+MAKE_FAPI_3(Fapi_Provision,
+    char const *, authValueEh,
+    char const *, authValueSh,
+    char const *, authValueLockout);
+MAKE_FAPI_3(Fapi_Provision_Async,
+    char const *, authValueEh,
+    char const *, authValueSh,
+    char const *, authValueLockout);
+MAKE_FAPI_0(Fapi_Provision_Finish);
+MAKE_FAPI_2(Fapi_GetPlatformCertificates,
+    uint8_t **, certificates,
+    size_t *, certificatesSize);
+MAKE_FAPI_0(Fapi_GetPlatformCertificates_Async);
+MAKE_FAPI_2(Fapi_GetPlatformCertificates_Finish,
+    uint8_t **, certificates,
+    size_t *, certificatesSize);
+MAKE_FAPI_2(Fapi_GetRandom,
+    size_t, numBytes,
+    uint8_t **, data);
+MAKE_FAPI_1(Fapi_GetRandom_Async,
+    size_t, numBytes);
+MAKE_FAPI_1(Fapi_GetRandom_Finish,
+    uint8_t **, data);
+MAKE_FAPI_2(Fapi_Import,
+    char const *, path,
+    char const *, importData);
+MAKE_FAPI_2(Fapi_Import_Async,
+    char const *, path,
+    char const *, importData);
+MAKE_FAPI_0(Fapi_Import_Finish);
+MAKE_FAPI_2(Fapi_List,
+    char const *, searchPath,
+    char **, pathList);
+MAKE_FAPI_1(Fapi_List_Async,
+    char const *, searchPath);
+MAKE_FAPI_1(Fapi_List_Finish,
+    char **, pathList);
+MAKE_FAPI_1(Fapi_Delete,
+    char const *, path);
+MAKE_FAPI_1(Fapi_Delete_Async,
+    char const *, path);
+MAKE_FAPI_0(Fapi_Delete_Finish);
+MAKE_FAPI_4(Fapi_GetEsysBlob,
+    char const *, path,
+    uint8_t *, type,
+    uint8_t **, data,
+    size_t *, length);
+MAKE_FAPI_1(Fapi_GetEsysBlob_Async,
+    char const *, path);
+MAKE_FAPI_3(Fapi_GetEsysBlob_Finish,
+    uint8_t *, type,
+    uint8_t **, data,
+    size_t *, length);
+MAKE_FAPI_2(Fapi_ChangeAuth,
+    char const *, entityPath,
+    char const *, authValue);
+MAKE_FAPI_2(Fapi_ChangeAuth_Async,
+    char const *, entityPath,
+    char const *, authValue);
+MAKE_FAPI_0(Fapi_ChangeAuth_Finish);
+MAKE_FAPI_2(Fapi_SetDescription,
+    char const *, path,
+    char const *, description);
+MAKE_FAPI_2(Fapi_SetDescription_Async,
+    char const *, path,
+    char const *, description);
+MAKE_FAPI_0(Fapi_SetDescription_Finish);
+MAKE_FAPI_2(Fapi_GetDescription,
+    char const *, path,
+    char **, description);
+MAKE_FAPI_1(Fapi_GetDescription_Async,
+    char const *, path);
+MAKE_FAPI_1(Fapi_GetDescription_Finish,
+    char **, description);
+MAKE_FAPI_3(Fapi_SetAppData,
+    char const *, path,
+    uint8_t const *, appData,
+    size_t, appDataSize);
+MAKE_FAPI_3(Fapi_SetAppData_Async,
+    char const *, path,
+    uint8_t const *, appData,
+    size_t, appDataSize);
+MAKE_FAPI_0(Fapi_SetAppData_Finish);
+MAKE_FAPI_3(Fapi_GetAppData,
+    char const *, path,
+    uint8_t **, appData,
+    size_t *, appDataSize);
+MAKE_FAPI_1(Fapi_GetAppData_Async,
+    char const *, path);
+MAKE_FAPI_2(Fapi_GetAppData_Finish,
+    uint8_t **, appData,
+    size_t *, appDataSize);
+MAKE_FAPI_6(Fapi_GetTpmBlobs,
+    char const *, path,
+    uint8_t **, tpm2bPublic,
+    size_t *, tpm2bPublicSize,
+    uint8_t **, tpm2bPrivate,
+    size_t *, tpm2bPrivateSize,
+    char **, policy);
+MAKE_FAPI_1(Fapi_GetTpmBlobs_Async,
+    char const *, path);
+MAKE_FAPI_5(Fapi_GetTpmBlobs_Finish,
+    uint8_t **, tpm2bPublic,
+    size_t *, tpm2bPublicSize,
+    uint8_t **, tpm2bPrivate,
+    size_t *, tpm2bPrivateSize,
+    char **, policy);
+MAKE_FAPI_4(Fapi_CreateKey,
+    char const *, path,
+    char const *, type,
+    char const *, policyPath,
+    char const *, authValue);
+MAKE_FAPI_4(Fapi_CreateKey_Async,
+    char const *, path,
+    char const *, type,
+    char const *, policyPath,
+    char const *, authValue);
+MAKE_FAPI_0(Fapi_CreateKey_Finish);
+MAKE_FAPI_8(Fapi_Sign,
+    char const *, keyPath,
+    char const *, padding,
+    uint8_t const *, digest,
+    size_t, digestSize,
+    uint8_t **, signature,
+    size_t *, signatureSize,
+    char **, publicKey,
+    char **, certificate);
+MAKE_FAPI_4(Fapi_Sign_Async,
+    char const *, keyPath,
+    char const *, padding,
+    uint8_t const *, digest,
+    size_t, digestSize);
+MAKE_FAPI_4(Fapi_Sign_Finish,
+    uint8_t **, signature,
+    size_t *, signatureSize,
+    char **, publicKey,
+    char **, certificate);
+MAKE_FAPI_5(Fapi_VerifySignature,
+    char const *, keyPath,
+    uint8_t const *, digest,
+    size_t, digestSize,
+    uint8_t const *, signature,
+    size_t, signatureSize);
+MAKE_FAPI_5(Fapi_VerifySignature_Async,
+    char const *, keyPath,
+    uint8_t const *, digest,
+    size_t, digestSize,
+    uint8_t const *, signature,
+    size_t, signatureSize);
+MAKE_FAPI_0(Fapi_VerifySignature_Finish);
+MAKE_FAPI_5(Fapi_Encrypt,
+    char const *, keyPath,
+    uint8_t const *, plainText,
+    size_t, plainTextSize,
+    uint8_t **, cipherText,
+    size_t *, cipherTextSize);
+MAKE_FAPI_3(Fapi_Encrypt_Async,
+    char const *, keyPath,
+    uint8_t const *, plainText,
+    size_t, plainTextSize);
+MAKE_FAPI_2(Fapi_Encrypt_Finish,
+    uint8_t **, cipherText,
+    size_t *, cipherTextSize );
+MAKE_FAPI_5(Fapi_Decrypt,
+    char const *, keyPath,
+    uint8_t const *, cipherText,
+    size_t, cipherTextSize,
+    uint8_t **, plainText,
+    size_t *, plainTextSize);
+MAKE_FAPI_3(Fapi_Decrypt_Async,
+    char const *, keyPath,
+    uint8_t const *, cipherText,
+    size_t, cipherTextSize);
+MAKE_FAPI_2(Fapi_Decrypt_Finish,
+    uint8_t **, plainText,
+    size_t *, plainTextSize);
+MAKE_FAPI_2(Fapi_SetCertificate,
+    char const *, path,
+    char const *, x509certData);
+MAKE_FAPI_2(Fapi_SetCertificate_Async,
+    char const *, path,
+    char const *, x509certData);
+MAKE_FAPI_0(Fapi_SetCertificate_Finish);
+MAKE_FAPI_2(Fapi_GetCertificate,
+    char const *, path,
+    char **, x509certData);
+MAKE_FAPI_1(Fapi_GetCertificate_Async,
+    char const *, path);
+MAKE_FAPI_1(Fapi_GetCertificate_Finish,
+    char **, x509certData);
+MAKE_FAPI_3(Fapi_ExportKey,
+    char const *, pathOfKeyToDuplicate,
+    char const *, pathToPublicKeyOfNewParent,
+    char **, exportedData);
+MAKE_FAPI_2(Fapi_ExportKey_Async,
+    char const *, pathOfKeyToDuplicate,
+    char const *, pathToPublicKeyOfNewParent);
+MAKE_FAPI_1(Fapi_ExportKey_Finish,
+    char **, exportedData);
+MAKE_FAPI_6(Fapi_CreateSeal,
+    char const *, path,
+    char const *, type,
+    size_t, size,
+    char const *, policyPath,
+    char const *, authValue,
+    uint8_t const *, data);
+MAKE_FAPI_6(Fapi_CreateSeal_Async,
+    char const *, path,
+    char const *, type,
+    size_t, size,
+    char const *, policyPath,
+    char const *, authValue,
+    uint8_t const *, data);
+MAKE_FAPI_0(Fapi_CreateSeal_Finish);
+MAKE_FAPI_3(Fapi_Unseal,
+    char const *, path,
+    uint8_t **, data,
+    size_t *, size);
+MAKE_FAPI_1(Fapi_Unseal_Async,
+    char const *, path);
+MAKE_FAPI_2(Fapi_Unseal_Finish,
+    uint8_t **, data,
+    size_t *, size);
+MAKE_FAPI_2(Fapi_ExportPolicy,
+    char const *, path,
+    char **, jsonPolicy);
+MAKE_FAPI_1(Fapi_ExportPolicy_Async,
+    char const *, path);
+MAKE_FAPI_1(Fapi_ExportPolicy_Finish,
+    char **, jsonPolicy);
+MAKE_FAPI_4(Fapi_AuthorizePolicy,
+    char const *, policyPath,
+    char const *, keyPath,
+    uint8_t const *, policyRef,
+    size_t, policyRefSize);
+MAKE_FAPI_4(Fapi_AuthorizePolicy_Async,
+    char const *, policyPath,
+    char const *, keyPath,
+    uint8_t const *, policyRef,
+    size_t, policyRefSize);
+MAKE_FAPI_0(Fapi_AuthorizePolicy_Finish);
+MAKE_FAPI_2(Fapi_WriteAuthorizeNv,
+    char const *, nvPath,
+    char const *, policyPath);
+MAKE_FAPI_2(Fapi_WriteAuthorizeNv_Async,
+    char const *, nvPath,
+    char const *, policyPath);
+MAKE_FAPI_0(Fapi_WriteAuthorizeNv_Finish);
+MAKE_FAPI_4(Fapi_PcrRead,
+    uint32_t, pcrIndex,
+    uint8_t **, pcrValue,
+    size_t *, pcrValueSize,
+    char **, pcrLog);
+MAKE_FAPI_1(Fapi_PcrRead_Async,
+    uint32_t, pcrIndex);
+MAKE_FAPI_3(Fapi_PcrRead_Finish,
+    uint8_t **, pcrValue,
+    size_t *, pcrValueSize,
+    char **, pcrLog);
+MAKE_FAPI_4(Fapi_PcrExtend,
+    uint32_t, pcr,
+    uint8_t const *, data,
+    size_t, dataSize,
+    char const *, logData);
+MAKE_FAPI_4(Fapi_PcrExtend_Async,
+    uint32_t, pcr,
+    uint8_t const *, data,
+    size_t, dataSize,
+    char const *, logData);
+MAKE_FAPI_0(Fapi_PcrExtend_Finish);
+MAKE_FAPI_11(Fapi_Quote,
+    uint32_t *, pcrList,
+    size_t, pcrListSize,
+    char const *, keyPath,
+    char const *, quoteType,
+    uint8_t const *, qualifyingData,
+    size_t, qualifyingDataSize,
+    char **, quoteInfo,
+    uint8_t **, signature,
+    size_t *, signatureSize,
+    char **, pcrLog,
+    char **, certificate);
+MAKE_FAPI_6(Fapi_Quote_Async,
+    uint32_t *, pcrList,
+    size_t, pcrListSize,
+    char const *, keyPath,
+    char const *, quoteType,
+    uint8_t const *, qualifyingData,
+    size_t, qualifyingDataSize);
+MAKE_FAPI_5(Fapi_Quote_Finish,
+    char **, quoteInfo,
+    uint8_t **, signature,
+    size_t *, signatureSize,
+    char **, pcrLog,
+    char **, certificate);
+MAKE_FAPI_7(Fapi_VerifyQuote,
+    char const *, publicKeyPath,
+    uint8_t const *, qualifyingData,
+    size_t, qualifyingDataSize,
+    char const *, quoteInfo,
+    uint8_t const *, signature,
+    size_t, signatureSize,
+    char const *, pcrLog);
+MAKE_FAPI_7(Fapi_VerifyQuote_Async,
+    char const *, publicKeyPath,
+    uint8_t const *, qualifyingData,
+    size_t, qualifyingDataSize,
+    char const *, quoteInfo,
+    uint8_t const *, signature,
+    size_t, signatureSize,
+    char const *, pcrLog);
+MAKE_FAPI_0(Fapi_VerifyQuote_Finish);
+MAKE_FAPI_5(Fapi_CreateNv,
+    char const *, path,
+    char const *, type,
+    size_t, size,
+    char const *, policyPath,
+    char const *, authValue);
+MAKE_FAPI_5(Fapi_CreateNv_Async,
+    char const *, path,
+    char const *, type,
+    size_t, size,
+    char const *, policyPath,
+    char const *, authValue);
+MAKE_FAPI_0(Fapi_CreateNv_Finish);
+MAKE_FAPI_4(Fapi_NvRead,
+    char const *, path,
+    uint8_t **, data,
+    size_t *, size,
+    char **, logData);
+MAKE_FAPI_1(Fapi_NvRead_Async,
+    char const *, path);
+MAKE_FAPI_3(Fapi_NvRead_Finish,
+    uint8_t **, data,
+    size_t *, size,
+    char **, logData);
+MAKE_FAPI_3(Fapi_NvWrite,
+    char const *, path,
+    uint8_t const *, data,
+    size_t, size);
+MAKE_FAPI_3(Fapi_NvWrite_Async,
+    char const *, path,
+    uint8_t const *, data,
+    size_t, size);
+MAKE_FAPI_0(Fapi_NvWrite_Finish);
+MAKE_FAPI_4(Fapi_NvExtend,
+    char const *, path,
+    uint8_t const *, data,
+    size_t, size,
+    char const *, logData);
+MAKE_FAPI_4(Fapi_NvExtend_Async,
+    char const *, path,
+    uint8_t const *, data,
+    size_t, size,
+    char const *, logData);
+MAKE_FAPI_0(Fapi_NvExtend_Finish);
+MAKE_FAPI_1(Fapi_NvIncrement,
+    char const *, path);
+MAKE_FAPI_1(Fapi_NvIncrement_Async,
+    char const *, path);
+MAKE_FAPI_0(Fapi_NvIncrement_Finish);
+MAKE_FAPI_2(Fapi_NvSetBits,
+    char const *, path,
+    uint64_t, bitmap);
+MAKE_FAPI_2(Fapi_NvSetBits_Async,
+    char const *, path,
+    uint64_t, bitmap);
+MAKE_FAPI_0(Fapi_NvSetBits_Finish);
+MAKE_FAPI_2(Fapi_SetAuthCB,
+    Fapi_CB_Auth, callback,
+    void *, userData);
+MAKE_FAPI_2(Fapi_SetBranchCB,
+    Fapi_CB_Branch, callback,
+    void *, userData);
+MAKE_FAPI_2(Fapi_SetSignCB,
+    Fapi_CB_Sign, callback,
+    void *, userData);
+MAKE_FAPI_2(Fapi_SetPolicyActionCB,
+    Fapi_CB_PolicyAction, callback,
+    void *, userData);

--- a/tss2-dlopen/tss2-dlopen-mu.c
+++ b/tss2-dlopen/tss2-dlopen-mu.c
@@ -1,0 +1,299 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2021, Fraunhofer SIT
+ * All rights reserved.
+ *******************************************************************************/
+
+/**
+ * The purpose of this file is to copy it into your project and
+ * include it during compilation if you don't want to link against
+ * libtss2-mu at compile time.
+ * It will attempt to load libtss2-mu.so during runtime.
+ * It will either work similarly to directly linking to libtss2-mu.so
+ * at compile-time or return a NOT_IMPLEMENTED error.
+ *
+ * For new versions of this file, please check:
+ * http://github.com/tpm2-software/tpm2-tss/tss2-dlopen
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <tss2/tss2_mu.h>
+
+#define str(s) xstr(s)
+#define xstr(s) #s
+
+#ifdef ENABLE_WARN
+#define WARN(str, ...) do { fprintf(stderr, "WARNING: " str "\n", ## __VA_ARGS__); } while (0)
+#else /* ENABLE_WARN */
+#define WARN(...) do { } while (0)
+#endif /* ENABLE_WARN */
+
+#define LIB "libtss2-mu.so.0"
+static void *dlhandle = NULL;
+
+static TSS2_RC
+init_dlhandle(void)
+{
+    if (dlhandle)
+        return TSS2_RC_SUCCESS;
+    dlhandle = dlopen(LIB, RTLD_NOW | RTLD_LOCAL);
+    if (!dlhandle) {
+        WARN("Library " LIB " not found: %s.", dlerror());
+        return TSS2_BASE_RC_NOT_IMPLEMENTED;
+    }
+    return TSS2_RC_SUCCESS;
+}
+
+#define MAKE_MU_BASE(typ) \
+TSS2_RC Tss2_MU_ ## typ ## _Marshal ( \
+    typ             src, \
+    uint8_t         buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (typ, uint8_t [], size_t, size_t *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Marshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Marshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(src, buffer, buffer_size, offset); \
+} \
+TSS2_RC Tss2_MU_ ## typ ## _Unmarshal ( \
+    uint8_t const   buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset, \
+    typ            *dest) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (const uint8_t [], size_t, size_t *, typ *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Unmarshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Unmarshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(buffer, buffer_size, offset, dest); \
+}
+
+#define MAKE_MU_STRUCT(typ) \
+TSS2_RC Tss2_MU_ ## typ ## _Marshal ( \
+    typ const      *src, \
+    uint8_t         buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (const typ *, uint8_t [], size_t, size_t *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Marshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Marshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(src, buffer, buffer_size, offset); \
+} \
+TSS2_RC Tss2_MU_ ## typ ## _Unmarshal ( \
+    uint8_t const   buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset, \
+    typ            *dest) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (const uint8_t [], size_t, size_t *, typ *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Unmarshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Unmarshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(buffer, buffer_size, offset, dest); \
+}
+
+#define MAKE_MU_UNION(typ) \
+TSS2_RC Tss2_MU_ ## typ ## _Marshal ( \
+    typ const      *src, \
+    uint32_t        selector_value, \
+    uint8_t         buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (const typ *, uint32_t, uint8_t [], size_t, size_t *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Marshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Marshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(src, selector_value, buffer, buffer_size, offset); \
+} \
+TSS2_RC Tss2_MU_ ## typ ## _Unmarshal ( \
+    uint8_t const   buffer[], \
+    size_t          buffer_size, \
+    size_t         *offset, \
+    uint32_t        selector_value, \
+    typ            *dest) \
+{ \
+    if (init_dlhandle() != TSS2_RC_SUCCESS) \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    static TSS2_RC (*sym) (const uint8_t [], size_t, size_t *, uint32_t, typ *) = NULL; \
+    if (!sym) \
+        sym = dlsym(dlhandle, str(Tss2_MU_ ## typ ## _Unmarshal)); \
+    if (!sym) { \
+        WARN("Function " str(Tss2_MU_ ## typ ## _Unmarshal) " not found."); \
+        return TSS2_BASE_RC_NOT_IMPLEMENTED; \
+    } \
+    return sym(buffer, buffer_size, offset, selector_value, dest); \
+}
+
+MAKE_MU_BASE(INT8);
+MAKE_MU_BASE(INT16);
+MAKE_MU_BASE(INT32);
+MAKE_MU_BASE(INT64);
+MAKE_MU_BASE(UINT8);
+MAKE_MU_BASE(UINT16);
+MAKE_MU_BASE(UINT32);
+MAKE_MU_BASE(UINT64);
+MAKE_MU_BASE(TPM2_CC);
+MAKE_MU_BASE(TPM2_ST);
+MAKE_MU_BASE(TPMA_ALGORITHM);
+MAKE_MU_BASE(TPMA_CC);
+MAKE_MU_BASE(TPMA_LOCALITY);
+MAKE_MU_BASE(TPMA_NV);
+MAKE_MU_BASE(TPMA_OBJECT);
+MAKE_MU_BASE(TPMA_PERMANENT);
+MAKE_MU_BASE(TPMA_SESSION);
+MAKE_MU_BASE(TPMA_STARTUP_CLEAR);
+MAKE_MU_STRUCT(TPM2B_DIGEST);
+MAKE_MU_STRUCT(TPM2B_ATTEST);
+MAKE_MU_STRUCT(TPM2B_NAME);
+MAKE_MU_STRUCT(TPM2B_MAX_NV_BUFFER);
+MAKE_MU_STRUCT(TPM2B_SENSITIVE_DATA);
+MAKE_MU_STRUCT(TPM2B_ECC_PARAMETER);
+MAKE_MU_STRUCT(TPM2B_PUBLIC_KEY_RSA);
+MAKE_MU_STRUCT(TPM2B_PRIVATE_KEY_RSA);
+MAKE_MU_STRUCT(TPM2B_PRIVATE);
+MAKE_MU_STRUCT(TPM2B_CONTEXT_SENSITIVE);
+MAKE_MU_STRUCT(TPM2B_CONTEXT_DATA);
+MAKE_MU_STRUCT(TPM2B_DATA);
+MAKE_MU_STRUCT(TPM2B_SYM_KEY);
+MAKE_MU_STRUCT(TPM2B_ECC_POINT);
+MAKE_MU_STRUCT(TPM2B_NV_PUBLIC);
+MAKE_MU_STRUCT(TPM2B_SENSITIVE);
+MAKE_MU_STRUCT(TPM2B_SENSITIVE_CREATE);
+MAKE_MU_STRUCT(TPM2B_CREATION_DATA);
+MAKE_MU_STRUCT(TPM2B_PUBLIC);
+MAKE_MU_STRUCT(TPM2B_ENCRYPTED_SECRET);
+MAKE_MU_STRUCT(TPM2B_ID_OBJECT);
+MAKE_MU_STRUCT(TPM2B_IV);
+MAKE_MU_STRUCT(TPM2B_AUTH);
+MAKE_MU_STRUCT(TPM2B_EVENT);
+MAKE_MU_STRUCT(TPM2B_MAX_BUFFER);
+MAKE_MU_STRUCT(TPM2B_NONCE);
+MAKE_MU_STRUCT(TPM2B_OPERAND);
+MAKE_MU_STRUCT(TPM2B_TIMEOUT);
+MAKE_MU_STRUCT(TPM2B_TEMPLATE);
+MAKE_MU_STRUCT(TPMS_CONTEXT);
+MAKE_MU_STRUCT(TPMS_TIME_INFO);
+MAKE_MU_STRUCT(TPMS_ECC_POINT);
+MAKE_MU_STRUCT(TPMS_NV_PUBLIC);
+MAKE_MU_STRUCT(TPMS_ALG_PROPERTY);
+MAKE_MU_STRUCT(TPMS_ALGORITHM_DESCRIPTION);
+MAKE_MU_STRUCT(TPMS_TAGGED_PROPERTY);
+MAKE_MU_STRUCT(TPMS_TAGGED_POLICY);
+MAKE_MU_STRUCT(TPMS_CLOCK_INFO);
+MAKE_MU_STRUCT(TPMS_TIME_ATTEST_INFO);
+MAKE_MU_STRUCT(TPMS_CERTIFY_INFO);
+MAKE_MU_STRUCT(TPMS_COMMAND_AUDIT_INFO);
+MAKE_MU_STRUCT(TPMS_SESSION_AUDIT_INFO);
+MAKE_MU_STRUCT(TPMS_CREATION_INFO);
+MAKE_MU_STRUCT(TPMS_NV_CERTIFY_INFO);
+MAKE_MU_STRUCT(TPMS_AUTH_COMMAND);
+MAKE_MU_STRUCT(TPMS_AUTH_RESPONSE);
+MAKE_MU_STRUCT(TPMS_SENSITIVE_CREATE);
+MAKE_MU_STRUCT(TPMS_SCHEME_HASH);
+MAKE_MU_STRUCT(TPMS_SCHEME_ECDAA);
+MAKE_MU_STRUCT(TPMS_SCHEME_XOR);
+MAKE_MU_STRUCT(TPMS_SIGNATURE_RSA);
+MAKE_MU_STRUCT(TPMS_SIGNATURE_ECC);
+MAKE_MU_STRUCT(TPMS_NV_PIN_COUNTER_PARAMETERS);
+MAKE_MU_STRUCT(TPMS_CONTEXT_DATA);
+MAKE_MU_STRUCT(TPMS_PCR_SELECT);
+MAKE_MU_STRUCT(TPMS_PCR_SELECTION);
+MAKE_MU_STRUCT(TPMS_TAGGED_PCR_SELECT);
+MAKE_MU_STRUCT(TPMS_QUOTE_INFO);
+MAKE_MU_STRUCT(TPMS_CREATION_DATA);
+MAKE_MU_STRUCT(TPMS_ECC_PARMS);
+MAKE_MU_STRUCT(TPMS_ATTEST);
+MAKE_MU_STRUCT(TPMS_ALGORITHM_DETAIL_ECC);
+MAKE_MU_STRUCT(TPMS_CAPABILITY_DATA);
+MAKE_MU_STRUCT(TPMS_KEYEDHASH_PARMS);
+MAKE_MU_STRUCT(TPMS_RSA_PARMS);
+MAKE_MU_STRUCT(TPMS_SYMCIPHER_PARMS);
+MAKE_MU_STRUCT(TPMS_AC_OUTPUT);
+MAKE_MU_STRUCT(TPMS_ID_OBJECT);
+MAKE_MU_STRUCT(TPMS_ACT_DATA);
+MAKE_MU_STRUCT(TPMS_NV_DIGEST_CERTIFY_INFO);
+MAKE_MU_STRUCT(TPML_CC);
+MAKE_MU_STRUCT(TPML_CCA);
+MAKE_MU_STRUCT(TPML_ALG);
+MAKE_MU_STRUCT(TPML_HANDLE);
+MAKE_MU_STRUCT(TPML_DIGEST);
+MAKE_MU_STRUCT(TPML_DIGEST_VALUES);
+MAKE_MU_STRUCT(TPML_PCR_SELECTION);
+MAKE_MU_STRUCT(TPML_ALG_PROPERTY);
+MAKE_MU_STRUCT(TPML_ECC_CURVE);
+MAKE_MU_STRUCT(TPML_TAGGED_PCR_PROPERTY);
+MAKE_MU_STRUCT(TPML_TAGGED_TPM_PROPERTY);
+MAKE_MU_STRUCT(TPML_INTEL_PTT_PROPERTY);
+MAKE_MU_STRUCT(TPML_AC_CAPABILITIES);
+MAKE_MU_STRUCT(TPML_TAGGED_POLICY);
+MAKE_MU_STRUCT(TPML_ACT_DATA);
+MAKE_MU_UNION(TPMU_HA);
+MAKE_MU_UNION(TPMU_CAPABILITIES);
+MAKE_MU_UNION(TPMU_ATTEST);
+MAKE_MU_UNION(TPMU_SYM_KEY_BITS);
+MAKE_MU_UNION(TPMU_SYM_MODE);
+MAKE_MU_UNION(TPMU_SIG_SCHEME);
+MAKE_MU_UNION(TPMU_KDF_SCHEME);
+MAKE_MU_UNION(TPMU_ASYM_SCHEME);
+MAKE_MU_UNION(TPMU_SCHEME_KEYEDHASH);
+MAKE_MU_UNION(TPMU_SIGNATURE);
+MAKE_MU_UNION(TPMU_SENSITIVE_COMPOSITE);
+MAKE_MU_UNION(TPMU_ENCRYPTED_SECRET);
+MAKE_MU_UNION(TPMU_PUBLIC_PARMS);
+MAKE_MU_UNION(TPMU_PUBLIC_ID);
+MAKE_MU_UNION(TPMU_NAME);
+MAKE_MU_STRUCT(TPMT_HA);
+MAKE_MU_STRUCT(TPMT_SYM_DEF);
+MAKE_MU_STRUCT(TPMT_SYM_DEF_OBJECT);
+MAKE_MU_STRUCT(TPMT_KEYEDHASH_SCHEME);
+MAKE_MU_STRUCT(TPMT_SIG_SCHEME);
+MAKE_MU_STRUCT(TPMT_KDF_SCHEME);
+MAKE_MU_STRUCT(TPMT_ASYM_SCHEME);
+MAKE_MU_STRUCT(TPMT_RSA_SCHEME);
+MAKE_MU_STRUCT(TPMT_RSA_DECRYPT);
+MAKE_MU_STRUCT(TPMT_ECC_SCHEME);
+MAKE_MU_STRUCT(TPMT_SIGNATURE);
+MAKE_MU_STRUCT(TPMT_SENSITIVE);
+MAKE_MU_STRUCT(TPMT_PUBLIC);
+MAKE_MU_STRUCT(TPMT_PUBLIC_PARMS);
+MAKE_MU_STRUCT(TPMT_TK_CREATION);
+MAKE_MU_STRUCT(TPMT_TK_VERIFIED);
+MAKE_MU_STRUCT(TPMT_TK_AUTH);
+MAKE_MU_STRUCT(TPMT_TK_HASHCHECK);
+MAKE_MU_BASE(TPM2_HANDLE);
+MAKE_MU_BASE(TPMI_ALG_HASH);
+MAKE_MU_BASE(BYTE);
+MAKE_MU_BASE(TPM2_SE);
+MAKE_MU_BASE(TPM2_NT);
+MAKE_MU_STRUCT(TPMS_EMPTY);

--- a/tss2-dlopen/tss2-dlopen-rc.c
+++ b/tss2-dlopen/tss2-dlopen-rc.c
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2021, Fraunhofer SIT
+ * All rights reserved.
+ *******************************************************************************/
+
+/**
+ * The purpose of this file is to copy it into your project and
+ * include it during compilation if you don't want to link against
+ * libtss2-rc at compile time.
+ * It will attempt to load libtss2-rc.so during runtime.
+ * It will either work similarly to directly linking to libtss2-rc.so
+ * at compile-time or return an error string or NULL.
+ *
+ * For new versions of this file, please check:
+ * http://github.com/tpm2-software/tpm2-tss/tss2-dlopen
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <tss2/tss2_rc.h>
+
+#define str(s) xstr(s)
+#define xstr(s) #s
+
+#ifdef ENABLE_WARN
+#define WARN(str, ...) do { fprintf(stderr, "WARNING: " str "\n", ## __VA_ARGS__); } while (0)
+#else /* ENABLE_WARN */
+#define WARN(...) do { } while (0)
+#endif /* ENABLE_WARN */
+
+#define LIB "libtss2-rc.so.0"
+static void *dlhandle = NULL;
+
+static TSS2_RC
+init_dlhandle(void)
+{
+    if (dlhandle)
+        return TSS2_RC_SUCCESS;
+    dlhandle = dlopen(LIB, RTLD_NOW | RTLD_LOCAL);
+    if (!dlhandle) {
+        WARN("Library " LIB " not found: %s.", dlerror());
+        return TSS2_BASE_RC_NOT_IMPLEMENTED;
+    }
+    return TSS2_RC_SUCCESS;
+}
+
+static const char *error = LIB " not found.";
+
+const char *
+Tss2_RC_Decode(TSS2_RC rc)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return error;
+
+    static const char * (*sym) (TSS2_RC rc) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_RC_Decode");
+    if (!sym) {
+        WARN("Function Tss2_RC_Decode not found.");
+        return error;
+    }
+
+    return sym(rc);
+}
+
+TSS2_RC_HANDLER
+Tss2_RC_SetHandler(uint8_t layer, const char *name, TSS2_RC_HANDLER handler)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return NULL;
+
+    TSS2_RC_HANDLER (*sym) (uint8_t layer, const char *name, TSS2_RC_HANDLER handler) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_RC_SetHandler");
+    if (!sym) {
+        WARN("Function Tss2_RC_SetHandler not found.");
+        return NULL;
+    }
+
+    return sym(layer, name, handler);
+}

--- a/tss2-dlopen/tss2-dlopen-tctildr.c
+++ b/tss2-dlopen/tss2-dlopen-tctildr.c
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2021, Fraunhofer SIT
+ * All rights reserved.
+ *******************************************************************************/
+
+/**
+ * The purpose of this file is to copy it into your project and
+ * include it during compilation if you don't want to link against
+ * libtss2-tctildr at compile time.
+ * It will attempt to load libtss2-esys.so during runtime.
+ * It will either work similarly to directly linking to libtss2-tctildr.so
+ * at compile-time or return a NOT_IMPLEMENTED error.
+ *
+ * For new versions of this file, please check:
+ * http://github.com/tpm2-software/tpm2-tss/tss2-dlopen
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <tss2/tss2_tctildr.h>
+
+#define str(s) xstr(s)
+#define xstr(s) #s
+
+#ifdef ENABLE_WARN
+#define WARN(str, ...) do { fprintf(stderr, "WARNING: " str "\n", ## __VA_ARGS__); } while (0)
+#else /* ENABLE_WARN */
+#define WARN(...) do { } while (0)
+#endif /* ENABLE_WARN */
+
+#define LIB "libtss2-tctildr.so.0"
+static void *dlhandle = NULL;
+
+static TSS2_RC
+init_dlhandle(void)
+{
+    if (dlhandle)
+        return TSS2_RC_SUCCESS;
+    dlhandle = dlopen(LIB, RTLD_NOW | RTLD_LOCAL);
+    if (!dlhandle) {
+        WARN("Library " LIB " not found: %s.", dlerror());
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+    }
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+Tss2_TctiLdr_Initialize_Ex (const char *name,
+                            const char *conf,
+                            TSS2_TCTI_CONTEXT **context)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (const char *name, const char *conf, TSS2_TCTI_CONTEXT **context) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_TctiLdr_Initialize_Ex");
+    if (!sym) {
+        WARN("Function Tss2_TctiLdr_Initialize_Ex not found.");
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(name, conf, context);
+}
+
+TSS2_RC
+Tss2_TctiLdr_Initialize (const char *nameConf,
+                         TSS2_TCTI_CONTEXT **context)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (const char *nameConf, TSS2_TCTI_CONTEXT **context) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_TctiLdr_Initialize");
+    if (!sym) {
+        WARN("Function Tss2_TctiLdr_Initialize not found.");
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(nameConf, context);
+}
+
+TSS2_RC
+Tss2_TctiLdr_GetInfo (const char *name,
+                      TSS2_TCTI_INFO **info)
+{
+    if (init_dlhandle() != TSS2_RC_SUCCESS)
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+
+    static TSS2_RC (*sym) (const char *name, TSS2_TCTI_INFO **info) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_TctiLdr_GetInfo");
+    if (!sym) {
+        WARN("Function Tss2_TctiLdr_GetInfo not found.");
+        return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+    }
+
+    return sym(name, info);
+}
+
+
+void
+Tss2_TctiLdr_Finalize (TSS2_TCTI_CONTEXT **context)
+{
+    if (!context || !*context)
+        return;
+    static void (*sym) (TSS2_TCTI_CONTEXT **context) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_TctiLdr_Finalize");
+    if (!sym) {
+        WARN("Function Tss2_TctiLdr_Finalize not found.");
+        return;
+    }
+
+    sym(context);
+}
+
+void
+Tss2_TctiLdr_FreeInfo (TSS2_TCTI_INFO **info)
+{
+    if (!info || !*info)
+        return;
+    static void (*sym) (TSS2_TCTI_INFO **info) = NULL;
+    if (!sym)
+        sym = dlsym(dlhandle, "Tss2_TctiLdr_FreeInfo");
+    if (!sym) {
+        WARN("Function Tss2_TctiLdr_FreeInfo not found.");
+        return;
+    }
+
+    sym(info);
+}


### PR DESCRIPTION
Add a tss2-dlopen-esys that can be copied into project that do not want to link against libtss2-esys at compile time.
Same for tctildr, mu, rc and fapi.
Also added tests for esys, mu, rc, fapi and failure.