### PR TITLE
FAPI: Remove faulty free of an unused field.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Encrypt.c
+++ b/src/tss2-fapi/api/Fapi_Encrypt.c
@@ -405,7 +405,6 @@ error_cleanup:
     SAFE_FREE(tpmCipherText);
     SAFE_FREE(command->keyPath);
     SAFE_FREE(command->in_data);
-    SAFE_FREE(command->out_data);
     ifapi_session_clean(context);
     LOG_TRACE("finished");
     return r;

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -386,7 +386,6 @@ typedef struct {
     uint8_t const *in_data;
     size_t in_dataSize;
     IFAPI_OBJECT *key_object;       /**< The IPAPI object for the encryption key */
-    uint8_t *out_data;               /**< The output of symmetric encrypt/decryption */
     ESYS_TR key_handle;                 /**< The ESYS handle of the encryption key */
     size_t numBytes;                /**< The number of bytes of a ESYS request */
     size_t decrypt;                 /**< Switch whether to encrypt or decrypt */


### PR DESCRIPTION
The field out_data in IFAPI_Data_EncryptDecrypt was not used but freed in Fapi_Encrypt.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>