### PR TITLE
FAPI: Set the init state of ifapi_get_certificates 2.4.x.

### DIFF
--- a/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
+++ b/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
@@ -148,6 +148,7 @@ Fapi_GetPlatformCertificates_Async(
 
     /* Initialize the context state for this operation. */
     context->state = GET_PLATFORM_CERTIFICATE;
+    context->get_cert_state = GET_CERT_INIT;
 
     LOG_TRACE("finished");
     return TSS2_RC_SUCCESS;


### PR DESCRIPTION
The init state of the state machine ifapi_get_certificates was not set before the
first call. Fixes #2091.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>