### PR TITLE
Fix pcr setauthvalue

### DIFF
--- a/src/tss2-esys/api/Esys_HMAC_Start.c
+++ b/src/tss2-esys/api/Esys_HMAC_Start.c
@@ -24,13 +24,11 @@ static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
     const TPM2B_AUTH *auth)
 {
-    if (auth == NULL) {
-        esysContext->in.HMAC_Start.auth = NULL;
-    } else {
+    if (auth == NULL)
+        memset(&esysContext->in.HMAC_Start.authData, 0,
+                sizeof(esysContext->in.HMAC_Start.authData));
+    else
         esysContext->in.HMAC_Start.authData = *auth;
-        esysContext->in.HMAC_Start.auth =
-            &esysContext->in.HMAC_Start.authData;
-    }
 }
 
 /** One-Call function for TPM2_HMAC_Start
@@ -346,11 +344,9 @@ Esys_HMAC_Start_Finish(
 
     /*  The name of a sequence object is an empty buffer */
     sequenceHandleNode->rsrc.name.size = 0;
-    /* Store the auth value parameter in the object meta data if passed */
-    if (esysContext->in.HMAC_Start.auth == NULL)
-        sequenceHandleNode->auth.size = 0;
-    else
-        sequenceHandleNode->auth = *esysContext->in.HMAC_Start.auth;
+
+    /* Store the auth value parameter in the object meta data */
+    sequenceHandleNode->auth = esysContext->in.HMAC_Start.authData;
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
+++ b/src/tss2-esys/api/Esys_HierarchyChangeAuth.c
@@ -26,13 +26,11 @@ static void store_input_parameters (
     const TPM2B_AUTH *newAuth)
 {
     esysContext->in.HierarchyChangeAuth.authHandle = authHandle;
-    if (newAuth == NULL) {
-        esysContext->in.HierarchyChangeAuth.newAuth = NULL;
-    } else {
-        esysContext->in.HierarchyChangeAuth.newAuthData = *newAuth;
-        esysContext->in.HierarchyChangeAuth.newAuth =
-            &esysContext->in.HierarchyChangeAuth.newAuthData;
-    }
+    if (newAuth == NULL)
+        memset(&esysContext->in.HierarchyChangeAuth.newAuth, 0,
+                sizeof(esysContext->in.HierarchyChangeAuth.newAuth));
+    else
+        esysContext->in.HierarchyChangeAuth.newAuth = *newAuth;
 }
 
 /** One-Call function for TPM2_HierarchyChangeAuth
@@ -322,10 +320,7 @@ Esys_HierarchyChangeAuth_Finish(
     r = esys_GetResourceObject(esysContext, authHandle, &authHandleNode);
     return_if_error(r, "get resource");
 
-    if (esysContext->in.HierarchyChangeAuth.newAuth == NULL)
-        authHandleNode->auth.size = 0;
-    else
-        authHandleNode->auth = *esysContext->in.HierarchyChangeAuth.newAuth;
+    authHandleNode->auth = esysContext->in.HierarchyChangeAuth.newAuth;
     iesys_compute_session_value(esysContext->session_tab[0],
                                 &authHandleNode->rsrc.name, &authHandleNode->auth);
 

--- a/src/tss2-esys/api/Esys_MAC_Start.c
+++ b/src/tss2-esys/api/Esys_MAC_Start.c
@@ -24,13 +24,11 @@ static void store_input_parameters (
     ESYS_CONTEXT *esysContext,
     const TPM2B_AUTH *auth)
 {
-    if (auth == NULL) {
-        esysContext->in.MAC_Start.auth = NULL;
-    } else {
+    if (auth == NULL)
+        memset(&esysContext->in.MAC_Start.authData, 0,
+                sizeof(esysContext->in.MAC_Start.authData));
+    else
         esysContext->in.MAC_Start.authData = *auth;
-        esysContext->in.MAC_Start.auth =
-            &esysContext->in.MAC_Start.authData;
-    }
 }
 
 /** One-Call function for TPM2_MAC_Start
@@ -350,11 +348,10 @@ TSS2_RC Esys_MAC_Start_Finish(
 
     /*  The name of a sequence object is an empty buffer */
     sequenceHandleNode->rsrc.name.size = 0;
-    /* Store the auth value parameter in the object meta data if passed */
-    if (esysContext->in.MAC_Start.auth == NULL)
-        sequenceHandleNode->auth.size = 0;
-    else
-        sequenceHandleNode->auth = *esysContext->in.MAC_Start.auth;
+
+    /* Store the auth value parameter in the object meta data */
+    sequenceHandleNode->auth = esysContext->in.HMAC_Start.authData;
+
     esysContext->state = _ESYS_STATE_INIT;
 
     return TSS2_RC_SUCCESS;

--- a/src/tss2-esys/api/Esys_NV_ChangeAuth.c
+++ b/src/tss2-esys/api/Esys_NV_ChangeAuth.c
@@ -26,13 +26,11 @@ static void store_input_parameters (
     const TPM2B_AUTH *newAuth)
 {
     esysContext->in.NV.nvIndex = nvIndex;
-    if (newAuth == NULL) {
-        esysContext->in.NV.auth = NULL;
-    } else {
+    if (newAuth == NULL)
+        memset(&esysContext->in.NV.authData, 0,
+                sizeof(esysContext->in.NV.authData));
+    else
         esysContext->in.NV.authData = *newAuth;
-        esysContext->in.NV.auth =
-            &esysContext->in.NV.authData;
-    }
 }
 
 /** One-Call function for TPM2_NV_ChangeAuth
@@ -318,10 +316,7 @@ Esys_NV_ChangeAuth_Finish(
     r = esys_GetResourceObject(esysContext, nvIndex, &nvIndexNode);
     return_if_error(r, "get resource");
 
-    if (esysContext->in.NV.auth == NULL)
-        nvIndexNode->auth.size = 0;
-    else
-        nvIndexNode->auth = *esysContext->in.NV.auth;
+    nvIndexNode->auth = esysContext->in.NV.authData;
 
     iesys_compute_session_value(esysContext->session_tab[0],
                                 &nvIndexNode->rsrc.name, &nvIndexNode->auth);

--- a/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
@@ -19,6 +19,21 @@
 #include "util/log.h"
 #include "util/aux_util.h"
 
+/** Store command parameters inside the ESYS_CONTEXT for use during _Finish */
+static void store_input_parameters (
+    ESYS_CONTEXT *esysContext,
+    const ESYS_TR pcrHandle,
+    const TPM2B_AUTH *auth)
+{
+    if (auth == NULL)
+        memset(&esysContext->in.PCR.authData, 0,
+                sizeof(esysContext->in.PCR.authData));
+    else
+        esysContext->in.PCR.authData = *auth;
+
+    esysContext->in.PCR.pcrHandle = pcrHandle;
+}
+
 /** One-Call function for TPM2_PCR_SetAuthValue
  *
  * This function invokes the TPM2_PCR_SetAuthValue command in a one-call
@@ -162,6 +177,8 @@ Esys_PCR_SetAuthValue_Async(
     r = check_session_feasibility(shandle1, shandle2, shandle3, 1);
     return_state_if_error(r, _ESYS_STATE_INIT, "Check session usage");
 
+    store_input_parameters(esysContext, pcrHandle, auth);
+
     /* Retrieve the metadata objects for provided handles */
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
     return_state_if_error(r, _ESYS_STATE_INIT, "pcrHandle unknown.");
@@ -236,6 +253,9 @@ TSS2_RC
 Esys_PCR_SetAuthValue_Finish(
     ESYS_CONTEXT *esysContext)
 {
+    ESYS_TR pcrHandle;
+    RSRC_NODE_T *pcrHandleNode;
+
     TSS2_RC r;
     LOG_TRACE("context=%p",
               esysContext);
@@ -292,6 +312,19 @@ Esys_PCR_SetAuthValue_Finish(
         esysContext->state = _ESYS_STATE_INTERNALERROR;
         return r;
     }
+
+    /*
+     * Session value has to be updated before checking the response to ensure
+     * correct computation of hmac with new auth value.
+     */
+    pcrHandle = esysContext->in.PCR.pcrHandle;
+    r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
+    return_if_error(r, "get resource");
+
+    pcrHandleNode->auth = esysContext->in.NV.authData;
+
+    iesys_compute_session_value(esysContext->session_tab[0],
+                                &pcrHandleNode->rsrc.name, &pcrHandleNode->auth);
 
     /*
      * Now the verification of the response (hmac check) and if necessary the

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -109,6 +109,11 @@ typedef struct {
     ESYS_TR flushHandle;
 } FlushContext_IN;
 
+typedef struct {
+    ESYS_TR pcrHandle;
+    TPM2B_AUTH authData;
+} PCR_IN;
+
 /** Union for input parameters.
  *
  * The input parameters of a command need to be stored if they are needed
@@ -131,6 +136,7 @@ typedef union {
     Policy_IN Policy;
     NV_IN NV;
     FlushContext_IN FlushContext;
+    PCR_IN PCR;
 } IESYS_CMD_IN_PARAM;
 
 /** The states for the ESAPI's internal state machine */

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -100,7 +100,6 @@ typedef struct {
 
 typedef struct {
     ESYS_TR nvIndex;
-    TPM2B_AUTH *auth;
     TPM2B_AUTH authData;
     TPM2B_NV_PUBLIC *publicInfo;
     TPM2B_NV_PUBLIC publicInfoData;

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -88,8 +88,7 @@ typedef HMAC_Start_IN MAC_Start_IN;
 
 typedef struct {
     ESYS_TR authHandle;
-    TPM2B_AUTH *newAuth;
-    TPM2B_AUTH newAuthData;
+    TPM2B_AUTH newAuth;
 } HierarchyChangeAuth_IN;
 
 typedef struct {

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -80,7 +80,6 @@ typedef struct {
 } EvictControl_IN;
 
 typedef struct {
-    TPM2B_AUTH *auth;
     TPM2B_AUTH authData;
 } HMAC_Start_IN;
 

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -70,6 +70,20 @@ test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
 
     goto_if_error(r, "Error: PCR_SetAuthValue", error);
 
+    /* This should work as the authValue should be remembered, see
+     *   - https://github.com/tpm2-software/tpm2-tss/issues/2099
+     * for details.
+     */
+    r = Esys_PCR_SetAuthValue(
+        esys_context,
+        pcrHandle_handle,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &auth
+        );
+    goto_if_error(r, "Error: PCR_SetAuthValue2", error);
+
     TPM2B_DIGEST authPolicy = {
         .size = 32,
         .buffer = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11, 12, 13, 14, 15, 16, 17,


### PR DESCRIPTION
- Simplification cleanups on how internal authValues we're stored in the ESAPI_CONTEXT
- Add support for Esys_PCR_SetAuthValue