### PR TITLE
Makefile-test.am: re-add accidentally removed directory to TEST_CFLAGS

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Fraunhofer SIT sponsored by Infineon Technologies AG
 # All rights reserved.
 
-TESTS_CFLAGS = $(AM_CFLAGS) $(CRYPTO_CFLAGS) -I$(srcdir)/src/tss2-mu \
+TESTS_CFLAGS = $(AM_CFLAGS) $(CRYPTO_CFLAGS) -I$(srcdir)/include -I$(srcdir)/src/tss2-mu \
     -I$(srcdir)/src/tss2-sys -I$(srcdir)/src/tss2-esys  -I$(srcdir)/src/tss2-fapi \
     -Wno-unused-parameter -Wno-missing-field-initializers
 TESTS_LDADD = $(check_LTLIBRARIES) $(lib_LTLIBRARIES) \


### PR DESCRIPTION
#2156 accidentally removed the include directory from `TEST_CFLAGS` (due to a conflict when rebasing), leading to a [build failure](https://github.com/tpm2-software/tpm2-tss/runs/3730707245#step:3:1526):
```
../tss2-dlopen/tss2-dlopen-rc.c:21:10: fatal error: tss2/tss2_rc.h: No such file or directory
 #include <tss2/tss2_rc.h>
           ^~~~~~~~~~~~~~~~
           compilation terminated.
```