### PR TITLE
fix the double free problem in CHECK_JSON_LIST

### DIFF
--- a/test/integration/test-fapi.h
+++ b/test/integration/test-fapi.h
@@ -113,7 +113,6 @@
         } \
         if (i >=  n) { \
             json_object_put(jso1); \
-            json_object_put(jso2); \
             LOG_ERROR("Mismatch" ); \
             goto LABEL; \
         } \


### PR DESCRIPTION
When JSO_STRING is found in LIST, it enters the branch i >= n. But json2 has been freed in for loop, it invokes double free. So when i >=n, I think json_object_put(jso2) should be deleted.