### PR TITLE
aux_util.h: add an ARRAY_LEN macro

### DIFF
--- a/src/tss2-rc/tss2_rc.c
+++ b/src/tss2-rc/tss2_rc.c
@@ -9,8 +9,6 @@
 #include "tss2_sys.h"
 #include "util/aux_util.h"
 
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
-
 /**
  * The maximum size of a layer name.
  */

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -53,10 +53,9 @@
 #include "tcti-common.h"
 #include "tcti-device.h"
 #include "util/io.h"
+#include "util/aux_util.h"
 #define LOGMODULE tcti
 #include "util/log.h"
-
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
 
 static char *default_conf[] = {
 #ifdef __VXWORKS__

--- a/src/tss2-tcti/tcti-libtpms.h
+++ b/src/tss2-tcti/tcti-libtpms.h
@@ -18,8 +18,7 @@
 
 #include "tcti-common.h"
 #include "util/io.h"
-
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+#include "util/aux_util.h"
 
 #define TCTI_LIBTPMS_MAGIC 0x49E299A554504D32ULL
 

--- a/src/util/aux_util.h
+++ b/src/util/aux_util.h
@@ -17,6 +17,8 @@ extern "C" {
 
 #define SAFE_FREE(S) if((S) != NULL) {free((void*) (S)); (S)=NULL;}
 
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
 #define TPM2_ERROR_FORMAT "%s%s (0x%08x)"
 #define TPM2_ERROR_TEXT(r) "Error", "Code", r
 #define SIZE_OF_ARY(ary) (sizeof(ary) / sizeof(ary[0]))

--- a/test/unit/test_tss2_rc.c
+++ b/test/unit/test_tss2_rc.c
@@ -13,8 +13,6 @@
 #include "tss2_rc.h"
 #include "util/aux_util.h"
 
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
-
 #define TPM2_ERROR_TSS2_RC_LAYER_COUNT (TSS2_RC_LAYER_MASK >> TSS2_RC_LAYER_SHIFT)
 
 #define assert_string_prefix(str, prefix) \


### PR DESCRIPTION
Stop duplicating this macro everywhere, make it common.

Signed-off-by: William Roberts <william.c.roberts@intel.com>