### PR TITLE
Add libltdl-dev to Ubuntu dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,8 @@ $ sudo apt -y install \
   doxygen \
   libjson-c-dev \
   libini-config-dev \
-  libcurl4-openssl-dev
+  libcurl4-openssl-dev \
+  libltdl-dev 
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 


### PR DESCRIPTION
Otherwise ./bootstrap will throw the following error: 

configure.ac:33: error: possibly undefined macro: LT_LIB_DLLOAD
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1