### PR TITLE
FAPI: fix curl_url_set call

### DIFF
--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -2526,10 +2526,11 @@ ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
         LOG_ERROR("curl_url failed.");
         goto out_easy_cleanup;
     }
-    rc = curl_url_set(urlp, CURLUPART_URL, url, CURLU_ALLOW_SPACE | CURLU_URLENCODE);
-    if (rc != CURLE_OK) {
+    CURLUcode url_rc;
+    url_rc = curl_url_set(urlp, CURLUPART_URL, (const char *)url, CURLU_ALLOW_SPACE | CURLU_URLENCODE);
+    if (url_rc) {
         LOG_ERROR("curl_url_set for CURUPART_URL failed: %s",
-                  curl_easy_strerror(rc));
+                  curl_url_strerror(url_rc));
         goto out_easy_cleanup;
     }
     rc = curl_easy_setopt(curl, CURLOPT_CURLU, urlp);


### PR DESCRIPTION
- The third argument of [`curl_url_set`](https://curl.se/libcurl/c/curl_url_set.html) is of type `const char *`, leading to the following compiler warning/error with GCC 11.2.0 and curl 7.81.0:
   ```C
    rc/tss2-fapi/ifapi_helpers.c:2529:44: error: pointer targets in passing argument 3 of 'curl_url_set' differ in signedness [-Werror=pointer-sign]
     2529 |     rc = curl_url_set(urlp, CURLUPART_URL, url, CURLU_ALLOW_SPACE | CURLU_URLENCODE);
          |                                            ^~~
          |                                            |
          |                                            unsigned char *

    /usr/include/curl/urlapi.h:132:48: note: expected 'const char *' but argument is of type 'unsigned char *'
      132 |                                    const char *part, unsigned int flags);
          |  
    ```

- The return value of `curl_url_set` is of type [`CURLUcode`](https://curl.se/libcurl/c/libcurl-errors.html) and needs to be interpreted using [`curl_url_strerror`](https://curl.se/libcurl/c/curl_url_strerror.html) instead of [`curl_easy_strerror`](https://curl.se/libcurl/c/curl_easy_strerror.html). This leads to the following compiler warning/error:
    ```C
    src/tss2-fapi/ifapi_helpers.c:2529:8: error: implicit conversion from 'CURLUcode' to 'CURLcode' [-Werror=enum-conversion]
     2529 |     rc = curl_url_set(urlp, CURLUPART_URL, url, CURLU_ALLOW_SPACE | CURLU_URLENCODE);
          |        ^
    ```