### PR TITLE
esapi: support runtime switchable crypto backends

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -55,6 +55,11 @@ echo "ls -la ../ $(ls -la ../)"
 make -j$(nproc)
 popd
 
+if [ "$WITH_CRYPTO" == "none" ]; then
+    echo "Exiting without running tests becuase crypto backend is none"
+    exit 0
+fi
+
 # build with all tests enabled
 mkdir ./build
 pushd ./build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,25 @@ jobs:
       - name: failure
         if: ${{ failure() }}
         run: cat $(find ../ -name test-suite.log) || true
+  test-no-crypto-build:
+    runs-on: ubuntu-latest
+    if: "!contains(github.ref, 'coverity_scan')"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+      - name: Launch Action
+        uses:
+          tpm2-software/ci/runCI@main
+        with:
+          CC: gcc
+          DOCKER_IMAGE: ubuntu-20.04
+          WITH_CRYPTO: none
+          PROJECT_NAME: ${{ github.event.repository.name }}
+      - name: failure
+        if: ${{ failure() }}
+        run: cat $(find ../ -name test-suite.log) || true
   test-coverage:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -214,6 +214,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-create-session-auth.int \
     test/integration/esys-create-session-auth-long.int \
     test/integration/esys-create-session-auth-xor.int \
+    test/integration/esys-crypto.int \
     test/integration/esys-ecc-parameters.int \
     test/integration/esys-ecdh-zgen.int \
     test/integration/esys-event-sequence-complete.int \
@@ -1657,6 +1658,12 @@ test_integration_esys_tpm_clear_auth_int_SOURCES = \
     test/integration/esys-tpm-clear-auth.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
 
+test_integration_esys_crypto_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_crypto_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_crypto_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_crypto_int_SOURCES = \
+    test/integration/esys-crypto.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
 endif #ESYS
 
 test_integration_sys_policy_template_int_CFLAGS  = $(TESTS_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ AC_ARG_ENABLE([policy],
 AM_CONDITIONAL(POLICY, test "x$enable_policy" = "xyes")
 
 AC_ARG_WITH([crypto],
-            [AS_HELP_STRING([--with-crypto={ossl,mbed}],
+            [AS_HELP_STRING([--with-crypto={ossl,mbed,none}],
                             [sets the ESYS crypto backend (default is OpenSSL)])],,
             [with_crypto=ossl])
 
@@ -158,6 +158,8 @@ AS_IF([test "x$enable_esys" = xyes],
            AC_DEFINE([MBED], [1], [mbedTLS cryptographic backend])
            TSS2_ESYS_CFLAGS_CRYPTO="$LIBMBED_CFLAGS"
            TSS2_ESYS_LDFLAGS_CRYPTO="-lmbedcrypto"
+       ], [test "x$with_crypto" = xnone], [
+           AC_MSG_NOTICE([No crypto backend selected! Users must set crypto functions!])
        ], [AC_MSG_ERROR([Bad value for --with-crypto $with_crypto])])])
 AC_SUBST([TSS2_ESYS_CFLAGS_CRYPTO])
 AC_SUBST([TSS2_ESYS_LDFLAGS_CRYPTO])

--- a/doc/doxygen.dox
+++ b/doc/doxygen.dox
@@ -24,6 +24,7 @@ Both the synchronous and asynchronous API are exposed through a single library: 
  \fn TSS2_RC Esys_GetPollHandles(ESYS_CONTEXT * esys_context, TSS2_TCTI_POLL_HANDLE ** handles, size_t * count)
  \fn TSS2_RC Esys_SetTimeout(ESYS_CONTEXT *esys_context, int32_t timeout)
  \fn TSS2_RC Esys_GetSysContext(ESYS_CONTEXT *esys_context, TSS2_SYS_CONTEXT **sys_context)
+ \fn TSS2_RC Esys_SetCryptoCallbacks(ESYS_CONTEXT *esys_context, ESYS_CRYPTO_CALLBACKS *callbacks)
  \fn void Esys_Free(void *__ptr)
  \}
 */

--- a/include/tss2/tss2_common.h
+++ b/include/tss2/tss2_common.h
@@ -122,6 +122,7 @@ typedef uint32_t TSS2_RC;
 #define TSS2_BASE_RC_NO_HANDLE                 51U
 #define TSS2_BASE_RC_NOT_PROVISIONED           52U
 #define TSS2_BASE_RC_ALREADY_PROVISIONED       53U
+#define TSS2_BASE_RC_CALLBACK_NULL             54U
 
 /* Base return codes in the range 0xf800 - 0xffff are reserved for
  * implementation-specific purposes.
@@ -254,7 +255,8 @@ typedef uint32_t TSS2_RC;
                                                         TSS2_BASE_RC_MULTIPLE_ENCRYPT_SESSIONS))
 #define TSS2_ESYS_RC_RSP_AUTH_FAILED             ((TSS2_RC)(TSS2_ESAPI_RC_LAYER | \
                                                         TSS2_BASE_RC_RSP_AUTH_FAILED))
-
+#define TSS2_ESYS_RC_CALLBACK_NULL               ((TSS2_RC)(TSS2_ESAPI_RC_LAYER | \
+                                                        TSS2_BASE_RC_RSP_AUTH_FAILED))
 /* FAPI Error Codes */
 
 #define TSS2_FAPI_RC_GENERAL_FAILURE             ((TSS2_RC)(TSS2_FEATURE_RC_LAYER | \

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -318,6 +318,7 @@ EXPORTS
     Esys_SetCommandCodeAuditStatus
     Esys_SetCommandCodeAuditStatus_Async
     Esys_SetCommandCodeAuditStatus_Finish
+    Esys_SetCryptoCallbacks
     Esys_SetPrimaryPolicy
     Esys_SetPrimaryPolicy_Async
     Esys_SetPrimaryPolicy_Finish

--- a/lib/tss2-esys.map
+++ b/lib/tss2-esys.map
@@ -365,6 +365,7 @@
         Esys_Initialize;
         Esys_GetPollHandles;
         Esys_Finalize;
+        Esys_SetCryptoCallbacks;
     local:
         *;
 };

--- a/src/tss2-esys/api/Esys_Create.c
+++ b/src/tss2-esys/api/Esys_Create.c
@@ -207,6 +207,7 @@ Esys_Create_Async(
     store_input_parameters (esysContext, inSensitive);
     if (inPublic) {
         r = iesys_hash_long_auth_values(
+                &esysContext->crypto_backend,
            &esysContext->in.Create.inSensitive->sensitive.userAuth,
             inPublic->publicArea.nameAlg);
         return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");

--- a/src/tss2-esys/api/Esys_CreateLoaded.c
+++ b/src/tss2-esys/api/Esys_CreateLoaded.c
@@ -204,6 +204,7 @@ Esys_CreateLoaded_Async(
         return_if_error(r, "Unmarshalling inPublic failed");
 
         r = iesys_hash_long_auth_values(
+            &esysContext->crypto_backend,
             &esysContext->in.CreateLoaded.inSensitive->sensitive.userAuth,
              publicArea.nameAlg);
         return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");
@@ -400,7 +401,7 @@ Esys_CreateLoaded_Finish(
     objectHandleNode->rsrc.misc.rsrc_key_pub = *loutPublic;
 
     /* Check name and outPublic for consistency */
-    if (!iesys_compare_name(&objectHandleNode->rsrc.misc.rsrc_key_pub, &name))
+    if (!iesys_compare_name(&esysContext->crypto_backend, &objectHandleNode->rsrc.misc.rsrc_key_pub, &name))
         goto_error(r, TSS2_ESYS_RC_MALFORMED_RESPONSE,
             "in Public name not equal name in response", error_cleanup);
 

--- a/src/tss2-esys/api/Esys_CreatePrimary.c
+++ b/src/tss2-esys/api/Esys_CreatePrimary.c
@@ -209,6 +209,7 @@ Esys_CreatePrimary_Async(
     store_input_parameters (esysContext, inSensitive);
     if (inPublic) {
         r = iesys_hash_long_auth_values(
+            &esysContext->crypto_backend,
             &esysContext->in.CreatePrimary.inSensitive->sensitive.userAuth,
              inPublic->publicArea.nameAlg);
         return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");
@@ -433,7 +434,7 @@ Esys_CreatePrimary_Finish(
 
 
     /* Check name and outPublic for consistency */
-    if (!iesys_compare_name(loutPublic, &name))
+    if (!iesys_compare_name(&esysContext->crypto_backend, loutPublic, &name))
         goto_error(r, TSS2_ESYS_RC_MALFORMED_RESPONSE,
             "in Public name not equal name in response", error_cleanup);
 

--- a/src/tss2-esys/api/Esys_Load.c
+++ b/src/tss2-esys/api/Esys_Load.c
@@ -350,7 +350,7 @@ Esys_Load_Finish(
 
 
     /* Check name and inPublic for consistency */
-    if (!iesys_compare_name(esysContext->in.Load.inPublic, &name)) {
+    if (!iesys_compare_name(&esysContext->crypto_backend, esysContext->in.Load.inPublic, &name)) {
         goto_error(r, TSS2_ESYS_RC_MALFORMED_RESPONSE,
                    "in Public name not equal name in response", error_cleanup);
     }

--- a/src/tss2-esys/api/Esys_LoadExternal.c
+++ b/src/tss2-esys/api/Esys_LoadExternal.c
@@ -340,7 +340,7 @@ Esys_LoadExternal_Finish(
 
 
     /* check name against inPublic */
-    if (!iesys_compare_name(esysContext->in.LoadExternal.inPublic, &name)) {
+    if (!iesys_compare_name(&esysContext->crypto_backend, esysContext->in.LoadExternal.inPublic, &name)) {
         goto_error(r, TSS2_ESYS_RC_MALFORMED_RESPONSE,
                       "in Public name not equal name in response", error_cleanup);
     }

--- a/src/tss2-esys/api/Esys_NV_DefineSpace.c
+++ b/src/tss2-esys/api/Esys_NV_DefineSpace.c
@@ -201,7 +201,7 @@ Esys_NV_DefineSpace_Async(
     store_input_parameters(esysContext, auth, publicInfo);
 
     if (publicInfo) {
-        r = iesys_hash_long_auth_values(esysContext->in.NV.auth,
+        r = iesys_hash_long_auth_values(&esysContext->crypto_backend, esysContext->in.NV.auth,
                                         publicInfo->nvPublic.nameAlg);
         return_state_if_error(r, _ESYS_STATE_INIT, "Adapt auth value.");
     }
@@ -369,7 +369,7 @@ Esys_NV_DefineSpace_Finish(
 
     /* Update the meta data of the ESYS_TR object */
     nvHandleNode->rsrc.rsrcType = IESYSC_NV_RSRC;
-    r = iesys_nv_get_name(esysContext->in.NV.publicInfo,
+    r = iesys_nv_get_name(&esysContext->crypto_backend, esysContext->in.NV.publicInfo,
                           &nvHandleNode->rsrc.name);
     if (r != TSS2_RC_SUCCESS) {
         LOG_ERROR("Error finish (ExecuteFinish) NV_DefineSpace: %" PRIx32, r);

--- a/src/tss2-esys/api/Esys_NV_Extend.c
+++ b/src/tss2-esys/api/Esys_NV_Extend.c
@@ -336,7 +336,7 @@ Esys_NV_Extend_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |= TPMA_NV_WRITTEN;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_NV_Increment.c
+++ b/src/tss2-esys/api/Esys_NV_Increment.c
@@ -338,7 +338,7 @@ Esys_NV_Increment_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |= TPMA_NV_WRITTEN;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_NV_ReadLock.c
+++ b/src/tss2-esys/api/Esys_NV_ReadLock.c
@@ -338,7 +338,7 @@ Esys_NV_ReadLock_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |=  TPMA_NV_READLOCKED;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_NV_SetBits.c
+++ b/src/tss2-esys/api/Esys_NV_SetBits.c
@@ -343,7 +343,7 @@ Esys_NV_SetBits_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |= TPMA_NV_WRITTEN;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_NV_Write.c
+++ b/src/tss2-esys/api/Esys_NV_Write.c
@@ -341,7 +341,7 @@ Esys_NV_Write_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |= TPMA_NV_WRITTEN;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_NV_WriteLock.c
+++ b/src/tss2-esys/api/Esys_NV_WriteLock.c
@@ -338,7 +338,7 @@ Esys_NV_WriteLock_Finish(
     /* Update name in meta data because of possibly changed attributes */
     if (nvIndexNode != NULL) {
         nvIndexNode->rsrc.misc.rsrc_nv_pub.nvPublic.attributes |=  TPMA_NV_WRITELOCKED;
-        r = iesys_nv_get_name(&nvIndexNode->rsrc.misc.rsrc_nv_pub,
+        r = iesys_nv_get_name(&esysContext->crypto_backend, &nvIndexNode->rsrc.misc.rsrc_nv_pub,
                               &nvIndexNode->rsrc.name);
         return_if_error(r, "Error get nvname")
     }

--- a/src/tss2-esys/api/Esys_StartAuthSession.c
+++ b/src/tss2-esys/api/Esys_StartAuthSession.c
@@ -229,7 +229,8 @@ Esys_StartAuthSession_Async(
         r2 = iesys_crypto_hash_get_digest_size(authHash,&authHash_size);
         return_state_if_error(r2, _ESYS_STATE_INIT, "Error in hash_get_digest_size.");
 
-        r2 = iesys_crypto_random2b(&esysContext->in.StartAuthSession.nonceCallerData,
+        r2 = iesys_crypto_get_random2b(&esysContext->crypto_backend,
+                &esysContext->in.StartAuthSession.nonceCallerData,
                                    authHash_size);
         return_state_if_error(r2, _ESYS_STATE_INIT, "Error in crypto_random2b.");
         esysContext->in.StartAuthSession.nonceCaller
@@ -473,7 +474,7 @@ Esys_StartAuthSession_Finish(
                                            &bindNode->auth,
                                            &sessionHandleNode->rsrc.misc.rsrc_session.bound_entity);
             LOGBLOB_DEBUG(secret, secret_size, "ESYS Session Secret");
-            r = iesys_crypto_KDFa(esysContext->in.StartAuthSession.authHash, secret,
+            r = iesys_crypto_KDFa(&esysContext->crypto_backend, esysContext->in.StartAuthSession.authHash, secret,
                                   secret_size, "ATH",
                                   &lnonceTPM, esysContext->in.StartAuthSession.nonceCaller,
                                   authHash_size*8, NULL,

--- a/src/tss2-esys/esys_crypto.h
+++ b/src/tss2-esys/esys_crypto.h
@@ -14,7 +14,20 @@
 #elif defined(MBED)
 #include "esys_crypto_mbed.h"
 #else
-#error "No crypto backend defined"
+#define _iesys_crypto_aes_decrypt NULL;
+#define _iesys_crypto_aes_encrypt NULL;
+#define _iesys_crypto_get_ecdh_point NULL;
+#define _iesys_crypto_hash_abort NULL;
+#define _iesys_crypto_hash_finish NULL;
+#define _iesys_crypto_hash_start NULL;
+#define _iesys_crypto_hash_update NULL;
+#define _iesys_crypto_hmac_abort NULL;
+#define _iesys_crypto_hmac_finish NULL;
+#define _iesys_crypto_hmac_start NULL;
+#define _iesys_crypto_hmac_update NULL;
+#define _iesys_crypto_init NULL;
+#define _iesys_crypto_get_random2b NULL;
+#define _iesys_crypto_rsa_pk_encrypt NULL;
 #endif
 
 #ifdef __cplusplus
@@ -26,6 +39,7 @@ extern "C" {
 TSS2_RC iesys_crypto_hash_get_digest_size(TPM2_ALG_ID hashAlg, size_t *size);
 
 TSS2_RC iesys_crypto_pHash(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2_ALG_ID alg,
     const uint8_t rcBuffer[4],
     const uint8_t ccBuffer[4],
@@ -37,17 +51,120 @@ TSS2_RC iesys_crypto_pHash(
     uint8_t *pHash,
     size_t *pHash_size);
 
-#define iesys_crypto_cpHash(alg, ccBuffer, name1, name2, name3, \
+#define iesys_crypto_cpHash(ectx, alg, ccBuffer, name1, name2, name3, \
                             cpBuffer, cpBuffer_size, cpHash, cpHash_size) \
-        iesys_crypto_pHash(alg, NULL, ccBuffer, name1, name2, name3, cpBuffer, \
+        iesys_crypto_pHash(ectx, alg, NULL, ccBuffer, name1, name2, name3, cpBuffer, \
                            cpBuffer_size, cpHash, cpHash_size)
-#define iesys_crypto_rpHash(alg, rcBuffer, ccBuffer, rpBuffer, rpBuffer_size, \
+#define iesys_crypto_rpHash(ectx, alg, rcBuffer, ccBuffer, rpBuffer, rpBuffer_size, \
                             rpHash, rpHash_size)                        \
-        iesys_crypto_pHash(alg, rcBuffer, ccBuffer, NULL, NULL, NULL, rpBuffer, \
+        iesys_crypto_pHash(ectx, alg, rcBuffer, ccBuffer, NULL, NULL, NULL, rpBuffer, \
                            rpBuffer_size, rpHash, rpHash_size)
 
+TSS2_RC iesys_crypto_hmac_finish2b(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB ** context,
+    TPM2B *tpm2b);
+
+TSS2_RC iesys_crypto_hmac_update2b(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB * context,
+    TPM2B *tpm2b);
+
+TSS2_RC iesys_crypto_hash_update2b(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB * context,
+    TPM2B *tpm2b);
+
+TSS2_RC iesys_crypto_rsa_pk_encrypt(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    TPM2B_PUBLIC * pub_tpm_key,
+    size_t in_size,
+    BYTE * in_buffer,
+    size_t max_out_size,
+    BYTE * out_buffer,
+    size_t * out_size,
+    const char *label);
+
+TSS2_RC iesys_crypto_hash_start(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    TPM2_ALG_ID hashAlg);
+
+TSS2_RC  iesys_crypto_hash_update(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB *context,
+    const uint8_t *buffer,
+    size_t size);
+
+TSS2_RC iesys_crypto_hash_finish(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB ** context,
+    uint8_t *buffer,
+    size_t *size);
+
+TSS2_RC iesys_crypto_hash_abort(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB **context);
+
+TSS2_RC iesys_crypto_hmac_start(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+   TPM2_ALG_ID hashAlg,
+   const uint8_t *key,
+   size_t size);
+
+TSS2_RC iesys_crypto_hmac_update(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB * context,
+    const uint8_t *buffer,
+    size_t size);
+
+TSS2_RC iesys_crypto_hmac_finish(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    uint8_t *buffer,
+    size_t * size);
+
+TSS2_RC iesys_crypto_hmac_abort(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CONTEXT_BLOB **context);
+
+TSS2_RC iesys_crypto_get_random2b(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    TPM2B_NONCE *nonce,
+    size_t num_bytes);
+
+TSS2_RC iesys_crypto_get_ecdh_point(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    TPM2B_PUBLIC *key,
+    size_t max_out_size,
+    TPM2B_ECC_PARAMETER *Z,
+    TPMS_ECC_POINT *Q,
+    BYTE * out_buffer,
+    size_t * out_size);
+
+ TSS2_RC iesys_crypto_aes_encrypt(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    uint8_t *key,
+    TPM2_ALG_ID tpm_sym_alg,
+    TPMI_AES_KEY_BITS key_bits,
+    TPM2_ALG_ID tpm_mode,
+    uint8_t *buffer,
+    size_t buffer_size,
+    uint8_t *iv);
+
+TSS2_RC iesys_crypto_aes_decrypt(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    uint8_t *key,
+    TPM2_ALG_ID tpm_sym_alg,
+    TPMI_AES_KEY_BITS key_bits,
+    TPM2_ALG_ID tpm_mode,
+    uint8_t *buffer,
+    size_t buffer_size,
+    uint8_t *iv);
 
 TSS2_RC iesys_crypto_authHmac(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2_ALG_ID alg,
     uint8_t *hmacKey,
     size_t hmacKeySize,
@@ -61,6 +178,7 @@ TSS2_RC iesys_crypto_authHmac(
     TPM2B_AUTH *hmac);
 
 TSS2_RC iesys_crypto_KDFaHmac(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2_ALG_ID alg,
     uint8_t *hmacKey,
     size_t hmacKeySize,
@@ -73,6 +191,7 @@ TSS2_RC iesys_crypto_KDFaHmac(
     size_t *hmacSize);
 
 TSS2_RC iesys_crypto_KDFa(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2_ALG_ID hashAlg,
     uint8_t *hmacKey,
     size_t hmacKeySize,
@@ -85,6 +204,7 @@ TSS2_RC iesys_crypto_KDFa(
     BOOL use_digest_size);
 
 TSS2_RC iesys_xor_parameter_obfuscation(
+    ESYS_CRYPTO_CALLBACKS *cryto_cb,
     TPM2_ALG_ID hash_alg,
     uint8_t *key,
     size_t key_size,
@@ -94,6 +214,7 @@ TSS2_RC iesys_xor_parameter_obfuscation(
     size_t data_size);
 
 TSS2_RC iesys_crypto_KDFe(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2_ALG_ID hashAlg,
     TPM2B_ECC_PARAMETER *Z,
     const char *label,
@@ -102,7 +223,9 @@ TSS2_RC iesys_crypto_KDFe(
     UINT32 bit_size,
     BYTE *key);
 
-TSS2_RC iesys_initialize_crypto();
+TSS2_RC iesys_initialize_crypto_backend(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
+    ESYS_CRYPTO_CALLBACKS *user_cb);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/tss2-esys/esys_crypto_mbed.c
+++ b/src/tss2-esys/esys_crypto_mbed.c
@@ -31,7 +31,7 @@
 #endif
 
 /** Context to hold temporary values for iesys_crypto */
-typedef struct _IESYS_CRYPTO_CONTEXT {
+typedef struct ESYS_CRYPTO_CONTEXT_BLOB {
     enum {
         IESYS_CRYPTMBED_TYPE_HASH = 1,
         IESYS_CRYPTMBED_TYPE_HMAC,
@@ -59,9 +59,12 @@ typedef struct _IESYS_CRYPTO_CONTEXT {
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
  */
 TSS2_RC
-iesys_cryptmbed_hash_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
-                           TPM2_ALG_ID hashAlg)
+iesys_cryptmbed_hash_start(ESYS_CRYPTO_CONTEXT_BLOB ** context,
+                           TPM2_ALG_ID hashAlg,
+                           void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     const mbedtls_md_info_t* md_info = NULL;
 
@@ -105,7 +108,7 @@ iesys_cryptmbed_hash_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
 
     mycontext->type = IESYS_CRYPTMBED_TYPE_HASH;
 
-    *context = (IESYS_CRYPTO_CONTEXT_BLOB *) mycontext;
+    *context = (ESYS_CRYPTO_CONTEXT_BLOB *) mycontext;
 
     return TSS2_RC_SUCCESS;
 
@@ -126,9 +129,12 @@ iesys_cryptmbed_hash_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters.
  */
 TSS2_RC
-iesys_cryptmbed_hash_update(IESYS_CRYPTO_CONTEXT_BLOB * context,
-                            const uint8_t * buffer, size_t size)
+iesys_cryptmbed_hash_update(ESYS_CRYPTO_CONTEXT_BLOB * context,
+                            const uint8_t * buffer, size_t size,
+                            void *userdata)
 {
+    UNUSED(userdata);
+
     if (context == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Null-Pointer passed");
     }
@@ -144,25 +150,6 @@ iesys_cryptmbed_hash_update(IESYS_CRYPTO_CONTEXT_BLOB * context,
     return TSS2_RC_SUCCESS;
 }
 
-/** Update the digest value of a digest object from a TPM2B object.
- *
- * The context of a digest object will be updated according to the hash
- * algorithm of the context.
- * @param[in,out] context The context of the digest object which will be updated.
- * @param[in] b The TPM2B object for the update.
- * @retval TSS2_RC_SUCCESS on success.
- * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters.
- */
-TSS2_RC
-iesys_cryptmbed_hash_update2b(IESYS_CRYPTO_CONTEXT_BLOB * context, TPM2B * b)
-{
-    if (context == NULL || b == NULL) {
-        return TSS2_ESYS_RC_BAD_REFERENCE;
-    }
-    TSS2_RC ret = iesys_cryptmbed_hash_update(context, &b->buffer[0], b->size);
-    return ret;
-}
-
 /** Get the digest value of a digest object and close the context.
  *
  * The digest value will written to a passed buffer and the resources of the
@@ -175,9 +162,11 @@ iesys_cryptmbed_hash_update2b(IESYS_CRYPTO_CONTEXT_BLOB * context, TPM2B * b)
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
  */
 TSS2_RC
-iesys_cryptmbed_hash_finish(IESYS_CRYPTO_CONTEXT_BLOB ** context,
-                            uint8_t * buffer, size_t * size)
+iesys_cryptmbed_hash_finish(ESYS_CRYPTO_CONTEXT_BLOB ** context,
+                            uint8_t * buffer, size_t * size,
+                            void *userdata)
 {
+    UNUSED(userdata);
 
     TSS2_RC r = TSS2_RC_SUCCESS;
 
@@ -214,8 +203,10 @@ iesys_cryptmbed_hash_finish(IESYS_CRYPTO_CONTEXT_BLOB ** context,
  * @param[in,out] context The context of the digest object.
  */
 void
-iesys_cryptmbed_hash_abort(IESYS_CRYPTO_CONTEXT_BLOB ** context)
+iesys_cryptmbed_hash_abort(ESYS_CRYPTO_CONTEXT_BLOB ** context, void *userdata)
 {
+    UNUSED(userdata);
+
     if (context == NULL || *context == NULL) {
         return;
     }
@@ -247,10 +238,13 @@ iesys_cryptmbed_hash_abort(IESYS_CRYPTO_CONTEXT_BLOB ** context)
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
  */
 TSS2_RC
-iesys_cryptmbed_hmac_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
+iesys_cryptmbed_hmac_start(ESYS_CRYPTO_CONTEXT_BLOB ** context,
                            TPM2_ALG_ID hashAlg,
-                           const uint8_t * key, size_t size)
+                           const uint8_t * key, size_t size,
+                           void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     const mbedtls_md_info_t* md_info = NULL;
 
@@ -294,7 +288,7 @@ iesys_cryptmbed_hmac_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
 
     mycontext->type = IESYS_CRYPTMBED_TYPE_HMAC;
 
-    *context = (IESYS_CRYPTO_CONTEXT_BLOB *) mycontext;
+    *context = (ESYS_CRYPTO_CONTEXT_BLOB *) mycontext;
 
     return TSS2_RC_SUCCESS;
 
@@ -315,9 +309,12 @@ iesys_cryptmbed_hmac_start(IESYS_CRYPTO_CONTEXT_BLOB ** context,
  * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters.
  */
 TSS2_RC
-iesys_cryptmbed_hmac_update(IESYS_CRYPTO_CONTEXT_BLOB * context,
-                            const uint8_t * buffer, size_t size)
+iesys_cryptmbed_hmac_update(ESYS_CRYPTO_CONTEXT_BLOB * context,
+                            const uint8_t * buffer, size_t size,
+                            void *userdata)
 {
+    UNUSED(userdata);
+
     if (context == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Null-Pointer passed");
     }
@@ -333,25 +330,6 @@ iesys_cryptmbed_hmac_update(IESYS_CRYPTO_CONTEXT_BLOB * context,
     return TSS2_RC_SUCCESS;
 }
 
-/** Update and HMAC digest value from a TPM2B object.
- *
- * The context of a digest object will be updated according to the hash
- * algorithm and the key of the context.
- * @param[in,out] context The context of the digest object which will be updated.
- * @param[in] b The TPM2B object for the update.
- * @retval TSS2_RC_SUCCESS on success.
- * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters.
- */
-TSS2_RC
-iesys_cryptmbed_hmac_update2b(IESYS_CRYPTO_CONTEXT_BLOB * context, TPM2B * b)
-{
-    if (context == NULL || b == NULL) {
-        return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Null-Pointer passed");
-    }
-    TSS2_RC ret = iesys_cryptmbed_hmac_update(context, &b->buffer[0], b->size);
-    return ret;
-}
-
 /** Write the HMAC digest value to a byte buffer and close the context.
  *
  * The digest value will written to a passed buffer and the resources of the
@@ -365,9 +343,11 @@ iesys_cryptmbed_hmac_update2b(IESYS_CRYPTO_CONTEXT_BLOB * context, TPM2B * b)
  * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
  */
 TSS2_RC
-iesys_cryptmbed_hmac_finish(IESYS_CRYPTO_CONTEXT_BLOB ** context,
-                            uint8_t * buffer, size_t * size)
+iesys_cryptmbed_hmac_finish(ESYS_CRYPTO_CONTEXT_BLOB ** context,
+                            uint8_t * buffer, size_t * size,
+                            void *userdata)
 {
+    UNUSED(userdata);
 
     TSS2_RC r = TSS2_RC_SUCCESS;
 
@@ -397,37 +377,16 @@ iesys_cryptmbed_hmac_finish(IESYS_CRYPTO_CONTEXT_BLOB ** context,
     return r;
 }
 
-/** Write the HMAC digest value to a TPM2B object and close the context.
- *
- * The digest value will written to a passed TPM2B object and the resources of
- * the HMAC object are released.
- * @param[in,out] context The context of the HMAC object.
- * @param[out] hmac The buffer for the digest value (caller-allocated).
- * @retval TSS2_RC_SUCCESS on success.
- * @retval TSS2_ESYS_RC_BAD_REFERENCE for invalid parameters.
- * @retval TSS2_ESYS_RC_BAD_SIZE if the size passed is lower than the HMAC length.
- * @retval TSS2_ESYS_RC_GENERAL_FAILURE for errors of the crypto library.
- */
-TSS2_RC
-iesys_cryptmbed_hmac_finish2b(IESYS_CRYPTO_CONTEXT_BLOB ** context, TPM2B * hmac)
-{
-    if (context == NULL || *context == NULL || hmac == NULL) {
-        return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Null-Pointer passed");
-    }
-    size_t s = hmac->size;
-    TSS2_RC ret = iesys_cryptmbed_hmac_finish(context, &hmac->buffer[0], &s);
-    hmac->size = s;
-    return ret;
-}
-
 /** Release the resources of an HAMC object.
  *
  * The assigned resources will be released and the context will be set to NULL.
  * @param[in,out] context The context of the HMAC object.
  */
 void
-iesys_cryptmbed_hmac_abort(IESYS_CRYPTO_CONTEXT_BLOB ** context)
+iesys_cryptmbed_hmac_abort(ESYS_CRYPTO_CONTEXT_BLOB ** context, void *userdata)
 {
+    UNUSED(userdata);
+
     if (context == NULL || *context == NULL) {
         return;
     }
@@ -492,10 +451,12 @@ cleanup:
  * NOTE: the TPM should not be used to obtain the random data
  */
 TSS2_RC
-iesys_cryptmbed_random2b(TPM2B_NONCE * nonce, size_t num_bytes)
+iesys_cryptmbed_random2b(TPM2B_NONCE * nonce, size_t num_bytes, void *userdata)
 {
+    UNUSED(userdata);
+
     if (num_bytes == 0) {
-        nonce->size = sizeof(TPMU_HA);
+        nonce->size = sizeof(nonce->buffer);
     } else {
         nonce->size = num_bytes;
     }
@@ -529,8 +490,12 @@ iesys_cryptmbed_pk_encrypt(TPM2B_PUBLIC * pub_tpm_key,
                            BYTE * in_buffer,
                            size_t max_out_size,
                            BYTE * out_buffer,
-                           size_t * out_size, const char *label)
+                           size_t * out_size,
+                           const char *label,
+                           void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     int hash_id = 0;
     mbedtls_rsa_context rsa_context;
@@ -667,8 +632,11 @@ iesys_cryptmbed_get_ecdh_point(TPM2B_PUBLIC *key,
                                TPM2B_ECC_PARAMETER *Z,
                                TPMS_ECC_POINT *Q,
                                BYTE * out_buffer,
-                               size_t * out_size)
+                               size_t * out_size,
+                               void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     mbedtls_ecp_group ecp_group;
     mbedtls_mpi ecp_d;
@@ -852,8 +820,11 @@ iesys_cryptmbed_sym_aes_encrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_mode,
                                 uint8_t * buffer,
                                 size_t buffer_size,
-                                uint8_t * iv)
+                                uint8_t * iv,
+                                void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     mbedtls_aes_context aes_ctx;
 
@@ -907,8 +878,11 @@ iesys_cryptmbed_sym_aes_decrypt(uint8_t * key,
                                 TPM2_ALG_ID tpm_mode,
                                 uint8_t * buffer,
                                 size_t buffer_size,
-                                uint8_t * iv)
+                                uint8_t * iv,
+                                void *userdata)
 {
+    UNUSED(userdata);
+
     TSS2_RC r = TSS2_RC_SUCCESS;
     mbedtls_aes_context aes_ctx;
 
@@ -944,4 +918,11 @@ iesys_cryptmbed_sym_aes_decrypt(uint8_t * key,
 cleanup:
     mbedtls_aes_free(&aes_ctx);
     return r;
+}
+
+TSS2_RC
+iesys_cryptmbed_init(void *userdata) {
+    UNUSED(userdata);
+
+    return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-esys/esys_crypto_mbed.h
+++ b/src/tss2-esys/esys_crypto_mbed.h
@@ -15,79 +15,64 @@
 extern "C" {
 #endif
 
-typedef struct _IESYS_CRYPTO_CONTEXT IESYS_CRYPTO_CONTEXT_BLOB;
-
 TSS2_RC iesys_cryptmbed_hash_start(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2_ALG_ID hashAlg);
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    TPM2_ALG_ID hashAlg,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_hash_update(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    const uint8_t *buffer, size_t size);
-
-TSS2_RC iesys_cryptmbed_hash_update2b(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    TPM2B *b);
+    ESYS_CRYPTO_CONTEXT_BLOB *context,
+    const uint8_t *buffer, size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_hash_finish(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     uint8_t *buffer,
-    size_t *size);
+    size_t *size,
+    void *userdata);
 
-TSS2_RC iesys_cryptmbed_hash_finish2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2B *b);
+void iesys_cryptmbed_hash_abort(
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    void *userdata);
 
-void iesys_cryptmbed_hash_abort(IESYS_CRYPTO_CONTEXT_BLOB **context);
-
-#define iesys_crypto_pk_encrypt iesys_cryptmbed_pk_encrypt
-#define iesys_crypto_hash_start iesys_cryptmbed_hash_start
-#define iesys_crypto_hash_update iesys_cryptmbed_hash_update
-#define iesys_crypto_hash_update2b iesys_cryptmbed_hash_update2b
-#define iesys_crypto_hash_finish iesys_cryptmbed_hash_finish
-#define iesys_crypto_hash_finish2b iesys_cryptmbed_hash_finish2b
-#define iesys_crypto_hash_abort iesys_cryptmbed_hash_abort
+#define _iesys_crypto_rsa_pk_encrypt iesys_cryptmbed_pk_encrypt
+#define _iesys_crypto_hash_start iesys_cryptmbed_hash_start
+#define _iesys_crypto_hash_update iesys_cryptmbed_hash_update
+#define _iesys_crypto_hash_finish iesys_cryptmbed_hash_finish
+#define _iesys_crypto_hash_abort iesys_cryptmbed_hash_abort
 
 TSS2_RC iesys_cryptmbed_hmac_start(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     TPM2_ALG_ID hmacAlg,
     const uint8_t *key,
-    size_t size);
-
-TSS2_RC iesys_cryptmbed_hmac_start2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2_ALG_ID hmacAlg,
-    TPM2B *b);
+    size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_hmac_update(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
+    ESYS_CRYPTO_CONTEXT_BLOB *context,
     const uint8_t *buffer,
-    size_t size);
-
-TSS2_RC iesys_cryptmbed_hmac_update2b(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    TPM2B *b);
+    size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_hmac_finish(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     uint8_t *buffer,
-    size_t *size);
+    size_t *size,
+    void *userdata);
 
-TSS2_RC iesys_cryptmbed_hmac_finish2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2B *b);
+void iesys_cryptmbed_hmac_abort(
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    void *userdata);
 
-void iesys_cryptmbed_hmac_abort(IESYS_CRYPTO_CONTEXT_BLOB **context);
+#define _iesys_crypto_hmac_start iesys_cryptmbed_hmac_start
+#define _iesys_crypto_hmac_update iesys_cryptmbed_hmac_update
+#define _iesys_crypto_hmac_finish iesys_cryptmbed_hmac_finish
+#define _iesys_crypto_hmac_abort iesys_cryptmbed_hmac_abort
 
-#define iesys_crypto_hmac_start iesys_cryptmbed_hmac_start
-#define iesys_crypto_hmac_start2b iesys_cryptmbed_hmac_start2b
-#define iesys_crypto_hmac_update iesys_cryptmbed_hmac_update
-#define iesys_crypto_hmac_update2b iesys_cryptmbed_hmac_update2b
-#define iesys_crypto_hmac_finish iesys_cryptmbed_hmac_finish
-#define iesys_crypto_hmac_finish2b iesys_cryptmbed_hmac_finish2b
-#define iesys_crypto_hmac_abort iesys_cryptmbed_hmac_abort
-
-TSS2_RC iesys_cryptmbed_random2b(TPM2B_NONCE *nonce, size_t num_bytes);
+TSS2_RC iesys_cryptmbed_random2b(
+    TPM2B_NONCE *nonce,
+    size_t num_bytes,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_pk_encrypt(
     TPM2B_PUBLIC *key,
@@ -96,7 +81,8 @@ TSS2_RC iesys_cryptmbed_pk_encrypt(
     size_t max_out_size,
     BYTE *out_buffer,
     size_t *out_size,
-    const char *label);
+    const char *label,
+    void *userdata);
 
 
 TSS2_RC iesys_cryptmbed_sym_aes_encrypt(
@@ -106,7 +92,8 @@ TSS2_RC iesys_cryptmbed_sym_aes_encrypt(
     TPM2_ALG_ID tpm_mode,
     uint8_t *dst,
     size_t dst_size,
-    uint8_t *iv);
+    uint8_t *iv,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_sym_aes_decrypt(
     uint8_t *key,
@@ -115,7 +102,8 @@ TSS2_RC iesys_cryptmbed_sym_aes_decrypt(
     TPM2_ALG_ID tpm_mode,
     uint8_t *dst,
     size_t dst_size,
-    uint8_t *iv);
+    uint8_t *iv,
+    void *userdata);
 
 TSS2_RC iesys_cryptmbed_get_ecdh_point(
     TPM2B_PUBLIC *key,
@@ -123,14 +111,17 @@ TSS2_RC iesys_cryptmbed_get_ecdh_point(
     TPM2B_ECC_PARAMETER *Z,
     TPMS_ECC_POINT *Q,
     BYTE * out_buffer,
-    size_t * out_size);
+    size_t * out_size,
+    void *userdata);
 
-#define iesys_crypto_random2b iesys_cryptmbed_random2b
-#define iesys_crypto_get_ecdh_point iesys_cryptmbed_get_ecdh_point
-#define iesys_crypto_sym_aes_encrypt iesys_cryptmbed_sym_aes_encrypt
-#define iesys_crypto_sym_aes_decrypt iesys_cryptmbed_sym_aes_decrypt
+TSS2_RC iesys_cryptmbed_init(void *userdata);
 
-#define iesys_crypto_init(...) TSS2_RC_SUCCESS;
+#define _iesys_crypto_get_random2b iesys_cryptmbed_random2b
+#define _iesys_crypto_get_ecdh_point iesys_cryptmbed_get_ecdh_point
+#define _iesys_crypto_aes_encrypt iesys_cryptmbed_sym_aes_encrypt
+#define _iesys_crypto_aes_decrypt iesys_cryptmbed_sym_aes_decrypt
+
+#define _iesys_crypto_init iesys_cryptmbed_init
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/tss2-esys/esys_crypto_ossl.h
+++ b/src/tss2-esys/esys_crypto_ossl.h
@@ -16,79 +16,67 @@ extern "C" {
 
 #define OSSL_FREE(S,TYPE) if((S) != NULL) {TYPE##_free((void*) (S)); (S)=NULL;}
 
-typedef struct _IESYS_CRYPTO_CONTEXT IESYS_CRYPTO_CONTEXT_BLOB;
-
 TSS2_RC iesys_cryptossl_hash_start(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2_ALG_ID hashAlg);
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    TPM2_ALG_ID hashAlg,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_hash_update(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    const uint8_t *buffer, size_t size);
-
-TSS2_RC iesys_cryptossl_hash_update2b(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    TPM2B *b);
+    ESYS_CRYPTO_CONTEXT_BLOB *context,
+    const uint8_t *buffer, size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_hash_finish(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     uint8_t *buffer,
-    size_t *size);
+    size_t *size,
+    void *userdata);
 
-TSS2_RC iesys_cryptossl_hash_finish2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2B *b);
+void iesys_cryptossl_hash_abort(
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    void *userdata);
 
-void iesys_cryptossl_hash_abort(IESYS_CRYPTO_CONTEXT_BLOB **context);
-
-#define iesys_crypto_pk_encrypt iesys_cryptossl_pk_encrypt
-#define iesys_crypto_hash_start iesys_cryptossl_hash_start
-#define iesys_crypto_hash_update iesys_cryptossl_hash_update
-#define iesys_crypto_hash_update2b iesys_cryptossl_hash_update2b
-#define iesys_crypto_hash_finish iesys_cryptossl_hash_finish
-#define iesys_crypto_hash_finish2b iesys_cryptossl_hash_finish2b
-#define iesys_crypto_hash_abort iesys_cryptossl_hash_abort
+#define _iesys_crypto_rsa_pk_encrypt iesys_cryptossl_pk_encrypt
+#define _iesys_crypto_hash_start iesys_cryptossl_hash_start
+#define _iesys_crypto_hash_update iesys_cryptossl_hash_update
+#define _iesys_crypto_hash_finish iesys_cryptossl_hash_finish
+#define _iesys_crypto_hash_abort iesys_cryptossl_hash_abort
 
 TSS2_RC iesys_cryptossl_hmac_start(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     TPM2_ALG_ID hmacAlg,
     const uint8_t *key,
-    size_t size);
-
-TSS2_RC iesys_cryptossl_hmac_start2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2_ALG_ID hmacAlg,
-    TPM2B *b);
+    size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_hmac_update(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
+    ESYS_CRYPTO_CONTEXT_BLOB *context,
     const uint8_t *buffer,
-    size_t size);
-
-TSS2_RC iesys_cryptossl_hmac_update2b(
-    IESYS_CRYPTO_CONTEXT_BLOB *context,
-    TPM2B *b);
+    size_t size,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_hmac_finish(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
     uint8_t *buffer,
-    size_t *size);
+    size_t *size,
+    void *userdata);
 
-TSS2_RC iesys_cryptossl_hmac_finish2b(
-    IESYS_CRYPTO_CONTEXT_BLOB **context,
-    TPM2B *b);
+void iesys_cryptossl_hmac_abort(
+    ESYS_CRYPTO_CONTEXT_BLOB **context,
+    void *userdata);
 
-void iesys_cryptossl_hmac_abort(IESYS_CRYPTO_CONTEXT_BLOB **context);
+#define _iesys_crypto_hmac_start iesys_cryptossl_hmac_start
+#define _iesys_crypto_hmac_start2b iesys_cryptossl_hmac_start2b
+#define _iesys_crypto_hmac_update iesys_cryptossl_hmac_update
+#define _iesys_crypto_hmac_update2b iesys_cryptossl_hmac_update2b
+#define _iesys_crypto_hmac_finish iesys_cryptossl_hmac_finish
+#define _iesys_crypto_hmac_finish2b iesys_cryptossl_hmac_finish2b
+#define _iesys_crypto_hmac_abort iesys_cryptossl_hmac_abort
 
-#define iesys_crypto_hmac_start iesys_cryptossl_hmac_start
-#define iesys_crypto_hmac_start2b iesys_cryptossl_hmac_start2b
-#define iesys_crypto_hmac_update iesys_cryptossl_hmac_update
-#define iesys_crypto_hmac_update2b iesys_cryptossl_hmac_update2b
-#define iesys_crypto_hmac_finish iesys_cryptossl_hmac_finish
-#define iesys_crypto_hmac_finish2b iesys_cryptossl_hmac_finish2b
-#define iesys_crypto_hmac_abort iesys_cryptossl_hmac_abort
-
-TSS2_RC iesys_cryptossl_random2b(TPM2B_NONCE *nonce, size_t num_bytes);
+TSS2_RC iesys_cryptossl_random2b(
+    TPM2B_NONCE *nonce,
+    size_t num_bytes,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_pk_encrypt(
     TPM2B_PUBLIC *key,
@@ -97,7 +85,8 @@ TSS2_RC iesys_cryptossl_pk_encrypt(
     size_t max_out_size,
     BYTE *out_buffer,
     size_t *out_size,
-    const char *label);
+    const char *label,
+    void *userdata);
 
 
 TSS2_RC iesys_cryptossl_sym_aes_encrypt(
@@ -107,7 +96,8 @@ TSS2_RC iesys_cryptossl_sym_aes_encrypt(
     TPM2_ALG_ID tpm_mode,
     uint8_t *dst,
     size_t dst_size,
-    uint8_t *iv);
+    uint8_t *iv,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_sym_aes_decrypt(
     uint8_t *key,
@@ -116,7 +106,8 @@ TSS2_RC iesys_cryptossl_sym_aes_decrypt(
     TPM2_ALG_ID tpm_mode,
     uint8_t *dst,
     size_t dst_size,
-    uint8_t *iv);
+    uint8_t *iv,
+    void *userdata);
 
 TSS2_RC iesys_cryptossl_get_ecdh_point(
     TPM2B_PUBLIC *key,
@@ -124,16 +115,17 @@ TSS2_RC iesys_cryptossl_get_ecdh_point(
     TPM2B_ECC_PARAMETER *Z,
     TPMS_ECC_POINT *Q,
     BYTE * out_buffer,
-    size_t * out_size);
+    size_t * out_size,
+    void *userdata);
 
-#define iesys_crypto_random2b iesys_cryptossl_random2b
-#define iesys_crypto_get_ecdh_point iesys_cryptossl_get_ecdh_point
-#define iesys_crypto_sym_aes_encrypt iesys_cryptossl_sym_aes_encrypt
-#define iesys_crypto_sym_aes_decrypt iesys_cryptossl_sym_aes_decrypt
+#define _iesys_crypto_get_random2b iesys_cryptossl_random2b
+#define _iesys_crypto_get_ecdh_point iesys_cryptossl_get_ecdh_point
+#define _iesys_crypto_aes_encrypt iesys_cryptossl_sym_aes_encrypt
+#define _iesys_crypto_aes_decrypt iesys_cryptossl_sym_aes_decrypt
 
-TSS2_RC iesys_cryptossl_init();
+TSS2_RC iesys_cryptossl_init(void *userdata);
 
-#define iesys_crypto_init iesys_cryptossl_init
+#define _iesys_crypto_init iesys_cryptossl_init
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -7,6 +7,7 @@
 #define ESYS_INT_H
 
 #include <stdint.h>
+#include "esys_crypto.h"
 #include "esys_types.h"
 
 #ifdef __cplusplus
@@ -182,6 +183,9 @@ struct ESYS_CONTEXT {
                                       automatically loaded. */
     IESYS_SESSION *enc_session;  /**< Ptr to the enc param session.
                                       Used to restore session attributes */
+
+    ESYS_CRYPTO_CALLBACKS crypto_backend; /**< The backend function pointers to use
+                                              for crypto operations */
 };
 
 /** The number of authomatic resubmissions.

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -89,6 +89,7 @@ TPM2_HT iesys_get_handle_type(
 TSS2_RC iesys_finalize(ESYS_CONTEXT *context);
 
 bool iesys_compare_name(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2B_PUBLIC *publicInfo,
     TPM2B_NAME *name);
 
@@ -139,6 +140,7 @@ void iesys_compute_session_value(
     const TPM2B_AUTH *auth_value);
 
 TSS2_RC iesys_compute_hmac(
+    ESYS_CONTEXT *esys_context,
     RSRC_NODE_T *session,
     HASH_TAB_ITEM cp_hash_tab[3],
     uint8_t cpHashNum,
@@ -157,10 +159,12 @@ TSS2_RC iesys_check_response(
     ESYS_CONTEXT * esys_context);
 
 TSS2_RC iesys_nv_get_name(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2B_NV_PUBLIC *publicInfo,
     TPM2B_NAME *name);
 
 TSS2_RC iesys_get_name(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2B_PUBLIC *publicInfo,
     TPM2B_NAME *name);
 
@@ -168,6 +172,7 @@ bool iesys_tpm_error(
     TSS2_RC r);
 
 TSS2_RC iesys_hash_long_auth_values(
+    ESYS_CRYPTO_CALLBACKS *crypto_cb,
     TPM2B_AUTH *auth_value,
     TPMI_ALG_HASH hash_alg);
 

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -405,7 +405,8 @@ Esys_TR_SetAuth(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
         esys_object->auth = *authValue;
         /* Adapt auth value to hash for large auth values. */
         if (name_alg != TPM2_ALG_NULL) {
-            r = iesys_hash_long_auth_values(&esys_object->auth, name_alg);
+            r = iesys_hash_long_auth_values(&esys_context->crypto_backend,
+                    &esys_object->auth, name_alg);
             return_if_error(r, "Hashing overlength authValue failed.");
         }
     }
@@ -447,12 +448,14 @@ Esys_TR_GetName(ESYS_CONTEXT * esys_context, ESYS_TR esys_handle,
         return TSS2_ESYS_RC_MEMORY;
     }
     if (esys_object->rsrc.rsrcType == IESYSC_KEY_RSRC) {
-        r = iesys_get_name(&esys_object->rsrc.misc.rsrc_key_pub, *name);
+        r = iesys_get_name(&esys_context->crypto_backend,
+                &esys_object->rsrc.misc.rsrc_key_pub, *name);
         goto_if_error(r, "Error get name", error_cleanup);
 
     } else {
         if (esys_object->rsrc.rsrcType == IESYSC_NV_RSRC) {
-            r = iesys_nv_get_name(&esys_object->rsrc.misc.rsrc_nv_pub, *name);
+            r = iesys_nv_get_name(&esys_context->crypto_backend,
+                    &esys_object->rsrc.misc.rsrc_nv_pub, *name);
             goto_if_error(r, "Error get name", error_cleanup);
 
         } else {

--- a/src/tss2-tcti/tctildr-interface.h
+++ b/src/tss2-tcti/tctildr-interface.h
@@ -8,6 +8,7 @@
 
 #include "tss2_tpm2_types.h"
 #include "tss2_tcti.h"
+#include "tss2_tctildr.h"
 
 TSS2_RC
 tctildr_get_tcti (const char *name,

--- a/test/integration/esys-crypto.int.c
+++ b/test/integration/esys-crypto.int.c
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+
+#include "tss2_esys.h"
+#include "esys_int.h"
+
+#include "esys_iutil.h"
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+#define TEST_FN_PTR ((void *)0xBADC0DE)
+
+#define CHECK_BACKEND_FN_NOT_TEST(backend, fn) \
+    if (backend.fn == TEST_FN_PTR) { \
+        LOG_ERROR("Expected function \"%s\" not to be test ptr", xstr(fn)); \
+        return EXIT_FAILURE; \
+    }
+
+/** This test is intended to test the ESYS command  Esys_SetCryptoCallbacks.
+ *
+ * The test checks whether callbacks are set as expected.
+ *
+ * Tested ESYS commands:
+ *  - Esys_Hash() (M)
+ *
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+
+static int init_called = 0;
+static TSS2_RC
+    init(void *userdata)
+{
+    init_called = 1;
+    return (void *)0xDEADBEEF ? TSS2_RC_SUCCESS : TSS2_ESYS_RC_BAD_VALUE;
+}
+
+int
+test_invoke_esys(ESYS_CONTEXT *esys_context)
+{
+    /*peer into the internals, state should be as expected in esys context */
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_start);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_update);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_finish);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_abort);
+
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_start);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_update);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_finish);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_abort);
+
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, aes_decrypt);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, aes_encrypt);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, get_ecdh_point);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, get_random2b);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, rsa_pk_encrypt);
+
+    ESYS_CRYPTO_CALLBACKS callbacks = {
+        .aes_decrypt = TEST_FN_PTR,
+        .aes_encrypt = TEST_FN_PTR,
+        .get_ecdh_point = TEST_FN_PTR,
+        .get_random2b = TEST_FN_PTR,
+        .rsa_pk_encrypt = TEST_FN_PTR,
+        .hash_abort = TEST_FN_PTR,
+        .hash_finish = TEST_FN_PTR,
+        .hash_start = TEST_FN_PTR,
+        .hash_update = TEST_FN_PTR,
+        .hmac_abort = TEST_FN_PTR,
+        .hmac_finish = TEST_FN_PTR,
+        .hmac_start = TEST_FN_PTR,
+        .hmac_update = TEST_FN_PTR,
+        .init = init,
+        .userdata = (void *)0xDEADBEEF
+    };
+
+    TSS2_RC r = Esys_SetCryptoCallbacks(
+            esys_context,
+            &callbacks);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Esys_SetCryptoCallbacks failed: 0x%x", r);
+        return EXIT_FAILURE;
+    }
+
+    if (!init_called) {
+        LOG_ERROR("user callback for init not invoked");
+        return EXIT_FAILURE;
+    }
+
+    /* peer back into internals and ensure state is correct */
+    if (memcmp(&esys_context->crypto_backend, &callbacks, sizeof(callbacks))) {
+        LOG_ERROR("ESYS_CONTEXT state for user callbacks not as expected");
+        return EXIT_FAILURE;
+    }
+
+    /* reset state */
+    r = Esys_SetCryptoCallbacks(
+            esys_context,
+            NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Esys_SetCryptoCallbacks failed: 0x%x", r);
+        return EXIT_FAILURE;
+    }
+
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_start);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_update);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_finish);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hash_abort);
+
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_start);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_update);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_finish);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, hmac_abort);
+
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, aes_decrypt);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, aes_encrypt);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, get_ecdh_point);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, get_random2b);
+    CHECK_BACKEND_FN_NOT_TEST(esys_context->crypto_backend, rsa_pk_encrypt);
+
+    return EXIT_SUCCESS;
+}

--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -31,111 +31,120 @@ static void
 check_hash_functions(void **state)
 {
     TSS2_RC rc;
-    IESYS_CRYPTO_CONTEXT_BLOB *context;
+    ESYS_CRYPTO_CONTEXT_BLOB *context;
     uint8_t buffer[10] = { 0 };
     TPM2B tpm2b;
     size_t size = 0;
 
-    rc = iesys_crypto_hash_start(NULL, TPM2_ALG_SHA384);
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    rc = iesys_crypto_hash_start(&crypto_cb, NULL, TPM2_ALG_SHA384);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
 #ifndef OSSL
-    rc = iesys_crypto_hash_start(&context, TPM2_ALG_SHA512);
+    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA512);
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
+    assert_null (context);
 #endif
 
-    rc = iesys_crypto_hash_start(&context, 0);
+    rc = iesys_crypto_hash_start(&crypto_cb, &context, 0);
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
 
-    rc = iesys_crypto_hash_start(&context, TPM2_ALG_SHA384);
+    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA384);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    rc = iesys_crypto_hash_finish(NULL, &buffer[0], &size);
+    rc = iesys_crypto_hash_finish(&crypto_cb, NULL, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hash_finish(&context, &buffer[0], &size);
+    rc = iesys_crypto_hash_finish(&crypto_cb, &context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_SIZE);
 
-    iesys_crypto_hash_abort(NULL);
-    iesys_crypto_hash_abort(&context);
+    iesys_crypto_hash_abort(&crypto_cb, NULL);
+    iesys_crypto_hash_abort(&crypto_cb, &context);
 
-    rc = iesys_crypto_hash_update(NULL, &buffer[0], 10);
+    rc = iesys_crypto_hash_update(&crypto_cb, NULL, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hash_update2b(NULL, &tpm2b);
+    rc = iesys_crypto_hash_update2b(&crypto_cb, NULL, &tpm2b);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
     /* Create invalid context */
-    rc = iesys_crypto_hmac_start(&context, TPM2_ALG_SHA1, &buffer[0], 10);
+    rc = iesys_crypto_hmac_start(&crypto_cb, &context, TPM2_ALG_SHA1, &buffer[0], 10);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    iesys_crypto_hash_abort(&context);
+    iesys_crypto_hash_abort(&crypto_cb, &context);
 
-    rc = iesys_crypto_hash_update(context, &buffer[0], 10);
+    rc = iesys_crypto_hash_update(&crypto_cb, context, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hash_finish(&context, &buffer[0], &size);
+    rc = iesys_crypto_hash_finish(&crypto_cb, &context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
     /* cleanup */
-    iesys_crypto_hmac_abort(&context);
+    iesys_crypto_hmac_abort(&crypto_cb, &context);
 }
 
 static void
 check_hmac_functions(void **state)
 {
     TSS2_RC rc;
-    IESYS_CRYPTO_CONTEXT_BLOB *context;
+    ESYS_CRYPTO_CONTEXT_BLOB *context;
     uint8_t buffer[10] = { 0 };
     TPM2B tpm2b;
     size_t size = 0;
 
-    rc = iesys_crypto_hmac_start(NULL, TPM2_ALG_SHA384, &buffer[0], 10);
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    rc = iesys_crypto_hmac_start(&crypto_cb, NULL, TPM2_ALG_SHA384, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
 #ifndef OSSL
-    rc = iesys_crypto_hmac_start(&context, TPM2_ALG_SHA512, &buffer[0], 10);
+    rc = iesys_crypto_hmac_start(&crypto_cb, &context, TPM2_ALG_SHA512, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
 #endif
 
-    rc = iesys_crypto_hmac_start(&context, 0,  &buffer[0], 10);
+    rc = iesys_crypto_hmac_start(&crypto_cb, &context, 0,  &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
 
-    rc = iesys_crypto_hmac_start(&context, TPM2_ALG_SHA1,  &buffer[0], 10);
+    rc = iesys_crypto_hmac_start(&crypto_cb, &context, TPM2_ALG_SHA1,  &buffer[0], 10);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    rc = iesys_crypto_hmac_finish(NULL, &buffer[0], &size);
+    rc = iesys_crypto_hmac_finish(&crypto_cb, NULL, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hmac_finish2b(NULL, &tpm2b);
+    rc = iesys_crypto_hmac_finish2b(&crypto_cb, NULL, &tpm2b);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hmac_finish(&context, &buffer[0], &size);
+    rc = iesys_crypto_hmac_finish(&crypto_cb, &context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_SIZE);
 
-    iesys_crypto_hmac_abort(NULL);
-    iesys_crypto_hmac_abort(&context);
+    iesys_crypto_hmac_abort(&crypto_cb, NULL);
+    iesys_crypto_hmac_abort(&crypto_cb, &context);
 
-    rc = iesys_crypto_hmac_update(NULL, &buffer[0], 10);
+    rc = iesys_crypto_hmac_update(&crypto_cb, NULL, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hmac_update2b(NULL, &tpm2b);
+    rc = iesys_crypto_hmac_update2b(&crypto_cb, NULL, &tpm2b);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
     /* Create invalid context */
-    rc = iesys_crypto_hash_start(&context, TPM2_ALG_SHA1);
+    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA1);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    iesys_crypto_hmac_abort(&context);
+    iesys_crypto_hmac_abort(&crypto_cb, &context);
 
-    rc = iesys_crypto_hmac_update(context, &buffer[0], 10);
+    rc = iesys_crypto_hmac_update(&crypto_cb, context, &buffer[0], 10);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_hmac_finish(&context, &buffer[0], &size);
+    rc = iesys_crypto_hmac_finish(&crypto_cb, &context, &buffer[0], &size);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
     /* cleanup */
-    iesys_crypto_hash_abort(&context);
+    iesys_crypto_hash_abort(&crypto_cb, &context);
 }
 
 static void
@@ -144,7 +153,12 @@ check_random(void **state)
     TSS2_RC rc;
     size_t num_bytes = 0;
     TPM2B_NONCE nonce;
-    rc = iesys_crypto_random2b(&nonce, num_bytes);
+
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    rc = iesys_crypto_get_random2b(&crypto_cb, &nonce, num_bytes);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 
@@ -191,12 +205,17 @@ check_pk_encrypt(void **state)
     };
 
     inPublicRSA.publicArea.nameAlg = 0;
-    rc = iesys_crypto_pk_encrypt(&inPublicRSA, size, &in_buffer[0], size, &out_buffer[0], &size, "LABEL");
+
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    rc = iesys_crypto_rsa_pk_encrypt(&crypto_cb, &inPublicRSA, size, &in_buffer[0], size, &out_buffer[0], &size, "LABEL");
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
 
     inPublicRSA.publicArea.nameAlg = TPM2_ALG_SHA1;
     inPublicRSA.publicArea.parameters.rsaDetail.scheme.scheme = 0;
-    rc = iesys_crypto_pk_encrypt(&inPublicRSA, size, &in_buffer[0], size, &out_buffer[0], &size, "LABEL");
+    rc = iesys_crypto_rsa_pk_encrypt(&crypto_cb, &inPublicRSA, size, &in_buffer[0], size, &out_buffer[0], &size, "LABEL");
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 }
 
@@ -209,34 +228,38 @@ check_aes_encrypt(void **state)
     uint8_t buffer[5] = { 1, 2, 3, 4, 5 };
     size_t size = 5;
 
-    rc = iesys_crypto_sym_aes_encrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 192, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, &key[0], TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, &key[0], TPM2_ALG_AES, 256, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], 0, 256, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, &key[0], 0, 256, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 256, 0,
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, &key[0], TPM2_ALG_AES, 256, 0,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_encrypt(&key[0], TPM2_ALG_AES, 999, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_encrypt(&crypto_cb, &key[0], TPM2_ALG_AES, 999, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 
-    rc = iesys_crypto_sym_aes_decrypt(NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_decrypt(&crypto_cb, NULL, TPM2_ALG_AES, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-    rc = iesys_crypto_sym_aes_decrypt(&key[0], 0, 192, TPM2_ALG_CFB,
+    rc = iesys_crypto_aes_decrypt(&crypto_cb, &key[0], 0, 192, TPM2_ALG_CFB,
                                       &buffer[0], size, &key[0]);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_VALUE);
 }
@@ -275,6 +298,82 @@ check_get_sys_context(void **state)
     Esys_Finalize(&ctx);
 }
 
+#define CHECK_BACKEND_FN(backend, fn) \
+    assert_int_equal(backend.fn, _iesys_crypto_##fn)
+
+static TSS2_RC
+    crypto_init(void *userdata)
+{
+    assert_int_equal(userdata, (void *)0xDEADBEEF);
+    return 0x42;
+}
+
+static void test_backend_set(void **state) {
+
+    ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };
+    TSS2_RC rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    CHECK_BACKEND_FN(crypto_cb, hash_start);
+    CHECK_BACKEND_FN(crypto_cb, hash_update);
+    CHECK_BACKEND_FN(crypto_cb, hash_finish);
+    CHECK_BACKEND_FN(crypto_cb, hash_abort);
+
+    CHECK_BACKEND_FN(crypto_cb, hmac_start);
+    CHECK_BACKEND_FN(crypto_cb, hmac_update);
+    CHECK_BACKEND_FN(crypto_cb, hmac_finish);
+    CHECK_BACKEND_FN(crypto_cb, hmac_abort);
+
+    CHECK_BACKEND_FN(crypto_cb, aes_decrypt);
+    CHECK_BACKEND_FN(crypto_cb, aes_encrypt);
+    CHECK_BACKEND_FN(crypto_cb, get_ecdh_point);
+    CHECK_BACKEND_FN(crypto_cb, get_random2b);
+    CHECK_BACKEND_FN(crypto_cb, rsa_pk_encrypt);
+
+    /* test a user change */
+    ESYS_CRYPTO_CALLBACKS user_cb = {
+        .aes_decrypt = (void *)0xBADCC0DE,
+        .aes_encrypt = (void *)0xBADCC0DE,
+        .get_ecdh_point = (void *)0xBADCC0DE,
+        .get_random2b = (void *)0xBADCC0DE,
+        .rsa_pk_encrypt = (void *)0xBADCC0DE,
+        .hash_abort = (void *)0xBADCC0DE,
+        .hash_finish = (void *)0xBADCC0DE,
+        .hash_start = (void *)0xBADCC0DE,
+        .hash_update = (void *)0xBADCC0DE,
+        .hmac_abort = (void *)0xBADCC0DE,
+        .hmac_finish = (void *)0xBADCC0DE,
+        .hmac_start = (void *)0xBADCC0DE,
+        .hmac_update = (void *)0xBADCC0DE,
+        .init = crypto_init,
+        .userdata = (void *)0xDEADBEEF
+    };
+
+    rc = iesys_initialize_crypto_backend(&crypto_cb, &user_cb);
+    assert_int_equal (rc, 0x42);
+    assert_memory_equal(&crypto_cb, &user_cb, sizeof(crypto_cb));
+
+    /* reset state */
+    rc = iesys_initialize_crypto_backend(&crypto_cb, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    CHECK_BACKEND_FN(crypto_cb, hash_start);
+    CHECK_BACKEND_FN(crypto_cb, hash_update);
+    CHECK_BACKEND_FN(crypto_cb, hash_finish);
+    CHECK_BACKEND_FN(crypto_cb, hash_abort);
+
+    CHECK_BACKEND_FN(crypto_cb, hmac_start);
+    CHECK_BACKEND_FN(crypto_cb, hmac_update);
+    CHECK_BACKEND_FN(crypto_cb, hmac_finish);
+    CHECK_BACKEND_FN(crypto_cb, hmac_abort);
+
+    CHECK_BACKEND_FN(crypto_cb, aes_decrypt);
+    CHECK_BACKEND_FN(crypto_cb, aes_encrypt);
+    CHECK_BACKEND_FN(crypto_cb, get_ecdh_point);
+    CHECK_BACKEND_FN(crypto_cb, get_random2b);
+    CHECK_BACKEND_FN(crypto_cb, rsa_pk_encrypt);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -286,6 +385,7 @@ main(int argc, char *argv[])
         cmocka_unit_test(check_aes_encrypt),
         cmocka_unit_test(check_free),
         cmocka_unit_test(check_get_sys_context),
+        cmocka_unit_test(test_backend_set)
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
ESAPI is currently configured at compile time for eithe the mbedtls or
openssl crypto backends. Support the ability to switch this at run time.
Note that the next path will be to support a configure option of none
for the crypto backend so no crypto is linked.

This will decouple ESAPI from needed direct integration with backends
that may not be publicly available and or easy to test due to
environmental constraints. This will also prevent folks from having to
carry out of tree patches for crypto backends.

The following scenarios are possible:

| configure time | run time set | outcome |
| -------------- | ------------ | ------- |
| mbedtls        | no           | mbedtls |
| mbedtls        | yes          | runtime |
| openssl        | no           | openssl |
| openssl        | yes          | runtime |
| none           | no           | none    |
| none           | yes          | runtime |

Thus runtime set is always used. To restore back to original call the
getter and save the callback function pointers before calling the set.

Signed-off-by: William Roberts <william.c.roberts@intel.com>