### PR TITLE
test: fix buffer too small in sys-session-util.c

### DIFF
--- a/test/integration/sys-util.c
+++ b/test/integration/sys-util.c
@@ -623,10 +623,11 @@ out:
 
 TSS2_RC
 ConcatSizedByteBuffer(
-        TPM2B_MAX_BUFFER *result,
+        TPM2B *result,
+        size_t maxlen,
         TPM2B *buf)
 {
-    if (result->size + buf->size > TPM2_MAX_DIGEST_BUFFER)
+    if (result->size + buf->size > maxlen)
         return TSS2_SYS_RC_BAD_VALUE;
 
     memmove(result->buffer + result->size,

--- a/test/integration/sys-util.h
+++ b/test/integration/sys-util.h
@@ -196,7 +196,8 @@ CompareSizedByteBuffer(
 
 TSS2_RC
 ConcatSizedByteBuffer(
-        TPM2B_MAX_BUFFER *result,
+        TPM2B *result,
+        size_t maxlen,
         TPM2B *buf);
 
 void


### PR DESCRIPTION
When the values being concatenated overflowed a TPM2B_MAX_BUFFER, which
is bounded on 1024 bytes, TSS2_SYS_RC_INSUFFICIENT_BUFFER was returned
from tpm_calc_phash due to a bound check in ConcatSizedByteBuffer.

Calculating the phash requires a lot of space becuase it could require 3
names which could be 512 bytes (SHA512 for instance) each, which
overflows the space available. Bump an internal buffer to 4096 for this
calculation, which should be plenty:
1. Command Code: 4 bytes
2. name1: Max 64 bytes
3. name2: Max 64 bytes
4. name3: Max 64 bytes
5. Remaining serialized paramters (command specific)

Items 1 through 4 yeild a size of 196 bytes which yeilds a remaining
3900 bytes bytes for the rest of the paramters. After that, the largest
commands seem to take a TPM2B_MAX_NV_BUFFER (2048 bytes) and then some
small scalar values.

Items 1 through 4 yeild a size of 1540 bytes which yeilds a remaining 2556 bytes bytes for the rest of the paramters. After that, the largest commands seem to take a TPM2B_MAX_NV_BUFFER (2048 bytes) and then some small scalar values.

Signed-off-by: William Roberts <william.c.roberts@intel.com>