### PR TITLE
fapi: fix usage of policy_nv.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -387,7 +387,8 @@ FAPI_TESTS_INTEGRATION += \
     test/integration/fapi-provision-certificate.fint \
     test/integration/fapi-provision-fingerprint_ecc.fint \
     test/integration/fapi-provision-certificate_ecc.fint \
-    test/integration/fapi-quote-destructive.fint
+    test/integration/fapi-quote-destructive.fint \
+    test/integration/fapi-key-create-policy-nv-tpm-idx-sign.fint
 endif #!TESTDEVICE
 
 TESTS_INTEGRATION += $(FAPI_TESTS_INTEGRATION)
@@ -1885,6 +1886,14 @@ test_integration_fapi_key_create_policy_nv_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
 test_integration_fapi_key_create_policy_nv_sign_fint_LDADD   = $(TESTS_LDADD)
 test_integration_fapi_key_create_policy_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_nv_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-policy-nv-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_policy_nv_tpm_idx_sign_fint_CFLAGS  = $(TESTS_CFLAGS) \
+    -DTPMIDX
+test_integration_fapi_key_create_policy_nv_tpm_idx_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_policy_nv_tpm_idx_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_policy_nv_tpm_idx_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-nv-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -577,6 +577,7 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_pcr16_0_or.json \
     test/data/fapi/policy/pol_pcr8_0.json \
     test/data/fapi/policy/pol_nv.json \
+    test/data/fapi/policy/pol_nv_tpm_idx.json \
     test/data/fapi/policy/pol_nv_counter.json \
     test/data/fapi/policy/pol_nv_written.json \
     test/data/fapi/policy/pol_signed.json \

--- a/include/tss2/tss2_policy.h
+++ b/include/tss2/tss2_policy.h
@@ -88,6 +88,7 @@ typedef TSS2_RC (*TSS2_POLICY_CB_PCR) (
 
 typedef TSS2_RC (*TSS2_POLICY_CB_NVPUBLIC) (
     const char *path,
+    TPMI_RH_NV_INDEX nv_index,
     TPM2B_NV_PUBLIC *nv_public,
     void *userdata);   /* e.g. for ESAPI_CONTEXT */
 

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -145,6 +145,13 @@ enum IFAPI_CLEANUP_STATE {
     CLEANUP_SRK
 };
 
+/** The states for the FAPI's reading nv public*/
+enum IFAPI_READ_NV_PUBLIC_STATE {
+    READ_NV_PUBLIC_INIT = 0,
+    READ_NV_PUBLIC_GET_ESYS_TR,
+    READ_NV_PUBLIC_GET_PUBLIC
+};
+
 #define IFAPI_MAX_CAP_INFO 17
 
 typedef struct {
@@ -1138,6 +1145,7 @@ struct FAPI_CONTEXT {
     enum IFAPI_GET_CERT_STATE get_cert_state;
     enum _FAPI_FLUSH_STATE flush_object_state;  /**< The current state of a flush operation */
     enum IFAPI_CLEANUP_STATE cleanup_state;     /**< The state of cleanup after command execution */
+    enum IFAPI_READ_NV_PUBLIC_STATE read_nv_public_state;
     IFAPI_CONFIG config;             /**< The profile independent configuration data */
     UINT32 nv_buffer_max;            /**< The maximal size for transfer of nv buffer content */
     IFAPI_CMD_STATE cmd;             /**< The state information of the currently executed

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -53,6 +53,7 @@ ifapi_get_object_name(
 TSS2_RC
 ifapi_get_nv_public(
     const char *path,
+    TPMI_RH_NV_INDEX nv_index,
     TPM2B_NV_PUBLIC *nv_public,
     void *context);
 

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -311,10 +311,10 @@ ifapi_policyeval_instantiate_finish(
                 break;
             }
 
-            CHECK_TEMPLATE_PATH(pol_element->element.PolicyNV.nvPath, "PolicyNv");
             CHECK_CALLBACK(context->callbacks.cbnvpublic, "cbnvpublic");
             /* Object name will be added to policy. */
             r = context->callbacks.cbnvpublic(pol_element->element.PolicyNV.nvPath,
+                                              pol_element->element.PolicyNV.nvIndex,
                                               &pol_element->element.PolicyNV.nvPublic,
                                               context->callbacks.cbnvpublic_userdata);
             return_try_again(r);
@@ -365,7 +365,7 @@ ifapi_policyeval_instantiate_finish(
                                 "PolicyAuthorizeNv");
             CHECK_CALLBACK(context->callbacks.cbnvpublic, "cbnvpublic");
             /* Object name will be added to policy. */
-            r = context->callbacks.cbnvpublic(pol_element->element.PolicyAuthorizeNv.nvPath,
+            r = context->callbacks.cbnvpublic(pol_element->element.PolicyAuthorizeNv.nvPath, 0,
                                               &pol_element->element.PolicyAuthorizeNv.nvPublic,
                                               context->callbacks.cbnvpublic_userdata);
             return_try_again(r);

--- a/test/data/fapi/policy/pol_nv_tpm_idx.json
+++ b/test/data/fapi/policy/pol_nv_tpm_idx.json
@@ -1,0 +1,11 @@
+{
+    "description":"Description pol_nv",
+    "policy":[
+        {
+            "type": "POLICYNV",
+            "nvIndex": 25165824,
+            "operandB": "01020304",
+            "operation": "EQ"
+        }
+    ]
+}

--- a/test/integration/fapi-key-create-policy-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-nv-sign.int.c
@@ -48,7 +48,11 @@ int
 test_fapi_key_create_policy_nv_sign(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
+#ifdef TPMIDX
     char *policy_name = "/policy/pol_nv";
+#else
+    char *policy_name = "/policy/pol_nv_tpm_idx";
+#endif
     char *policy_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_nv.json";;
     FILE *stream = NULL;
     char *json_policy = NULL;
@@ -56,6 +60,7 @@ test_fapi_key_create_policy_nv_sign(FAPI_CONTEXT *context)
     char    *publicKey = NULL;
     char    *certificate = NULL;
     long policy_size;
+
     char *nvPathOrdinary = "/nv/Owner/myNV";
     uint8_t data_nv[NV_SIZE] = { 1, 2, 3, 4 };
     char *pathList = NULL;

--- a/test/unit/tss2_policy.c
+++ b/test/unit/tss2_policy.c
@@ -126,10 +126,12 @@ TSS2_RC policy_cb_pcr (
 
 TSS2_RC policy_cb_nvpublic (
     const char *path,
+    TPMI_RH_NV_INDEX nv_index,
     TPM2B_NV_PUBLIC *nv_public,
     void *userdata)
 {
     UNUSED(path);
+    UNUSED(nv_index);
     UNUSED(nv_public);
     UNUSED(userdata);
 


### PR DESCRIPTION
* Currently it was not possible to define a policy nv with a TPM nv index.
    The callback to get the public nv data related to the policy was extended
    to get public nv data from the TPM in this case.
    Addresses #2383
* Also an integration test was added.
 
Signed-off-by: Juergen Repp <juergen_repp@web.de>