### PR TITLE
CI: Add images with alpine 3.15 und ubuntu 20.04 with openssl3.0

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -59,7 +59,7 @@ popd
 mkdir ./build
 pushd ./build
 
-if [ "$CC" == "gcc" ]; then
+if [ "$CC" == "gcc" && type -p lcov 2>/dev/null ]; then
   export CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage";
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap]
+        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap, "alpine-3.15", "ubuntu-20.04-ossl3"]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository


### PR DESCRIPTION
* Alpine 3.15 with openssl 1.1 was added.
* Ubuntu 20.04 with openssl 3.0 was added.
* A check whether lcov is available was added to docker.run because lcov was
  not available for installation with apk on alpine.


Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>