### PR TITLE
Fapi fix leak in Fapi_Quote and remove useless code

### DIFF
--- a/src/tss2-fapi/api/Fapi_Quote.c
+++ b/src/tss2-fapi/api/Fapi_Quote.c
@@ -246,6 +246,7 @@ Fapi_Quote_Async(
 
     /* Initialize the context state for this operation. */
     context->state = PCR_QUOTE_WAIT_FOR_GET_CAP;
+    command->handle = ESYS_TR_NONE;
     LOG_TRACE("finished");
     return TSS2_RC_SUCCESS;
 
@@ -472,6 +473,9 @@ error_cleanup:
     ifapi_cleanup_ifapi_object(&context->createPrimary.pkey_object);
     ifapi_cleanup_ifapi_object(command->key_object);
     ifapi_session_clean(context);
+    if (command->handle != ESYS_TR_NONE) {
+        Esys_FlushContext(context->esys, command->handle);
+    }
     LOG_TRACE("finished");
     return r;
 }

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -51,9 +51,6 @@ typedef struct _IFAPI_CRYPTO_CONTEXT {
     size_t hashSize;
 } IFAPI_CRYPTO_CONTEXT;
 
-/** A singleton crypto engine for hash operations */
-static ENGINE *engine = NULL;
-
 /**
  * Returns the signature scheme that is currently used in the FAPI context.
  *
@@ -208,23 +205,6 @@ ifapi_bn2binpad(const BIGNUM *bn, unsigned char *bin, int binSize)
     memset(bin, 0, offset);
     BN_bn2bin(bn, bin + offset);
     return 1;
-}
-
-/**
- * Returns the singleton hash engine for the use in ifapi_hash operations. If
- * it does not yet exist, this function creates it.
- *
- * @retval A singleton hash engine
- */
-static ENGINE *
-get_engine()
-{
-    /* If an engine is present, it is returned */
-    if (engine)
-        return engine;
-    /* Otherwise, engine is created and returned */
-    engine = ENGINE_by_id(NULL);
-    return engine;
 }
 
 /**
@@ -1470,7 +1450,7 @@ ifapi_crypto_hash_start(IFAPI_CRYPTO_CONTEXT_BLOB **context,
     }
 
     if (1 != EVP_DigestInit_ex(mycontext->osslContext,
-                               mycontext->osslHashAlgorithm, get_engine())) {
+                               mycontext->osslHashAlgorithm, NULL)) {
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "Error EVP_DigestInit_ex",
                    cleanup);
     }


### PR DESCRIPTION
* A leak in Fapi_Quote was fixed.
* The useless code get_engine was removed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>
