### PR TITLE
FAPI: Allow following of redirects for curl downloads.

### DIFF
--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -2447,6 +2447,13 @@ ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
         goto out_easy_cleanup;
     }
 
+    rc = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+    if (rc != CURLE_OK) {
+        LOG_ERROR("curl_easy_setopt for CURLOPT_FOLLOWLOCATION failed: %s",
+                  curl_easy_strerror(rc));
+        goto out_easy_cleanup;
+    }
+
     if (LOGMODULE_status == LOGLEVEL_TRACE) {
         if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L)) {
             LOG_WARNING("Curl easy setopt verbose failed");


### PR DESCRIPTION
For the download of some certificates 3xx redirects are used by the provider.
Thus redirects have to be allowed.
If https URLs are used the certificate needed for verification must exists in the ssl
certificate store.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>