### PR TITLE
Fapi several backports for 3.1.x

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -639,7 +639,6 @@ test_unit_fapi_io_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_fapi_io_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_fapi_io_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
                             -Wl,--wrap=fopen \
-                            -Wl,--wrap=lockf \
                             -Wl,--wrap=fseek \
                             -Wl,--wrap=ftell \
                             -Wl,--wrap=fcntl \

--- a/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
+++ b/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
@@ -156,6 +156,7 @@ Fapi_GetPlatformCertificates_Async(
 
     /* Initialize the context state for this operation. */
     context->state = GET_PLATFORM_CERTIFICATE;
+    context->get_cert_state = GET_CERT_INIT;
 
     LOG_TRACE("finished");
     return TSS2_RC_SUCCESS;

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1274,6 +1274,10 @@ copy_policy_element(const TPMT_POLICYELEMENT *from_policy, TPMT_POLICYELEMENT *t
                      from_policy->element.PolicyDuplicationSelect.newParentPath,
                      r, error);
         break;
+    case POLICYACTION:
+        strdup_check(to_policy->element.PolicyAction.action,
+                     from_policy->element.PolicyAction.action, r, error);
+        break;
     case POLICYNAMEHASH:
         for (size_t i = 0; i < from_policy->element.PolicyNameHash.count; i++) {
             strdup_check(to_policy->element.PolicyNameHash.namePaths[i],

--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -69,15 +69,6 @@ __wrap_fopen(const char *pathname, const char* mode, ...)
 }
 
 int
-__real_lockf(int fd, int cmd, off_t len, ...);
-int
-__wrap_lockf(int fd, int cmd, off_t len, ...)
-{
-    errno = EAGAIN;
-    return mock_type(int);
-}
-
-int
 __real_fclose(FILE *stream, ...);
 
 int
@@ -187,8 +178,9 @@ check_io_read_async(void **state) {
     r = ifapi_io_read_async(&io, "tss_unit_dummyf");
     assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
 
+    wrap_fcntl_test = true;
     will_return(__wrap_fopen, &mock_stream);
-    will_return(__wrap_lockf, -1);
+    will_return(__wrap_fcntl, -1);
     will_return_always(__wrap_fclose, 0);
     errno = EAGAIN;
     io.char_buffer = NULL;
@@ -197,7 +189,7 @@ check_io_read_async(void **state) {
 
     will_return(__wrap_fopen, &mock_stream);
     will_return(__wrap_fopen, &mock_stream);
-    will_return(__wrap_lockf, 0);
+    will_return(__wrap_fcntl, 0);
     will_return(__wrap_fseek, 0);
     will_return(__wrap_ftell, 1);
     will_return(__wrap_malloc, NULL);
@@ -212,7 +204,7 @@ check_io_read_async(void **state) {
 
     will_return(__wrap_fopen, &mock_stream);
     will_return(__wrap_fopen, &mock_stream);
-    will_return(__wrap_lockf, 0);
+    will_return(__wrap_fcntl, 0);
     will_return(__wrap_fseek, 0);
     will_return(__wrap_ftell, 1);
     will_return(__wrap_fcntl, 0);
@@ -220,7 +212,6 @@ check_io_read_async(void **state) {
 
     errno = 0;
     io.char_buffer = NULL;
-    wrap_fcntl_test = true;
     r = ifapi_io_read_async(&io, "tss_unit_dummyf");
     assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
     wrap_fcntl_test = false;
@@ -306,8 +297,9 @@ check_io_write_async(void **state) {
     r = ifapi_io_write_async(&io, "tss_unit_dummyf", &buffer[0], 5);
     assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
 
+    wrap_fcntl_test = true;
     will_return(__wrap_fopen, &mock_stream);
-    will_return(__wrap_lockf, -1);
+    will_return(__wrap_fcntl, -1);
 
     errno = EAGAIN;
     r = ifapi_io_write_async(&io, "tss_unit_dummyf", &buffer[0], 5);
@@ -315,8 +307,7 @@ check_io_write_async(void **state) {
 
     io.char_rbuffer = NULL;
     will_return(__wrap_fopen, &mock_stream);
-    will_return(__wrap_lockf, 0);
-    wrap_fcntl_test = true;
+    will_return(__wrap_fcntl, 0);
     will_return(__wrap_fcntl, 0);
     will_return(__wrap_fcntl, -1);
     errno = 0;


### PR DESCRIPTION
* Fix usage of lockf in fapi-io.
* Adapt unit test for fapi-io
* Fix double free for policy action.
* Set the init state of ifapi_get_certificates.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>