### PR TITLE
FAPI: Fixed some memory leak

### DIFF
--- a/src/tss2-fapi/api/Fapi_GetEsysBlob.c
+++ b/src/tss2-fapi/api/Fapi_GetEsysBlob.c
@@ -395,7 +395,7 @@ error_cleanup:
     ifapi_cleanup_ifapi_object(object);
     ifapi_cleanup_ifapi_object(key_object);
     SAFE_FREE(command->path);
-    SAFE_FREE(*data);
+    SAFE_FREE(command->data);
     SAFE_FREE(key_context);
     ifapi_session_clean(context);
     ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -4309,7 +4309,7 @@ ifapi_get_certificates(
         context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes = TPMA_NV_NO_DA;
 
         r = ifapi_keystore_load_async(&context->keystore, &context->io, "/HS");
-        return_if_error2(r, "Could not open hierarchy /HS");
+        goto_if_error_reset_state(r, "Could not open hierarchy /HS", error);
 
         fallthrough;
 
@@ -4333,7 +4333,7 @@ ifapi_get_certificates(
         context->session2 = ESYS_TR_NONE;
         context->nv_cmd.nv_read_state = NV_READ_INIT;
         memset(&context->nv_cmd.nv_object, 0, sizeof(IFAPI_OBJECT));
-        Esys_Free(context->cmd.Provision.nvPublic);
+        SAFE_FREE(context->cmd.Provision.nvPublic);
         fallthrough;
 
     statecase(context->get_cert_state, GET_CERT_READ_CERT);
@@ -4363,7 +4363,7 @@ ifapi_get_certificates(
     }
 
 error:
-    SAFE_FREE(context->cmd.Provision.capabilityData);
+    SAFE_FREE(context->cmd.Provision.nvPublic);
     SAFE_FREE(context->cmd.Provision.capabilityData);
     ifapi_cleanup_ifapi_object(&context->nv_cmd.auth_object);
     ifapi_free_object_list(*cert_list);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1206,6 +1206,7 @@ cleanup:
         r = TSS2_FAPI_RC_KEY_NOT_FOUND;
     }
     keystore->key_search.state = KSEARCH_INIT;
+    ifapi_cleanup_ifapi_object(&object);
     return r;
 }
 


### PR DESCRIPTION
1. In ifapi_get_certificates, when ifapi_keystore_load_async or ifapi_keystore_load_finish or ifapi_initialize_object failed, it leads to leak memory that is allocated for context->cmd.Provision.nvPublic.
2. object should be freed when keystore_search_obj failed.
3. command->data should be freed when Fapi_GetEsysBlob_Finish failed