### PR TITLE
FAPI: Fix deviation from spec.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -777,7 +777,7 @@ equal_policy_authorization(
                     pem_public.publicArea.parameters.rsaDetail.scheme
                         = authorizations->authorizations[i].rsaScheme;
                 }
-                pem_public.publicArea.nameAlg = authorizations->authorizations[i].keyPEMhashAlg;
+                pem_public.publicArea.nameAlg = authorizations->authorizations[i].hashAlg;
 
                 /* Check public information if key and policyRef */
                 if (ifapi_TPMT_PUBLIC_cmp(public, &pem_public.publicArea) &&
@@ -1068,13 +1068,13 @@ get_policy_signature(
                 pem_public.publicArea.parameters.rsaDetail.scheme
                     = authorizations->authorizations[i].rsaScheme;
             }
-            pem_public.publicArea.nameAlg = authorizations->authorizations[i].keyPEMhashAlg;
+            pem_public.publicArea.nameAlg = authorizations->authorizations[i].hashAlg;
 
             if (ifapi_TPMT_PUBLIC_cmp(public, &pem_public.publicArea)) {
                 r = ifapi_der_sig_to_tpm(&pem_public.publicArea,
                                          authorizations->authorizations[i].pemSignature.buffer,
                                          authorizations->authorizations[i].pemSignature.size,
-                                         authorizations->authorizations[i].keyPEMhashAlg,
+                                         authorizations->authorizations[i].hashAlg,
                                          signature);
 
                 return_if_error(r, "Invalid signature.");

--- a/src/tss2-fapi/ifapi_policy_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_deserialize.c
@@ -1382,17 +1382,21 @@ ifapi_json_TPMS_POLICYAUTHORIZATION_deserialize(json_object *jso,
         r = ifapi_json_char_deserialize(jso2, &out->keyPEM);
         return_if_error(r, "Bad value for field \"key\".");
         if (ifapi_get_sub_object(jso, "keyPEMhashAlg", &jso2)) {
-            r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->keyPEMhashAlg);
+            /* Allow value not defined in spec to achieve backward compatibility. */
+            r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
             return_if_error(r, "Bad value for field \"keyPEMhashAlg\".");
+        } else if (ifapi_get_sub_object(jso, "hashAlg", &jso2)) {
+            r = ifapi_json_TPMI_ALG_HASH_deserialize(jso2, &out->hashAlg);
+            return_if_error(r, "Bad value for field \"hashAlg\".");
         } else {
-            out->keyPEMhashAlg = TPM2_ALG_SHA256;
+            out->hashAlg = TPM2_ALG_SHA256;
         }
         if (ifapi_get_sub_object(jso, "rsaScheme", &jso2)) {
             r = ifapi_json_TPMT_RSA_SCHEME_deserialize(jso2, &out->rsaScheme);
             return_if_error(r, "Bad value for field \"rsaScheme\".");
         } else {
             out->rsaScheme.scheme = TPM2_ALG_RSAPSS;
-            out->rsaScheme.details.rsapss.hashAlg = out->keyPEMhashAlg;
+            out->rsaScheme.details.rsapss.hashAlg = out->hashAlg;
         }
         if (!ifapi_get_sub_object(jso, "signature", &jso2)) {
             LOG_ERROR("Field \"signature\" not found.");

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -1082,10 +1082,10 @@ ifapi_json_TPMS_POLICYAUTHORIZATION_serialize(
         json_object_object_add(*jso, "rsaScheme", jso2);
 
         jso2 = NULL;
-        r = ifapi_json_TPMI_ALG_HASH_serialize(in->keyPEMhashAlg, &jso2);
+        r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
         return_if_error(r, "Serialize hash alg.");
 
-        json_object_object_add(*jso, "keyPEMhashAlg", jso2);
+        json_object_object_add(*jso, "hashAlg", jso2);
     } else {
         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid key type.");
     }

--- a/src/tss2-fapi/ifapi_policy_types.h
+++ b/src/tss2-fapi/ifapi_policy_types.h
@@ -130,7 +130,7 @@ typedef struct {
     TPMT_PUBLIC                                     key;    /**< Selector of the algorithm used for the signature and the pub */
     TPM2B_NONCE                               policyRef;    /**< None */
     TPMT_SIGNATURE                            signature;    /**< None */
-    TPMI_ALG_HASH                         keyPEMhashAlg;
+    TPMI_ALG_HASH                               hashAlg;
     UINT8_ARY                              pemSignature;
     char                                        *keyPEM;
     TPMT_RSA_SCHEME                           rsaScheme;


### PR DESCRIPTION
The current implementation did use the field keyPEMhashAlg in the structure TPMS_POLICYAUTHORIZATION instead of hashAlg as defined in "TCG TSS 2.0 JSON Data Types and Policy Language Specification". Also in the JSON represention keyPEMhashAlg was used instead of hashAlg. To achieve backward compatibility keyPEMhashAlg is still allowed.

Signed-off-by: Juergen Repp <juergen_repp@web.de>