### PR TITLE
Test: Remove duplicate openssl req -new

### DIFF
--- a/script/ekca/create_ca.sh
+++ b/script/ekca/create_ca.sh
@@ -94,11 +94,6 @@ ${SED_CMD} "s|ROOTCRT|$ROOT_URL|g" $OPENSSL_CONF
 
 openssl req -new -out intermed-ca.req.pem -passout file:pass.txt
 
-openssl req -new \
-    -key private/intermed-ca.key.pem \
-    -out intermed-ca.req.pem \
-    -passin file:pass.txt
-
 openssl rsa -inform PEM -in private/intermed-ca.key.pem \
         -outform DER -out private/intermed-ca.key.der -passin file:pass.txt
 


### PR DESCRIPTION
The `openssl req -new` command is called twice, which is superfluous. Both the key and the certificate are created already by the first `openssl req -new` command.
