### PR TITLE
FAPI Test: Fix incorrect usage of OpenSSL EVP API

### DIFF
--- a/test/integration/fapi-data-crypt.int.c
+++ b/test/integration/fapi-data-crypt.int.c
@@ -129,8 +129,8 @@ signatureCallback(
     mdctx = EVP_MD_CTX_create();
     chknull(mdctx);
 
-    if (1 != EVP_DigestSignInit(mdctx, &pctx, NULL, NULL, priv_key)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL digest sign init.",
+    if (1 != EVP_DigestSignInit(mdctx, &pctx, ossl_hash, NULL, priv_key)) {
+        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
                    error_cleanup);
     }
     if (EVP_PKEY_type(EVP_PKEY_id(priv_key)) == EVP_PKEY_RSA) {
@@ -139,10 +139,6 @@ signatureCallback(
             goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL set RSA padding.",
                        error_cleanup);
         }
-    }
-    if (1 != EVP_DigestSignInit(mdctx, &pctx, ossl_hash, NULL, priv_key)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
-                   error_cleanup);
     }
     if (1 != EVP_DigestSignUpdate(mdctx, dataToSign, dataToSignSize)) {
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign update.",

--- a/test/integration/fapi-data-crypt.int.c
+++ b/test/integration/fapi-data-crypt.int.c
@@ -133,7 +133,7 @@ signatureCallback(
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
                    error_cleanup);
     }
-    if (EVP_PKEY_type(EVP_PKEY_id(priv_key)) == EVP_PKEY_RSA) {
+    if (EVP_PKEY_base_id(priv_key) == EVP_PKEY_RSA) {
         int signing_scheme = RSA_SIG_SCHEME;
         if (1 != EVP_PKEY_CTX_set_rsa_padding(pctx, signing_scheme)) {
             goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL set RSA padding.",

--- a/test/integration/fapi-key-create-policy-signed.int.c
+++ b/test/integration/fapi-key-create-policy-signed.int.c
@@ -143,8 +143,8 @@ signatureCallback(
     mdctx = EVP_MD_CTX_create();
     chknull(mdctx);
 
-    if (1 != EVP_DigestSignInit(mdctx, &pctx, NULL, NULL, priv_key)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL digest sign init.",
+    if (1 != EVP_DigestSignInit(mdctx, &pctx, ossl_hash, NULL, priv_key)) {
+        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
                    error_cleanup);
     }
     if (EVP_PKEY_type(EVP_PKEY_id(priv_key)) == EVP_PKEY_RSA) {
@@ -153,10 +153,6 @@ signatureCallback(
             goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL set RSA padding.",
                        error_cleanup);
         }
-    }
-    if (1 != EVP_DigestSignInit(mdctx, &pctx, ossl_hash, NULL, priv_key)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
-                   error_cleanup);
     }
     if (1 != EVP_DigestSignUpdate(mdctx, dataToSign, dataToSignSize)) {
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign update.",

--- a/test/integration/fapi-key-create-policy-signed.int.c
+++ b/test/integration/fapi-key-create-policy-signed.int.c
@@ -147,7 +147,7 @@ signatureCallback(
         goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL sign init.",
                    error_cleanup);
     }
-    if (EVP_PKEY_type(EVP_PKEY_id(priv_key)) == EVP_PKEY_RSA) {
+    if (EVP_PKEY_base_id(priv_key) == EVP_PKEY_RSA) {
         int signing_scheme = RSA_SIG_SCHEME;
         if (1 != EVP_PKEY_CTX_set_rsa_padding(pctx, signing_scheme)) {
             goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "OSSL set RSA padding.",


### PR DESCRIPTION
OpenSSL EVP API is not used correctly, which (mysteriously) works in OpenSSL 1.x, but fails with OpenSSL 3.0. This PR makes the code compatible with OpenSSL 1.0 through 3.0.

This PR combines two commits of a similar nature:
* The `EVP_DigestSignInit` should be called only once and before calling `EVP_PKEY_CTX_set_rsa_padding`. See a corresponding example [here](https://www.openssl.org/docs/man1.0.2/man3/EVP_PKEY_sign_init.html).

* The `EVP_PKEY_base_id` is the right way to detect key type, used also by OpenSSL itself. This function is available since OpenSSL 1.0.0 (as is the `EVP_DigestSignInit`) so it can be used also here.


