### PR TITLE
Remove deprecated OpenSSL_add_all_algorithms

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -1156,7 +1156,7 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t * key,
  *
  * Initialize OpenSSL internal tables.
  *
- * @retval TSS2_RC_SUCCESS always returned because OpenSSL_add_all_algorithms
+ * @retval TSS2_RC_SUCCESS always returned
  * does not deliver
  * a return code.
  */

--- a/src/tss2-fapi/ifapi_get_intl_cert.c
+++ b/src/tss2-fapi/ifapi_get_intl_cert.c
@@ -386,9 +386,6 @@ out_free_json:
     json_object_put(jso);
 
 out:
-    /* In some case this call was necessary after curl usage */
-    OpenSSL_add_all_algorithms();
-
     free(hash);
     if (rc == 0) {
         return TSS2_RC_SUCCESS;


### PR DESCRIPTION
From OpenSSL 1.1.0 it is deprecated. No explicit initialisation or de-initialisation is required.
This change should have been included in 73d25d6834ad362f9a9a907cb78452deaa336ec0, but it slipped off.