### PR TITLE
FAPI: Change SHA256_Update to EVP_DigestUpdate

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -701,7 +701,7 @@ test_unit_fapi_get_intl_cert_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_fapi_get_intl_cert_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
 test_unit_fapi_get_intl_cert_LDFLAGS = $(TESTS_LDFLAGS) $(JSONC_LIBS) $(CURL_LIBS) \
                                        -Wl,--wrap=ifapi_get_curl_buffer \
-                                       -Wl,--wrap=SHA256_Update
+                                       -Wl,--wrap=EVP_DigestUpdate
 test_unit_fapi_get_intl_cert_SOURCES = test/unit/fapi-get-intl-cert.c \
 	                                   src/tss2-fapi/ifapi_get_intl_cert.c \
                                        src/tss2-fapi/ifapi_json_deserialize.c \


### PR DESCRIPTION
This PR should work with OpenSSL 1.1.0 through 3.0.0 only, hence it depends on #2130.

Although the `EVP_DigestUpdate` functions are available in all OpenSSL versions and the `EVP_DigestFinal_ex` was added in OpenSSL 0.9.7, the `EVP_MD_CTX_new` was introduced in OpenSSL 1.1.0 (it was called `EVP_MD_CTX_create` before).
The `SHA256_Update` function was deprecated in OpenSSL 3.0.0, so it needs to be replaced.