### PR TITLE
FAPI: Fix policy secret 3.2.x.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Sign.c
+++ b/src/tss2-fapi/api/Fapi_Sign.c
@@ -285,7 +285,7 @@ Fapi_Sign_Finish(
             r = ifapi_load_key(context, command->keyPath,
                                &command->key_object);
             return_try_again(r);
-            goto_if_error(r, "Fapi load key.", error_cleanup);
+            goto_if_error(r, "Fapi load key.", cleanup);
 
             fallthrough;
 
@@ -325,15 +325,17 @@ Fapi_Sign_Finish(
         statecasedefault(context->state);
     }
 
-error_cleanup:
+ error_cleanup:
+    ifapi_cleanup_ifapi_object(command->key_object);
+    ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);
+    ifapi_cleanup_ifapi_object(context->loadKey.key_object);
+
+ cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
     SAFE_FREE(command->tpm_signature);
     SAFE_FREE(command->keyPath);
     SAFE_FREE(command->padding);
     ifapi_session_clean(context);
-    ifapi_cleanup_ifapi_object(command->key_object);
-    ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);
-    ifapi_cleanup_ifapi_object(context->loadKey.key_object);
     ifapi_cleanup_ifapi_object(&context->createPrimary.pkey_object);
     LOG_TRACE("finished");
     return r;

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -585,6 +585,7 @@ enum IFAPI_STATE_POLICY {
     POLICY_READ_FINISH,
     POLICY_INSTANTIATE_PREPARE,
     POLICY_INSTANTIATE,
+    POLICY_EXECUTE_PREPARE,
     POLICY_EXECUTE,
     POLICY_FLUSH
 };
@@ -639,6 +640,14 @@ typedef struct {
     size_t numPaths;                /**< Number of all objects in data store */
     char *current_path;
 } IFAPI_FILE_SEARCH_CTX;
+
+/** The states for the FAPI's prepare key loading */
+enum _FAPI_STATE_PREPARE_LOAD_KEY {
+    PREPARE_LOAD_KEY_INIT = 0,
+    PREPARE_LOAD_KEY_WAIT_FOR_SESSION,
+    PREPARE_LOAD_KEY_INIT_KEY,
+    PREPARE_LOAD_KEY_WAIT_FOR_KEY
+};
 
 /** The states for the FAPI's key loading */
 enum _FAPI_STATE_LOAD_KEY {
@@ -698,6 +707,7 @@ typedef struct {
  */
 typedef struct {
     enum _FAPI_STATE_LOAD_KEY state;   /**< The current state of key  loading */
+    enum  _FAPI_STATE_PREPARE_LOAD_KEY prepare_state;
     NODE_STR_T *path_list;        /**< The current used hierarchy for CreatePrimary */
     NODE_OBJECT_T *key_list;
     IFAPI_OBJECT auth_object;
@@ -707,6 +717,7 @@ typedef struct {
     bool parent_handle_persistent;
     IFAPI_OBJECT *key_object;
     char *key_path;
+    char const *path;
 } IFAPI_LoadKey;
 
 /** The data structure holding internal state of entity delete.
@@ -838,6 +849,8 @@ enum _FAPI_STATE {
     PROVISION_READ_CERT,
     PROVISION_PREPARE_READ_ROOT_CERT,
     PROVISION_READ_ROOT_CERT,
+    PROVISION_PREPARE_READ_INT_CERT,
+    PROVISION_READ_INT_CERT,
     PROVISION_INIT,
     PROVISION_INIT_SRK,
     PROVISION_WAIT_FOR_EK_SESSION,

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -2733,9 +2733,9 @@ ifapi_load_key(
     return_if_null(keyPath, "Bad reference for key path.",
                    TSS2_FAPI_RC_BAD_REFERENCE);
 
-    switch (context->Key_Sign.state) {
-    statecase(context->Key_Sign.state, SIGN_INIT);
-        context->Key_Sign.keyPath = keyPath;
+    switch (context->loadKey.prepare_state) {
+    statecase(context->loadKey.prepare_state, PREPARE_LOAD_KEY_INIT);
+        context->loadKey.path = keyPath;
 
         /* Prepare the session creation. */
         r = ifapi_get_sessions_async(context,
@@ -2744,8 +2744,8 @@ ifapi_load_key(
         goto_if_error_reset_state(r, "Create sessions", error_cleanup);
         fallthrough;
 
-    statecase(context->Key_Sign.state, SIGN_WAIT_FOR_SESSION);
-        r = ifapi_profiles_get(&context->profiles, context->Key_Sign.keyPath, &profile);
+    statecase(context->loadKey.prepare_state, PREPARE_LOAD_KEY_WAIT_FOR_SESSION);
+        r = ifapi_profiles_get(&context->profiles, context->loadKey.path, &profile);
         goto_if_error_reset_state(r, "Reading profile data", error_cleanup);
 
         r = ifapi_get_sessions_finish(context, profile, profile->nameAlg);
@@ -2753,21 +2753,30 @@ ifapi_load_key(
         goto_if_error_reset_state(r, " FAPI create session", error_cleanup);
 
         /* Prepare the key loading. */
-        r = ifapi_load_keys_async(context, context->Key_Sign.keyPath);
+        r = ifapi_load_keys_async(context, context->loadKey.path);
         goto_if_error(r, "Load keys.", error_cleanup);
         fallthrough;
 
-    statecase(context->Key_Sign.state, SIGN_WAIT_FOR_KEY);
+    statecase(context->loadKey.prepare_state, PREPARE_LOAD_KEY_WAIT_FOR_KEY);
         r = ifapi_load_keys_finish(context, IFAPI_FLUSH_PARENT,
-                                   &context->Key_Sign.handle,
+                                   &context->loadKey.handle,
                                    key_object);
         return_try_again(r);
         goto_if_error_reset_state(r, " Load key.", error_cleanup);
 
-        context->Key_Sign.state = SIGN_INIT;
+        context->loadKey.prepare_state = PREPARE_LOAD_KEY_INIT;
         break;
 
-    statecasedefault(context->Key_Sign.state);
+    statecase(context->loadKey.prepare_state, PREPARE_LOAD_KEY_INIT_KEY);
+        context->loadKey.path = keyPath;
+        r = ifapi_load_keys_async(context, context->loadKey.path);
+        goto_if_error(r, "Load keys.", error_cleanup);
+
+        context->loadKey.prepare_state =  PREPARE_LOAD_KEY_WAIT_FOR_KEY;
+
+        return TSS2_FAPI_RC_TRY_AGAIN;
+
+    statecasedefault(context->loadKey.prepare_state);
     }
 
 error_cleanup:
@@ -2840,6 +2849,7 @@ ifapi_key_sign(
     switch (context->Key_Sign.state) {
     statecase(context->Key_Sign.state, SIGN_INIT);
         sig_key_object = context->Key_Sign.key_object;
+        context->Key_Sign.handle = sig_key_object->handle;
 
         r = ifapi_authorize_object(context, sig_key_object, &session);
         FAPI_SYNC(r, "Authorize signature key.", cleanup);

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -492,7 +492,6 @@ ifapi_policyeval_cbauth(
     FAPI_CONTEXT *fapi_ctx = userdata;
     IFAPI_POLICY_EXEC_CTX *current_policy;
     IFAPI_POLICY_EXEC_CB_CTX *cb_ctx;
-    bool next_case;
 
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
     return_if_null(fapi_ctx->policy.policyutil_stack, "Policy not initialized.",
@@ -507,84 +506,118 @@ ifapi_policyeval_cbauth(
     }
     cb_ctx = current_policy->app_data;
 
-    do {
-        next_case = false;
-        switch (cb_ctx->cb_state) {
+    switch (cb_ctx->cb_state) {
         statecase(cb_ctx->cb_state, POL_CB_EXECUTE_INIT);
-            cb_ctx->auth_index = ESYS_TR_NONE;
-            /* Search object with name in keystore. */
-            r = ifapi_keystore_search_obj(&fapi_ctx->keystore, &fapi_ctx->io,
-                                          name,
-                                          &cb_ctx->object_path);
-            FAPI_SYNC(r, "Search Object", cleanup);
+        cb_ctx->flush_handle = false;
+        cb_ctx->auth_index = ESYS_TR_NONE;
+        /* Search object with name in keystore. */
+        r = ifapi_keystore_search_obj(&fapi_ctx->keystore, &fapi_ctx->io,
+                                      name,
+                                      &cb_ctx->object_path);
+        FAPI_SYNC(r, "Search Object", cleanup);
 
-            r = ifapi_keystore_load_async(&fapi_ctx->keystore, &fapi_ctx->io,
-                                          cb_ctx->object_path);
-            return_if_error2(r, "Could not open: %s", cb_ctx->object_path);
-            SAFE_FREE(cb_ctx->object_path);
-            fallthrough;
+        r = ifapi_keystore_load_async(&fapi_ctx->keystore, &fapi_ctx->io,
+                                      cb_ctx->object_path);
+        return_if_error2(r, "Could not open: %s", cb_ctx->object_path);
+        SAFE_FREE(cb_ctx->object_path);
+        fallthrough;
 
         statecase(cb_ctx->cb_state, POL_CB_READ_OBJECT);
-            /* Get object from file */
-            r = ifapi_keystore_load_finish(&fapi_ctx->keystore, &fapi_ctx->io,
-                                           &cb_ctx->object);
-            return_try_again(r);
-            return_if_error(r, "read_finish failed");
+        /* Get object from file */
+        r = ifapi_keystore_load_finish(&fapi_ctx->keystore, &fapi_ctx->io,
+                                       &cb_ctx->object);
+        return_try_again(r);
+        return_if_error(r, "read_finish failed");
 
-            r = ifapi_initialize_object(fapi_ctx->esys, &cb_ctx->object);
-            goto_if_error(r, "Initialize NV object", cleanup);
+        r = ifapi_initialize_object(fapi_ctx->esys, &cb_ctx->object);
+        goto_if_error(r, "Initialize NV object", cleanup);
 
-            if (cb_ctx->object.objectType == IFAPI_NV_OBJ) {
-                /* NV Authorization */
+        if (cb_ctx->object.objectType == IFAPI_NV_OBJ) {
+            /* NV Authorization */
 
-                cb_ctx->nv_index = cb_ctx->object.handle;
+            cb_ctx->nv_index = cb_ctx->object.handle;
 
-                /* Determine the object used for authorization. */
-                get_nv_auth_object(&cb_ctx->object,
-                                   cb_ctx->object.handle,
-                                   &cb_ctx->auth_object,
-                                   &cb_ctx->auth_index);
+            /* Determine the object used for authorization. */
+            get_nv_auth_object(&cb_ctx->object,
+                               cb_ctx->object.handle,
+                               &cb_ctx->auth_object,
+                               &cb_ctx->auth_index);
 
-                goto_if_error(r, "PolicySecret set authorization", cleanup);
-                cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
+            goto_if_error(r, "PolicySecret set authorization", cleanup);
+            cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
 
-                cb_ctx->auth_object_ptr = &cb_ctx->auth_object;
-                next_case = true;
-                break;
-            } else if (cb_ctx->object.objectType == IFAPI_HIERARCHY_OBJ) {
-                cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
-                cb_ctx->auth_object_ptr = &cb_ctx->object;
-                next_case = true;
-                break;
-            } else {
-                cb_ctx->key_handle = cb_ctx->object.handle;
-                cb_ctx->cb_state = POL_CB_LOAD_KEY;
-            }
-            fallthrough;
-
-        statecase(cb_ctx->cb_state, POL_CB_LOAD_KEY);
-            /* Key loading and authorization */
-            r = ifapi_load_key(fapi_ctx, cb_ctx->object_path,
-                               &cb_ctx->auth_object_ptr);
-            FAPI_SYNC(r, "Fapi load key.", cleanup);
-
-            cb_ctx->object = *cb_ctx->key_object_ptr;
-            SAFE_FREE(cb_ctx->key_object_ptr);
+            cb_ctx->auth_object_ptr = &cb_ctx->auth_object;
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        } else if (cb_ctx->object.objectType == IFAPI_HIERARCHY_OBJ) {
+            cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
             cb_ctx->auth_object_ptr = &cb_ctx->object;
-            fallthrough;
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        } else {
+            cb_ctx->key_handle = cb_ctx->object.handle;
+            if (cb_ctx->key_handle == ESYS_TR_NONE) {
+                cb_ctx->cb_state = POL_CB_LOAD_KEY;
+                return TSS2_FAPI_RC_TRY_AGAIN;
+            }
+        }
+        fallthrough;
 
         statecase(cb_ctx->cb_state, POL_CB_AUTHORIZE_OBJECT);
-            r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
-            return_try_again(r);
-            goto_if_error(r, "Authorize  object.", cleanup);
+        r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
+        return_try_again(r);
+        goto_if_error(r, "Authorize  object.", cleanup);
 
-            cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
-            break;
-            /* FALLTHRU */
+        cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
+        break;
+        /* FALLTHRU */
+
+        statecase(cb_ctx->cb_state, POL_CB_LOAD_KEY);
+        /* Prepare new context for loadkey in policy and skip session creation. */
+        memset(&cb_ctx->load_ctx, 0, sizeof(IFAPI_LoadKey));
+        cb_ctx->load_ctx.prepare_state = PREPARE_LOAD_KEY_INIT_KEY;
+        memset(&cb_ctx->create_primary_ctx, 0, sizeof(IFAPI_CreatePrimary));
+        fallthrough;
+
+        statecase(cb_ctx->cb_state, POL_CB_LOAD_KEY_FINISH);
+        cb_ctx->load_ctx_sav = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx_sav = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx;
+        cb_ctx->auth_object_ptr = &cb_ctx->load_ctx.auth_object;
+        r = ifapi_load_key(fapi_ctx, ifapi_get_object_path(&cb_ctx->object),
+                           &cb_ctx->auth_object_ptr);
+        if (r == TSS2_RC_SUCCESS &&
+            !cb_ctx->load_ctx.auth_object.misc.key.persistent_handle) {
+            current_policy->flush_handle = true;
+        }
+        cb_ctx->load_ctx = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx_sav;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx_sav;
+        FAPI_SYNC(r, "Fapi load key.", cleanup);
+
+        ifapi_cleanup_ifapi_object(&cb_ctx->object);
+        cb_ctx->object = *cb_ctx->auth_object_ptr;
+        fallthrough;
+
+        statecase(cb_ctx->cb_state, POL_CB_AUTHORIZE_KEY);
+        cb_ctx->load_ctx_sav = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx_sav = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx;
+        cb_ctx->object = *cb_ctx->auth_object_ptr;
+        *auth_handle = cb_ctx->auth_object_ptr->handle;
+
+        r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
+        return_try_again(r);
+        goto_if_error(r, "Authorize  object.", cleanup);
+
+        fapi_ctx->loadKey = cb_ctx->load_ctx_sav;
+        cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
+        break;
+        /* FALLTHRU */
 
         statecasedefault(cb_ctx->cb_state);
-        }
-    } while (next_case);
+    }
     *object_handle = cb_ctx->object.handle;
     if (cb_ctx->object.objectType == IFAPI_NV_OBJ)
         *auth_handle = cb_ctx->auth_index;
@@ -595,7 +628,6 @@ ifapi_policyeval_cbauth(
         fapi_ctx->policy.session = current_policy->policySessionSav;
 
 cleanup:
-    ifapi_cleanup_ifapi_object(&cb_ctx->object);
     if (current_policy->policySessionSav
         && current_policy->policySessionSav != ESYS_TR_NONE)
         fapi_ctx->policy.session = current_policy->policySessionSav;

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -11,12 +11,14 @@
 enum IFAPI_STATE_POL_CB_EXCECUTE {
     POL_CB_EXECUTE_INIT = 0,
     POL_CB_LOAD_KEY,
+    POL_CB_LOAD_KEY_FINISH,
     POL_CB_SEARCH_POLICY,
     POL_CB_EXECUTE_SUB_POLICY,
     POL_CB_NV_READ,
     POL_CB_READ_NV_POLICY,
     POL_CB_READ_OBJECT,
-    POL_CB_AUTHORIZE_OBJECT
+    POL_CB_AUTHORIZE_OBJECT,
+    POL_CB_AUTHORIZE_KEY
 };
 
 /** The context of the policy execution */
@@ -28,7 +30,12 @@ typedef struct {
     ESYS_TR key_handle;             /**< Handle of a used key */
     ESYS_TR nv_index;               /**< Index of nv object storing a policy */
     ESYS_TR auth_index;             /**< Index of authorization object */
+    ESYS_TR flush_handle;           /**< Handle which has to be flushed after policy execution */
     IFAPI_OBJECT auth_object;       /**< FAPI auth object needed for authorization */
+    IFAPI_LoadKey load_ctx_sav;
+    IFAPI_LoadKey load_ctx;
+    IFAPI_CreatePrimary create_primary_ctx_sav;
+    IFAPI_CreatePrimary create_primary_ctx;
     IFAPI_OBJECT *key_object_ptr;
     IFAPI_OBJECT *auth_object_ptr;
     IFAPI_NV_Cmds nv_cmd_state;

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -120,7 +120,8 @@ enum IFAPI_STATE_POLICY_EXCECUTE {
     POLICY_VERIFY,
     POLICY_AUTH_CALLBACK,
     POLICY_AUTH_SENT,
-    POLICY_EXEC_ESYS
+    POLICY_EXEC_ESYS,
+    POLICY_LOAD_SYM_KEY
 };
 
 typedef struct IFAPI_POLICY_CALLBACK_CTX IFAPI_POLICY_CALLBACK_CTX;
@@ -152,6 +153,7 @@ struct IFAPI_POLICY_EXEC_CTX {
     char *pem_key;                   /**< Pem key recreated during policy execution */
     struct POLICY_LIST *policy_list;
                                     /**< List of policies for authorization selection */
+    bool flush_handle;              /**< Handle to be flushed after policy execution */
     ifapi_policyeval_EXEC_CB callbacks;
                                     /**< callbacks used for execution of sub
                                          policies and actions which require access


### PR DESCRIPTION
The authorization did not work when key objects were used as secret. The current object to be authorized was overwritten by the secret object. To fix this problem backups of the objects to be authorized were stored in the policy stack. The loaded secret key is  flushed after policy execution if it's a transient key.
Fixes #2448.

Signed-off-by: Juergen Repp <juergen_repp@web.de>