### PR TITLE
dist/tpm-udev.rules: drop owner root from tpmrm*

### DIFF
--- a/dist/tpm-udev.rules
+++ b/dist/tpm-udev.rules
@@ -1,4 +1,4 @@
 # tpm devices can only be accessed by the tss user but the tss
 # group members can access tpmrm devices
 KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
-KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss", GROUP="tss"
+KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", GROUP="tss"


### PR DESCRIPTION
Requiring user to be tss doesn't really add a whole lot, the root user should be able to use the interface as well.

Fixes: #2292

Signed-off-by: William Roberts <william.c.roberts@intel.com>