### PR TITLE
SAPI: fix number of handles for FlushContext

### DIFF
--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -261,7 +261,7 @@ static int GetNumHandles(TPM2_CC commandCode, bool req)
         { TPM2_CC_FirmwareRead, 0, 0 },
         { TPM2_CC_ContextSave, 1, 0 },
         { TPM2_CC_ContextLoad, 0, 1 },
-        { TPM2_CC_FlushContext, 1, 0 },
+        { TPM2_CC_FlushContext, 0, 0 },
         { TPM2_CC_EvictControl, 2, 0 },
         { TPM2_CC_ReadClock, 0, 0 },
         { TPM2_CC_ClockSet, 1, 0 },


### PR DESCRIPTION
Fixes #2382 

The lookup table for the number of command handles for
Tss2_Sys_FlushContext has the count set to 1, when in reality the
command takes no handles in the handle area but a handle as the input
parameter. This works currently because handles and parameters are just
concatenated and the parsing logic on the TPM just unpacks them, so in
this case, thet're in the same spot with the same value. This goes
unnoticed until you call Tss2_Sys_GetCpBuffer and the buffer is empty as
the logic things its a handle in the handle area and not a handle in the
parameter area.

Signed-off-by: William Roberts <william.c.roberts@intel.com>