### PR TITLE
FAPI: Header file circular dependency

### DIFF
--- a/src/tss2-fapi/ifapi_policy.h
+++ b/src/tss2-fapi/ifapi_policy.h
@@ -16,7 +16,6 @@
 #include "tss2_esys.h"
 #include "tss2_fapi.h"
 #include "fapi_int.h"
-#include "fapi_policy.h"
 
 TSS2_RC
 get_policy_digest_idx(


### PR DESCRIPTION
ifapi_policy.h and fapi_policy.h cyclically are cyclically dependent on each other.