### PR TITLE
Fapi fix some leaks 3.1.x

### DIFF
--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -419,14 +419,14 @@ Fapi_Delete_Async(
         /* No session will be needed these files can be deleted without
            interaction with the TPM */
         r = ifapi_non_tpm_mode_init(context);
-        return_if_error(r, "Initialize Entity_Delete");
+        goto_if_error(r, "Initialize Entity_Delete", error_cleanup);
         context->session1 = ESYS_TR_NONE;
 
         context->state = ENTITY_DELETE_GET_FILE;
     } else {
         /* Check whether TCTI and ESYS are initialized */
-        return_if_null(context->esys, "Command can't be executed in none TPM mode.",
-                       TSS2_FAPI_RC_NO_TPM);
+        goto_if_null(context->esys, "Command can't be executed in none TPM mode.",
+                       TSS2_FAPI_RC_NO_TPM, error_cleanup);
 
         /* If the async state automata of FAPI shall be tested, then we must not set
            the timeouts of ESYS to blocking mode.
@@ -435,12 +435,12 @@ Fapi_Delete_Async(
            to block until a result is available. */
 #ifndef TEST_FAPI_ASYNC
         r = Esys_SetTimeout(context->esys, TSS2_TCTI_TIMEOUT_BLOCK);
-        return_if_error_reset_state(r, "Set Timeout to blocking");
+        goto_if_error_reset_state(r, "Set Timeout to blocking", error_cleanup);
 #endif /* TEST_FAPI_ASYNC */
 
         /* A TPM session will be created to enable object authorization */
         r = ifapi_session_init(context);
-        return_if_error(r, "Initialize Entity_Delete");
+        goto_if_error(r, "Initialize Entity_Delete", error_cleanup);
 
         r = ifapi_get_sessions_async(context,
                                  IFAPI_SESSION_GENEK | IFAPI_SESSION1,

--- a/src/tss2-fapi/api/Fapi_GetEsysBlob.c
+++ b/src/tss2-fapi/api/Fapi_GetEsysBlob.c
@@ -157,8 +157,8 @@ Fapi_GetEsysBlob_Async(
     authObject->objectType = IFAPI_OBJ_NONE;
 
     /* Check whether TCTI and ESYS are initialized */
-    return_if_null(context->esys, "Command can't be executed in none TPM mode.",
-                   TSS2_FAPI_RC_NO_TPM);
+    goto_if_null(context->esys, "Command can't be executed in none TPM mode.",
+                   TSS2_FAPI_RC_NO_TPM, error_cleanup);
 
     /* If the async state automata of FAPI shall be tested, then we must not set
        the timeouts of ESYS to blocking mode.
@@ -167,12 +167,12 @@ Fapi_GetEsysBlob_Async(
        to block until a result is available. */
 #ifndef TEST_FAPI_ASYNC
     r = Esys_SetTimeout(context->esys, TSS2_TCTI_TIMEOUT_BLOCK);
-    return_if_error_reset_state(r, "Set Timeout to blocking");
+    goto_if_error_reset_state(r, "Set Timeout to blocking", error_cleanup);
 #endif /* TEST_FAPI_ASYNC */
 
     /* A TPM session will be created to enable object authorization */
     r = ifapi_session_init(context);
-    return_if_error(r, "Initialize GetEsysBlob");
+    goto_if_error(r, "Initialize GetEsysBlob", error_cleanup);
 
     context->state = GET_ESYS_BLOB_GET_FILE;
 

--- a/src/tss2-fapi/api/Fapi_GetEsysBlob.c
+++ b/src/tss2-fapi/api/Fapi_GetEsysBlob.c
@@ -395,7 +395,7 @@ error_cleanup:
     ifapi_cleanup_ifapi_object(object);
     ifapi_cleanup_ifapi_object(key_object);
     SAFE_FREE(command->path);
-    SAFE_FREE(*data);
+    SAFE_FREE(command->data);
     SAFE_FREE(key_context);
     ifapi_session_clean(context);
     ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -4340,7 +4340,7 @@ ifapi_get_certificates(
         context->nv_cmd.nv_object.misc.nv.public.nvPublic.attributes = TPMA_NV_NO_DA;
 
         r = ifapi_keystore_load_async(&context->keystore, &context->io, "/HS");
-        return_if_error2(r, "Could not open hierarchy /HS");
+        goto_if_error_reset_state(r, "Could not open hierarchy /HS", error);
 
         fallthrough;
 
@@ -4364,7 +4364,7 @@ ifapi_get_certificates(
         context->session2 = ESYS_TR_NONE;
         context->nv_cmd.nv_read_state = NV_READ_INIT;
         memset(&context->nv_cmd.nv_object, 0, sizeof(IFAPI_OBJECT));
-        Esys_Free(context->cmd.Provision.nvPublic);
+        SAFE_FREE(context->cmd.Provision.nvPublic);
         fallthrough;
 
     statecase(context->get_cert_state, GET_CERT_READ_CERT);
@@ -4394,7 +4394,7 @@ ifapi_get_certificates(
     }
 
 error:
-    SAFE_FREE(context->cmd.Provision.capabilityData);
+    SAFE_FREE(context->cmd.Provision.nvPublic);
     SAFE_FREE(context->cmd.Provision.capabilityData);
     ifapi_cleanup_ifapi_object(&context->nv_cmd.auth_object);
     ifapi_free_object_list(*cert_list);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1205,6 +1205,7 @@ cleanup:
         r = TSS2_FAPI_RC_KEY_NOT_FOUND;
     }
     keystore->key_search.state = KSEARCH_INIT;
+    ifapi_cleanup_ifapi_object(&object);
     return r;
 }
 

--- a/test/integration/fapi-key-create-policy-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-nv-sign.int.c
@@ -149,6 +149,7 @@ error:
     SAFE_FREE(publicKey);
     SAFE_FREE(certificate);
     SAFE_FREE(json_policy);
+    SAFE_FREE(pathList);
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
1. In ifapi_get_certificates, when ifapi_keystore_load_async or ifapi_keystore_load_finish or ifapi_initialize_object failed, it leads to leak memory that is allocated for context->cmd.Provision.nvPublic.
2. In keystore_search_obj, object may be leak when ifapi_keystore_load_finish failed.
3. command->data may be leak when Fapi_GetEsysBlob_Finish failed. Because when it successed, *data = command->data .
4. In test_fapi_key_create_policy_nv_sign, when Fapi_List_Finish failed, Fapi_List will failed and pathlist may be leaked.
5. Clean up memory when Fapi_Delete_Async failed
6. Clean up memory when Fapi_GetEsysBlob_Async failed

Signed-off-by: JerryDevis <JerryDevis@users.noreply.github.com>
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>