### PR TITLE
FAPI: Add test profile P_ECC384

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -570,6 +570,7 @@ EXTRA_DIST +=  \
     test/data/fapi/P_RSA_sh_policy.json \
     test/data/fapi/P_RSA256.json \
     test/data/fapi/P_ECC.json \
+    test/data/fapi/P_ECC384.json \
     test/data/fapi/policy/pol_pcr16_0.json \
     test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json \
     test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json \

--- a/test/data/fapi/P_ECC384.json
+++ b/test/data/fapi/P_ECC384.json
@@ -1,0 +1,94 @@
+{
+    "type": "TPM2_ALG_ECC",
+    "nameAlg":"TPM2_ALG_SHA384",
+    "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
+    "srk_persistent": 0,
+    "ek_template":  "system,restricted,decrypt,user",
+    "ek_description": "Endorsement key EK",
+    "ecc_signing_scheme": {
+        "scheme":"TPM2_ALG_ECDSA",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        },
+    },
+    "sym_mode":"TPM2_ALG_CFB",
+    "sym_parameters": {
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "sym_block_size": 16,
+    "pcr_selection": [
+       { "hash": "TPM2_ALG_SHA1",
+         "pcrSelect": [ ],
+       },
+       { "hash": "TPM2_ALG_SHA256",
+         "pcrSelect": [ 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+       }
+    ],
+    "curveID": "TPM2_ECC_NIST_P384",
+    "ek_policy": {
+        "description": "Endorsement hierarchy used for policy secret.",
+        "policy":[
+            {
+                "type": "PolicyOR",
+                "branches": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"POLICYSECRET",
+                                "objectName": "4000000b"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "B",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"AUTHORIZENV",
+                                "nvPublic": {
+				    "size": 60,
+				    "nvPublic": {
+                                        "nvIndex": 29392642,
+                                        "nameAlg":"SHA384",
+                                        "attributes":{
+                                          "PPWRITE":0,
+                                          "OWNERWRITE":0,
+                                          "AUTHWRITE":0,
+                                          "POLICYWRITE":1,
+                                          "POLICY_DELETE":0,
+                                          "WRITELOCKED":0,
+                                          "WRITEALL":1,
+                                          "WRITEDEFINE":0,
+                                          "WRITE_STCLEAR":0,
+                                          "GLOBALLOCK":0,
+                                          "PPREAD":1,
+                                          "OWNERREAD":1,
+                                          "AUTHREAD":1,
+                                          "POLICYREAD":1,
+                                          "NO_DA":1,
+                                          "ORDERLY":0,
+                                          "CLEAR_STCLEAR":0,
+                                          "READLOCKED":0,
+                                          "WRITTEN":1,
+                                          "PLATFORMCREATE":0,
+                                          "READ_STCLEAR":0,
+                                          "TPM2_NT":"ORDINARY"
+                                        },
+                                        "authPolicy":"8bbf2266537c171cb56e403c4dc1d4b64f432611dc386e6f532050c3278c930e143e8bb1133824ccb431053871c6db53",
+                                        "dataSize":50
+				    }
+	                        }
+
+                           }
+		        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -110,7 +110,11 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "    {" \
         "      \"hashAlg\":\"SHA1\"," \
         "      \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
-        "    }" \
+        "    },"                                                        \
+        "    { " \
+        "         \"hashAlg\":\"SHA384\"," \
+        "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "     }" \
         "  ]," \
         "  \"policy\":[" \
         "    {" \
@@ -123,7 +127,11 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "        {" \
         "          \"hashAlg\":\"SHA1\"," \
         "          \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
-        "        }" \
+        "        },"                                                    \
+        "    { " \
+        "         \"hashAlg\":\"SHA384\"," \
+        "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "     }" \
         "      ]," \
         "      \"pcrs\":[" \
         "        {" \


### PR DESCRIPTION
The profile P_ECC384 defined in PR #2418 was added. The ci tests failed for this test. The failed integration test was adapted to run with this additional profile.
The curveID TPM2_ECC_NIST_P384, the nameAlg SHA384, and the autpolicy according to the EK Template (TPMT_PUBLIC) H-2: ECC NIST P256 were used in the profile.

Signed-off-by: Juergen Repp <juergen_repp@web.de>