### PR TITLE
FAPI: Prohibit deletion of already existing persistent SRK.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -1030,6 +1030,11 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             pkeyObject->objectType = IFAPI_KEY_OBJ;
             pkeyObject->system = command->public_templ.system;
 
+            /* Prohibit deletion of already exiting persistent SRK */
+            if (command->public_templ.persistent_handle & command->srk_exists) {
+                pkeyObject->misc.key.delete_prohibited = TPM2_YES;
+            }
+
             /* Perform esys serialization if necessary */
             r = ifapi_esys_serialize_object(context->esys, pkeyObject);
             goto_if_error(r, "Prepare serialization", error_cleanup);

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -214,6 +214,14 @@ ifapi_json_IFAPI_KEY_deserialize(json_object *jso,  IFAPI_KEY *out)
         out->reset_count = 0;
     }
 
+    if (ifapi_get_sub_object(jso, "delete_prohibited", &jso2)) {
+        r = ifapi_json_TPMI_YES_NO_deserialize(jso2, &out->delete_prohibited);
+        return_if_error(r, "Bad value for field \"delete_prohibited\".");
+
+    } else {
+        out->delete_prohibited = TPM2_NO;
+    }
+
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -186,6 +186,12 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
 
         json_object_object_add(*jso, "reset_count", jso2);
     }
+    jso2 = NULL;
+    r = ifapi_json_TPMI_YES_NO_serialize(in->delete_prohibited, &jso2);
+    return_if_error(r, "Serialize TPMI_YES_NO");
+
+    json_object_object_add(*jso, "delete_prohibited", jso2);
+
 
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -40,6 +40,7 @@ typedef struct {
     TPM2B_NAME                                     name;    /**< Name of the key */
     TPMI_YES_NO                               with_auth;    /**< Authorization provided during creation */
     UINT32                                  reset_count;    /**< The TPM reset count during key creation */
+    TPMI_YES_NO                       delete_prohibited;    /**< Persistent object should not be deleted.  */
 } IFAPI_KEY;
 
 /** Type for representing a external public key


### PR DESCRIPTION
If the SRK did already exist during provisioning the persistent SRK will not be removed
by Fapi_Delete. Only the corresponding files in the keystore will be deleted.
Addresses #2098.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>