### PR TITLE
FAPI: Fix cipherText logging in Fapi_Decrypt_Async

### DIFF
--- a/src/tss2-fapi/api/Fapi_Decrypt.c
+++ b/src/tss2-fapi/api/Fapi_Decrypt.c
@@ -159,7 +159,7 @@ Fapi_Decrypt_Async(
     size_t         cipherTextSize)
 {
     LOG_TRACE("called for context:%p", context);
-    LOG_TRACE("cipherText: %s", cipherText);
+    LOGBLOB_TRACE(cipherText, cipherTextSize, "cipherText");
 
     TSS2_RC r;
 


### PR DESCRIPTION
The `cipherText` is a binary structure, so logging with `%s` often overflows the buffer as there is no NULL at the end, besides printing non-ASCII characters.