### PR TITLE
tcti: Fix file descriptor leak when tcti initialization failed(3.1.x)

### DIFF
--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -309,6 +309,16 @@ out:
     return rc;
 }
 
+static void close_tpm(int *fd)
+{
+    if (fd == NULL || *fd < 0) {
+        return;
+    }
+
+    close(*fd);
+    *fd = -1;
+}
+
 void
 tcti_device_finalize (
     TSS2_TCTI_CONTEXT *tctiContext)
@@ -319,7 +329,7 @@ tcti_device_finalize (
     if (tcti_dev == NULL) {
         return;
     }
-    close (tcti_dev->fd);
+    close_tpm (&tcti_dev->fd);
     tcti_common->state = TCTI_STATE_FINAL;
 }
 
@@ -457,6 +467,7 @@ Tss2_Tcti_Device_Init (
     ssize_t sz = write_all (tcti_dev->fd, cmd, sizeof(cmd));
     if (sz < 0 || sz != sizeof(cmd)) {
         LOG_ERROR ("Could not probe device for partial response read support");
+        close_tpm (&tcti_dev->fd);
         return TSS2_TCTI_RC_IO_ERROR;
     }
     LOG_DEBUG ("Command sent, reading header");
@@ -467,12 +478,14 @@ Tss2_Tcti_Device_Init (
     if (rc_poll < 0 || rc_poll == 0) {
         LOG_ERROR ("Failed to poll for response from fd %d, rc %d, errno %d: %s",
                    tcti_dev->fd, rc_poll, errno, strerror(errno));
+        close_tpm (&tcti_dev->fd);
         return TSS2_TCTI_RC_IO_ERROR;
     } else if (fds.revents == POLLIN) {
         TEMP_RETRY (sz, read (tcti_dev->fd, rsp, TPM_HEADER_SIZE));
         if (sz < 0 || sz != TPM_HEADER_SIZE) {
             LOG_ERROR ("Failed to read response header fd %d, got errno %d: %s",
                        tcti_dev->fd, errno, strerror (errno));
+            close_tpm (&tcti_dev->fd);
             return TSS2_TCTI_RC_IO_ERROR;
         }
     }
@@ -484,6 +497,7 @@ Tss2_Tcti_Device_Init (
     if (rc_poll < 0) {
         LOG_DEBUG ("Failed to poll for response from fd %d, rc %d, errno %d: %s",
                    tcti_dev->fd, rc_poll, errno, strerror(errno));
+        close_tpm (&tcti_dev->fd);
         return TSS2_TCTI_RC_IO_ERROR;
 	} else if (rc_poll == 0) {
         LOG_ERROR ("timeout waiting for response from fd %d", tcti_dev->fd);
@@ -497,7 +511,7 @@ Tss2_Tcti_Device_Init (
         LOG_DEBUG ("Failed to get response tail fd %d, got errno %d: %s",
                    tcti_dev->fd, errno, strerror (errno));
         tcti_common->partial_read_supported = 0;
-        close(tcti_dev->fd);
+        close_tpm (&tcti_dev->fd);
         tcti_dev->fd = open_tpm (used_conf);
         if (tcti_dev->fd < 0) {
             LOG_ERROR ("Failed to open specified TCTI device file %s: %s",


### PR DESCRIPTION
Signed-off-by: JerryDevis <JerryDevis@users.noreply.github.com>