### PR TITLE
fapi: improve error message curve not implemented.

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -1162,7 +1162,7 @@ get_ecc_tpm2b_public_from_evp(
 #endif
     default:
         goto_error(r, TSS2_FAPI_RC_BAD_VALUE,
-                   "Curve %x not implemented", cleanup, curveId);
+                   "Curve %i not implemented", cleanup, curveId);
     }
     tpmPublic->publicArea.parameters.eccDetail.curveID = tpmCurveId;
 


### PR DESCRIPTION
Currently the number of curves not implemented are displaye as
hex number but not marked with 0x.
Integers are used in the corresponding openssl h file.
To make debugging easier the curve number now is displayed as
integer.

Signed-off-by: Juergen Repp <juergen_repp@web.de>