### PR TITLE
Implement EVP_PKEY export/import for OpenSSL 3.0

### DIFF
--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -69,13 +69,13 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-Win32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-v11-Win32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-Win32\lib\libeay32.lib;C:\OpenSSL-Win32\lib\libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-v11-Win32\lib\libcrypto.lib;C:\OpenSSL-v11-Win32\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -84,7 +84,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;OSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-Win32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-v11-Win32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -92,27 +92,27 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-Win32\lib\libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-v11-Win32\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-Win64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-v11-Win64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;OSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-Win64\lib\libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-v11-Win64\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-Win64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;$(SolutionDir)\src\tss2-esys;C:\OpenSSL-v11-Win64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;OSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-Win64\lib\libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;C:\OpenSSL-v11-Win64\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/test/helper/tpm_getek.c
+++ b/test/helper/tpm_getek.c
@@ -147,20 +147,9 @@ main (int argc, char *argv[])
         exp = out_public.publicArea.parameters.rsaDetail.exponent;
     BN_set_word(e, exp);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000
-    rsa->e = e;
-    rsa->n = n;
-    rsa->d = d;
-    rsa->p = p;
-    rsa->q = q;
-    rsa->dmp1 = dmp1;
-    rsa->dmq1 = dmq1;
-    rsa->iqmp = iqmp;
-#else /* OPENSSL_VERSION_NUMBER < 0x10100000 */
     RSA_set0_key(rsa, n, e, d);
     RSA_set0_factors(rsa, p, q);
     RSA_set0_crt_params(rsa, dmp1, dmq1, iqmp);
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
 
     EVP_PKEY_assign_RSA(evp, rsa);
 

--- a/test/helper/tpm_getek_ecc.c
+++ b/test/helper/tpm_getek_ecc.c
@@ -128,14 +128,6 @@ main (int argc, char *argv[])
     /* Convert the key from out_public to PEM */
 
     EVP_PKEY *evp = EVP_PKEY_new();
-
-    OpenSSL_add_all_algorithms();
-
-    OpenSSL_add_all_algorithms();
-
-    ERR_load_crypto_strings();
-
-
     EC_KEY *ecc_key = EC_KEY_new();
     BIGNUM *x = NULL, *y = NULL;
     BIO *bio;
@@ -159,7 +151,6 @@ main (int argc, char *argv[])
     if (!EC_KEY_set_group(ecc_key, ecgroup))
         exit(1);
 
-    EC_KEY_set_asn1_flag(ecc_key, OPENSSL_EC_NAMED_CURVE);
     EC_GROUP_free(ecgroup);
 
     /* Set the ECC parameters in the OpenSSL key */

--- a/test/helper/tpm_getek_ecc.c
+++ b/test/helper/tpm_getek_ecc.c
@@ -7,9 +7,15 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <openssl/evp.h>
-#include <openssl/rsa.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+#include <openssl/ec.h>
+#else
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/param_build.h>
+#endif
 #include <string.h>
 
 #include "tss2_sys.h"
@@ -127,8 +133,7 @@ main (int argc, char *argv[])
 
     /* Convert the key from out_public to PEM */
 
-    EVP_PKEY *evp = EVP_PKEY_new();
-    EC_KEY *ecc_key = EC_KEY_new();
+    EVP_PKEY *evp = NULL;
     BIGNUM *x = NULL, *y = NULL;
     BIO *bio;
     FILE *out = NULL;
@@ -148,11 +153,6 @@ main (int argc, char *argv[])
     nid = EC_curve_nist2nid("P-256");
     EC_GROUP *ecgroup = EC_GROUP_new_by_curve_name(nid);
 
-    if (!EC_KEY_set_group(ecc_key, ecgroup))
-        exit(1);
-
-    EC_GROUP_free(ecgroup);
-
     /* Set the ECC parameters in the OpenSSL key */
     x = BN_bin2bn(out_public.publicArea.unique.ecc.x.buffer,
                   out_public.publicArea.unique.ecc.x.size, NULL);
@@ -164,15 +164,46 @@ main (int argc, char *argv[])
         exit(1);
     }
 
-    if (!EC_KEY_set_public_key_affine_coordinates(ecc_key, x, y)) {
+    EC_POINT *point = EC_POINT_new(ecgroup);
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+    EC_POINT_set_affine_coordinates_GFp(ecgroup, point, x, y, NULL);
+#else
+    EC_POINT_set_affine_coordinates(ecgroup, point, x, y, NULL);
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+    EC_KEY *ecc_key = EC_KEY_new();
+    if (!EC_KEY_set_group(ecc_key, ecgroup))
+        exit(1);
+
+    if (!EC_KEY_set_public_key(ecc_key, point)) {
         exit(1);
     }
 
+    evp = EVP_PKEY_new();
     if (!EVP_PKEY_assign_EC_KEY(evp, ecc_key)) {
         handleErrors();
         LOG_ERROR("PEM_write failed");
         exit(1);
     }
+#else /* OPENSSL_VERSION_NUMBER < 0x30000000 */
+    unsigned char *puboct = NULL;
+    size_t bsize;
+
+    bsize = EC_POINT_point2buf(ecgroup, point, POINT_CONVERSION_UNCOMPRESSED,
+                               &puboct, NULL);
+
+    OSSL_PARAM_BLD *build = OSSL_PARAM_BLD_new();
+    OSSL_PARAM_BLD_push_utf8_string(build, OSSL_PKEY_PARAM_GROUP_NAME,
+                                    (char *)OBJ_nid2sn(nid), 0);
+    OSSL_PARAM_BLD_push_octet_string(build, OSSL_PKEY_PARAM_PUB_KEY,
+                                     puboct, bsize);
+    OSSL_PARAM *params = OSSL_PARAM_BLD_to_param(build);
+
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    EVP_PKEY_fromdata_init(ctx);
+    EVP_PKEY_fromdata(ctx, &evp, EVP_PKEY_PUBLIC_KEY, params);
+#endif /* OPENSSL_VERSION_NUMBER < 0x30000000 */
 
     if (!PEM_write_bio_PUBKEY(bio, evp)) {
         handleErrors();
@@ -180,9 +211,19 @@ main (int argc, char *argv[])
         exit(1);
     }
 
+    EVP_PKEY_free(evp);
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+    /* ownership was taken by the EVP_PKEY */
+#else
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(build);
+    OPENSSL_free(puboct);
+#endif
+    EC_POINT_free(point);
+    EC_GROUP_free(ecgroup);
     BN_free(y);
     BN_free(x);
-    EVP_PKEY_free(evp);
     BIO_free(bio);
     fclose(out);
 


### PR DESCRIPTION
This is the main (and last) PR for OpenSSL 3.0 support. For easier review it is split into two commits:
1) Drop support for OpenSSL < 1.1.0, which includes removal of code intended for old OpenSSL versions as well as functions that have no effect in OpenSSL >= 1.1.0
2) Implement EVP_PKEY export/import for OpenSSL 3.0, which covers TSS to OSSL and OSSL to TSS key conversion for RSA and ECC at ESYS and FAPI layers.

For more technical explanation please see the individual commit messages.