### PR TITLE
tss2: update defines for spec version to 1.38

### DIFF
--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -262,9 +262,9 @@ typedef UINT16 TPM2_KEY_BITS;           /* a key size in bits */
 typedef UINT32 TPM2_SPEC;
 #define TPM2_SPEC_FAMILY      ((TPM2_SPEC) 0x322E3000) /* ASCII 2.0 with null terminator */
 #define TPM2_SPEC_LEVEL       ((TPM2_SPEC) 00)         /* the level number for the specification */
-#define TPM2_SPEC_VERSION     ((TPM2_SPEC) 126)        /* the version number of the spec 001.26 * 100 */
-#define TPM2_SPEC_YEAR        ((TPM2_SPEC) 2015)       /* the year of the version */
-#define TPM2_SPEC_DAY_OF_YEAR ((TPM2_SPEC) 233)        /* the day of the year August 21 2015 */
+#define TPM2_SPEC_VERSION     ((TPM2_SPEC) 138)        /* the version number of the spec 001.38 * 100 */
+#define TPM2_SPEC_YEAR        ((TPM2_SPEC) 2016)       /* the year of the version */
+#define TPM2_SPEC_DAY_OF_YEAR ((TPM2_SPEC) 260)        /* the day of the year September 16 2016 */
 
 /* Definition of UINT32 TPM2_GENERATED Constants <O> */
 typedef UINT32 TPM2_GENERATED;


### PR DESCRIPTION
It was set for 1.26, which AFAICT, was never released. Set this for the implemented version of 1.38. FYI, the TSS supports a small smattering of the 1.59 constructs currently.

Signed-off-by: William Roberts <william.c.roberts@intel.com>