### PR TITLE
fapi: make ordering of search directories filesystem-independent

### DIFF
--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -107,14 +107,14 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "      \"hashAlg\":\"SHA256\"," \
         "      \"digest\":\"bff2d58e9813f97cefc14f72ad8133bc7092d652b7c877959254af140c841f36\"" \
         "    }," \
-        "    {" \
-        "      \"hashAlg\":\"SHA1\"," \
-        "      \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
-        "    },"                                                        \
         "    { " \
         "         \"hashAlg\":\"SHA384\"," \
         "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
-        "     }" \
+        "    }," \
+        "    {" \
+        "      \"hashAlg\":\"SHA1\"," \
+        "      \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
+        "    }" \
         "  ]," \
         "  \"policy\":[" \
         "    {" \
@@ -124,14 +124,14 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "          \"hashAlg\":\"SHA256\"," \
         "          \"digest\":\"bff2d58e9813f97cefc14f72ad8133bc7092d652b7c877959254af140c841f36\"" \
         "        }," \
+        "        { " \
+        "          \"hashAlg\":\"SHA384\"," \
+        "          \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
+        "        }," \
         "        {" \
         "          \"hashAlg\":\"SHA1\"," \
         "          \"digest\":\"eab0d71ae6088009cbd0b50729fde69eb453649c\"" \
-        "        },"                                                    \
-        "    { " \
-        "         \"hashAlg\":\"SHA384\"," \
-        "         \"digest\":\"c1923346b6d44a154b58b57b4327ee70c29ac536f9209d94880de6834f370587846a2834e3e88af61efd8679fcccedd5\"" \
-        "     }" \
+        "        }" \
         "      ]," \
         "      \"pcrs\":[" \
         "        {" \


### PR DESCRIPTION
`ifapi_io_dirfiles()` currently uses `readdir()` to list all the entries of a directory, which does not guarantee any particular ordering. This is a problem because some structures are dependent on the ordering of the profiles in the profile directory: e.g. [`Fapi_ExportPolicy()` loops over all profiles in the order that they have been added and extracts the hash algorithms from them](https://github.com/tpm2-software/tpm2-tss/blob/9288970a3e657cdee85d08d3813199ec864de3ad/src/tss2-fapi/api/Fapi_ExportPolicy.c#L263-L265). This means that the ordering of its JSON output depends on the ordering of the profiles array.

This problem surfaced with commit 67f72e4741b1d50d43d845c5a99fd976b4210f66 ("FAPI: Add profile P_ECC384"): it adds a new profile file for P_ECC384. Since it is a new file, many file systems return it at the end of the `readdir()` listing, which is also how it has been added to the expected `policy_sha256_export_check` JSON output. However, with a fresh checkout of the Git sources this assumption might not hold any more, making the test fail due to the differing ordering of the hash algorithms.

To solve this, use `scandir()` instead of `readdir()`, which makes it possible to specify a certain ordering of the directory entries. Also adjust the expected output of the test to this ordering.