### PR TITLE
policy: use correct base RC for NULL callback

### DIFF
--- a/include/tss2/tss2_policy.h
+++ b/include/tss2/tss2_policy.h
@@ -28,7 +28,7 @@
 #define TSS2_POLICY_RC_BUFFER_TOO_SMALL            ((TSS2_RC)(TSS2_POLICY_RC_LAYER | \
                                                         TSS2_BASE_RC_BAD_SIZE))
 #define TSS2_POLICY_RC_NULL_CALLBACK               ((TSS2_RC)(TSS2_POLICY_RC_LAYER | \
-                                                        TSS2_BASE_RC_NULL_CALLBACK))
+                                                        TSS2_BASE_RC_CALLBACK_NULL))
 
 typedef struct TSS2_POLICY_CTX TSS2_POLICY_CTX;
 

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -260,7 +260,7 @@ execute_policy_duplicate(
     switch (current_policy->state) {
     statecase(current_policy->state, POLICY_EXECUTE_INIT)
         TSS2_POLICY_EXEC_CALLBACKS *cb = &current_policy->callbacks;
-        return_if_null(cb->cbauth, "Policy Duplicate Callback Not Set",
+        return_if_null(cb->cbdup, "Policy Duplicate Callback Not Set",
             TSS2_FAPI_RC_NULL_CALLBACK);
         r = cb->cbdup(&policy->objectName, cb->cbdup_userdata);
         return_if_error(r, "Get name for policy duplicate select.");

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -772,7 +772,7 @@ execute_policy_authorize_nv(
         /* Execute the policy stored in the NV object. */
         return_if_null(cb->cbauthnv, "Authorize NV Callback Not Set",
                 TSS2_FAPI_RC_NULL_CALLBACK);
-        r = cb->cbauthnv(&policy->nvPublic, hash_alg, cb->cbauthpol_userdata);
+        r = cb->cbauthnv(&policy->nvPublic, hash_alg, cb->cbauthnv_userdata);
         try_again_or_error(r, "Execute policy authorize nv callback.");
 
         r = ifapi_nv_get_name(&policy->nvPublic, &current_policy->name);

--- a/src/tss2-rc/tss2_rc.c
+++ b/src/tss2-rc/tss2_rc.c
@@ -850,7 +850,7 @@ static struct {
                                             /* The RM usually duplicates TPM responses */
                                             /* So just default the handler to tpm2. */
     ADD_HANDLER("rm", NULL),                /* layer 12 is the rm rc */
-    ADD_HANDLER("drvr", NULL),              /* layer 13 is the driver rc */
+    ADD_HANDLER("policy", tss_err_handler), /* layer 13 is the policy rc */
 };
 
 /**

--- a/test/unit/test_tss2_rc.c
+++ b/test/unit/test_tss2_rc.c
@@ -37,7 +37,7 @@ test_layers(void **state)
         "tcti:",
         "rmt",
         "rm",
-        "drvr",
+        "policy",
     };
 
     UINT8 layer;


### PR DESCRIPTION
TSS2_BASE_RC_NULL_CALLBACK is not defined, FAPI uses TSS2_BASE_RC_CALLBACK_NULL so use that
Fix two cases where the wrong callback/userdata is used and add support for decoding policy return codes