### PR TITLE
FAPI: Fix the authorization of hierarchy objects 3.1.x.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -311,6 +311,7 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-get-random.fint \
     test/integration/fapi-platform-certificates.fint \
     test/integration/fapi-key-create-sign.fint \
+    test/integration/fapi-key-create-he-sign.fint \
     test/integration/fapi-key-create-primary-sign.fint \
     test/integration/fapi-key-create2-sign.fint \
     test/integration/fapi-key-create-null-key-sign.fint \
@@ -610,14 +611,19 @@ if FAPI
 
 test_unit_fapi_json_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_fapi_json_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
-test_unit_fapi_json_LDFLAGS = $(TESTS_LDFLAGS) -ljson-c
+test_unit_fapi_json_LDFLAGS = $(TESTS_LDFLAGS)  $(CURL_LIBS) -ljson-c
 test_unit_fapi_json_SOURCES = test/unit/fapi-json.c \
                               src/tss2-fapi/ifapi_json_deserialize.c \
                               src/tss2-fapi/ifapi_json_serialize.c \
                               src/tss2-fapi/ifapi_policy_json_deserialize.c \
                               src/tss2-fapi/ifapi_policy_json_serialize.c \
                               src/tss2-fapi/tpm_json_deserialize.c \
-                              src/tss2-fapi/tpm_json_serialize.c
+                              src/tss2-fapi/tpm_json_serialize.c \
+                              src/tss2-fapi/ifapi_helpers.c \
+                              src/tss2-fapi/fapi_crypto.c \
+                              src/tss2-fapi/ifapi_eventlog.c \
+                              src/tss2-fapi/ifapi_keystore.c  \
+                              src/tss2-fapi/ifapi_io.c
 
 test_unit_fapi_helpers_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_fapi_helpers_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD)
@@ -1622,6 +1628,13 @@ test_integration_fapi_key_create_sign_fint_LDADD   = $(TESTS_LDADD)
 test_integration_fapi_key_create_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_sign_fint_SOURCES = \
     test/integration/fapi-key-create-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_he_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_fapi_key_create_he_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_he_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_he_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-he-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_primary_sign_fint_CFLAGS  = $(TESTS_CFLAGS)

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -159,6 +159,8 @@ Fapi_Import_Async(
     IFAPI_OBJECT *object = &command->object;
     IFAPI_EXT_PUB_KEY * extPubKey = &object->misc.ext_pub_key;
     IFAPI_DUPLICATE * keyTree = &object->misc.key_tree;
+    command->private = NULL;
+    command->parent_path = NULL;
 
     if (context->state != _FAPI_STATE_INIT) {
         return_error(TSS2_FAPI_RC_BAD_SEQUENCE, "Invalid State");

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -799,9 +799,7 @@ ifapi_init_primary_finish(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype, IFAPI_OBJE
             pkey->signing_scheme = context->profiles.default_profile.ecc_signing_scheme;
         context->createPrimary.pkey_object.handle = primaryHandle;
         SAFE_FREE(pkey->serialization.buffer);
-        ifapi_cleanup_ifapi_object(&context->createPrimary.pkey_object);
         return TSS2_RC_SUCCESS;
-
 
     statecasedefault(context->primary_state);
     }
@@ -2995,8 +2993,6 @@ ifapi_initialize_object(
 {
     TSS2_RC r = TSS2_RC_SUCCESS;
     ESYS_TR handle;
-    const char *path;
-    size_t pos = 0, pos2;
 
     switch (object->objectType) {
     case IFAPI_NV_OBJ:
@@ -3021,38 +3017,6 @@ ifapi_initialize_object(
         }
         object->authorization_state = AUTH_INIT;
         object->handle = handle;
-        break;
-
-    case IFAPI_HIERARCHY_OBJ:
-        path = object->rel_path;
-        if (path) {
-            /* Determine esys handle from pathname. */
-            if (strncmp("/", &path[0], 1) == 0)
-                pos += 1;
-            /* Skip profile if it does exist in path */
-            if (strncmp("P_", &path[pos], 2) == 0) {
-                char *  start = strchr(&path[pos], IFAPI_FILE_DELIM_CHAR);
-                if (start) {
-                    pos2 = (int)(start - &path[pos]);
-                    pos = pos2 + 2;
-                } else {
-                    return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid path.");
-                }
-            }
-
-            if (strcmp(&path[pos], "HS") == 0) {
-                object->handle = ESYS_TR_RH_OWNER;
-            } else if (strcmp(&path[pos], "HE") == 0) {
-                object->handle = ESYS_TR_RH_ENDORSEMENT;
-            } else if (strcmp(&path[pos], "LOCKOUT") == 0) {
-                object->handle = ESYS_TR_RH_LOCKOUT;
-            } else  if (strcmp(&path[pos], "HN") == 0) {
-                object->handle = ESYS_TR_RH_NULL;
-            } else {
-                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid path.");
-            }
-        }
-        object->authorization_state = AUTH_INIT;
         break;
 
     default:

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -922,12 +922,51 @@ append_object_to_list(void *object, NODE_OBJECT_T **object_list)
     return TSS2_RC_SUCCESS;
 }
 
+/**  Compute the name of a hierarchy object.
+ *
+ * The TPM handle will be computed from the esys handle and the name
+ * will be computed from the TPM handle.
+ *
+ * @param[in,out] hierarchy The hierarchy object.
+ */
+static void
+set_name_hierarchy_object(IFAPI_OBJECT *object)
+{
+    TPM2_HANDLE handle = 0;
+    size_t offset = 0;
+    switch (object->handle) {
+    case ESYS_TR_RH_NULL:
+        handle = TPM2_RH_NULL;
+        break;
+    case ESYS_TR_RH_OWNER:
+        handle = TPM2_RH_OWNER;
+        break;
+    case ESYS_TR_RH_ENDORSEMENT:
+        handle = TPM2_RH_ENDORSEMENT;
+        break;
+    case ESYS_TR_RH_LOCKOUT:
+        handle = TPM2_RH_LOCKOUT;
+        break;
+    case ESYS_TR_RH_PLATFORM:
+        handle = TPM2_RH_PLATFORM;
+        break;
+    case ESYS_TR_RH_PLATFORM_NV:
+        handle = TPM2_RH_PLATFORM_NV;
+        break;
+    }
+    Tss2_MU_TPM2_HANDLE_Marshal(handle,
+                                &object->misc.hierarchy.name.name[0], sizeof(TPM2_HANDLE),
+                                &offset);
+    object->misc.hierarchy.name.size = offset;
+}
+
 /** Initialize the internal representation of a FAPI hierarchy object.
  *
  * The object will be cleared and the type of the general fapi object will be
  * set to hierarchy.
  *
- * @param[out] hierarchy The caller allocated hierarchy object.
+ * @param[in,out] hierarchy The caller allocated hierarchy object. The name of the
+ *                object will be computed.
  * @param[in] esys_handle The ESAPI handle of the hierarchy which will be added to
  *            to the object.
  */
@@ -940,6 +979,54 @@ ifapi_init_hierarchy_object(
     hierarchy->system = TPM2_YES;
     hierarchy->objectType = IFAPI_HIERARCHY_OBJ;
     hierarchy->handle = esys_handle;
+    hierarchy->misc.hierarchy.esysHandle = esys_handle;
+    set_name_hierarchy_object(hierarchy);
+}
+
+/**  Initialize a hierarchy object read from a file.
+ *
+ * The esys handles will be set depending on the object path and the
+ * object name will be computed.
+ *
+ * @param[in,out] hierarchy The caller allocated hierarchy object.
+ * @retval TSS2_RC_SUCCESS if the hierarchy could be initialized.
+ * @retval TSS2_FAPI_RC_GENERAL_FAILURE For an invalid hierarchy path.
+ */
+TSS2_RC
+ifapi_set_name_hierarchy_object(IFAPI_OBJECT *object)
+{
+    const char *path = object->rel_path;
+    size_t pos = 0, pos2;
+    if (path) {
+        /* Determine esys handle from pathname. */
+        if (strncmp("/", &path[0], 1) == 0)
+            pos += 1;
+        /* Skip profile if it does exist in path */
+        if (strncmp("P_", &path[pos], 2) == 0) {
+            char *  start = strchr(&path[pos], IFAPI_FILE_DELIM_CHAR);
+            if (start) {
+                pos2 = (int)(start - &path[pos]);
+                pos = pos2 + 2;
+            } else {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid path.");
+            }
+        }
+        if (strcmp(&path[pos], "HS") == 0) {
+            object->handle = ESYS_TR_RH_OWNER;
+            object->misc.hierarchy.esysHandle = ESYS_TR_RH_OWNER;
+        } else if (strcmp(&path[pos], "HE") == 0) {
+            object->handle = ESYS_TR_RH_ENDORSEMENT;
+            object->misc.hierarchy.esysHandle = ESYS_TR_RH_ENDORSEMENT;
+        } else if (strcmp(&path[pos], "LOCKOUT") == 0) {
+            object->handle = ESYS_TR_RH_LOCKOUT;
+            object->misc.hierarchy.esysHandle = ESYS_TR_RH_LOCKOUT;
+        } else  if (strcmp(&path[pos], "HN") == 0) {
+            object->handle = ESYS_TR_RH_NULL;
+            object->misc.hierarchy.esysHandle = ESYS_TR_RH_NULL;
+        }
+    }
+    set_name_hierarchy_object(object);
+    return TSS2_RC_SUCCESS;
 }
 
 /** Create a directory and all sub directories.
@@ -1516,6 +1603,9 @@ ifapi_object_cmp_name(IFAPI_OBJECT *object, void *name, bool *equal)
     TPM2B_NAME nv_name;
 
     switch (object->objectType) {
+    case IFAPI_HIERARCHY_OBJ:
+        obj_name = &object->misc.hierarchy.name;
+        break;
     case IFAPI_KEY_OBJ:
         obj_name = &object->misc.key.name;
         break;

--- a/src/tss2-fapi/ifapi_helpers.h
+++ b/src/tss2-fapi/ifapi_helpers.h
@@ -47,6 +47,10 @@ ifapi_init_hierarchy_object(
     IFAPI_OBJECT *hierarchy,
     ESYS_TR esys_handle);
 
+TSS2_RC
+ifapi_set_name_hierarchy_object(
+    IFAPI_OBJECT *hierarchy);
+
 char *
 get_description(IFAPI_OBJECT *object);
 

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -655,8 +655,6 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out)
         return TSS2_FAPI_RC_BAD_VALUE;
     }
 
-    out->rel_path = NULL;
-
     r = ifapi_json_IFAPI_OBJECT_TYPE_CONSTANT_deserialize(jso2, &out->objectType);
     return_if_error(r, "Bad value for field \"objectType\".");
 
@@ -681,6 +679,9 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out)
     case IFAPI_HIERARCHY_OBJ:
         r = ifapi_json_IFAPI_HIERARCHY_deserialize(jso, &out->misc.hierarchy);
         return_if_error(r, "Bad value for hierarchy.");
+
+        r = ifapi_set_name_hierarchy_object(out);
+        return_if_error(r, "Bad hierarchy.");
 
         break;
     case IFAPI_KEY_OBJ:

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -628,10 +628,10 @@ ifapi_keystore_load_finish(
     goto_if_null2(jso, "Keystore is corrupted (Json error).", r, TSS2_FAPI_RC_GENERAL_FAILURE,
                   error_cleanup);
 
+    object->rel_path = keystore->rel_path;
     r = ifapi_json_IFAPI_OBJECT_deserialize(jso, object);
     goto_if_error(r, "Deserialize object.", error_cleanup);
 
-    object->rel_path = keystore->rel_path;
     SAFE_FREE(buffer);
     if (jso)
         json_object_put(jso);

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -58,6 +58,7 @@ typedef struct {
     TPM2B_DIGEST                             authPolicy;
     ESYS_TR                                  esysHandle;
     bool                                      authorized;   /**< Switch whether hiearchy is authorized. */
+    TPM2B_NAME                                     name;    /**< Name of the hierarchy */
 } IFAPI_HIERARCHY;
 
 /** Type for representing a FAPI NV object

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -512,6 +512,7 @@ ifapi_policyeval_cbauth(
                 break;
             } else if (cb_ctx->object.objectType == IFAPI_HIERARCHY_OBJ) {
                 cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
+                cb_ctx->auth_object_ptr = &cb_ctx->object;
                 next_case = true;
                 break;
             } else {

--- a/test/integration/fapi-export-policy.int.c
+++ b/test/integration/fapi-export-policy.int.c
@@ -231,6 +231,9 @@ test_fapi_export_policy(FAPI_CONTEXT *context)
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 
+    r = pcr_reset(context, 16);
+    goto_if_error(r, "Error pcr_reset", error);
+
     for (i = 0; i < sizeof(policies) / sizeof(policies[0]); i++) {
         fprintf(stderr, "\nTest policy: %s\n",  policies[i].path);
         json_policy = read_policy(context, policies[i].path);

--- a/test/integration/fapi-key-create-he-sign.int.c
+++ b/test/integration/fapi-key-create-he-sign.int.c
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tss2_fapi.h"
+
+#include "test-fapi.h"
+#include "fapi_util.h"
+#include "fapi_int.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+#define PASSWORD "abc"
+#define SIGN_TEMPLATE  "sign,noDa"
+#ifndef FAPI_PROFILE
+#define FAPI_PROFILE "P_ECC"
+#endif /* FAPI_PROFILE */
+
+static TSS2_RC
+auth_callback(
+    char const *objectPath,
+    char const *description,
+    const char **auth,
+    void *userData)
+{
+    UNUSED(description);
+    UNUSED(userData);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
+    return TSS2_RC_SUCCESS;
+}
+
+/** Test creation of a signing key in the endorsement hierarchy.
+ *
+ * Tested FAPI commands:
+ *  - Fapi_Provision()
+ *  - Fapi_SetAuthCB()
+ *  - Fapi_CreateKey()
+ *  - Fapi_Sign()
+ *  - Fapi_VerifySignature()
+ *  - Fapi_List()
+ *  - Fapi_Delete()
+ *
+ * @param[in,out] context The FAPI_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_fapi_key_create_he_sign(FAPI_CONTEXT *context)
+{
+    TSS2_RC r;
+    char *sigscheme = NULL;
+
+    uint8_t       *signature = NULL;
+    char          *publicKey = NULL;
+    char          *path_list = NULL;
+
+    if (strcmp("P_ECC", fapi_profile) != 0)
+        sigscheme = "RSA_PSS";
+
+    /* We need to reset the passwords again, in order to not brick physical TPMs */
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+    goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = Fapi_SetAuthCB(context, auth_callback, NULL);
+    goto_if_error(r, "Error SetPolicyAuthCallback", error);
+
+    r = Fapi_CreateKey(context, "HE/EK/mySignKey", SIGN_TEMPLATE , "",
+                       PASSWORD);
+
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+    size_t signatureSize = 0;
+
+    TPM2B_DIGEST digest = {
+        .size = 32,
+        .buffer = {
+            0x67, 0x68, 0x03, 0x3e, 0x21, 0x64, 0x68, 0x24, 0x7b, 0xd0,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x67, 0x68
+        }
+    };
+
+
+    r = Fapi_Sign(context, "HE/EK/mySignKey", sigscheme,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, NULL);
+    goto_if_error(r, "Error Fapi_Sign", error);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(strlen(publicKey) > ASSERT_SIZE);
+
+    r = Fapi_VerifySignature(context, "HE/EK/mySignKey",
+                  &digest.buffer[0], digest.size, signature, signatureSize);
+    goto_if_error(r, "Error Fapi_VerifySignature", error);
+
+     r = Fapi_Delete(context, "/");
+    goto_if_error(r, "Error Fapi_Delete", error);
+
+    SAFE_FREE(path_list);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(signature);
+    return EXIT_SUCCESS;
+
+error:
+    Fapi_Delete(context, "/");
+    SAFE_FREE(path_list);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(signature);
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_fapi(FAPI_CONTEXT *fapi_context)
+{
+    return test_fapi_key_create_he_sign(fapi_context);
+}

--- a/test/integration/fapi-key-create-sign-password-provision.int.c
+++ b/test/integration/fapi-key-create-sign-password-provision.int.c
@@ -113,6 +113,9 @@ test_fapi_key_create_sign_password_provision(FAPI_CONTEXT *context)
     r = Fapi_Provision(context, NULL, PASSWORD, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 
+    r = pcr_reset(context, 16);
+    goto_if_error(r, "Error pcr_reset", error);
+
     r = Fapi_SetAuthCB(context, auth_callback, NULL);
     goto_if_error(r, "Error SetPolicyAuthCallback", error);
 

--- a/test/unit/fapi-json.c
+++ b/test/unit/fapi-json.c
@@ -31,36 +31,6 @@
 #define LOGMODULE tests
 #include "util/log.h"
 
-/* 4 copies from ifapi_helpers.c */
-
-void
-ifapi_check_json_object_fields(
-    json_object *jso,
-    char** field_tab,
-    size_t size_of_tab)
-{
-    enum json_type type;
-    bool found;
-    size_t i;
-
-    type = json_object_get_type(jso);
-    if (type == json_type_object) {
-        json_object_object_foreach(jso, key, val) {
-            UNUSED(val);
-            found = false;
-            for (i = 0; i < size_of_tab; i++) {
-                if (strcmp(key, field_tab[i]) == 0) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                LOG_WARNING("Invalid field: %s", key);
-            }
-        }
-    }
-}
-
 static void
 cleanup_policy_element(TPMT_POLICYELEMENT *policy)
 {


### PR DESCRIPTION
The default policy "policy secret" for the endorsement key is defined for the
endorsement hierarchy. The corresponding object had to be searched in the
keystore during policy execution. This search did not work, due to various
bugs.
* A erroneous cleanup of the EK was executed where the policy was deleted.
* The name needed for the search in the keystore was not stored in the
  hierarchy object.
* The esys handle stored in the hierarchy object was not correct.

To ensure compatibility with existing system keystores the initialization
of the hierarchy objects was fixed as follows:

* The initialization of the hierarchy object was moved to to object
  deserialization.
* Depending on the pathname the esys handle in the hierarchy initialized.
* The name of the hierarchy object was computed.
* The object needed for authorization during policy execution was initialized
  with the hierarchy object.
* The searching of objects in the keystore was fixed.
* Objects to be freed in Fapi_Import were initialzed with NULL.

The tests were adapted:
* The linking of the unit test for FAPI deserialization had to be adapted.
* An integration test where a key in the endorsement hierarchy was used
  for signing was added.
* PCR 16 was not reset int all tests expecting pcr 16 equal 0.

Fixes #2253

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>