### PR TITLE
esys_iutil: fix possible NPD

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1352,7 +1352,7 @@ iesys_gen_auths(ESYS_CONTEXT * esys_context,
                                 && encryptNonceIdx > 0) ? encryptNonce : NULL,
                                &auths->auths[session_idx]);
         return_if_error(r, "Error while computing hmacs");
-        if (esys_context->session_tab[session_idx] != NULL) {
+        if (esys_context->session_tab[session_idx] != NULL && session != NULL) {
             auths->auths[auths->count].sessionHandle = session->rsrc.handle;
             auths->count++;
         }


### PR DESCRIPTION
Clang-10 scan-build reports:
src/tss2-esys/esys_iutil.c:1366:56: warning: Dereference of null pointer
            auths->auths[auths->count].sessionHandle = session->rsrc.handle;
                                                       ^~~~~~~~~~~~~~~~~~~~
1 warning generated.

The code above the report checks that session might be NULL:
RSRC_NODE_T *session = esys_context->session_tab[session_idx];
    if (session != NULL) {
        IESYS_SESSION *rsrc_session = &session->rsrc.misc.rsrc_session;
        if (rsrc_session->type_policy_session == POLICY_PASSWORD) {

Thus suggesting/indicating session may be NULL in subsequent code where
session is dereferenced.

Signed-off-by: William Roberts <william.c.roberts@intel.com>