### PR TITLE
tcti: support swtpm and mssim running over unix domain sockets

### DIFF
--- a/src/tss2-tcti/tcti-mssim.h
+++ b/src/tss2-tcti/tcti-mssim.h
@@ -19,9 +19,11 @@
 #define TCTI_MSSIM_CONF_MAX (_HOST_NAME_MAX + 16)
 #define TCTI_MSSIM_DEFAULT_HOST "localhost"
 #define TCTI_MSSIM_DEFAULT_PORT 2321
+#define TCTI_MSSIM_DEFAULT_PATH NULL
 #define MSSIM_CONF_DEFAULT_INIT { \
     .host = TCTI_MSSIM_DEFAULT_HOST, \
     .port = TCTI_MSSIM_DEFAULT_PORT, \
+    .path = TCTI_MSSIM_DEFAULT_PATH, \
 }
 
 #define TCTI_MSSIM_MAGIC 0xf05b04cd9f02728dULL
@@ -29,6 +31,8 @@
 typedef struct {
     char *host;
     uint16_t port;
+    /* if path is NULL, we use host/port */
+    char *path;
 } mssim_conf_t;
 
 typedef struct {

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -135,9 +135,15 @@ TSS2_RC tcti_control_command (
     uint8_t resp_buf[SWTPM_CTRL_RESP_MAX_LEN] = { 0 };
     size_t resp_buf_len = sizeof(uint32_t);
 
-    rc = socket_connect (tcti_swtpm->swtpm_conf.host,
-                         tcti_swtpm->swtpm_conf.port + 1,
-                         &tcti_swtpm->ctrl_sock);
+    if (tcti_swtpm->swtpm_conf.path)
+        rc = socket_connect_unix (tcti_swtpm->swtpm_conf.path,
+                                  1,
+                                  &tcti_swtpm->ctrl_sock);
+    else
+        rc = socket_connect (tcti_swtpm->swtpm_conf.host,
+                             tcti_swtpm->swtpm_conf.port,
+                             1,
+                             &tcti_swtpm->ctrl_sock);
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR ("Failed to connect to control socket.");
         rc = TSS2_TCTI_RC_IO_ERROR;
@@ -274,9 +280,15 @@ tcti_swtpm_transmit (
     LOG_DEBUG ("Sending command with TPM_CC 0x%" PRIx32 " and size %" PRIu32,
                header.code, header.size);
 
-    rc = socket_connect (tcti_swtpm->swtpm_conf.host,
-                         tcti_swtpm->swtpm_conf.port,
-                         &tcti_swtpm->tpm_sock);
+    if (tcti_swtpm->swtpm_conf.path)
+        rc = socket_connect_unix (tcti_swtpm->swtpm_conf.path,
+                                  0,
+                                  &tcti_swtpm->tpm_sock);
+    else
+        rc = socket_connect (tcti_swtpm->swtpm_conf.host,
+                             tcti_swtpm->swtpm_conf.port,
+                             0,
+                             &tcti_swtpm->tpm_sock);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -496,12 +508,17 @@ swtpm_kv_callback (const key_value_t *key_value,
     LOG_DEBUG ("key: %s / value: %s\n", key_value->key, key_value->value);
     if (strcmp (key_value->key, "host") == 0) {
         swtpm_conf->host = key_value->value;
+        swtpm_conf->path = NULL;
         return TSS2_RC_SUCCESS;
     } else if (strcmp (key_value->key, "port") == 0) {
         swtpm_conf->port = string_to_port (key_value->value);
         if (swtpm_conf->port == 0) {
             return TSS2_TCTI_RC_BAD_VALUE;
         }
+        return TSS2_RC_SUCCESS;
+    } else if (strcmp (key_value->key, "path") == 0) {
+        swtpm_conf->path = key_value->value;
+        swtpm_conf->host = NULL;
         return TSS2_RC_SUCCESS;
     } else {
         return TSS2_TCTI_RC_BAD_VALUE;
@@ -583,9 +600,15 @@ Tss2_Tcti_Swtpm_Init (
     tcti_swtpm->ctrl_sock = -1;
 
     /* sanity check */
-    rc = socket_connect (tcti_swtpm->swtpm_conf.host,
-                         tcti_swtpm->swtpm_conf.port,
-                         &tcti_swtpm->tpm_sock);
+    if (tcti_swtpm->swtpm_conf.path)
+        rc = socket_connect_unix (tcti_swtpm->swtpm_conf.path,
+                                  0,
+                                  &tcti_swtpm->tpm_sock);
+    else
+        rc = socket_connect (tcti_swtpm->swtpm_conf.host,
+                             tcti_swtpm->swtpm_conf.port,
+                             0,
+                             &tcti_swtpm->tpm_sock);
     socket_close (&tcti_swtpm->tpm_sock);
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERROR ("Cannot connect to swtpm TPM socket");

--- a/src/tss2-tcti/tcti-swtpm.h
+++ b/src/tss2-tcti/tcti-swtpm.h
@@ -19,9 +19,11 @@
 #define TCTI_SWTPM_CONF_MAX (_HOST_NAME_MAX + 16)
 #define TCTI_SWTPM_DEFAULT_HOST "localhost"
 #define TCTI_SWTPM_DEFAULT_PORT 2321
+#define TCTI_SWTPM_DEFAULT_PATH NULL
 #define SWTPM_CONF_DEFAULT_INIT { \
     .host = TCTI_SWTPM_DEFAULT_HOST, \
     .port = TCTI_SWTPM_DEFAULT_PORT, \
+    .path = TCTI_SWTPM_DEFAULT_PATH, \
 }
 
 #define TCTI_SWTPM_MAGIC 0x496E66696E656F6EULL
@@ -36,6 +38,8 @@
 typedef struct {
     char *host;
     uint16_t port;
+    /* if path is NULL, we use host/port */
+    char *path;
 } swtpm_conf_t;
 
 typedef struct {

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -75,10 +75,26 @@ write_all (
     SOCKET fd,
     const uint8_t *buf,
     size_t size);
+/*
+ * Connect to the given target using TCP. 'control' is to distinguish the data
+ * socket from the control socket. For TCP, the data socket and control socket
+ * are assumed to be on the same host and consecutive port numbers, so 'port'
+ * is incremented by 1 if 'control' is non-zero.
+ */
 TSS2_RC
 socket_connect (
     const char *hostname,
     uint16_t port,
+    int control,
+    SOCKET *socket);
+/*
+ * Connect to the given target using unix domain sockets. (Not available on
+ * "_WIN32".) If 'control' is non-zero, ".ctrl" is appended to 'path'.
+ */
+TSS2_RC
+socket_connect_unix (
+    const char *path,
+    int control,
     SOCKET *socket);
 TSS2_RC
 socket_close (

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -123,7 +123,7 @@ socket_connect_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, 0);
     will_return (__wrap_connect, 1);
-    rc = socket_connect ("127.0.0.1", 666, &sock);
+    rc = socket_connect ("127.0.0.1", 666, 0, &sock);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 static void
@@ -134,7 +134,7 @@ socket_connect_socket_fail_test (void **state)
 
     will_return (__wrap_socket, EINVAL);
     will_return (__wrap_socket, -1);
-    rc = socket_connect ("127.0.0.1", 555, &sock);
+    rc = socket_connect ("127.0.0.1", 555, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 static void
@@ -147,7 +147,7 @@ socket_connect_connect_fail_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, ENOTSOCK);
     will_return (__wrap_connect, -1);
-    rc = socket_connect ("127.0.0.1", 444, &sock);
+    rc = socket_connect ("127.0.0.1", 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 
@@ -162,7 +162,7 @@ socket_ipv6_connect_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, 0);
     will_return (__wrap_connect, 1);
-    rc = socket_connect ("::1", 666, &sock);
+    rc = socket_connect ("::1", 666, 0, &sock);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 static void
@@ -173,7 +173,7 @@ socket_ipv6_connect_socket_fail_test (void **state)
 
     will_return (__wrap_socket, EINVAL);
     will_return (__wrap_socket, -1);
-    rc = socket_connect ("::1", 555, &sock);
+    rc = socket_connect ("::1", 555, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 static void
@@ -186,7 +186,7 @@ socket_ipv6_connect_connect_fail_test (void **state)
     will_return (__wrap_socket, 1);
     will_return (__wrap_connect, ENOTSOCK);
     will_return (__wrap_connect, -1);
-    rc = socket_connect ("::1", 444, &sock);
+    rc = socket_connect ("::1", 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_IO_ERROR);
 }
 
@@ -196,7 +196,7 @@ socket_connect_null_test (void **state)
     TSS2_RC rc;
     SOCKET sock;
 
-    rc = socket_connect (NULL, 444, &sock);
+    rc = socket_connect (NULL, 444, 0, &sock);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 

--- a/test/unit/tcti-swtpm.c
+++ b/test/unit/tcti-swtpm.c
@@ -32,84 +32,108 @@
 TSS2_RC
 swtpm_kv_callback (const key_value_t *key_value,
                    void *user_data);
+
 /*
- * This tests our ability to handle conf strings that have a port
- * component. In this case the 'conf_str_to_host_port' function
- * should set the 'port' parameter and so we check to be sure it's
- * set.
+ * In the tests below where 'host' is set (implying TCP and excluding unix domain
+ * sockets), we ensure that 'path' comes back NULL. Similarly, when 'path' is
+ * set (implying unix domain sockets), we ensure that 'host' is NULL.
+ */
+#define NO_HOST_VALUE "no.host.xyz"
+#define NO_PORT_VALUE 646
+#define NO_PATH_VALUE "/bad/path"
+
+/*
+ * This tests our ability to handle conf strings that have a port component. In
+ * this case the 'conf_str_to_host_port' function should set the 'host' and
+ * 'port' parameters and so we check to be sure they're set. (And that 'path'
+ * is unset.)
  */
 static void
 conf_str_to_host_port_success_test (void **state)
 {
     TSS2_RC rc;
     char conf[] = "host=127.0.0.1,port=2321";
-    swtpm_conf_t swtpm_conf = { 0 };
+    char unusedpath[] = NO_PATH_VALUE;
+    swtpm_conf_t swtpm_conf = {
+        .path = unusedpath
+    };
 
     rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (swtpm_conf.port, 2321);
     assert_string_equal (swtpm_conf.host, "127.0.0.1");
+    assert_null (swtpm_conf.path);
 }
 
 /*
  * This tests our ability to handle conf strings that don't have the port
  * component of the URI. In this case the 'conf_str_to_host_port' function
  * should not touch the 'port' parameter and so we check to be sure it's
- * unchanged.
+ * unchanged. (And that 'path' is unset.)
  */
-#define NO_PORT_VALUE 646
 static void
 conf_str_to_host_port_no_port_test (void **state)
 {
     TSS2_RC rc;
     char conf[] = "host=127.0.0.1";
+    char unusedpath[] = NO_PATH_VALUE;
     swtpm_conf_t swtpm_conf = {
         .host = "foo",
         .port = NO_PORT_VALUE,
+        .path = unusedpath
     };
 
     rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_string_equal (swtpm_conf.host, "127.0.0.1");
     assert_int_equal (swtpm_conf.port, NO_PORT_VALUE);
+    assert_null (swtpm_conf.path);
 }
 
 /*
  * This tests our ability to handle conf strings that have an IPv6 address
  * and port component. In this case the 'conf_str_to_host_port' function
  * should set the 'hostname' parameter and so we check to be sure it's
- * set without the [] brackets.
+ * set without the [] brackets. (And that 'path' is unset.)
  */
 static void
 conf_str_to_host_ipv6_port_success_test (void **state)
 {
     TSS2_RC rc;
     char conf[] = "host=::1,port=2321";
-    swtpm_conf_t swtpm_conf = { 0 };
+    char unusedpath[] = NO_PATH_VALUE;
+    swtpm_conf_t swtpm_conf = {
+        .path = unusedpath
+    };
 
     rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (swtpm_conf.port, 2321);
     assert_string_equal (swtpm_conf.host, "::1");
+    assert_null (swtpm_conf.path);
 }
 
 /*
  * This tests our ability to handle conf strings that have an IPv6 address
  * but no port component. In this case the 'conf_str_to_host_port' function
  * should not touch the 'port' parameter and so we check to be sure it's
- * unchanged.
+ * unchanged. (And that 'path' is unset.)
  */
 static void
 conf_str_to_host_ipv6_port_no_port_test (void **state)
 {
     TSS2_RC rc;
     char conf[] = "host=::1";
-    swtpm_conf_t swtpm_conf = { .port = NO_PORT_VALUE };
+    swtpm_conf_t swtpm_conf = {
+        .port = NO_PORT_VALUE,
+        .path = NO_PATH_VALUE
+    };
 
     rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (swtpm_conf.port, NO_PORT_VALUE);
     assert_string_equal (swtpm_conf.host, "::1");
+    assert_null (swtpm_conf.path);
 }
 
 /*
@@ -135,6 +159,28 @@ conf_str_to_host_port_invalid_port_0_test (void **state)
 
     rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
+}
+
+/*
+ * This tests our ability to handle conf strings that have a path
+ * component. In this case the 'conf_str_to_host_port' function
+ * should set the 'path' parameter and so we check to be sure it's
+ * set. (And that 'host' is unset.)
+ */
+static void
+conf_str_to_path_success_test (void **state)
+{
+    TSS2_RC rc;
+    char conf[] = "path=/some/path";
+    char unusedhost[] = NO_HOST_VALUE;
+    swtpm_conf_t swtpm_conf = {
+        .host = unusedhost
+    };
+
+    rc = parse_key_value_string (conf, swtpm_kv_callback, &swtpm_conf);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_string_equal (swtpm_conf.path, "/some/path");
+    assert_null (swtpm_conf.host);
 }
 
 /* When passed all NULL values ensure that we get back the expected RC. */
@@ -249,6 +295,17 @@ tcti_swtpm_setup (void **state)
     printf ("%s: done\n", __func__);
     return 0;
 }
+#ifndef _WIN32
+/* variant of tcti_swtpm_setup() for unix domain sockets. */
+static int
+tcti_swtpm_setup_unix (void **state)
+{
+    printf ("%s: before tcti_swtpm_init_from_conf\n", __func__);
+    *state = tcti_swtpm_init_from_conf ("path=/notarealdirectory/notarealfile");
+    printf ("%s: done\n", __func__);
+    return 0;
+}
+#endif
 static void
 tcti_swtpm_init_null_conf_test (void **state)
 {
@@ -717,6 +774,7 @@ main (int   argc,
         cmocka_unit_test (conf_str_to_host_ipv6_port_no_port_test),
         cmocka_unit_test (conf_str_to_host_port_invalid_port_large_test),
         cmocka_unit_test (conf_str_to_host_port_invalid_port_0_test),
+        cmocka_unit_test (conf_str_to_path_success_test),
         cmocka_unit_test (tcti_swtpm_init_all_null_test),
         cmocka_unit_test (tcti_swtpm_init_size_test),
         cmocka_unit_test (tcti_swtpm_init_null_conf_test),
@@ -772,6 +830,11 @@ main (int   argc,
         cmocka_unit_test_setup_teardown (tcti_swtpm_locality_test,
                                          tcti_swtpm_setup,
                                          tcti_swtpm_teardown),
+#ifndef _WIN32
+        cmocka_unit_test_setup_teardown (tcti_swtpm_receive_success_test,
+                                         tcti_swtpm_setup_unix,
+                                         tcti_swtpm_teardown),
+#endif
     };
     return cmocka_run_group_tests (tests, NULL, NULL);
 }


### PR DESCRIPTION
socket_connect() provides TCP, so we add socket_connect_unix() for unix
domain sockets, which takes 'path' rather than 'host'+'port'.

The convention for data/control pairs of sockets with TCP is that they use
a common hostname and consecutive port numbers. This patch adds a
'control' parameter to both API functions, and updates existing callers of
socket_connect() to provide it. Calls to create control sockets no longer
increment the port number caller-side, it is incremented within the
implementation instead. For the socket_connect_unix() case, the control
socket is implemented by appending ".ctrl" to the path.

Signed-off-by: Geoff Thorpe <geoffrey@twosigma.com>