### PR TITLE
Conditionally check for user/group manipulation commands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,7 +489,7 @@ AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
 AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
 
 # Check all tools used by make install
-AS_IF([test "$HOSTOS" = "Linux"],
+AS_IF([test "$HOSTOS" = "Linux" && test "x$systemd_sysusers" != "xyes"],
     [ AC_CHECK_PROG(useradd, useradd, yes)
       AC_CHECK_PROG(groupadd, groupadd, yes)
       AC_CHECK_PROG(adduser, adduser, yes)


### PR DESCRIPTION
Only check for useradd/adduser and groupadd/addgroup when
systemd_sysusers is not present on the system.