### PR TITLE
configure: Check system with busybox.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -636,8 +636,21 @@ define make_parent_dir
 endef
 
 define make_tss_user_and_group
-    (id -g tss 2>/dev/null || groupadd -r tss) && \
-    (id -u tss 2>/dev/null || useradd -r -g tss tss)
+    if type -p groupadd > /dev/null; then \
+        id -g tss 2>/dev/null || groupadd --system tss; \
+    else \
+        id -g tss 2>/dev/null || \
+        addgroup --system tss; \
+    fi && \
+    if type -p useradd > /dev/null; then \
+        id -u tss 2>/dev/null || \
+        useradd --system --home-dir / --shell `type -p nologin` \
+                         --no-create-home -g tss tss; \
+    else \
+        id -u tss 2>/dev/null || \
+        adduser --system --home / --shell `type -p nologin` \
+                --no-create-home --ingroup tss tss; \
+    fi
 endef
 
 define make_tss_dir

--- a/configure.ac
+++ b/configure.ac
@@ -487,15 +487,17 @@ AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
 AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
 AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
 AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+
 # Check all tools used by make install
 AS_IF([test "$HOSTOS" = "Linux"],
-      [ERROR_IF_NO_PROG([groupadd])
-       ERROR_IF_NO_PROG([useradd])
-       ERROR_IF_NO_PROG([id])
-       ERROR_IF_NO_PROG([chown])
-       ERROR_IF_NO_PROG([chmod])
-       ERROR_IF_NO_PROG([mkdir])
-       ERROR_IF_NO_PROG([setfacl])])
+    [ AC_CHECK_PROG(useradd, useradd, yes)
+      AC_CHECK_PROG(groupadd, groupadd, yes)
+      AC_CHECK_PROG(adduser, adduser, yes)
+      AC_CHECK_PROG(addgroup, addgroup, yes)
+      AS_IF([test "x$addgroup" != "xyes" && test "x$groupadd" != "xyes" ],
+         [AC_MSG_ERROR([addgroup or groupadd are needed.])])
+      AS_IF([test "x$adduser" != "xyes" && test "x$useradd" != "xyes" ],
+         [AC_MSG_ERROR([adduser or useradd are needed.])])])
 
 AC_SUBST([PATH])
 


### PR DESCRIPTION
Busybox does not support usseradd and groupadd. So for systems with busybox
(e.g. Alpine Linux) adduser and addgroup have to be used for FAPI configuration.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>