### PR TITLE
Store VERSION into the release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,7 +207,8 @@ EXTRA_DIST += \
     LICENSE \
     MAINTAINERS \
     README.md \
-    RELEASE.md
+    RELEASE.md \
+    VERSION
 
 # Windows code / core build files
 EXTRA_DIST += \

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+git describe --tags --always --dirty > VERSION
+
 # generate list of source files for use in Makefile.am
 # if you add new source files, you must run ./bootstrap again
 src_listvar () {

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # All rights reserved.
 
 AC_INIT([tpm2-tss],
-        [m4_esyscmd_s([git describe --tags --always --dirty])],
+        [m4_esyscmd_s([cat ./VERSION])],
         [https://github.com/tpm2-software/tpm2-tss/issues],
         [],
         [https://github.com/tpm2-software/tpm2-tss])


### PR DESCRIPTION
This way autoreconf can still be run on release tarballs (e.g. to apply patches to the build system) while preserving the version number. The tpm2-abrmd already uses this approach.

Fixes: #2329