### PR TITLE
FAPI: Fix usage of second profile in path.

### DIFF
--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -250,7 +250,7 @@ ifapi_profiles_get(
     size_t len;
 
     /* if no name or nor profile prefix is given, use the default profile */
-    if (!name || strncmp(name, "P_", 2) != 0 || strncmp(name, "/P_", 2) != 0) {
+    if (!name || !(strncmp(name, "P_", 2) == 0 || strncmp(name, "/P_", 3) == 0)) {
         *profile = &profiles->default_profile;
         return TSS2_RC_SUCCESS;
     }


### PR DESCRIPTION
The usage of a second profile in a path was not possible because allways the default profile was used.
So after a second provisioning with a second fapi config file this profile could not be uses in fapi pathnames.

Signed-off-by: Juergen Repp <juergen_repp@web.de>