### PR TITLE
FAPI: Fix double free for policy action 2.4.x

### DIFF
--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1346,6 +1346,10 @@ copy_policy_element(const TPMT_POLICYELEMENT *from_policy, TPMT_POLICYELEMENT *t
                      from_policy->element.PolicyDuplicationSelect.newParentPath,
                      r, error);
         break;
+    case POLICYACTION:
+        strdup_check(to_policy->element.PolicyAction.action,
+                     from_policy->element.PolicyAction.action, r, error);
+        break;
     case POLICYNAMEHASH:
         for (size_t i = 0; i < from_policy->element.PolicyNameHash.count; i++) {
             strdup_check(to_policy->element.PolicyNameHash.namePaths[i],


### PR DESCRIPTION
The action string was not duplicated when the policy was copied.
Fixes: #2089

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>