### PR TITLE
Require OpenSSL >= 1.1.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ following sections describe them for the supported platforms.
 * C library development libraries and header files
 * pkg-config
 * doxygen
-* OpenSSL development libraries and header files
+* OpenSSL development libraries and header files, version >= 1.1.0
 * libcurl development libraries
 * Access Control List utility (acl)
 * JSON C Development library
@@ -73,7 +73,6 @@ C Runtime (UCRT) version 10.0.16299.0. Building the type marshaling library
 (tss2-mu.dll) and the system API (tss2-sapi.dll) should be as simple as
 loading the tpm2-tss solution (tpm2-tss.sln) with a compatible and properly
 configured version of Visual Studio 2017 and pressing the 'build' button.
-Windows build setup requires OpenSSL >= v1.0.2 crypto library.
 
 ### References
 Visual Studio 2017 with "Clang for Windows": https://blogs.msdn.microsoft.com/vcblog/2017/03/07/use-any-c-compiler-with-visual-studio/

--- a/configure.ac
+++ b/configure.ac
@@ -132,9 +132,13 @@ AC_ARG_WITH([crypto],
 AM_CONDITIONAL(ESYS_OSSL, test "x$with_crypto" = "xossl")
 AM_CONDITIONAL(ESYS_MBED, test "x$with_crypto" = "xmbed")
 
+m4_define([ossl_min_version], [1.1.0])
+m4_define([ossl_err], [OpenSSL libcrypto is missing or version requirements not met. OpenSSL version must be >= ossl_min_version])
 AS_IF([test "x$enable_esys" = xyes],
       [AS_IF([test "x$with_crypto" = xossl], [
-           PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto])
+           PKG_CHECK_MODULES([LIBCRYPTO],
+                             [libcrypto >= ossl_min_version],,
+                             [AC_MSG_ERROR([ossl_err])])
            AC_DEFINE([OSSL], [1], [OpenSSL cryptographic backend])
            TSS2_ESYS_CFLAGS_CRYPTO="$LIBCRYPTO_CFLAGS"
            TSS2_ESYS_LDFLAGS_CRYPTO="$LIBCRYPTO_LIBS"


### PR DESCRIPTION
To reduce the amount of `#ifdefs` and version-specific code we drop support for OpenSSL prior 1.1.0, including all forks such as LibreSSL, which are not API compatible with OpenSSL >= 1.1.0. This simplifies code review and maintenance. Moreover, the old OpenSSL versions are not maintained anymore, so using these libraries is not recommended from security reasons anyway.