### PR TITLE
tcti: drop unused inclusions of errno.h

### DIFF
--- a/src/tss2-tcti/tcti-common.h
+++ b/src/tss2-tcti/tcti-common.h
@@ -6,7 +6,6 @@
 #ifndef TCTI_COMMON_H
 #define TCTI_COMMON_H
 
-#include <errno.h>
 #include <stdbool.h>
 
 #include "tss2_tcti.h"

--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -10,7 +10,6 @@
 #endif
 
 #include <stdlib.h>
-#include <errno.h>
 #include <string.h>
 #include <inttypes.h>
 #include <dlfcn.h>

--- a/src/tss2-tcti/tctildr-nodl.c
+++ b/src/tss2-tcti/tctildr-nodl.c
@@ -34,7 +34,6 @@
 #endif
 
 #include <stdlib.h>
-#include <errno.h>
 #include <string.h>
 #include <inttypes.h>
 

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <stddef.h>
 #if defined(__linux__)
 #include <linux/limits.h>
 #elif defined(_MSC_VER)

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stddef.h>
+#include <stdlib.h>
 #if defined(__linux__)
 #include <linux/limits.h>
 #elif defined(_MSC_VER)

--- a/test/helper/tpm_cmd_tcti_dummy.c
+++ b/test/helper/tpm_cmd_tcti_dummy.c
@@ -4,6 +4,7 @@
 #include <config.h>
 #endif
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -8,6 +8,7 @@
 #include <config.h>
 #endif
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/test/unit/tctildr-getinfo.c
+++ b/test/unit/tctildr-getinfo.c
@@ -3,6 +3,7 @@
  * Copyright 2019, Intel Corporation
  */
 
+#include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdarg.h>


### PR DESCRIPTION
Signed-off-by: William Roberts <william.c.roberts@intel.com>