### PR TITLE
Test: Remove unused configuration fields

### DIFF
--- a/script/ekca/intermed-ca.cnf
+++ b/script/ekca/intermed-ca.cnf
@@ -6,13 +6,6 @@
 # This definition doesn't work if HOME isn't defined.
 CA_HOME                 = .
 RANDFILE                = $ENV::CA_HOME/private/.rnd
-oid_section             = new_oids
-
-#
-# XMPP address Support
-[ new_oids ]
-xmppAddr          = 1.3.6.1.5.5.7.8.5
-dnsSRV            = 1.3.6.1.5.5.7.8.7
 
 #
 # Default Certification Authority
@@ -64,7 +57,6 @@ organizationName        = optional
 organizationalUnitName  = optional
 commonName              = supplied
 emailAddress            = supplied
-#xmppAddr               = optional # Added to SubjAltName by req
 
 #
 # Intermediate CA request options


### PR DESCRIPTION
I double-searched and triple-searched-- these fields are (to my best knowledge) not used anywehere. Hence we can remove them to avoid conflicts when OpenSSL 3.0 is used, because it does natively recognize these OIDs.