### PR TITLE
tss2_tpm2_types: deprecate TPMS_ALGORITHM_DESCRIPTION

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@
 INCLUDE_DIRS    = -I$(srcdir)/src -I$(srcdir)/include/tss2
 ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
-				  $(SANITIZER_CFLAGS)
+				  $(SANITIZER_CFLAGS) -DINTERNALBUILD=1
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(SANITIZER_LDFLAGS)
 
 # Initialize empty variables to be extended throughout

--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -753,14 +753,16 @@ Tss2_MU_TPMS_ALGORITHM_DESCRIPTION_Marshal(
     TPMS_ALGORITHM_DESCRIPTION  const *src,
     uint8_t         buffer[],
     size_t          buffer_size,
-    size_t         *offset);
+    size_t         *offset)
+	__attribute__((deprecated));
 
 TSS2_RC
 Tss2_MU_TPMS_ALGORITHM_DESCRIPTION_Unmarshal(
     uint8_t const   buffer[],
     size_t          buffer_size,
     size_t         *offset,
-    TPMS_ALGORITHM_DESCRIPTION *dest);
+    TPMS_ALGORITHM_DESCRIPTION *dest)
+    __attribute__((deprecated));
 
 TSS2_RC
 Tss2_MU_TPMS_TAGGED_PROPERTY_Marshal(

--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -912,12 +912,21 @@ struct TPMS_EMPTY {
     BYTE empty[1]; /* a structure with no member */
 };
 
-/* Definition of TPMS_ALGORITHM_DESCRIPTION Structure <OUT> */
-typedef struct TPMS_ALGORITHM_DESCRIPTION TPMS_ALGORITHM_DESCRIPTION;
+/* This is DEPRECATED as it's an unused structure included by accident and never used
+ * by a TPM 2.0 device as either an input or output structure.
+ * Definition of TPMS_ALGORITHM_DESCRIPTION Structure <OUT>
+ */
+#if defined(INTERNALBUILD)
+    #define DEPRECATED
+#else
+    #define DEPRECATED __attribute__((deprecated))
+#endif
+
+typedef struct TPMS_ALGORITHM_DESCRIPTION TPMS_ALGORITHM_DESCRIPTION DEPRECATED;
 struct TPMS_ALGORITHM_DESCRIPTION {
     TPM2_ALG_ID alg;            /* an algorithm */
     TPMA_ALGORITHM  attributes; /* the attributes of the algorithm */
-};
+} DEPRECATED;
 
 /* Definition of TPMU_HA Union <INOUT S> */
 typedef union TPMU_HA TPMU_HA;


### PR DESCRIPTION
Deprecate the type TPMS_ALGORITHM_DESCRIPTION as well as its
coresponding MU routines.

Fixes: #2228

Signed-off-by: William Roberts <william.c.roberts@intel.com>