### PR TITLE
configure: change LIBCRYPTO to CRYPTO

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -3,11 +3,11 @@
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.
 
-TESTS_CFLAGS = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/include -I$(srcdir)/src/tss2-mu \
+TESTS_CFLAGS = $(AM_CFLAGS) $(CRYPTO_CFLAGS) -I$(srcdir)/src/tss2-mu \
     -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys  -I$(srcdir)/src/tss2-fapi \
     -Wno-unused-parameter -Wno-missing-field-initializers
 TESTS_LDADD = $(check_LTLIBRARIES) $(lib_LTLIBRARIES) \
-    $(LIBCRYPTO_LIBS) $(libutil)
+    $(CRYPTO_LIBS) $(libutil)
 
 check_LTLIBRARIES =
 # test harness configuration

--- a/Makefile.am
+++ b/Makefile.am
@@ -572,8 +572,8 @@ src_tss2_fapi_libtss2_fapi_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) $(libtss2_e
     $(libutil) $(libtss2_tctildr)
 
 src_tss2_fapi_libtss2_fapi_la_SOURCES = $(TSS2_FAPI_SRC)
-src_tss2_fapi_libtss2_fapi_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-fapi $(LIBCRYPTO_CFLAGS) $(JSONC_CFLAGS) $(CURL_CFLAGS)
-src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LIBS) $(JSONC_LIBS) $(CURL_LIBS)
+src_tss2_fapi_libtss2_fapi_la_CFLAGS  = $(AM_CFLAGS) -I$(srcdir)/src/tss2-fapi $(CRYPTO_CFLAGS) $(JSONC_CFLAGS) $(CURL_CFLAGS)
+src_tss2_fapi_libtss2_fapi_la_LDFLAGS = $(AM_LDFLAGS) $(CRYPTO_LIBS) $(JSONC_LIBS) $(CURL_LIBS)
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_fapi_libtss2_fapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/lib/tss2-fapi.map
 endif # HAVE_LD_VERSION_SCRIPT

--- a/configure.ac
+++ b/configure.ac
@@ -136,12 +136,12 @@ m4_define([ossl_min_version], [1.1.0])
 m4_define([ossl_err], [OpenSSL libcrypto is missing or version requirements not met. OpenSSL version must be >= ossl_min_version])
 AS_IF([test "x$enable_esys" = xyes],
       [AS_IF([test "x$with_crypto" = xossl], [
-           PKG_CHECK_MODULES([LIBCRYPTO],
+           PKG_CHECK_MODULES([CRYPTO],
                              [libcrypto >= ossl_min_version],,
                              [AC_MSG_ERROR([ossl_err])])
            AC_DEFINE([OSSL], [1], [OpenSSL cryptographic backend])
-           TSS2_ESYS_CFLAGS_CRYPTO="$LIBCRYPTO_CFLAGS"
-           TSS2_ESYS_LDFLAGS_CRYPTO="$LIBCRYPTO_LIBS"
+           TSS2_ESYS_CFLAGS_CRYPTO="$CRYPTO_CFLAGS"
+           TSS2_ESYS_LDFLAGS_CRYPTO="$CRYPTO_LIBS"
        ], [test "x$with_crypto" = xmbed], [
            AC_CHECK_HEADER(mbedtls/md.h, [], [AC_MSG_ERROR([Missing required mbedTLS library])])
            AC_DEFINE([MBED], [1], [mbedTLS cryptographic backend])
@@ -317,7 +317,7 @@ AS_IF([test "x$enable_integration" = "xyes"],
        ERROR_IF_NO_PROG([env])
        ERROR_IF_NO_PROG([rm])
        AS_IF([test "x$with_crypto" != xossl -o "x$enable_esys" != xyes],
-           [PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto])])
+           [PKG_CHECK_MODULES([CRYPTO],[libcrypto])])
        AC_CHECK_HEADER(uthash.h, [], [AC_MSG_ERROR([Can not find uthash.h. Please install uthash-dev])])
 
        # choose tcti for testing and look for TPM simulator binary


### PR DESCRIPTION
All of the tpm2-software projects that need libcrypto, the configure.ac check
using PKG_CHECK_MODULES uses "CRYPTO" except the tss project which uses
LIBCRYPTO. This means that when exporting variables for building against a
custom libcrypto, the variables will be LIBCRYPTO_CFLAGS and LIBCRYPTO_LIBS,
where as all the other projects are just CRYPTO_CFLAGS and CRYPTO_LIBS. Unify
this by changing it to CRYPTO.

Signed-off-by: William Roberts <william.c.roberts@intel.com>