### PR TITLE
tctildr.h: drop extra tcti_from_info declaration

### DIFF
--- a/src/tss2-tcti/tctildr.h
+++ b/src/tss2-tcti/tctildr.h
@@ -32,10 +32,6 @@ tcti_from_init(TSS2_TCTI_INIT_FUNC init,
                const char* conf,
                TSS2_TCTI_CONTEXT **tcti);
 TSS2_RC
-tcti_from_info(TSS2_TCTI_INFO_FUNC infof,
-               const char* conf,
-               TSS2_TCTI_CONTEXT **tcti);
-TSS2_RC
 tctildr_conf_parse (const char *name_conf,
                     char *name,
                     char *conf);


### PR DESCRIPTION
Fixes: #2299

Signed-off-by: William Roberts <william.c.roberts@intel.com>