### PR TITLE
fapi/tests: Clear PCR 16 after setting it

### DIFF
--- a/test/integration/fapi-quote-destructive.int.c
+++ b/test/integration/fapi-quote-destructive.int.c
@@ -111,6 +111,9 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
     ASSERT(pathlist != NULL);
     ASSERT(strlen(pathlist) > ASSERT_SIZE);
 
+    r = pcr_reset(context, 16);
+    goto_if_error(r, "Error pcr_reset", error);
+
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);
 


### PR DESCRIPTION
Subsequent tests expect PCR 16 to be clear so clean up after setting it in the testcase.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>