### PR TITLE
FAPI: Simplify key size retrieval

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1049,9 +1049,7 @@ get_ecc_tpm2b_public_from_evp(
                     "Get public key", cleanup);
      }
     curveId = OBJ_txt2nid(curveName);
-    EC_GROUP *ecGroup = EC_GROUP_new_by_curve_name(curveId);
-    ecKeySize = (EC_GROUP_get_degree(ecGroup) + 7) / 8;
-    EC_GROUP_free(ecGroup);
+    ecKeySize = (EVP_PKEY_bits(publicKey) + 7) / 8;
 #endif
     tpmPublic->publicArea.unique.ecc.x.size = ecKeySize;
     tpmPublic->publicArea.unique.ecc.y.size = ecKeySize;


### PR DESCRIPTION
The EVP_PKEY_bits can be used to get the key size instead, which simplifies the code. The function is available even in OpenSSL 1.0.2.
