### PR TITLE
FAPI: Fix policy secret.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -16,7 +16,8 @@ enum IFAPI_STATE_POL_CB_EXCECUTE {
     POL_CB_NV_READ,
     POL_CB_READ_NV_POLICY,
     POL_CB_READ_OBJECT,
-    POL_CB_AUTHORIZE_OBJECT
+    POL_CB_AUTHORIZE_OBJECT,
+    POL_CB_AUTHORIZE_KEY
 };
 
 /** The context of the policy execution */
@@ -28,7 +29,9 @@ typedef struct {
     ESYS_TR key_handle;             /**< Handle of a used key */
     ESYS_TR nv_index;               /**< Index of nv object storing a policy */
     ESYS_TR auth_index;             /**< Index of authorization object */
+    ESYS_TR flush_handle;           /**< Handle which has to be flushed after policy execution */
     IFAPI_OBJECT auth_object;       /**< FAPI auth object needed for authorization */
+    IFAPI_OBJECT auth_object_sav;
     IFAPI_OBJECT *key_object_ptr;
     IFAPI_OBJECT *auth_object_ptr;
     IFAPI_NV_Cmds nv_cmd_state;

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -89,6 +89,7 @@ struct IFAPI_POLICY_EXEC_CTX {
     char *pem_key;                   /**< Pem key recreated during policy execution */
     struct POLICY_LIST *policy_list;
                                     /**< List of policies for authorization selection */
+    bool flush_handle;              /**< Handle to be flushed after policy execution */
     TSS2_POLICY_EXEC_CALLBACKS callbacks;
                                     /**< callbacks used for execution of sub
                                          policies and actions which require access


### PR DESCRIPTION
The authorization did not work when key objects were used as secret. The current object to be authorized was overwritten by the secret object. To fix this problem backups of the objects to be authorized were stored in the policy stack. The loaded secret key is  flushed after policy execution if it's a transient key.
Fixes #2448.

Signed-off-by: Juergen Repp <juergen_repp@web.de>