### PR TITLE
CI: Add ubuntu 20.04 image with openssl3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap]
+        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-20.04-ossl3]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository


### PR DESCRIPTION
The image ubuntu-20.4-ossl3 was added to the workflow matrix.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>