### PR TITLE
ossl: Fix check whether SM3 is available

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -123,7 +123,7 @@ get_ossl_hash_md(TPM2_ALG_ID hashAlg)
         return EVP_sha384();
     case TPM2_ALG_SHA512:
         return EVP_sha512();
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
     case TPM2_ALG_SM3_256:
         return EVP_sm3();
 #endif

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -254,7 +254,7 @@ get_ossl_hash_md(TPM2_ALG_ID hashAlgorithm)
         return EVP_sha384();
     case TPM2_ALG_SHA512:
         return EVP_sha512();
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
     case TPM2_ALG_SM3_256:
         return EVP_sm3();
 #endif
@@ -929,7 +929,7 @@ rsa_verify_signature(
     }
 
     r = rsa_evp_verify_signature(publicKey, signature, signatureSize, mdType, digest, digestSize);
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
     if (r == TSS2_FAPI_RC_SIGNATURE_VERIFICATION_FAILED) {
     /* retry sm3 if digestSize is 32 bytes */
         r = rsa_evp_verify_signature(publicKey, signature, signatureSize, EVP_sm3(), digest, digestSize);

--- a/test/integration/sys-util.c
+++ b/test/integration/sys-util.c
@@ -454,7 +454,7 @@ encrypt_cfb (
     return encrypt_decrypt_cfb(data_out, data_in, NO, key, iv);
 }
 
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
 static unsigned char *SM3(const unsigned char *d, size_t n, unsigned char *md)
 {
     EVP_MD_CTX *ctx;
@@ -501,7 +501,7 @@ hash (
         SHA512(data, size, out->buffer);
         out->size = TPM2_SHA512_DIGEST_SIZE;
         break;
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
     case TPM2_ALG_SM3_256:
         SM3(data, size, out->buffer);
         out->size = TPM2_SM3_256_DIGEST_SIZE;
@@ -555,7 +555,7 @@ hmac(
         evp = (EVP_MD *) EVP_sha512();
         out->size = TPM2_SHA512_DIGEST_SIZE;
         break;
-#if HAVE_EVP_SM3
+#if HAVE_EVP_SM3 && !defined(OPENSSL_NO_SM3)
     case TPM2_ALG_SM3_256:
         evp = (EVP_MD *) EVP_sm3();
         out->size = TPM2_SM3_256_DIGEST_SIZE;


### PR DESCRIPTION
Use also OPENSSL_NO_SM3 to check whether SM3 is available and the correct library is used.
Fixes #2287.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>