### PR TITLE
Fix errors if log is disabled and check availability of sanitizer

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -63,15 +63,19 @@ if [ "$CC" == "gcc" ]; then
   export CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage";
 fi
 
+if [ ldconfig -p 2>/dev/null| grep libasan > /dev/null && ldconfig -p 2>/dev/null| grep libubsan > /dev/null ]; then
+  SANITIZER_OPTION="--with-sanitizer=undefined,address"
+fi
+
 if [ "$SCANBUILD" == "yes" ]; then
   scan-build --status-bugs ../configure --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 elif [ "$CC" == "clang" ]; then
   ../configure --enable-unit --enable-self-generated-certificate  --enable-integration --with-maxloglevel=none --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
 else
   if [ "$WITH_TCTI" == "mssim" ]; then
-    ../configure --with-sanitizer=undefined,address --disable-tcti-swtpm --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+    ../configure $SANITIZER_OPTION --disable-tcti-swtpm --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
   else
-    ../configure --with-sanitizer=undefined,address --with-maxloglevel=none --enable-debug=yes --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
+    ../configure $SANITIZER_OPTION --with-maxloglevel=none --enable-debug=yes --enable-unit --enable-self-generated-certificate --enable-integration --with-crypto=$WITH_CRYPTO $CONFIGURE_OPTIONS
   fi
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           DOCKER_IMAGE: ${{ matrix.docker_image }}
@@ -27,6 +29,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           CC: clang
@@ -42,6 +46,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           CC: gcc
@@ -57,6 +63,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           CC: gcc
@@ -72,6 +80,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           CC: gcc
@@ -87,6 +97,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           DOCKER_IMAGE: fedora-32
@@ -103,6 +115,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - name: Launch Container
         env:
           REPO_BRANCH: ${{ github.ref }}

--- a/src/tss2-esys/esys_crypto.c
+++ b/src/tss2-esys/esys_crypto.c
@@ -499,7 +499,7 @@ iesys_xor_parameter_obfuscation(TPM2_ALG_ID hash_alg,
     size_t data_size_bits = data_size * 8;
     size_t rest_size = data_size;
     BYTE *kdfa_byte_ptr;
-    BYTE *data_start = data;
+    BYTE *data_start MAYBE_UNUSED = data;
 
     if (key == NULL || data == NULL) {
         LOG_ERROR("Bad reference");

--- a/src/tss2-tcti/tcti-libtpms.c
+++ b/src/tss2-tcti/tcti-libtpms.c
@@ -644,10 +644,10 @@ tcti_libtpms_cb_nvram_init(void)
 
 TPM_RESULT
 tcti_libtpms_cb_nvram_loaddata(
-    unsigned char **data,
-    uint32_t *length,
-    uint32_t tpm_number,
-    const char *name)
+    unsigned char **data MAYBE_UNUSED,
+    uint32_t *length MAYBE_UNUSED,
+    uint32_t tpm_number MAYBE_UNUSED,
+    const char *name MAYBE_UNUSED)
 {
     LOG_TRACE("tcti-libtpms callback nvram_loaddata() called: "
               "data=0x%" PRIxPTR ", "
@@ -661,10 +661,10 @@ tcti_libtpms_cb_nvram_loaddata(
 
 TPM_RESULT
 tcti_libtpms_cb_nvram_storedata(
-    const unsigned char *data,
-    uint32_t length,
-    uint32_t tpm_number,
-    const char *name)
+    const unsigned char *data MAYBE_UNUSED,
+    uint32_t length MAYBE_UNUSED,
+    uint32_t tpm_number MAYBE_UNUSED,
+    const char *name MAYBE_UNUSED)
 {
     LOG_TRACE("tcti-libtpms callback nvram_storedata() called: "
               "data=0x%" PRIxPTR ", "
@@ -678,9 +678,9 @@ tcti_libtpms_cb_nvram_storedata(
 
 TPM_RESULT
 tcti_libtpms_cb_nvram_deletename(
-    uint32_t tpm_number,
-    const char *name,
-    TPM_BOOL must_exist)
+    uint32_t tpm_number MAYBE_UNUSED,
+    const char *name MAYBE_UNUSED,
+    TPM_BOOL must_exist MAYBE_UNUSED)
 {
     LOG_TRACE("tcti-libtpms callback nvram_deletename() called: "
               "tpm_number=%" PRIu32 ", "
@@ -704,7 +704,7 @@ tcti_libtpms_cb_io_init(void)
 TPM_RESULT
 tcti_libtpms_cb_io_getlocality(
     TPM_MODIFIER_INDICATOR *locality_modifer,
-    uint32_t tpm_number)
+    uint32_t tpm_number MAYBE_UNUSED)
 {
     TSS2_TCTI_COMMON_CONTEXT *tcti_common;
 
@@ -729,8 +729,8 @@ tcti_libtpms_cb_io_getlocality(
 
 TPM_RESULT
 tcti_libtpms_cb_io_getphysicalpresence(
-    TPM_BOOL *physical_presence,
-    uint32_t tpm_number)
+    TPM_BOOL *physical_presence MAYBE_UNUSED,
+    uint32_t tpm_number MAYBE_UNUSED)
 {
     LOG_TRACE("tcti-libtpms callback io_getphysicalpresence() called: "
               "physical_presence=0x%" PRIxPTR ", "


### PR DESCRIPTION
* esys: Mark variable only used for logging maybe-unused.
* tcti: Mark variables only used for logging maybe-unused.
* ci: Set fetch-depth to 0 fot github actions.
* ci: Check whether sanitizer libs are available.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>