### PR TITLE
FAPI: Initialize object used for keystore search 3.0.x.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1173,6 +1173,9 @@ keystore_search_obj(
     IFAPI_OBJECT object;
     size_t i;
 
+    /* Mark object "unread" */
+    object.objectType = IFAPI_OBJ_NONE;
+
     switch (keystore->key_search.state) {
     statecase(keystore->key_search.state, KSEARCH_INIT)
         r = ifapi_keystore_list_all(keystore,


### PR DESCRIPTION
For an empty keystore a cleanup of an uninitialized object was executed. No the object
type now is initialized with IFAPI_OBJ_NONE to prevent the cleanup.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>