### PR TITLE
esys: Return an error if ESYS_TR_NONE is passed to Esys_TR_GetName.

### DIFF
--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -421,6 +421,7 @@ Esys_TR_SetAuth(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
  * @retval TSS2_ESYS_RC_MEMORY if needed memory can't be allocated.
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext is NULL.
+ * @retval TSS2_ESYS_RC_BAD_TR if the handle is invalid.
  * @retval TSS2_SYS_RC_* for SAPI errors.
  */
 TSS2_RC
@@ -430,6 +431,10 @@ Esys_TR_GetName(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
     RSRC_NODE_T *esys_object;
     TSS2_RC r;
     _ESYS_ASSERT_NON_NULL(esys_context);
+
+    if (esys_handle == ESYS_TR_NONE) {
+        return_error(TSS2_ESYS_RC_BAD_TR, "Name for ESYS_TR_NONE can't be determined.");
+    }
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");


### PR DESCRIPTION
A segfault was produced in this case. Fixes #2243.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>