### PR TITLE
configure: Check system with busybox.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -635,10 +635,17 @@ define make_parent_dir
     if [ ! -d $(dir $1) ]; then mkdir -p $(dir $1); fi
 endef
 
+#if BUSYBOX
+define make_tss_user_and_group
+    (id -g tss 2>/dev/null || addgroup -S tss) && \
+    (id -u tss 2>/dev/null || adduser -S -G tss tss)
+endef
+#else
 define make_tss_user_and_group
     (id -g tss 2>/dev/null || groupadd -r tss) && \
     (id -u tss 2>/dev/null || useradd -r -g tss tss)
 endef
+#endif #BUSYBOX
 
 define make_tss_dir
     ($(call make_parent_dir,$1))

--- a/configure.ac
+++ b/configure.ac
@@ -488,10 +488,16 @@ AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
 AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
 AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
 # Check all tools used by make install
+
+AC_CHECK_PROG(busybox,busybox,yes)
+AS_IF([test x"$busybox" == x"yes"],
+    [ AS_IF([test "$HOSTOS" = "Linux"],
+        [AC_DEFINE([BUSYBOX], [1], [System with busybox])
+         ERROR_IF_NO_PROG([groupadd])
+         ERROR_IF_NO_PROG([useradd])])])
+
 AS_IF([test "$HOSTOS" = "Linux"],
-      [ERROR_IF_NO_PROG([groupadd])
-       ERROR_IF_NO_PROG([useradd])
-       ERROR_IF_NO_PROG([id])
+      [ERROR_IF_NO_PROG([id])
        ERROR_IF_NO_PROG([chown])
        ERROR_IF_NO_PROG([chmod])
        ERROR_IF_NO_PROG([mkdir])


### PR DESCRIPTION
Busybox does not support usseradd and groupadd. So for systems with busybox
(e.g. Alpine Linux) adduser and addgroup have to be used for FAPI configuration.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>