### PR TITLE
FAPI: Improve error messages for invalid JSON.

### DIFF
--- a/src/tss2-fapi/ifapi_config.c
+++ b/src/tss2-fapi/ifapi_config.c
@@ -240,7 +240,7 @@ ifapi_config_initialize_finish(IFAPI_IO *io, IFAPI_CONFIG *config)
     }
 
     /* Parse and deserialize the configuration file */
-    jso = json_tokener_parse((char *)configFileContent);
+    jso = ifapi_parse_json((char *)configFileContent);
     goto_if_null(jso, "Could not parse JSON objects",
             TSS2_FAPI_RC_GENERAL_FAILURE, error);
     r = ifapi_json_IFAPI_CONFIG_deserialize(jso, config);

--- a/src/tss2-fapi/ifapi_eventlog.c
+++ b/src/tss2-fapi/ifapi_eventlog.c
@@ -12,6 +12,7 @@
 
 #include "ifapi_helpers.h"
 #include "ifapi_eventlog.h"
+#include "tpm_json_deserialize.h"
 #include "ifapi_json_serialize.h"
 
 #define LOGMODULE fapi
@@ -171,7 +172,7 @@ loop:
         return_try_again(r);
         return_if_error(r, "read_finish failed");
 
-        logpart = json_tokener_parse(logstr);
+        logpart = ifapi_parse_json(logstr);
         SAFE_FREE(logstr);
         return_if_null(log, "JSON parsing error", TSS2_FAPI_RC_BAD_VALUE);
 
@@ -246,7 +247,7 @@ ifapi_eventlog_append_check(
 
         /* If a log was read, we deserialize it to JSON. Otherwise we start a new log. */
         if (logstr) {
-            eventlog->log = json_tokener_parse(logstr);
+            eventlog->log = ifapi_parse_json(logstr);
             SAFE_FREE(logstr);
             return_if_null(eventlog->log, "JSON parsing error", TSS2_FAPI_RC_BAD_VALUE);
 

--- a/src/tss2-fapi/ifapi_get_intl_cert.c
+++ b/src/tss2-fapi/ifapi_get_intl_cert.c
@@ -17,6 +17,7 @@
 
 #include "fapi_crypto.h"
 #include "ifapi_helpers.h"
+#include "tpm_json_deserialize.h"
 
 #define LOGMODULE fapi
 #include "util/log.h"
@@ -330,7 +331,7 @@ ifapi_get_intl_ek_certificate(FAPI_CONTEXT *context, TPM2B_PUBLIC *ek_public,
     LOGBLOB_DEBUG((uint8_t *)cert_ptr, *cert_size, "%s", "Certificate");
 
     /* Parse certificate data out of the json structure */
-    struct json_object *jso_cert, *jso = json_tokener_parse(cert_ptr);
+    struct json_object *jso_cert, *jso = ifapi_parse_json(cert_ptr);
     if (jso == NULL)
         goto_error(rc, TSS2_FAPI_RC_GENERAL_FAILURE,
                    "Failed to parse EK cert data", out_free_json);

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1715,7 +1715,7 @@ ifapi_get_quote_info(
     TSS2_RC r;
     size_t offset = 0;
 
-    jso = json_tokener_parse(quoteInfo);
+    jso = ifapi_parse_json(quoteInfo);
     return_if_null(jso, "Json error.", TSS2_FAPI_RC_BAD_VALUE);
 
     memset(&fapi_quote_info->attest.attested.quote.pcrSelect, 0,

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -14,8 +14,10 @@
 #include "ifapi_json_serialize.h"
 #include "tpm_json_serialize.h"
 #include "fapi_policy.h"
+#include "tpm_json_deserialize.h"
 #include "ifapi_policy_json_serialize.h"
 #include "ifapi_config.h"
+#include "ifapi_helpers.h"
 
 #define LOGMODULE fapijson
 #include "util/log.h"
@@ -710,7 +712,7 @@ ifapi_json_IFAPI_TSS_EVENT_serialize(const IFAPI_TSS_EVENT *in,
            object that shall be serialized under the event field. Thus we
            first have to deserialize the string before we can add it to
            the data structure. */
-        jso2 = json_tokener_parse(in->event);
+        jso2 = ifapi_parse_json(in->event);
         return_if_null(jso2, "Event is not valid JSON.", TSS2_FAPI_RC_BAD_VALUE);
 
         json_object_object_add(*jso, "event", jso2);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -16,6 +16,7 @@
 #define LOGMODULE fapi
 #include "util/log.h"
 #include "util/aux_util.h"
+#include "tpm_json_deserialize.h"
 #include "ifapi_json_deserialize.h"
 #include "ifapi_json_serialize.h"
 
@@ -623,7 +624,7 @@ ifapi_keystore_load_finish(
     return_if_error(r, "keystore read_finish failed");
 
     /* If json objects can't be parse the object store is corrupted */
-    jso = json_tokener_parse((char *)buffer);
+    jso = ifapi_parse_json((char *)buffer);
     SAFE_FREE(buffer);
     goto_if_null2(jso, "Keystore is corrupted (Json error).", r, TSS2_FAPI_RC_GENERAL_FAILURE,
                   error_cleanup);

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -17,6 +17,7 @@
 #define LOGMODULE fapi
 #include "util/log.h"
 #include "util/aux_util.h"
+#include "tpm_json_deserialize.h"
 #include "ifapi_policy_json_deserialize.h"
 #include "ifapi_policy_json_serialize.h"
 
@@ -199,7 +200,7 @@ ifapi_policy_store_load_finish(
     return_if_error(r, "keystore read_finish failed");
 
     /* If json objects can't be parse the object store is corrupted */
-    jso = json_tokener_parse((char *)buffer);
+    jso = ifapi_parse_json((char *)buffer);
     SAFE_FREE(buffer);
     return_if_null(jso, "Policy store is corrupted (Json error).", TSS2_FAPI_RC_GENERAL_FAILURE);
 

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -165,7 +165,7 @@ ifapi_profiles_initialize_finish(
     r = ifapi_io_read_finish(io, &buffer, NULL);
     return_if_error(r, "Reading profile failed");
 
-    jso = json_tokener_parse((char *) buffer);
+    jso = ifapi_parse_json((char *) buffer);
     free(buffer);
     if (jso == NULL) {
         LOG_ERROR("Failed to parse profile %s", profiles->filenames[profiles->profiles_idx]);

--- a/src/tss2-fapi/tpm_json_deserialize.h
+++ b/src/tss2-fapi/tpm_json_deserialize.h
@@ -15,6 +15,9 @@
 #define YES 1
 #define NO 0
 
+json_object*
+ifapi_parse_json(const char *jstring) ;
+
 TSS2_RC
 ifapi_json_BYTE_array_deserialize(size_t max, json_object *jso, BYTE *out);
 

--- a/test/unit/fapi-json.c
+++ b/test/unit/fapi-json.c
@@ -2260,6 +2260,12 @@ check_tpmjson_tofromtxt(void **state)
     }
 }
 
+static void
+check_invalid_json(void **state) {
+      json_object *jso = ifapi_parse_json("{\n \"field\", \"value\"");
+      assert_null(jso);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -2275,6 +2281,7 @@ main(int argc, char *argv[])
         cmocka_unit_test(check_policy_bin),
         cmocka_unit_test(check_error),
         cmocka_unit_test(check_json_policy),
+        cmocka_unit_test(check_invalid_json),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
For invalid JSON currently the position an type of the error is not displayed
in the error message. The user has to check the JSON data with another tool.
Now the line number and the column of the error will be displayed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>