### PR TITLE
esys: fix usage of HMAC sessions for Esys_TR_FromTPMPublic

### DIFF
--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -183,6 +183,11 @@ struct ESYS_CONTEXT {
                                       automatically loaded. */
     IESYS_SESSION *enc_session;  /**< Ptr to the enc param session.
                                       Used to restore session attributes */
+    ESYS_TR sav_session1;        /**< Used to store session for cases where call
+                                      with ESYS_TR_NONE is needed to determine object
+                                      name */
+    ESYS_TR sav_session2;
+    ESYS_TR sav_session3;
 
     ESYS_CRYPTO_CALLBACKS crypto_backend; /**< The backend function pointers to use
                                               for crypto operations */


### PR DESCRIPTION
The ESAPI spec states that it must be possible to use HMAC sessions
for Esys_TR_FromTPMPublic.
Currently it was not implemented to call Esys_TR_FromPublic twice.
The first call has to be used to determine the object name which
will be used to compute the HMAC of the session.
If the esys object already exists the existing object will be used.
If a session is used in this case the name retrieved from the
TPM will be compared with name stored in the object.

The integration test for the test with Esys_TR_FromTPMPublic was
extended to add a call with a HMAC session.
Addresses: #2171

Signed-off-by: Juergen Repp <juergen_repp@web.de>