### PR TITLE
FAPI: Add CreationHash to keystore

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -783,6 +783,7 @@ ifapi_init_primary_finish(FAPI_CONTEXT *context, TSS2_KEY_TYPE ktype, IFAPI_OBJE
         pkey->public = *outPublic;
         pkey->policyInstance = NULL;
         pkey->creationData = *creationData;
+        pkey->creationHash = *creationHash;
         pkey->creationTicket = *creationTicket;
         pkey->description = NULL;
         pkey->certificate = NULL;
@@ -3417,6 +3418,7 @@ ifapi_key_create(
                                                  &outPrivate->buffer[0], outPrivate->size);
         object->misc.key.policyInstance = NULL;
         object->misc.key.creationData = *creationData;
+        object->misc.key.creationHash = *creationHash;
         object->misc.key.creationTicket = *creationTicket;
         object->misc.key.description = NULL;
         object->misc.key.certificate = NULL;
@@ -4671,6 +4673,7 @@ ifapi_create_primary(
         object->misc.key.private.buffer = NULL;
         object->misc.key.policyInstance = NULL;
         object->misc.key.creationData = *creationData;
+        object->misc.key.creationHash = *creationHash;
         object->misc.key.creationTicket = *creationTicket;
         object->misc.key.description = NULL;
         object->misc.key.certificate = NULL;

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -169,12 +169,20 @@ ifapi_json_IFAPI_KEY_deserialize(json_object *jso,  IFAPI_KEY *out)
         memset(&out->creationData, 0, sizeof(TPM2B_CREATION_DATA));
     }
 
+    if (ifapi_get_sub_object(jso, "creationHash", &jso2)) {
+        r = ifapi_json_TPM2B_DIGEST_deserialize(jso2, &out->creationHash);
+        return_if_error(r, "Bad value for field \"creationHash\".");
+
+    } else {
+        memset(&out->creationHash, 0, sizeof(TPM2B_DIGEST));
+    }
+
     if (ifapi_get_sub_object(jso, "creationTicket", &jso2)) {
         r = ifapi_json_TPMT_TK_CREATION_deserialize(jso2, &out->creationTicket);
         return_if_error(r, "Bad value for field \"creationTicket\".");
 
     } else {
-        memset(&out->creationData, 0, sizeof(TPMT_TK_CREATION));
+        memset(&out->creationTicket, 0, sizeof(TPMT_TK_CREATION));
     }
     if (!ifapi_get_sub_object(jso, "description", &jso2)) {
         LOG_ERROR("Field \"description\" not found.");

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -149,6 +149,14 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
 
         json_object_object_add(*jso, "creationData", jso2);
     }
+    /* Creation Hash is not available for imported keys */
+    if (in->creationHash.size) {
+        jso2 = NULL;
+        r = ifapi_json_TPM2B_DIGEST_serialize(&in->creationHash, &jso2);
+        return_if_error(r, "Serialize TPM2B_DIGEST");
+
+        json_object_object_add(*jso, "creationHash", jso2);
+    }
     /* Creation Ticket is not available for imported keys */
     if (in->creationTicket.tag) {
         jso2 = NULL;

--- a/src/tss2-fapi/ifapi_keystore.h
+++ b/src/tss2-fapi/ifapi_keystore.h
@@ -32,6 +32,7 @@ typedef struct {
     UINT8_ARY                             serialization;    /**< None */
     UINT8_ARY                                   private;    /**< None */
     char                                *policyInstance;    /**<  Keys policy */
+    TPM2B_DIGEST                            creationHash;   /**< Hash create by Create or CreatePrimary */
     TPM2B_CREATION_DATA                    creationData;    /**< None */
     TPMT_TK_CREATION                     creationTicket;    /**< None */
     char                                   *description;    /**< Human readable description of key */


### PR DESCRIPTION
Currently only CreationData and CreationHash were stored in the FAPI keystore.
Creation hash is now added to provide the possibility for the tpm2 tool command
tss2_gettpm2object to extract also CreationData, CreationTicket, and CreationHash.
Also the initialization of cretionTicket during deserialization was fixed.
Addresses #2360

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>