### PR TITLE
Correct [out] param documentation

### DIFF
--- a/src/tss2-esys/api/Esys_Commit.c
+++ b/src/tss2-esys/api/Esys_Commit.c
@@ -42,7 +42,6 @@
  * @param[out] E ECC point E := [r]P1.
  *             (callee-allocated)
  * @param[out] counter Least-significant 16 bits of commitCount.
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input
  *         pointers or required output handle references are NULL.
@@ -235,7 +234,6 @@ Esys_Commit_Async(
  * @param[out] E ECC point E := [r]P1.
  *             (callee-allocated)
  * @param[out] counter Least-significant 16 bits of commitCount.
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS on success
  * @retval ESYS_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input

--- a/src/tss2-esys/api/Esys_EC_Ephemeral.c
+++ b/src/tss2-esys/api/Esys_EC_Ephemeral.c
@@ -34,7 +34,6 @@
  * @param[out] Q Ephemeral public key Q := [r]G.
  *             (callee-allocated)
  * @param[out] counter Least-significant 16 bits of commitCount.
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input
  *         pointers or required output handle references are NULL.
@@ -198,7 +197,6 @@ Esys_EC_Ephemeral_Async(
  * @param[out] Q Ephemeral public key Q := [r]G.
  *             (callee-allocated)
  * @param[out] counter Least-significant 16 bits of commitCount.
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS on success
  * @retval ESYS_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input

--- a/src/tss2-esys/api/Esys_GetCapability.c
+++ b/src/tss2-esys/api/Esys_GetCapability.c
@@ -36,7 +36,6 @@
  * @param[in]  propertyCount Number of properties of the indicated type to
  *             return.
  * @param[out] moreData Flag to indicate if there are more values of this type.
- *             (callee-allocated)
  * @param[out] capabilityData The capability data.
  *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS if the function call was a success.
@@ -216,7 +215,6 @@ Esys_GetCapability_Async(
  *
  * @param[in,out] esysContext The ESYS_CONTEXT.
  * @param[out] moreData Flag to indicate if there are more values of this type.
- *             (callee-allocated)
  * @param[out] capabilityData The capability data.
  *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS on success

--- a/src/tss2-esys/api/Esys_GetTestResult.c
+++ b/src/tss2-esys/api/Esys_GetTestResult.c
@@ -33,7 +33,6 @@
  * @param[out] outData Test result data.
  *             (callee-allocated)
  * @param[out] testResult .
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input
  *         pointers or required output handle references are NULL.
@@ -193,7 +192,6 @@ Esys_GetTestResult_Async(
  * @param[out] outData Test result data.
  *             (callee-allocated)
  * @param[out] testResult .
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS on success
  * @retval ESYS_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input

--- a/src/tss2-esys/api/Esys_PCR_Allocate.c
+++ b/src/tss2-esys/api/Esys_PCR_Allocate.c
@@ -33,14 +33,10 @@
  * @param[in]  shandle3 Third session handle.
  * @param[in]  pcrAllocation The requested allocation.
  * @param[out] allocationSuccess YES if the allocation succeeded.
- *             (callee-allocated)
  * @param[out] maxPCR Maximum number of PCR that may be in a bank.
- *             (callee-allocated)
  * @param[out] sizeNeeded Number of octets required to satisfy the request.
- *             (callee-allocated)
  * @param[out] sizeAvailable Number of octets available. Computed before the
  *             allocation..
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input
  *         pointers or required output handle references are NULL.
@@ -233,14 +229,10 @@ Esys_PCR_Allocate_Async(
  *
  * @param[in,out] esysContext The ESYS_CONTEXT.
  * @param[out] allocationSuccess YES if the allocation succeeded.
- *             (callee-allocated)
  * @param[out] maxPCR Maximum number of PCR that may be in a bank.
- *             (callee-allocated)
  * @param[out] sizeNeeded Number of octets required to satisfy the request.
- *             (callee-allocated)
  * @param[out] sizeAvailable Number of octets available. Computed before the
  *             allocation..
- *             (callee-allocated)
  * @retval TSS2_RC_SUCCESS on success
  * @retval ESYS_RC_SUCCESS if the function call was a success.
  * @retval TSS2_ESYS_RC_BAD_REFERENCE if the esysContext or required input

--- a/src/tss2-esys/api/Esys_PCR_Read.c
+++ b/src/tss2-esys/api/Esys_PCR_Read.c
@@ -32,7 +32,6 @@
  * @param[in]  shandle3 Third session handle.
  * @param[in]  pcrSelectionIn The selection of PCR to read.
  * @param[out] pcrUpdateCounter The current value of the PCR update counter.
- *             (callee-allocated)
  * @param[out] pcrSelectionOut The PCR in the returned list.
  *             (callee-allocated)
  * @param[out] pcrValues The contents of the PCR indicated in pcrSelectOut->
@@ -207,7 +206,6 @@ Esys_PCR_Read_Async(
  *
  * @param[in,out] esysContext The ESYS_CONTEXT.
  * @param[out] pcrUpdateCounter The current value of the PCR update counter.
- *             (callee-allocated)
  * @param[out] pcrSelectionOut The PCR in the returned list.
  *             (callee-allocated)
  * @param[out] pcrValues The contents of the PCR indicated in pcrSelectOut->

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -99,10 +99,9 @@ tcti_swtpm_down_cast (TSS2_TCTI_SWTPM_CONTEXT *tcti_swtpm)
  * @param[in]  cmd_code Control command code to send
  * @param[in]  cmd_sdu Control command payload to send (can be NULL)
  * @param[in]  cmd_sdu_len Length of the control command payload
- * @param[out] resp_code Response code received, callee-allocated (can be NULL)
- * @param[out] resp_sdu Payload of the response, callee-allocated (can be NULL)
- * @param[out] resp_sdu_len Length of the response's payload, callee-allocated
- *             (can be NULL)
+ * @param[out] resp_code Response code received (can be NULL)
+ * @param[out] resp_sdu Payload of the response (can be NULL)
+ * @param[out] resp_sdu_len Length of the response's payload (can be NULL)
  * @retval TSS2_RC_SUCCESS if the received response code is zero, a TCTI error
  *         code otherwise
  */


### PR DESCRIPTION
Several [out] pointers are described in the comments as
"callee-allocated" but this seems incorrect - they would need to be
pointers to pointers to be callee-allocated. This removes the
"callee-allocated" notes from comments where they are incorrect.

Signed-off-by: Erik Bryan <erik.bryan@hp.com>