### PR TITLE
Tss2 mu precision fixes

### DIFF
--- a/src/tss2-mu/base-types.c
+++ b/src/tss2-mu/base-types.c
@@ -64,13 +64,13 @@ Tss2_MU_##type##_Marshal ( \
         case 1: \
             break; \
         case 2: \
-            src = HOST_TO_BE_16(src); \
+            src = (type)HOST_TO_BE_16((UINT16)src); \
             break; \
         case 4: \
-            src = HOST_TO_BE_32(src); \
+            src = (type)HOST_TO_BE_32((UINT32)src); \
             break; \
         case 8: \
-            src = HOST_TO_BE_64(src); \
+            src = (type)HOST_TO_BE_64((UINT64)src); \
             break; \
 \
     } \
@@ -133,13 +133,13 @@ Tss2_MU_##type##_Unmarshal ( \
             *dest = (type)tmp; \
             break; \
         case 2: \
-            *dest = BE_TO_HOST_16(tmp); \
+            *dest = (type)BE_TO_HOST_16((UINT16)tmp); \
             break; \
         case 4: \
-            *dest = BE_TO_HOST_32(tmp); \
+            *dest = (type)BE_TO_HOST_32((UINT32)tmp); \
             break; \
         case 8: \
-            *dest = BE_TO_HOST_64(tmp); \
+            *dest = (type)BE_TO_HOST_64((UINT64)tmp); \
             break; \
 \
     } \

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -209,7 +209,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
 \
     /* Update the size to the real value */ \
     if (buffer) { \
-        UINT16 t = HOST_TO_BE_16(buffer + local_offset - ptr - 2); \
+        UINT16 t = HOST_TO_BE_16((UINT16)(buffer + local_offset - ptr - 2)); \
         memcpy(ptr, &t, sizeof(t)); \
     } \
 \

--- a/src/tss2-mu/tpma-types.c
+++ b/src/tss2-mu/tpma-types.c
@@ -60,13 +60,13 @@ TSS2_RC Tss2_MU_##type##_Marshal(type src, uint8_t buffer[], \
         case 1: \
             break; \
         case 2: \
-            src = HOST_TO_BE_16(src); \
+            src = (type)HOST_TO_BE_16((UINT16)src); \
             break; \
         case 4: \
-            src = HOST_TO_BE_32(src); \
+            src = (type)HOST_TO_BE_32(src); \
             break; \
         case 8: \
-            src = HOST_TO_BE_64(src); \
+            src = (type)HOST_TO_BE_64(src); \
             break; \
 \
     } \
@@ -123,16 +123,16 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
 \
     switch (sizeof(tmp)) { \
         case 1: \
-            *dest = tmp; \
+            *dest = (type)tmp; \
             break; \
         case 2: \
-            *dest = BE_TO_HOST_16(tmp); \
+            *dest = (type)BE_TO_HOST_16((UINT16)tmp); \
             break; \
         case 4: \
-            *dest = BE_TO_HOST_32(tmp); \
+            *dest = (type)BE_TO_HOST_32(tmp); \
             break; \
         case 8: \
-            *dest = BE_TO_HOST_64(tmp); \
+            *dest = (type)BE_TO_HOST_64(tmp); \
             break; \
 \
     } \


### PR DESCRIPTION
You can enabled this warnings on gcc/clang via -Wconversion. I guess do we want to enable this for libmu?