### PR TITLE
FAPI: Add an integration test for a high range EK policy.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -600,7 +600,8 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_pcr16_read.json \
     test/data/fapi/policy/pol_action.json \
     test/data/fapi/policy/pol_cphash.json \
-    test/data/fapi/policy/pol_or_read_write_secret.json
+    test/data/fapi/policy/pol_or_read_write_secret.json \
+    test/data/fapi/policy/pol_ek_high_range_sha256.json
 
 src_tss2_fapi_libtss2_fapi_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) $(libtss2_esys) \
     $(libutil) $(libtss2_tctildr)

--- a/test/data/fapi/policy/pol_ek_high_range_sha256.json
+++ b/test/data/fapi/policy/pol_ek_high_range_sha256.json
@@ -1,0 +1,62 @@
+{
+    "description":"Policy for EK",
+    "policy":[
+        {
+            "type":"POLICYOR",
+            "branches":[
+                {
+                    "name":"PolicySecret",
+                    "description":"Policy Secret for EK",
+                    "policy":[
+                        {
+                            "type":"POLICYSECRET",
+                            "objectName": "4000000b",
+                        }
+                    ],
+                },
+                {
+                    "name":"PolicyNV",
+                    "description":"Policy NV for EK",
+                    "policy":[
+                        {
+                            "type": "POLICYAUTHORIZENV",
+                            "nvPublic": {
+                                "size":0,
+                                "nvPublic":{
+                                    "nvIndex":"0x01c07f01",
+                                    "nameAlg":"SHA256",
+                                    "attributes":{
+                                        "PPWRITE":0,
+                                        "OWNERWRITE":0,
+                                        "AUTHWRITE":0,
+                                        "POLICYWRITE":1,
+                                        "POLICY_DELETE":0,
+                                        "WRITELOCKED":0,
+                                        "WRITEALL":1,
+                                        "WRITEDEFINE":0,
+                                        "WRITE_STCLEAR":0,
+                                        "GLOBALLOCK":0,
+                                        "PPREAD":1,
+                                        "OWNERREAD":1,
+                                        "AUTHREAD":1,
+                                        "POLICYREAD":1,
+                                        "NO_DA":1,
+                                        "ORDERLY":0,
+                                        "CLEAR_STCLEAR":0,
+                                        "READLOCKED":0,
+                                        "WRITTEN":1,
+                                        "PLATFORMCREATE":0,
+                                        "READ_STCLEAR":0,
+                                        "TPM2_NT":"ORDINARY"
+                                    },
+                                    "authPolicy":"837197674484b3f81a90cc8d46a5d724fd52d76e06520b64f2a1da1b331469aa",
+                                    "dataSize":34
+                                }
+                            }
+		                }
+                    ],
+                }
+            ]
+        }
+    ]
+}

--- a/test/data/test-fapi-policies.h
+++ b/test/data/test-fapi-policies.h
@@ -83,5 +83,8 @@ static policy_digests _test_fapi_policy_policies[] = {
     { .path = "/policy/pol_signed",
       .sha1 = "85bf0403e87d3c29c3daa5c87efb111cb717875d",
       .sha256 = "b1969529af7796c5b4f5e4781713f4525049f36cb12ec63f996dad1c4401c068" },
+    { .path = "/policy/pol_ek_high_range_sha256",
+      .sha1 = "23694f69a8f33f588a93879021a294f3ed73b361",
+      .sha256 = "ca3d0a99a2b93906f7a3342414efcfb3a385d44cd1fd459089d19b5071c0b7a0" },
 };
 #endif


### PR DESCRIPTION
* TCG EK Credential Profile TPM 2.0, Version 2.4 Rev. 3, 2021 defines policies
  for the low and high address range of EK templates.
* A policy for a high range template with sha256 was added to the test policies
  and The policy digests for policy A, B, and C defined in the profile were computed
  in the integration test for Fapi_PolicyExport.
* This policy could be used in a FAPI profile as "ek_policy".

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>