### PR TITLE
rc: add format field to TSS2_RC_INFO and clear it when decoding

### DIFF
--- a/include/tss2/tss2_rc.h
+++ b/include/tss2/tss2_rc.h
@@ -20,6 +20,7 @@ TSS2_RC_HANDLER Tss2_RC_SetHandler(uint8_t layer, const char *name, TSS2_RC_HAND
 typedef struct TSS2_RC_INFO TSS2_RC_INFO;
 struct TSS2_RC_INFO {
     UINT8 layer;
+    UINT8 format;
     TSS2_RC error;
     UINT8 parameter;
     UINT8 session;

--- a/src/tss2-rc/tss2_rc.c
+++ b/src/tss2-rc/tss2_rc.c
@@ -1000,9 +1000,12 @@ Tss2_RC_DecodeInfo(TSS2_RC rc, TSS2_RC_INFO *info)
         return TSS2_BASE_RC_BAD_REFERENCE;
     }
 
-    info->layer = tss2_rc_layer_number_get(rc);
+    memset(info, 0, sizeof(TSS2_RC_INFO));
 
-    if (tss2_rc_layer_format_get(rc)) {
+    info->layer = tss2_rc_layer_number_get(rc);
+    info->format = tss2_rc_layer_format_get(rc);
+
+    if (info->format) {
         info->error = tpm2_rc_fmt1_error_get(rc) | TPM2_RC_FMT1;
         n = tpm2_rc_fmt1_N_index_get(rc);
         if (tpm2_rc_fmt1_P_get(rc)) {

--- a/test/unit/test_tss2_rc.c
+++ b/test/unit/test_tss2_rc.c
@@ -283,10 +283,11 @@ test_tcti(void **state)
 static void
 test_info_fmt0(void **state)
 {
-    TSS2_RC_INFO info = { 0, 0, 0, 0, 0 };
+    TSS2_RC_INFO info = { 1, 2, 3, 4, 5, 6 };
     TSS2_RC test_rc = TSS2_MU_RC_LAYER | TPM2_RC_SESSION_HANDLES;
     TSS2_RC r = Tss2_RC_DecodeInfo(test_rc, &info);
     assert_int_equal(info.layer, 9);
+    assert_int_equal(info.format, 0);
     assert_int_equal(info.error, TPM2_RC_SESSION_HANDLES);
     assert_int_equal(info.parameter, 0);
     assert_int_equal(info.handle, 0);
@@ -297,10 +298,11 @@ test_info_fmt0(void **state)
 static void
 test_info_fmt1_parameter(void **state)
 {
-    TSS2_RC_INFO info = { 0, 0, 0, 0, 0 };
+    TSS2_RC_INFO info;
     TSS2_RC test_rc = TSS2_SYS_RC_LAYER | TPM2_RC_ASYMMETRIC | TPM2_RC_P | TPM2_RC_1;
     TSS2_RC r = Tss2_RC_DecodeInfo(test_rc, &info);
     assert_int_equal(info.layer, 8);
+    assert_int_equal(info.format, 1);
     assert_int_equal(info.error, TPM2_RC_ASYMMETRIC);
     assert_int_equal(info.parameter, 1);
     assert_int_equal(info.handle, 0);
@@ -311,7 +313,7 @@ test_info_fmt1_parameter(void **state)
 static void
 test_info_fmt1_handle(void **state)
 {
-    TSS2_RC_INFO info = { 0, 0, 0, 0, 0 };
+    TSS2_RC_INFO info;
     TSS2_RC test_rc = TSS2_ESAPI_RC_LAYER | TPM2_RC_HANDLE | TPM2_RC_H | TPM2_RC_2;
     TSS2_RC r = Tss2_RC_DecodeInfo(test_rc, &info);
     assert_int_equal(info.layer, 7);
@@ -325,7 +327,7 @@ test_info_fmt1_handle(void **state)
 static void
 test_info_fmt1_session(void **state)
 {
-    TSS2_RC_INFO info = { 0, 0, 0, 0, 0 };
+    TSS2_RC_INFO info;
     TSS2_RC test_rc = TSS2_FEATURE_RC_LAYER | TPM2_RC_EXPIRED | TPM2_RC_S | TPM2_RC_3;
     TSS2_RC r = Tss2_RC_DecodeInfo(test_rc, &info);
     assert_int_equal(info.layer, 6);


### PR DESCRIPTION
As discussed in https://github.com/tpm2-software/tpm2-tss/pull/2416 add format fields to users don't need to check the parameter, session and handle fields unless needed and ensure that the struct is initialized when decoding