### PR TITLE
tcti: support swtpm and mssim running over unix domain sockets

### DIFF
--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -29,6 +29,8 @@
 typedef struct {
     char *host;
     uint16_t port;
+    /* if path is NULL, we use host/port */
+    char *path;
 } mssim_conf_t;
 
 typedef struct {

--- a/src/tss2-tcti/tcti-swtpm.h
+++ b/src/tss2-tcti/tcti-swtpm.h
@@ -36,6 +36,8 @@
 typedef struct {
     char *host;
     uint16_t port;
+    /* if path is NULL, we use host/port */
+    char *path;
 } swtpm_conf_t;
 
 typedef struct {

--- a/src/util/io.c
+++ b/src/util/io.c
@@ -28,6 +28,12 @@
 #include "util/log.h"
 
 #define MAX_PORT_STR_LEN    sizeof("65535")
+
+/* sockaddr_un::sun_path is documented as char[108], but it seems safer to let
+ * the compiler (or rather, the headers) derive this for us. (Cast to int to
+ * avoid signed/unsigned comparison warnings.) */
+#define MAX_SADDR_UN_PATH  (int)sizeof(((struct sockaddr_un *)0)->sun_path)
+
 /*
  * The 'read_all' function attempts to read all of the 'size' bytes requested
  * from the 'fd' provided into the buffer 'data'. This function will continue
@@ -181,6 +187,7 @@ TSS2_RC
 socket_connect (
     const char *hostname,
     uint16_t port,
+    int control,
     SOCKET *sock)
 {
     static const struct addrinfo hints = { .ai_socktype = SOCK_STREAM,
@@ -207,6 +214,9 @@ socket_connect (
     if (hostname == NULL || sock == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
+
+    if (control)
+        port++;
 
     ret = snprintf(port_str, sizeof(port_str), "%u", port);
     if (ret < 0)
@@ -257,6 +267,46 @@ socket_connect (
     }
 
     return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+socket_connect_unix (
+    const char *path,
+    int control,
+    SOCKET *sock)
+{
+#ifdef _WIN32
+    return TSS2_TCTI_RC_BAD_REFERENCE;
+#else
+    struct sockaddr_un saddr;
+
+    if (path == NULL)
+        return TSS2_TCTI_RC_BAD_REFERENCE;
+
+    saddr.sun_family = AF_UNIX;
+
+    if (snprintf(saddr.sun_path, MAX_SADDR_UN_PATH,
+                 control ? "%s.ctrl" : "%s", path) >= MAX_SADDR_UN_PATH) {
+        LOG_ERROR ("Socket %s%s is too long for AF_UNIX",
+	           path, control ? ".ctrl" : "");
+	return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    *sock = socket (AF_UNIX, SOCK_STREAM, 0);
+
+    if (*sock == INVALID_SOCKET) {
+        LOG_WARNING ("Failed to create AF_UNIX socket");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    LOG_DEBUG ("Attempting UNIX connection to %s", saddr.sun_path);
+    if (connect (*sock, (struct sockaddr *)&saddr, sizeof(saddr)) == SOCKET_ERROR) {
+        LOG_WARNING ("Failed to connect to %s", saddr.sun_path);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return TSS2_RC_SUCCESS;
+#endif
 }
 
 TSS2_RC

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -75,10 +75,26 @@ write_all (
     SOCKET fd,
     const uint8_t *buf,
     size_t size);
+/*
+ * Connect to the given target using TCP. 'control' is to distinguish the data
+ * socket from the control socket. For TCP, the data socket and control socket
+ * are assumed to be on the same host and consecutive port numbers, so 'port'
+ * is incremented by 1 if 'control' is non-zero.
+ */
 TSS2_RC
 socket_connect (
     const char *hostname,
     uint16_t port,
+    int control,
+    SOCKET *socket);
+/*
+ * Connect to the given target using unix domain sockets. (Not available on
+ * "_WIN32".) If 'control' is non-zero, ".ctrl" is appended to 'path'.
+ */
+TSS2_RC
+socket_connect_unix (
+    const char *path,
+    int control,
     SOCKET *socket);
 TSS2_RC
 socket_close (

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -123,7 +123,7 @@ socket_connect_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, 0);
     will_return (__wrap_connect, 1);
-    rc = socket_connect ("127.0.0.1", 666, &sock);
+    rc = socket_connect ("127.0.0.1", 666, 0, &sock);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 static void
@@ -134,7 +134,7 @@ socket_connect_socket_fail_test (void **state)
 
     will_return (__wrap_socket, EINVAL);
     will_return (__wrap_socket, -1);
-    rc = socket_connect ("127.0.0.1", 555, &sock);
+    rc = socket_connect ("127.0.0.1", 555, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 static void
@@ -147,7 +147,7 @@ socket_connect_connect_fail_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, ENOTSOCK);
     will_return (__wrap_connect, -1);
-    rc = socket_connect ("127.0.0.1", 444, &sock);
+    rc = socket_connect ("127.0.0.1", 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 
@@ -162,7 +162,7 @@ socket_ipv6_connect_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, 0);
     will_return (__wrap_connect, 1);
-    rc = socket_connect ("::1", 666, &sock);
+    rc = socket_connect ("::1", 666, 0, &sock);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 static void
@@ -173,7 +173,7 @@ socket_ipv6_connect_socket_fail_test (void **state)
 
     will_return (__wrap_socket, EINVAL);
     will_return (__wrap_socket, -1);
-    rc = socket_connect ("::1", 555, &sock);
+    rc = socket_connect ("::1", 555, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 static void
@@ -186,7 +186,7 @@ socket_ipv6_connect_connect_fail_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, ENOTSOCK);
     will_return (__wrap_connect, -1);
-    rc = socket_connect ("::1", 444, &sock);
+    rc = socket_connect ("::1", 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 
@@ -196,7 +196,7 @@ socket_connect_null_test (void **state)
     TSS2_RC rc;
     SOCKET sock;
 
-    rc = socket_connect (NULL, 444, &sock);
+    rc = socket_connect (NULL, 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 


### PR DESCRIPTION
On non-windows systems, passing port=0 to socket_connect() now causes it
to treat the 'hostname' parameter as a filesystem path to a unix domain
socket. For systems that want to support domain sockets using host/port
parameters in TCTI strings can in principle do this, if they don't prevent
the 'host' string from being a path nor prevent 'port' from being zero.
More naturally, swtpm/mssim TCTI strings can specify a 'path' attribute
directly, avoiding 'host' and 'port' altogether.

The convention for data/control pairs of sockets (with TCP) is to use the
same hostname and two consecutive port numbers. This change introduces a
'control' parameter to the socket_connect() API, updates existing callers
to use it, such that the control cases now pass a non-zero 'control'
instead of incrementing the port number caller-side. The increment of the
port number is now done within the API, so that the unix domain socket
case can implement it differently; by appending ".ctrl" to the socket path.

Signed-off-by: Geoff Thorpe <geoffrey@twosigma.com>