### PR TITLE
ci: add alpine 3.15 and ubuntu-22.04-mbedtls-3.1

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -17,3 +17,6 @@ export LD_LIBRARY_PATH=/usr/local/lib/
 # Change to the build dir
 echo "echo changing to $DOCKER_BUILD_DIR"
 cd $DOCKER_BUILD_DIR
+
+# workaround to solve problem with unsafe directory with alpine
+git config --global --add safe.directory /workspace/tpm2-tss

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -59,8 +59,8 @@ popd
 mkdir ./build
 pushd ./build
 
-if [ "$CC" == "gcc" ]; then
-  export CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage";
+if [[ "$CC" == "gcc" && "$ENABLE_COVERAGE" == "true" ]]; then
+    export CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage";
 fi
 
 if [ ldconfig -p 2>/dev/null| grep libasan > /dev/null && ldconfig -p 2>/dev/null| grep libubsan > /dev/null ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-22.04]
+        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-22.04, alpine-3.15]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
@@ -66,6 +66,9 @@ jobs:
   test-mbedtls:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"
+    strategy:
+      matrix:
+        docker_image: [ubuntu-20.04, ubuntu-22.04-mbedtls-3.1]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -76,7 +79,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ${{ matrix.docker_image }}
           WITH_CRYPTO: mbed
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure


### PR DESCRIPTION
* lcov ist not available for alpine. Thus compiling with --enabable-coverage will
   only used for the action test-coverage.
* To test version of mbedtls 3.1 thei image ubuntu-22.04-mbedtls-3.1 was added.
    

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>