### PR TITLE
FAPI: Enable usage of profile P_ECC384 for integration test.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -604,7 +604,14 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_action.json \
     test/data/fapi/policy/pol_cphash.json \
     test/data/fapi/policy/pol_or_read_write_secret.json \
-    test/data/fapi/policy/pol_ek_high_range_sha256.json
+    test/data/fapi/policy/pol_ek_high_range_sha256.json \
+    test/data/fapi/P_ECC_sh_eh_policy_sha384.json \
+	test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json \
+	test/data/fapi/policy/pol_authorize_nv_complex_tpm2b_sha384.json \
+	test/data/fapi/policy/pol_authorize_nv_tpms_sha384.json \
+	test/data/fapi/policy/pol_authorize_nv_sha384.json \
+	test/data/fapi/policy/pol_cphash_sha384.json \
+	test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json
 
 src_tss2_fapi_libtss2_fapi_la_LIBADD  = $(libtss2_sys) $(libtss2_mu) $(libtss2_esys) \
     $(libutil) $(libtss2_tctildr)

--- a/test/data/fapi/P_ECC_sh_eh_policy_sha384.json
+++ b/test/data/fapi/P_ECC_sh_eh_policy_sha384.json
@@ -1,0 +1,124 @@
+{
+    "type": "TPM2_ALG_ECC",
+    "nameAlg":"TPM2_ALG_SHA384",
+    "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
+    "srk_persistent": 0,
+    "ek_template":  "system,restricted,decrypt,user",
+    "ek_description": "Endorsement key EK",
+    "ecc_signing_scheme": {
+        "scheme":"TPM2_ALG_ECDSA",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        },
+    },
+    "sym_mode":"TPM2_ALG_CFB",
+    "sym_parameters": {
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "sym_block_size": 16,
+    "pcr_selection": [
+        { "hash": "TPM2_ALG_SHA1",
+          "pcrSelect": [ ],
+        },
+        { "hash": "TPM2_ALG_SHA256",
+          "pcrSelect": [ 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+        }
+    ],
+    "curveID": "TPM2_ECC_NIST_P384",
+    "ek_policy": {
+        "description": "Endorsement hierarchy used for policy secret.",
+        "policy":[
+            {
+                "type": "PolicyOR",
+                "branches": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"POLICYSECRET",
+                                "objectName": "4000000b"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "B",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"AUTHORIZENV",
+                                "nvPublic": {
+				                    "size": 60,
+				                    "nvPublic": {
+                                        "nvIndex": 29392642,
+                                        "nameAlg":"SHA384",
+                                        "attributes":{
+                                            "PPWRITE":0,
+                                            "OWNERWRITE":0,
+                                            "AUTHWRITE":0,
+                                            "POLICYWRITE":1,
+                                            "POLICY_DELETE":0,
+                                            "WRITELOCKED":0,
+                                            "WRITEALL":1,
+                                            "WRITEDEFINE":0,
+                                            "WRITE_STCLEAR":0,
+                                            "GLOBALLOCK":0,
+                                            "PPREAD":1,
+                                            "OWNERREAD":1,
+                                            "AUTHREAD":1,
+                                            "POLICYREAD":1,
+                                            "NO_DA":1,
+                                            "ORDERLY":0,
+                                            "CLEAR_STCLEAR":0,
+                                            "READLOCKED":0,
+                                            "WRITTEN":1,
+                                            "PLATFORMCREATE":0,
+                                            "READ_STCLEAR":0,
+                                            "TPM2_NT":"ORDINARY"
+                                        },
+                                        "authPolicy":"8bbf2266537c171cb56e403c4dc1d4b64f432611dc386e6f532050c3278c930e143e8bb1133824ccb431053871c6db53",
+                                        "dataSize":50
+				                    }
+	                            }
+
+                            }
+		                ]
+                    }
+                ]
+            }
+        ]
+    },
+    "sh_policy": {
+        "description":"Description pol_16_0",
+        "policy":[
+            {
+                "type":"POLICYPCR",
+                "pcrs":[
+                    {
+                        "pcr":16,
+                        "hashAlg":"TPM2_ALG_SHA256",
+                        "digest":"00000000000000000000000000000000000000000000000000000000000000000"
+                    }
+                ]
+            }
+        ]
+    },
+    "eh_policy": {
+        "description":"Description pol_16_0",
+        "policy":[
+            {
+                "type":"POLICYPCR",
+                "pcrs":[
+                    {
+                        "pcr":16,
+                        "hashAlg":"TPM2_ALG_SHA256",
+                        "digest":"00000000000000000000000000000000000000000000000000000000000000000"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json
+++ b/test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json
@@ -1,0 +1,15 @@
+{
+    "description":"Description pol_authorize",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZE",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "keyPEMhashAlg": "SHA384",
+			"keyPEM": "-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPnzYHCTqHAJnCcLRQC4bL/r2t9P1bJJE
+27tHWVxxRtdUNPQceF9sFPE1AgafveTyLrf/V2TwYqpOgMw3hseFlpXAgQl0klqN
+ZPX3zQ+iOfcHhZ7YPjSXzBghWF67oxat
+-----END PUBLIC KEY-----"
+		}
+    ]
+}

--- a/test/data/fapi/policy/pol_authorize_nv_complex_tpm2b_sha384.json
+++ b/test/data/fapi/policy/pol_authorize_nv_complex_tpm2b_sha384.json
@@ -1,0 +1,41 @@
+{
+    "description":"Description pol_authorize_nv",
+    "policy":[
+      {
+        "type":"POLICYAUTHORIZENV",
+        "nvPublic":{
+          "size":0,
+          "nvPublic":{
+            "nvIndex":25165824,
+            "nameAlg":"SHA384",
+            "attributes":{
+              "PPWRITE":0,
+              "OWNERWRITE":0,
+              "AUTHWRITE":1,
+              "POLICYWRITE":0,
+              "POLICY_DELETE":0,
+              "WRITELOCKED":0,
+              "WRITEALL":0,
+              "WRITEDEFINE":0,
+              "WRITE_STCLEAR":1,
+              "GLOBALLOCK":0,
+              "PPREAD":0,
+              "OWNERREAD":0,
+              "AUTHREAD":1,
+              "POLICYREAD":0,
+              "NO_DA":1,
+              "ORDERLY":0,
+              "CLEAR_STCLEAR":0,
+              "READLOCKED":0,
+              "WRITTEN":1,
+              "PLATFORMCREATE":0,
+              "READ_STCLEAR":1,
+              "TPM2_NT":"ORDINARY"
+            },
+            "authPolicy":"",
+            "dataSize":50
+          }
+        }
+      }
+   ]
+}

--- a/test/data/fapi/policy/pol_authorize_nv_sha384.json
+++ b/test/data/fapi/policy/pol_authorize_nv_sha384.json
@@ -1,0 +1,9 @@
+{
+    "description":"Description pol_authorize_nv",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZENV",
+			"nvPath": "/nv/Owner/myNV",
+		}
+  ]
+}

--- a/test/data/fapi/policy/pol_authorize_nv_tpms_sha384.json
+++ b/test/data/fapi/policy/pol_authorize_nv_tpms_sha384.json
@@ -1,0 +1,41 @@
+{
+    "description":"Description pol_authorize_nv",
+    "policy":[
+      {
+        "type":"POLICYAUTHORIZENV",
+        "nvPublic":{
+          "size":0,
+          "nvPublic":{
+            "nvIndex":25165824,
+            "nameAlg":"SHA384",
+            "attributes":{
+              "PPWRITE":0,
+              "OWNERWRITE":0,
+              "AUTHWRITE":1,
+              "POLICYWRITE":0,
+              "POLICY_DELETE":0,
+              "WRITELOCKED":0,
+              "WRITEALL":0,
+              "WRITEDEFINE":0,
+              "WRITE_STCLEAR":1,
+              "GLOBALLOCK":0,
+              "PPREAD":0,
+              "OWNERREAD":0,
+              "AUTHREAD":1,
+              "POLICYREAD":0,
+              "NO_DA":1,
+              "ORDERLY":0,
+              "CLEAR_STCLEAR":0,
+              "READLOCKED":0,
+              "WRITTEN":1,
+              "PLATFORMCREATE":0,
+              "READ_STCLEAR":1,
+              "TPM2_NT":"ORDINARY"
+            },
+            "authPolicy":"",
+            "dataSize":50
+          }
+        }
+      }
+   ]
+}

--- a/test/data/fapi/policy/pol_cphash_sha384.json
+++ b/test/data/fapi/policy/pol_cphash_sha384.json
@@ -1,0 +1,9 @@
+{
+    "description":"Policy CpHash",
+    "policy":[
+        {
+            "type": "POLICYCPHASH",
+			"cpHash": "ba11b25c2c85b71577252b7d6b2003711aa87795b888e2d37050a54e5e2236be2c8de2248b5e250a6fb3e1e20b5e5caa"
+		}
+    ]
+}

--- a/test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json
+++ b/test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json
@@ -1,0 +1,37 @@
+{
+    "description":"Policy PCR",
+    "policyDigests":[
+        {
+            "hashAlg":"sha384",
+            "digest":"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5"
+        }
+    ],
+    "policyAuthorizations":[ {
+        "type": "pem",
+        "policyRef": [ 1, 2, 3, 4, 5 ],
+        "keyPEMhashAlg": "sha384",
+        "key": "-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPnzYHCTqHAJnCcLRQC4bL/r2t9P1bJJE
+27tHWVxxRtdUNPQceF9sFPE1AgafveTyLrf/V2TwYqpOgMw3hseFlpXAgQl0klqN
+ZPX3zQ+iOfcHhZ7YPjSXzBghWF67oxat
+-----END PUBLIC KEY-----",
+        "signature": "306402304425034749d3eb9a89d1dbcfa4b1bb82be991c3eef7e97dd6ab42db676b1a866c0f1f1b75b3a0ac921518be251175d8f0230576a6919bffe62c27c8db9ea170ee83ffee1ffb634f7c63e2cc7393e0f80b45889c817149b0716df8f34216848d5d222" } ],
+    "policy":[
+    {
+      "type":"POLICYPCR",
+      "policyDigests":[
+        {
+          "hashAlg":"sha384",
+          "digest":"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5"
+        }
+      ],
+      "pcrs":[
+        {
+          "pcr":16,
+          "hashAlg":"sha256",
+          "digest":"0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/fapi-key-create-he-sign.int.c
+++ b/test/integration/fapi-key-create-he-sign.int.c
@@ -25,6 +25,41 @@
 #define PASSWORD "abc"
 #define SIGN_TEMPLATE  "sign,noDa"
 
+static bool cb_called = false;
+
+static TSS2_RC
+branch_callback(
+    char   const *objectPath,
+    char   const *description,
+    char  const **branchNames,
+    size_t        numBranches,
+    size_t       *selectedBranch,
+    void         *userData)
+{
+    UNUSED(description);
+    UNUSED(userData);
+
+    if (numBranches != 2) {
+        LOG_ERROR("Wrong number of branches");
+        return TSS2_FAPI_RC_GENERAL_FAILURE;
+    }
+
+    /* The policy branch A A will be used. */
+
+    if (!strcmp(branchNames[0], "A"))
+        *selectedBranch = 0;
+    else if (!strcmp(branchNames[1], "B"))
+        *selectedBranch = 1;
+    else {
+        LOG_ERROR("BranchName not found. Got \"%s\" and \"%s\"",
+                  branchNames[0], branchNames[1]);
+        return TSS2_FAPI_RC_GENERAL_FAILURE;
+    }
+
+    cb_called = true;
+    return TSS2_RC_SUCCESS;
+}
+
 static TSS2_RC
 auth_callback(
     char const *objectPath,
@@ -74,6 +109,9 @@ test_fapi_key_create_he_sign(FAPI_CONTEXT *context)
     /* We need to reset the passwords again, in order to not brick physical TPMs */
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
+
+    r = Fapi_SetBranchCB(context, branch_callback, NULL);
+    goto_if_error(r, "Error SetPolicybranchselectioncallback", error);
 
     r = Fapi_SetAuthCB(context, auth_callback, NULL);
     goto_if_error(r, "Error SetPolicyAuthCallback", error);

--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -53,13 +53,8 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
     char *policy_pcr = "/policy/pol_pcr";
-#ifdef TEST_ECC
-    char *policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json";
-    char *policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem.json";
-#else
-    char *policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json";
-    char *policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_rsa_pem.json";
-#endif
+    char *policy_file_pcr;
+    char *policy_file_authorize;
     char *policy_name_authorize = "/policy/pol_authorize";
     // uint8_t policyRef[] = { 1, 2, 3, 4, 5 };
     FILE *stream = NULL;
@@ -69,6 +64,19 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
     uint8_t *signature = NULL;
     char *publicKey = NULL;
     char *pathList = NULL;
+
+#ifdef TEST_ECC
+    if (strcmp(FAPI_PROFILE, "P_ECC") == 0) {
+        policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem.json";
+        policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json";
+    } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json";
+        policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json";
+    }
+#else
+    policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json";
+    policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_rsa_pem.json";
+#endif
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);

--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -99,6 +99,35 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "  ]" \
         "}";
 
+    const char *policy_sha384_check =
+        "{" \
+        "  \"description\":\"Description pol_16_0\"," \
+        "  \"policyDigests\":[" \
+        "    {" \
+        "      \"hashAlg\":\"SHA384\"," \
+        "      \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "    }" \
+        "  ]," \
+        "  \"policy\":[" \
+        "    {" \
+        "      \"type\":\"POLICYPCR\"," \
+        "      \"policyDigests\":[" \
+        "        {" \
+        "          \"hashAlg\":\"SHA384\"," \
+        "          \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "        }" \
+        "      ]," \
+        "      \"pcrs\":[" \
+        "        {" \
+        "          \"pcr\":16," \
+        "          \"hashAlg\":\"SHA256\"," \
+        "          \"digest\":\"0000000000000000000000000000000000000000000000000000000000000000\"" \
+        "        }" \
+        "      ]" \
+        "    }" \
+        "  ]" \
+        "}" ;
+
     const char *policy_sha256_export_check =
         "{" \
         "  \"description\":\"Description pol_16_0\"," \
@@ -143,6 +172,52 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "    }" \
         "  ]" \
         "}";
+
+       const char *policy_sha384_export_check =
+        "{" \
+        "  \"description\":\"Description pol_16_0\"," \
+        "  \"policyDigests\":[" \
+        "    { " \
+        "         \"hashAlg\":\"SHA384\"," \
+        "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "     }," \
+        "    {" \
+        "      \"hashAlg\":\"SHA256\"," \
+        "      \"digest\":\"bff2d58e9813f97cefc14f72ad8133bc7092d652b7c877959254af140c841f36\"" \
+        "    }," \
+        "    {" \
+        "      \"hashAlg\":\"SHA1\"," \
+        "      \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
+        "    }"                                                        \
+        "  ]," \
+        "  \"policy\":[" \
+        "    {" \
+        "      \"type\":\"POLICYPCR\"," \
+        "      \"policyDigests\":[" \
+        "    { "                           \
+        "         \"hashAlg\":\"SHA384\"," \
+        "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "     }," \
+        "        {" \
+        "          \"hashAlg\":\"SHA256\"," \
+        "          \"digest\":\"bff2d58e9813f97cefc14f72ad8133bc7092d652b7c877959254af140c841f36\"" \
+        "        }," \
+        "        {" \
+        "          \"hashAlg\":\"SHA1\"," \
+        "          \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
+        "        }" \
+        "      ]," \
+        "      \"pcrs\":[" \
+        "        {" \
+        "          \"pcr\":16," \
+        "          \"hashAlg\":\"SHA256\"," \
+        "          \"digest\":\"0000000000000000000000000000000000000000000000000000000000000000\"" \
+        "        }" \
+        "      ]" \
+        "    }" \
+        "  ]" \
+        "}";
+
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
@@ -206,9 +281,13 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     ASSERT(policy != NULL);
     LOG_INFO("\nTEST_JSON\nPolicy_sha256:\n%s\nEND_JSON", policy);
 
-    CHECK_JSON(policy, policy_sha256_check, error);
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        CHECK_JSON(policy, policy_sha384_check, error);
+    } else {
+        CHECK_JSON(policy, policy_sha256_check, error);
+    }
+
     ASSERT(strlen(policy) > ASSERT_SIZE);
-    fprintf(stderr, "\nPolicy from key:\n%s\n", policy);
 
     SAFE_FREE(policy);
 
@@ -217,8 +296,11 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_ExportPolicy", error);
     ASSERT(policy != NULL);
     LOG_INFO("\nTEST_JSON\nPolicy export1:\n%s\nEND_JSON", policy);
-    CHECK_JSON(policy, policy_sha256_export_check, error);
-    fprintf(stderr, "\nPolicy from policy file:\n%s\n", policy);
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        CHECK_JSON(policy, policy_sha384_export_check, error)
+    } else {
+        CHECK_JSON(policy, policy_sha256_export_check, error)
+    }
 
     /* Run test with policy which should fail. */
     r = Fapi_Delete(context, "/HS/SRK/mySignKey");
@@ -344,7 +426,12 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     r = Fapi_ExportPolicy(context, "HS/SRK/mySignKey", &policy);
     goto_if_error(r, "Error Fapi_ExportPolicy", error);
     ASSERT(policy != NULL);
-    CHECK_JSON(policy, policy_sha256_check, error);
+
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        CHECK_JSON(policy, policy_sha384_check, error);
+    } else {
+        CHECK_JSON(policy, policy_sha256_check, error);
+    }
     fprintf(stderr, "\nPolicy from key:\n%s\n", policy);
 
     jso = json_tokener_parse(policy);

--- a/test/integration/fapi-nv-extend.int.c
+++ b/test/integration/fapi-nv-extend.int.c
@@ -90,9 +90,17 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
     ASSERT(log != NULL);
     LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
     char *fields_log1[] =  { "0", "digests", "0", "digest" };
-    CHECK_JSON_FIELDS(log, fields_log1,
-                      "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
-                      error);
+
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        CHECK_JSON_FIELDS(log, fields_log1,
+                          "c8ffec7d7d70c61b16adaab88925a1759b94cf6b50669b04aef1a8427fabb131eafbf9a21e3b8bddd9c5d5e7",
+                          error);
+    } else {
+        CHECK_JSON_FIELDS(log, fields_log1,
+                          "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
+                          error);
+    }
+
     ASSERT(strlen(log) > ASSERT_SIZE);
 
     fprintf(stderr, "\nLog:\n%s\n", log);
@@ -111,9 +119,16 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
     ASSERT(strlen(log) > ASSERT_SIZE);
     LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
     char *fields_log2[] =  { "1", "digests", "0", "digest" };
-    CHECK_JSON_FIELDS(log, fields_log2,
-                      "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
-                      error);
+
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        CHECK_JSON_FIELDS(log, fields_log2,
+                          "c8ffec7d7d70c61b16adaab88925a1759b94cf6b50669b04aef1a8427fabb131eafbf9a21e3b8bddd9c5d5e7",
+                          error);
+    } else {
+        CHECK_JSON_FIELDS(log, fields_log2,
+                          "dcb1ac4a5de370cad091c13f13aee2f936c278fa05d264653c0c1321852a35e8",
+                          error);
+    }
 
     fprintf(stderr, "\nLog:\n%s\n", log);
 

--- a/test/integration/fapi-second-provisioning.int.c
+++ b/test/integration/fapi-second-provisioning.int.c
@@ -129,7 +129,13 @@ test_fapi_test_second_provisioning(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_Delete", error);
 
     Fapi_Finalize(&context);
-    rc = init_fapi("P_ECC_sh_eh_policy", &context);
+
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        rc = init_fapi("P_ECC_sh_eh_policy_sha384", &context);
+    } else {
+         rc = init_fapi("P_ECC_sh_eh_policy", &context);
+    }
+
     if (rc)
         goto error;
 
@@ -139,7 +145,14 @@ test_fapi_test_second_provisioning(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_Provision", error);
 
     Fapi_Finalize(&context);
-    rc = init_fapi("P_ECC", &context);
+    if (strcmp(FAPI_PROFILE, "P_ECC") == 0) {
+        rc = init_fapi("P_ECC", &context);
+    } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        rc = init_fapi("P_ECC384", &context);
+    } else {
+        LOG_ERROR("Profile %s not supported for this test!", FAPI_PROFILE);
+    }
+
     if (rc)
         goto error;
 


### PR DESCRIPTION
* Usage of NIST P-384 ECC keys was prepared by: #2418 .
* The integration tests now were adapted to enable the running with
  A device provisioned with an ECC-384 EK instead of ECC-256.
* Several policies appropriate for the P_ECC384 were added.
* If necessary it's checked what policy has to be used depending
  on the profile.
* If e.g The device is provisioned with swtpm-setup and an EK
  certificate for ECC NIST P-384 is produced, the integration
  test with the device can be configured  as follows:
  ```
     configure --enable-integration --enable-unit
            --with-device=/dev/tpm0  \
            --with-default-test-fapi-profile=P_ECC384 \
            --enable-self-generated-certificate```
* Before running the test the test certificates from swtpm must be assigned:
  `export FAPI_TEST_ROOT_CERT=../swtpm-localca/swtpm-localca-rootca-cert.pem`
  `export FAPI_TEST_INT_CERT=../swtpm-localca/issuercert.pem`

Signed-off-by: Juergen Repp <juergen_repp@web.de>


