### PR TITLE
FAPI TEST: Auth value for storage hierarchy was not reset 3.1.x.

### DIFF
--- a/test/integration/fapi-key-create-primary-sign.int.c
+++ b/test/integration/fapi-key-create-primary-sign.int.c
@@ -173,6 +173,10 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
                   &digest.buffer[0], digest.size, signature, signatureSize);
     goto_if_error(r, "Error Fapi_VerifySignature", error);
 
+    /* We need to reset the passwords again, in order to not brick physical TPMs */
+    r = Fapi_ChangeAuth(context, "/HS", NULL);
+    goto_if_error(r, "Error Fapi_ChangeAuth", error);
+
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);
 


### PR DESCRIPTION
The auth value for the storage hierarchy was set in provisioning but not reset at
the end of the test fapi-key-create-primary-sign.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>