### PR TITLE
fapi: fix usage of policy_nv (3.2.x).

### DIFF
--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -145,6 +145,13 @@ enum IFAPI_CLEANUP_STATE {
     CLEANUP_SRK
 };
 
+/** The states for the FAPI's reading nv public*/
+enum IFAPI_READ_NV_PUBLIC_STATE {
+    READ_NV_PUBLIC_INIT = 0,
+    READ_NV_PUBLIC_GET_ESYS_TR,
+    READ_NV_PUBLIC_GET_PUBLIC
+};
+
 #define IFAPI_MAX_CAP_INFO 17
 
 typedef struct {
@@ -1137,6 +1144,7 @@ struct FAPI_CONTEXT {
     enum IFAPI_GET_CERT_STATE get_cert_state;
     enum _FAPI_FLUSH_STATE flush_object_state;  /**< The current state of a flush operation */
     enum IFAPI_CLEANUP_STATE cleanup_state;     /**< The state of cleanup after command execution */
+    enum IFAPI_READ_NV_PUBLIC_STATE read_nv_public_state;
     IFAPI_CONFIG config;             /**< The profile independent configuration data */
     UINT32 nv_buffer_max;            /**< The maximal size for transfer of nv buffer content */
     IFAPI_CMD_STATE cmd;             /**< The state information of the currently executed

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -53,6 +53,7 @@ ifapi_get_object_name(
 TSS2_RC
 ifapi_get_nv_public(
     const char *path,
+    TPMI_RH_NV_INDEX nv_index,
     TPM2B_NV_PUBLIC *nv_public,
     void *context);
 

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -294,9 +294,9 @@ ifapi_policyeval_instantiate_finish(
                 break;
             }
 
-            CHECK_TEMPLATE_PATH(pol_element->element.PolicyNV.nvPath, "PolicyNv");
             /* Object name will be added to policy. */
             r = context->callbacks.cbnvpublic(pol_element->element.PolicyNV.nvPath,
+                                              pol_element->element.PolicyNV.nvIndex,
                                               &pol_element->element.PolicyNV.nvPublic,
                                               context->callbacks.cbnvpublic_userdata);
             return_try_again(r);
@@ -346,7 +346,7 @@ ifapi_policyeval_instantiate_finish(
             CHECK_TEMPLATE_PATH(pol_element->element.PolicyAuthorizeNv.nvPath,
                                 "PolicyAuthorizeNv");
             /* Object name will be added to policy. */
-            r = context->callbacks.cbnvpublic(pol_element->element.PolicyAuthorizeNv.nvPath,
+            r = context->callbacks.cbnvpublic(pol_element->element.PolicyAuthorizeNv.nvPath, 0,
                                               &pol_element->element.PolicyAuthorizeNv.nvPublic,
                                               context->callbacks.cbnvpublic_userdata);
             return_try_again(r);

--- a/src/tss2-fapi/ifapi_policy_instantiate.h
+++ b/src/tss2-fapi/ifapi_policy_instantiate.h
@@ -36,6 +36,7 @@ typedef TSS2_RC (*ifapi_policyeval_cbnvindex) (
 
 typedef TSS2_RC (*ifapi_policyeval_cbnvpublic) (
     const char *path,
+    TPMI_RH_NV_INDEX nv_index,
     TPM2B_NV_PUBLIC *nv_public,
     void *userdata);   /* e.g. for FAPI_CONTEXT */
 


### PR DESCRIPTION
Currently it was not possible to define a policy nv with a TPM nv index.
the callback to get the public nv data related to the policy was extended
to get public nv data from the TPM in this case.
Addresses #2383.

Signed-off-by: Juergen Repp <juergen_repp@web.de>