### PR TITLE
test: add wrapper fix for musl on 32 bit systems

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -447,7 +447,8 @@ if ENABLE_TCTI_PCAP
 test_unit_tcti_pcap_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_pcap_LDADD   = $(CMOCKA_LIBS) $(libtss2_mu) $(libutil)
 test_unit_tcti_pcap_LDFLAGS = -Wl,--wrap=getenv -Wl,--wrap=rand -Wl,--wrap=clock_gettime \
-        -Wl,--wrap=open -Wl,--wrap=read -Wl,--wrap=write -Wl,--wrap=close
+        -Wl,--wrap=open -Wl,--wrap=read -Wl,--wrap=write -Wl,--wrap=close \
+        -Wl,--wrap=__clock_gettime64
 test_unit_tcti_pcap_SOURCES = test/unit/tcti-pcap.c \
     src/tss2-tcti/tcti-common.c \
     src/tss2-tcti/tcti-pcap.c src/tss2-tcti/tcti-pcap.h \
@@ -474,7 +475,7 @@ test_unit_tctildr_dl_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) \
         -UESYS_TCTI_DEFAULT_MODULE -UESYS_TCTI_DEFAUT_CONFIG
 test_unit_tctildr_dl_LDADD = $(CMOCKA_LIBS) $(TESTS_LDADD) $(LIBADD_DL)
 test_unit_tctildr_dl_LDFLAGS = -Wl,--wrap=dlopen,--wrap=dlclose,--wrap=dlsym \
-    -Wl,--wrap=tcti_from_init,--wrap=tcti_from_info
+    -Wl,--wrap=tcti_from_init,--wrap=tcti_from_info,--wrap=__dlsym_time64
 test_unit_tctildr_dl_SOURCES = test/unit/tctildr-dl.c \
         src/tss2-tcti/tctildr-dl.c
 

--- a/test/unit/tcti-pcap.c
+++ b/test/unit/tcti-pcap.c
@@ -288,6 +288,11 @@ __wrap_clock_gettime (clockid_t clk_id, struct timespec *tp)
     return EXIT_FAILURE;
 }
 
+int
+__wrap___clock_gettime64 (clockid_t clk_id, struct timespec *tp)
+{
+    return __wrap_clock_gettime(clk_id, tp);
+}
 
 int
 __real_open (const char *pathname, int flags, mode_t mode);

--- a/test/unit/tctildr-dl.c
+++ b/test/unit/tctildr-dl.c
@@ -55,6 +55,12 @@ __wrap_dlsym(void *handle, const char *symbol)
     return mock_type(void *);
 }
 
+void *
+__wrap___dlsym_time64(void *handle, const char *symbol)
+{
+    return __wrap_dlsym(handle, symbol);
+}
+
 TSS2_TCTI_INFO *
 __wrap_Tss2_Tcti_Fake_Info(void)
 {


### PR DESCRIPTION
For some reason wrapping clock_gettime doesn't work with musl on 32 bit systems, but wrapping __clock_gettime64 does.
Tested (via alpine linux aports CI) on x86, x86_64, armv7, armhf, aarch64 and ppc64le.
Also tested on my laptop running debian unstable x86_64, but I haven't been able to test it on 32 bit systems using glibc.

Edit: added the same type of fix for dlsym, with the same level of testing, which fixes https://github.com/tpm2-software/tpm2-tss/issues/1808