### PR TITLE
FAPI: Free certificate when failed 3.1.x

### DIFF
--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -250,6 +250,7 @@ error:
     SAFE_FREE(policy);
     SAFE_FREE(publicKey);
     SAFE_FREE(signature);
+    SAFE_FREE(certificate);
     return EXIT_FAILURE;
 }
 

--- a/test/integration/fapi-key-create2-sign.int.c
+++ b/test/integration/fapi-key-create2-sign.int.c
@@ -409,6 +409,7 @@ error:
     SAFE_FREE(policy);
     SAFE_FREE(publicKey);
     SAFE_FREE(signature);
+    SAFE_FREE(certificate);
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
In fapi-key-create2-sign.int.c and fapi-key-create-sign.int.c, when test_fapi_key_create_sign and test_fapi_key_create_sign fails, it will go to “error” to exit. the certifacate needs to free.

Signed-off-by: JerryDevis <JerryDevis@users.noreply.github.com>