### PR TITLE
fapi: Fix close of stream twice.

### DIFF
--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -76,7 +76,6 @@ ifapi_io_read_async(
     flock.l_whence = SEEK_SET;
 
     if (fcntl(fileno(io->stream), F_SETLK, &flock) == -1) {
-        fclose(io->stream);
         LOG_ERROR("File \"%s\" could not be locked: %s",
                   filename, strerror(errno));
         fclose(io->stream);


### PR DESCRIPTION
The input stream in ifapi_io_read_async was closed twice.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>