### PR TITLE
policy: drop complex TPM2B from callback interface

### DIFF
--- a/include/tss2/tss2_policy.h
+++ b/include/tss2/tss2_policy.h
@@ -89,7 +89,7 @@ typedef TSS2_RC (*TSS2_POLICY_CB_PCR) (
 typedef TSS2_RC (*TSS2_POLICY_CB_NVPUBLIC) (
     const char *path,
     TPMI_RH_NV_INDEX nv_index,
-    TPM2B_NV_PUBLIC *nv_public,
+    TPMS_NV_PUBLIC *nv_public,
     void *userdata);   /* e.g. for ESAPI_CONTEXT */
 
 typedef struct TSS2_POLICY_CALC_CALLBACKS TSS2_POLICY_CALC_CALLBACKS;
@@ -137,7 +137,7 @@ typedef TSS2_RC (*TSS2_POLICY_CB_EXEC_POLAUTH) (
     void *userdata);
 
 typedef TSS2_RC (*TSS2_POLICY_CB_EXEC_POLAUTHNV) (
-    TPM2B_NV_PUBLIC *nv_public,
+    TPMS_NV_PUBLIC *nv_public,
     TPMI_ALG_HASH hash_alg,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1526,7 +1526,7 @@ ifapi_get_name(TPMT_PUBLIC *publicInfo, TPM2B_NAME *name)
  * @retval TSS2_SYS_RC_* for SAPI errors.
  */
 TSS2_RC
-ifapi_nv_get_name(TPM2B_NV_PUBLIC *publicInfo, TPM2B_NAME *name)
+ifapi_nv_get_name(TPMS_NV_PUBLIC *publicInfo, TPM2B_NAME *name)
 {
     BYTE buffer[sizeof(TPMS_NV_PUBLIC)];
     size_t offset = 0;
@@ -1534,18 +1534,18 @@ ifapi_nv_get_name(TPM2B_NV_PUBLIC *publicInfo, TPM2B_NAME *name)
     size_t len_alg_id = sizeof(TPMI_ALG_HASH);
     IFAPI_CRYPTO_CONTEXT_BLOB *cryptoContext;
 
-    if (publicInfo->nvPublic.nameAlg == TPM2_ALG_NULL) {
+    if (publicInfo->nameAlg == TPM2_ALG_NULL) {
         name->size = 0;
         return TSS2_RC_SUCCESS;
     }
     TSS2_RC r;
 
     /* Initialize the hash computation with the nameAlg. */
-    r = ifapi_crypto_hash_start(&cryptoContext, publicInfo->nvPublic.nameAlg);
+    r = ifapi_crypto_hash_start(&cryptoContext, publicInfo->nameAlg);
     return_if_error(r, "Crypto hash start");
 
     /* Get the marshaled data of the public area. */
-    r = Tss2_MU_TPMS_NV_PUBLIC_Marshal(&publicInfo->nvPublic,
+    r = Tss2_MU_TPMS_NV_PUBLIC_Marshal(publicInfo,
                                        &buffer[0], sizeof(TPMS_NV_PUBLIC),
                                        &offset);
     if (r) {
@@ -1572,7 +1572,7 @@ ifapi_nv_get_name(TPM2B_NV_PUBLIC *publicInfo, TPM2B_NAME *name)
 
     offset = 0;
     /* Store the nameAlg in the result. */
-    r = Tss2_MU_TPMI_ALG_HASH_Marshal(publicInfo->nvPublic.nameAlg,
+    r = Tss2_MU_TPMI_ALG_HASH_Marshal(publicInfo->nameAlg,
                                       &name->name[0], sizeof(TPMI_ALG_HASH),
                                       &offset);
     return_if_error(r, "Marshaling TPMI_ALG_HASH");
@@ -1609,7 +1609,7 @@ ifapi_object_cmp_name(IFAPI_OBJECT *object, void *name, bool *equal)
         obj_name = &object->misc.key.name;
         break;
     case IFAPI_NV_OBJ:
-        r = ifapi_nv_get_name(&object->misc.nv.public, &nv_name);
+        r = ifapi_nv_get_name(&object->misc.nv.public.nvPublic, &nv_name);
         return_if_error(r, "Get NV name.");
 
         obj_name = &nv_name;

--- a/src/tss2-fapi/ifapi_helpers.h
+++ b/src/tss2-fapi/ifapi_helpers.h
@@ -104,7 +104,7 @@ ifapi_get_name(
 
 TSS2_RC
 ifapi_nv_get_name(
-    TPM2B_NV_PUBLIC *publicInfo,
+    TPMS_NV_PUBLIC *publicInfo,
     TPM2B_NAME *name);
 
 TSS2_RC

--- a/src/tss2-fapi/ifapi_policy_calculate.c
+++ b/src/tss2-fapi/ifapi_policy_calculate.c
@@ -289,7 +289,7 @@ ifapi_calculate_policy_authorize_nv(
 
     /* Written flag has to be set for policy calculation, because during
        policy execution it will be set. */
-    policy->nvPublic.nvPublic.attributes |= TPMA_NV_WRITTEN;
+    policy->nvPublic.attributes |= TPMA_NV_WRITTEN;
 
     r = ifapi_nv_get_name(&policy->nvPublic, &nv_name);
     return_if_error(r, "Compute NV name");
@@ -1061,7 +1061,7 @@ ifapi_calculate_policy_nv(
 
     /* Written flag has to be set for policy calculation, because during
        policy execution it will be set. */
-    policy->nvPublic.nvPublic.attributes |= TPMA_NV_WRITTEN;
+    policy->nvPublic.attributes |= TPMA_NV_WRITTEN;
 
     /* Compute NV name from public info */
 

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -54,7 +54,7 @@ TSS2_RC
 ifapi_get_nv_public(
     const char *path,
     TPMI_RH_NV_INDEX nv_index,
-    TPM2B_NV_PUBLIC *nv_public,
+    TPMS_NV_PUBLIC *nv_public,
     void *context);
 
 TSS2_RC
@@ -102,7 +102,7 @@ ifapi_exec_auth_policy(
 
 TSS2_RC
 ifapi_exec_auth_nv_policy(
-    TPM2B_NV_PUBLIC *nv_public,
+    TPMS_NV_PUBLIC *nv_public,
     TPMI_ALG_HASH hash_alg,
     void *userdata);
 

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -303,10 +303,10 @@ ifapi_policyeval_instantiate_finish(
             break;
 
         case POLICYNV:
-            if (pol_element->element.PolicyNV.nvPublic.nvPublic.nvIndex) {
+            if (pol_element->element.PolicyNV.nvPublic.nvIndex) {
                 /* nvIndex is already set in policy. Path will not be needed */
                 pol_element->element.PolicyNV.nvIndex
-                    = pol_element->element.PolicyNV.nvPublic.nvPublic.nvIndex;
+                    = pol_element->element.PolicyNV.nvPublic.nvIndex;
                 SAFE_FREE(pol_element->element.PolicyNV.nvPath);
                 break;
             }
@@ -321,7 +321,7 @@ ifapi_policyeval_instantiate_finish(
             return_if_error(r, "read_finish failed");
 
             pol_element->element.PolicyNV.nvIndex
-                = pol_element->element.PolicyNV.nvPublic.nvPublic.nvIndex;
+                = pol_element->element.PolicyNV.nvPublic.nvIndex;
 
             /* Clear NV path, only public data will be needed */
             SAFE_FREE(pol_element->element.PolicyNV.nvPath);
@@ -355,7 +355,7 @@ ifapi_policyeval_instantiate_finish(
             break;
 
         case POLICYAUTHORIZENV:
-            if (pol_element->element.PolicyAuthorizeNv.nvPublic.nvPublic.nvIndex) {
+            if (pol_element->element.PolicyAuthorizeNv.nvPublic.nvIndex) {
                 /* nvIndex is already set in policy. Path will not be needed */
                 SAFE_FREE(pol_element->element.PolicyAuthorizeNv.nvPath);
                 break;

--- a/src/tss2-fapi/ifapi_policy_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_deserialize.c
@@ -444,8 +444,10 @@ ifapi_json_TPMS_POLICYNV_deserialize(json_object *jso,  TPMS_POLICYNV *out)
     if (!ifapi_get_sub_object(jso, "nvPublic", &jso2)) {
         memset(&out->nvPublic, 0, sizeof(TPM2B_NV_PUBLIC));
     } else {
-        r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &out->nvPublic);
+        TPM2B_NV_PUBLIC tmp = { 0 };
+        r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &tmp);
         return_if_error(r, "Bad value for field \"nvPublic\".");
+        out->nvPublic = tmp.nvPublic;
     }
 
     if (!ifapi_get_sub_object(jso, "operandB", &jso2)) {
@@ -1110,8 +1112,10 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_deserialize(json_object *jso,
         memset(&out->nvPublic, 0, sizeof(TPM2B_NV_PUBLIC));
     } else {
         cond_cnt++;
-        r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &out->nvPublic);
+        TPM2B_NV_PUBLIC tmp = { 0 };
+        r = ifapi_json_TPM2B_NV_PUBLIC_deserialize(jso2, &tmp);
         return_if_error(r, "Bad value for field \"nvPublic\".");
+        out->nvPublic = tmp.nvPublic;
     }
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -327,9 +327,11 @@ ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
         json_object_object_add(*jso, "nvIndex", jso2);
     }
 
-    if (in->nvPublic.nvPublic.nvIndex) {
+    if (in->nvPublic.nvIndex) {
         jso2 = NULL;
-        r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&in->nvPublic, &jso2);
+        TPM2B_NV_PUBLIC tmp = { 0 };
+        tmp.nvPublic = in->nvPublic;
+        r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&tmp, &jso2);
         return_if_error(r, "Serialize TPM2B_NV_PUBLIC");
 
         json_object_object_add(*jso, "nvPublic", jso2);
@@ -848,10 +850,12 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_serialize(const TPMS_POLICYAUTHORIZENV *in,
         json_object_object_add(*jso, "nvPath", jso2);
     }
     jso2 = NULL;
-    if (in->nvPublic.nvPublic.nvIndex > 0) {
+    if (in->nvPublic.nvIndex > 0) {
         cond_cnt++;
+        TPM2B_NV_PUBLIC tmp = { 0 };
+        tmp.nvPublic = in->nvPublic;
         /* Template already instantiated */
-        r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&in->nvPublic, &jso2);
+        r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&tmp, &jso2);
         return_if_error(r, "Serialize TPM2B_NV_PUBLIC");
 
         json_object_object_add(*jso, "nvPublic", jso2);

--- a/src/tss2-fapi/ifapi_policy_types.h
+++ b/src/tss2-fapi/ifapi_policy_types.h
@@ -71,7 +71,7 @@ typedef struct {
 typedef struct {
     char                                        *nvPath;    /**< None */
     TPMI_RH_NV_INDEX                            nvIndex;    /**< None */
-    TPM2B_NV_PUBLIC                            nvPublic;    /**< None */
+    TPMS_NV_PUBLIC                             nvPublic;    /**< None */
     TPMI_RH_NV_AUTH                          authHandle;    /**< This is determined by FAPI at runtime. */
     TPM2B_OPERAND                              operandB;    /**< None */
     UINT16                                       offset;    /**< Default value is 0 */
@@ -181,7 +181,7 @@ typedef struct {
  */
 typedef struct {
     char                                        *nvPath;    /**< None */
-    TPM2B_NV_PUBLIC                            nvPublic;    /**< None */
+    TPMS_NV_PUBLIC                             nvPublic;    /**< None */
     TPM2B_DIGEST                                 policy;    /**< Policy Digest */
     TPMT_HA                                   nv_policy;    /**< Policy stored in NV ram */
     uint8_t                               *policy_buffer;

--- a/test/unit/tss2_policy.c
+++ b/test/unit/tss2_policy.c
@@ -127,7 +127,7 @@ TSS2_RC policy_cb_pcr (
 TSS2_RC policy_cb_nvpublic (
     const char *path,
     TPMI_RH_NV_INDEX nv_index,
-    TPM2B_NV_PUBLIC *nv_public,
+    TPMS_NV_PUBLIC *nv_public,
     void *userdata)
 {
     UNUSED(path);


### PR DESCRIPTION
Rather then using types like TPM2B_NV_PUBLIC just use the TPMS_NV_PUBLIC
since the size field is never needed. Keep the ondisk representation
in JSON going through the same routines and convert between the two
types this way we don't break on disk representation of existin objects.

Fixes: #2383

Signed-off-by: William Roberts <william.c.roberts@intel.com>