### PR TITLE
man: add vtpm example in tss2-tcti-swtpm

### DIFF
--- a/man/tss2-tcti-swtpm.7.in
+++ b/man/tss2-tcti-swtpm.7.in
@@ -13,3 +13,10 @@ with the interface and protocol exposed by the daemon hosting the TPM2
 reference implementation. The interface exposed by this library is defined
 in the \*(lqTSS System Level API and TPM Command Transmission Interface
 Specification\*(rq specification.
+.SH NOTES
+It is best not to use the CUSE interface when setting up swtpm, but rather
+to use the vtpm module proxy:
+.EX
+modprobe tpm_vtpm_proxy
+swtpm chardev --vtpm-proxy --tpmstate dir=... --tpm2 ...
+.EE


### PR DESCRIPTION
Per the discussion in bug #918, add the virtual tpm driver example and
discourage use of the CUSE interface.

Fixes: https://github.com/tpm2-software/tpm2-tss/issues/1918

Signed-off-by: William Roberts <william.c.roberts@intel.com>