### PR TITLE
test: check return value of fread

### DIFF
--- a/test/integration/policy-execute.int.c
+++ b/test/integration/policy-execute.int.c
@@ -70,8 +70,11 @@ static char *read_all(const char *path) {
         return NULL;
     }
 
-    fread(buffer, fsize, 1, f);
+    size_t count_read = fread(buffer, fsize, 1, f);
     fclose(f);
+    if (count_read != 1) {
+        return NULL;
+    }
 
     return buffer;
 }

--- a/test/unit/tss2_policy.c
+++ b/test/unit/tss2_policy.c
@@ -50,8 +50,11 @@ static char *read_all(const char *path) {
         return NULL;
     }
 
-    fread(buffer, fsize, 1, f);
+    size_t count_read = fread(buffer, fsize, 1, f);
     fclose(f);
+    if (count_read != 1) {
+        return NULL;
+    }
 
     return buffer;
 }


### PR DESCRIPTION
Check whether `fread` was able to read the complete file and fail with an assertion if not. This fixes the following warnings/errors when building with GCC 12.1.0:

```C
test/integration/policy-execute.int.c: In function 'read_all':
test/integration/policy-execute.int.c:73:5: error: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   73 |     fread(buffer, fsize, 1, f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
```C
test/unit/tss2_policy.c: In function 'read_all':
test/unit/tss2_policy.c:53:5: error: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   53 |     fread(buffer, fsize, 1, f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
  CC       test/integration/sys_asymmetric_encrypt_decrypt_int-sys-asymmetric-encrypt-decrypt.int.o
```