### PR TITLE
FAPI: Fix loading of keys during policy execution

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -378,6 +378,7 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-key-create-policy-authorize-nv-tpms-sign.fint \
     test/integration/fapi-key-create-policy-authorize-nv-complex-tpm2b-sign.fint \
     test/integration/fapi-key-create-policy-secret-nv-sign.fint \
+    test/integration/fapi-key-create-policy-secret-key-sign.fint \
     test/integration/fapi-key-create-policy-pcr-sign.fint \
     test/integration/fapi-key-create-policy-signed.fint \
     test/integration/fapi-key-create-policy-signed-ecc.fint \
@@ -2084,6 +2085,13 @@ test_integration_fapi_key_create_policy_secret_nv_sign_fint_LDADD   = $(TESTS_LD
 test_integration_fapi_key_create_policy_secret_nv_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_fapi_key_create_policy_secret_nv_sign_fint_SOURCES = \
     test/integration/fapi-key-create-policy-secret-nv-sign.int.c \
+    test/integration/main-fapi.c test/integration/test-fapi.h
+
+test_integration_fapi_key_create_policy_secret_key_sign_fint_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_fapi_key_create_policy_secret_key_sign_fint_LDADD   = $(TESTS_LDADD)
+test_integration_fapi_key_create_policy_secret_key_sign_fint_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_fapi_key_create_policy_secret_key_sign_fint_SOURCES = \
+    test/integration/fapi-key-create-policy-secret-key-sign.int.c \
     test/integration/main-fapi.c test/integration/test-fapi.h
 
 test_integration_fapi_key_create_policy_pcr_sign_fint_CFLAGS  = $(TESTS_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -618,6 +618,7 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_authorize_nv_tpms.json \
     test/data/fapi/policy/pol_authorize_nv_complex_tpm2b.json \
     test/data/fapi/policy/pol_secret.json \
+    test/data/fapi/policy/pol_secret_key.json \
     test/data/fapi/policy/pol_password.json \
     test/data/fapi/policy/pol_auth_value.json \
     test/data/fapi/policy/pol_command_code.json \

--- a/src/tss2-fapi/api/Fapi_Sign.c
+++ b/src/tss2-fapi/api/Fapi_Sign.c
@@ -285,7 +285,7 @@ Fapi_Sign_Finish(
             r = ifapi_load_key(context, command->keyPath,
                                &command->key_object);
             return_try_again(r);
-            goto_if_error(r, "Fapi load key.", error_cleanup);
+            goto_if_error(r, "Fapi load key.", cleanup);
 
             fallthrough;
 
@@ -296,7 +296,7 @@ Fapi_Sign_Finish(
                     &command->publicKey,
                     (certificate) ? &command->certificate : NULL);
             return_try_again(r);
-            goto_if_error(r, "Fapi sign.", error_cleanup);
+            goto_if_error(r, "Fapi sign.", cleanup);
 
             /* Convert the TPM datatype signature to something useful for the caller. */
             r = ifapi_tpm_to_fapi_signature(command->key_object,
@@ -325,15 +325,17 @@ Fapi_Sign_Finish(
         statecasedefault(context->state);
     }
 
-error_cleanup:
+ error_cleanup:
+    ifapi_cleanup_ifapi_object(command->key_object);
+    ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);
+    ifapi_cleanup_ifapi_object(context->loadKey.key_object);
+
+ cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
     SAFE_FREE(command->tpm_signature);
     SAFE_FREE(command->keyPath);
     SAFE_FREE(command->padding);
     ifapi_session_clean(context);
-    ifapi_cleanup_ifapi_object(command->key_object);
-    ifapi_cleanup_ifapi_object(&context->loadKey.auth_object);
-    ifapi_cleanup_ifapi_object(context->loadKey.key_object);
     ifapi_cleanup_ifapi_object(&context->createPrimary.pkey_object);
     LOG_TRACE("finished");
     return r;

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -641,6 +641,14 @@ typedef struct {
     char *current_path;
 } IFAPI_FILE_SEARCH_CTX;
 
+/** The states for the FAPI's prepare key loading */
+enum _FAPI_STATE_PREPARE_LOAD_KEY {
+    PREPARE_LOAD_KEY_INIT = 0,
+    PREPARE_LOAD_KEY_WAIT_FOR_SESSION,
+    PREPARE_LOAD_KEY_INIT_KEY,
+    PREPARE_LOAD_KEY_WAIT_FOR_KEY
+};
+
 /** The states for the FAPI's key loading */
 enum _FAPI_STATE_LOAD_KEY {
     LOAD_KEY_GET_PATH = 0,
@@ -699,6 +707,7 @@ typedef struct {
  */
 typedef struct {
     enum _FAPI_STATE_LOAD_KEY state;   /**< The current state of key  loading */
+    enum  _FAPI_STATE_PREPARE_LOAD_KEY prepare_state;
     NODE_STR_T *path_list;        /**< The current used hierarchy for CreatePrimary */
     NODE_OBJECT_T *key_list;
     IFAPI_OBJECT auth_object;
@@ -708,6 +717,7 @@ typedef struct {
     bool parent_handle_persistent;
     IFAPI_OBJECT *key_object;
     char *key_path;
+    char const *path;
 } IFAPI_LoadKey;
 
 /** The data structure holding internal state of entity delete.

--- a/src/tss2-fapi/ifapi_policy_callbacks.c
+++ b/src/tss2-fapi/ifapi_policy_callbacks.c
@@ -465,7 +465,6 @@ ifapi_policyeval_cbauth(
     FAPI_CONTEXT *fapi_ctx = userdata;
     IFAPI_POLICY_EXEC_CTX *current_policy;
     IFAPI_POLICY_EXEC_CB_CTX *cb_ctx;
-    bool next_case;
 
     return_if_null(fapi_ctx, "Bad user data.", TSS2_FAPI_RC_BAD_REFERENCE);
     return_if_null(fapi_ctx->policy.policyutil_stack, "Policy not initialized.",
@@ -480,110 +479,118 @@ ifapi_policyeval_cbauth(
     }
     cb_ctx = current_policy->app_data;
 
-    do {
-        next_case = false;
-        switch (cb_ctx->cb_state) {
+    switch (cb_ctx->cb_state) {
         statecase(cb_ctx->cb_state, POL_CB_EXECUTE_INIT);
-            cb_ctx->flush_handle = false;
-            cb_ctx->auth_index = ESYS_TR_NONE;
-            /* Search object with name in keystore. */
-            r = ifapi_keystore_search_obj(&fapi_ctx->keystore, &fapi_ctx->io,
-                                          name,
-                                          &cb_ctx->object_path);
-            FAPI_SYNC(r, "Search Object", cleanup);
+        cb_ctx->flush_handle = false;
+        cb_ctx->auth_index = ESYS_TR_NONE;
+        /* Search object with name in keystore. */
+        r = ifapi_keystore_search_obj(&fapi_ctx->keystore, &fapi_ctx->io,
+                                      name,
+                                      &cb_ctx->object_path);
+        FAPI_SYNC(r, "Search Object", cleanup);
 
-            r = ifapi_keystore_load_async(&fapi_ctx->keystore, &fapi_ctx->io,
-                                          cb_ctx->object_path);
-            return_if_error2(r, "Could not open: %s", cb_ctx->object_path);
-            SAFE_FREE(cb_ctx->object_path);
-            fallthrough;
+        r = ifapi_keystore_load_async(&fapi_ctx->keystore, &fapi_ctx->io,
+                                      cb_ctx->object_path);
+        return_if_error2(r, "Could not open: %s", cb_ctx->object_path);
+        SAFE_FREE(cb_ctx->object_path);
+        fallthrough;
 
         statecase(cb_ctx->cb_state, POL_CB_READ_OBJECT);
-            /* Get object from file */
-            r = ifapi_keystore_load_finish(&fapi_ctx->keystore, &fapi_ctx->io,
-                                           &cb_ctx->object);
-            return_try_again(r);
-            return_if_error(r, "read_finish failed");
+        /* Get object from file */
+        r = ifapi_keystore_load_finish(&fapi_ctx->keystore, &fapi_ctx->io,
+                                       &cb_ctx->object);
+        return_try_again(r);
+        return_if_error(r, "read_finish failed");
 
-            r = ifapi_initialize_object(fapi_ctx->esys, &cb_ctx->object);
-            goto_if_error(r, "Initialize NV object", cleanup);
+        r = ifapi_initialize_object(fapi_ctx->esys, &cb_ctx->object);
+        goto_if_error(r, "Initialize NV object", cleanup);
 
-            if (cb_ctx->object.objectType == IFAPI_NV_OBJ) {
-                /* NV Authorization */
+        if (cb_ctx->object.objectType == IFAPI_NV_OBJ) {
+            /* NV Authorization */
 
-                cb_ctx->nv_index = cb_ctx->object.public.handle;
+            cb_ctx->nv_index = cb_ctx->object.public.handle;
 
-                /* Determine the object used for authorization. */
-                get_nv_auth_object(&cb_ctx->object,
-                                   cb_ctx->object.public.handle,
-                                   &cb_ctx->auth_object,
-                                   &cb_ctx->auth_index);
+            /* Determine the object used for authorization. */
+            get_nv_auth_object(&cb_ctx->object,
+                               cb_ctx->object.public.handle,
+                               &cb_ctx->auth_object,
+                               &cb_ctx->auth_index);
 
-                goto_if_error(r, "PolicySecret set authorization", cleanup);
-                cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
+            goto_if_error(r, "PolicySecret set authorization", cleanup);
+            cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
 
-                cb_ctx->auth_object_ptr = &cb_ctx->auth_object;
-                next_case = true;
-                break;
-            } else if (cb_ctx->object.objectType == IFAPI_HIERARCHY_OBJ) {
-                cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
-                cb_ctx->auth_object_ptr = &cb_ctx->object;
-                next_case = true;
-                break;
-            } else {
-                cb_ctx->key_handle = cb_ctx->object.public.handle;
-                next_case = true;
-                if (cb_ctx->key_handle == ESYS_TR_NONE) {
-                    cb_ctx->cb_state = POL_CB_LOAD_KEY;
-                    next_case = true;
-                    break;
-                }
+            cb_ctx->auth_object_ptr = &cb_ctx->auth_object;
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        } else if (cb_ctx->object.objectType == IFAPI_HIERARCHY_OBJ) {
+            cb_ctx->cb_state = POL_CB_AUTHORIZE_OBJECT;
+            cb_ctx->auth_object_ptr = &cb_ctx->object;
+            return TSS2_FAPI_RC_TRY_AGAIN;
+        } else {
+            cb_ctx->key_handle = cb_ctx->object.public.handle;
+            if (cb_ctx->key_handle == ESYS_TR_NONE) {
+                cb_ctx->cb_state = POL_CB_LOAD_KEY;
+                return TSS2_FAPI_RC_TRY_AGAIN;
             }
-            fallthrough;
+        }
+        fallthrough;
 
         statecase(cb_ctx->cb_state, POL_CB_AUTHORIZE_OBJECT);
-            r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
-            return_try_again(r);
-            goto_if_error(r, "Authorize  object.", cleanup);
+        r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
+        return_try_again(r);
+        goto_if_error(r, "Authorize  object.", cleanup);
 
-            cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
-            break;
-            /* FALLTHRU */
+        cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
+        break;
+        /* FALLTHRU */
 
         statecase(cb_ctx->cb_state, POL_CB_LOAD_KEY);
-            /* Key loading and authorization */
-            cb_ctx->auth_object_sav = fapi_ctx->loadKey.auth_object;
-            fapi_ctx->loadKey.auth_object = cb_ctx->auth_object;
-            r = ifapi_load_key(fapi_ctx, ifapi_get_object_path(&cb_ctx->object),
-                               &cb_ctx->auth_object_ptr);
-            if (r == TSS2_RC_SUCCESS &&
-                !cb_ctx->auth_object_ptr->misc.key.persistent_handle) {
-                current_policy->flush_handle = true;
-            }
-            cb_ctx->auth_object = fapi_ctx->loadKey.auth_object;
-            fapi_ctx->loadKey.auth_object = cb_ctx->auth_object_sav;
-            FAPI_SYNC(r, "Fapi load key.", cleanup);
+        /* Prepare new context for loadkey in policy and skip session creation. */
+        memset(&cb_ctx->load_ctx, 0, sizeof(IFAPI_LoadKey));
+        cb_ctx->load_ctx.prepare_state = PREPARE_LOAD_KEY_INIT_KEY;
+        memset(&cb_ctx->create_primary_ctx, 0, sizeof(IFAPI_CreatePrimary));
+        fallthrough;
 
-            ifapi_cleanup_ifapi_object(&cb_ctx->object);
-            cb_ctx->auth_object_ptr = &cb_ctx->auth_object;
-            cb_ctx->object = *cb_ctx->auth_object_ptr;
-            fallthrough;
+        statecase(cb_ctx->cb_state, POL_CB_LOAD_KEY_FINISH);
+        cb_ctx->load_ctx_sav = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx_sav = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx;
+        cb_ctx->auth_object_ptr = &cb_ctx->load_ctx.auth_object;
+        r = ifapi_load_key(fapi_ctx, ifapi_get_object_path(&cb_ctx->object),
+                           &cb_ctx->auth_object_ptr);
+        if (r == TSS2_RC_SUCCESS &&
+            !cb_ctx->load_ctx.auth_object.misc.key.persistent_handle) {
+            current_policy->flush_handle = true;
+        }
+        cb_ctx->load_ctx = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx_sav;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx_sav;
+        FAPI_SYNC(r, "Fapi load key.", cleanup);
+
+        ifapi_cleanup_ifapi_object(&cb_ctx->object);
+        cb_ctx->object = *cb_ctx->auth_object_ptr;
+        fallthrough;
 
         statecase(cb_ctx->cb_state, POL_CB_AUTHORIZE_KEY);
-            cb_ctx->auth_object_sav = fapi_ctx->loadKey.auth_object;
-            fapi_ctx->loadKey.auth_object = cb_ctx->auth_object;
-            r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
-            return_try_again(r);
-            goto_if_error(r, "Authorize  object.", cleanup);
+        cb_ctx->load_ctx_sav = fapi_ctx->loadKey;
+        cb_ctx->create_primary_ctx_sav = fapi_ctx->createPrimary;
+        fapi_ctx->loadKey = cb_ctx->load_ctx;
+        fapi_ctx->createPrimary = cb_ctx->create_primary_ctx;
+        cb_ctx->object = *cb_ctx->auth_object_ptr;
+        *auth_handle = cb_ctx->auth_object_ptr->public.handle;
 
-            fapi_ctx->loadKey.auth_object = cb_ctx->auth_object_sav;
-            cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
-            break;
-            /* FALLTHRU */
+        r = ifapi_authorize_object(fapi_ctx, cb_ctx->auth_object_ptr, authSession);
+        return_try_again(r);
+        goto_if_error(r, "Authorize  object.", cleanup);
+
+        fapi_ctx->loadKey = cb_ctx->load_ctx_sav;
+        cb_ctx->cb_state = POL_CB_EXECUTE_INIT;
+        break;
+        /* FALLTHRU */
 
         statecasedefault(cb_ctx->cb_state);
-        }
-    } while (next_case);
+    }
     *object_handle = cb_ctx->object.public.handle;
     if (cb_ctx->object.objectType == IFAPI_NV_OBJ)
         *auth_handle = cb_ctx->auth_index;
@@ -594,7 +601,6 @@ ifapi_policyeval_cbauth(
         fapi_ctx->policy.session = current_policy->policySessionSav;
 
 cleanup:
-    ifapi_cleanup_ifapi_object(&cb_ctx->object);
     if (current_policy->policySessionSav
         && current_policy->policySessionSav != ESYS_TR_NONE)
         fapi_ctx->policy.session = current_policy->policySessionSav;

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -11,6 +11,7 @@
 enum IFAPI_STATE_POL_CB_EXCECUTE {
     POL_CB_EXECUTE_INIT = 0,
     POL_CB_LOAD_KEY,
+    POL_CB_LOAD_KEY_FINISH,
     POL_CB_SEARCH_POLICY,
     POL_CB_EXECUTE_SUB_POLICY,
     POL_CB_NV_READ,
@@ -31,7 +32,10 @@ typedef struct {
     ESYS_TR auth_index;             /**< Index of authorization object */
     ESYS_TR flush_handle;           /**< Handle which has to be flushed after policy execution */
     IFAPI_OBJECT auth_object;       /**< FAPI auth object needed for authorization */
-    IFAPI_OBJECT auth_object_sav;
+    IFAPI_LoadKey load_ctx_sav;
+    IFAPI_LoadKey load_ctx;
+    IFAPI_CreatePrimary create_primary_ctx_sav;
+    IFAPI_CreatePrimary create_primary_ctx;
     IFAPI_OBJECT *key_object_ptr;
     IFAPI_OBJECT *auth_object_ptr;
     IFAPI_NV_Cmds nv_cmd_state;

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -904,7 +904,7 @@ execute_policy_secret(
         r = Esys_PolicySecret_Finish(esys_ctx, NULL,
                                      NULL);
         return_try_again(r);
-        goto_if_error(r, "FAPI PolicyAuthorizeNV_Finish", error_cleanup);
+        goto_if_error(r, "FAPI PolicySecret_Finish", cleanup);
         if (!current_policy->flush_handle) {
             current_policy->state = POLICY_EXECUTE_INIT;
             return r;
@@ -922,10 +922,9 @@ execute_policy_secret(
     statecasedefault(current_policy->state);
     }
 
-cleanup:
     return r;
 
- error_cleanup:
+ cleanup:
     if (current_policy->flush_handle) {
          Esys_FlushContext(esys_ctx, current_policy->auth_handle);
     }

--- a/test/data/fapi/policy/pol_secret_key.json
+++ b/test/data/fapi/policy/pol_secret_key.json
@@ -1,0 +1,9 @@
+{
+    "description":"Description pol_authorize",
+    "policy":[
+        {
+            "type": "POLICYSECRET",
+			"objectPath": "/SRK/secret_key",
+		}
+    ]
+}

--- a/test/integration/fapi-key-create-policy-secret-key-sign.int.c
+++ b/test/integration/fapi-key-create-policy-secret-key-sign.int.c
@@ -1,0 +1,203 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+
+#include "tss2_fapi.h"
+
+#include "test-fapi.h"
+
+#define LOGMODULE test
+#include "util/log.h"
+#include "util/aux_util.h"
+
+#define NV_SIZE 34
+#define PASSWORD "abc"
+#define SIGN_TEMPLATE "sign"
+
+static TSS2_RC
+auth_callback(
+    char const *objectPath,
+    char const *description,
+    const char **auth,
+    void *userData)
+{
+    UNUSED(description);
+    UNUSED(userData);
+
+    if (!objectPath) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "No path.");
+    }
+
+    *auth = PASSWORD;
+    return TSS2_RC_SUCCESS;
+}
+
+static char *
+read_policy(FAPI_CONTEXT *context, char *policy_name)
+{
+    FILE *stream = NULL;
+    long policy_size;
+    char *json_policy = NULL;
+    char policy_file[1024];
+
+    if (snprintf(&policy_file[0], 1023, TOP_SOURCEDIR "/test/data/fapi/%s.json", policy_name) < 0)
+        return NULL;
+
+    stream = fopen(policy_file, "r");
+    if (!stream) {
+        LOG_ERROR("File %s does not exist", policy_file);
+        return NULL;
+    }
+    fseek(stream, 0L, SEEK_END);
+    policy_size = ftell(stream);
+    fclose(stream);
+    json_policy = malloc(policy_size + 1);
+    return_if_null(json_policy,
+            "Could not allocate memory for the JSON policy",
+            NULL);
+    stream = fopen(policy_file, "r");
+    ssize_t ret = read(fileno(stream), json_policy, policy_size);
+    if (ret != policy_size) {
+        LOG_ERROR("IO error %s.", policy_file);
+        return NULL;
+    }
+    json_policy[policy_size] = '\0';
+    return json_policy;
+}
+
+/** Test the FAPI PolicySecret and PolicyAuthValue handling.
+ *
+ * Tested FAPI commands:
+ *  - Fapi_Provision()
+ *  - Fapi_Import()
+ *  - Fapi_CreateKey()
+ *  - Fapi_Sign()
+ *  - Fapi_SetAuthCB()
+ *  - Fapi_Delete()
+ *
+ * Tested Policies:
+ *  - PolicySecret
+ *  - PolicyAuthValue
+ *
+ * @param[in,out] context The FAPI_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_fapi_key_create_policy_secret_key_sign(FAPI_CONTEXT *context)
+{
+    TSS2_RC r;
+    char *path_auth_object = "/SRK/secret_key";
+    char *policy_secret = "/policy/pol_secret_key";
+    char *sign_key = "/HS/SRK/mySignkey";
+    char *json_policy = NULL;
+
+    uint8_t *signature = NULL;
+    char    *publicKey = NULL;
+    char    *certificate = NULL;
+
+    r = Fapi_Provision(context, NULL, NULL, NULL);
+    goto_if_error(r, "Error Fapi_Provision", error);
+
+    /* Create key for policy which will be used for key authorization */
+    r = Fapi_CreateKey(context, path_auth_object, SIGN_TEMPLATE,
+                       NULL, PASSWORD);
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    SAFE_FREE(json_policy);
+
+    json_policy = read_policy(context, policy_secret);
+    if (!json_policy)
+        goto error;
+
+    r = Fapi_Import(context, policy_secret, json_policy);
+    goto_if_error(r, "Error Fapi_Import", error);
+
+    r = Fapi_CreateKey(context, sign_key, SIGN_TEMPLATE,
+                       policy_secret, "");
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    r = Fapi_SetCertificate(context, sign_key, "-----BEGIN "\
+        "CERTIFICATE-----[...]-----END CERTIFICATE-----");
+    goto_if_error(r, "Error Fapi_CreateKey", error);
+
+    size_t signatureSize = 0;
+
+    TPM2B_DIGEST digest = {
+        .size = 32,
+        .buffer = {
+            0x67, 0x68, 0x03, 0x3e, 0x21, 0x64, 0x68, 0x24, 0x7b, 0xd0,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x31, 0xa0, 0xa2, 0xd9, 0x87, 0x6d, 0x79, 0x81, 0x8f, 0x8f,
+            0x41, 0x42
+        }
+    };
+
+    LOG_ERROR("***** START TEST ERROR ******");
+    r = Fapi_Sign(context, sign_key, NULL,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, &certificate);
+
+    LOG_ERROR("***** END TEST ERROR ******");
+
+    if (r == TSS2_RC_SUCCESS)
+        goto error;
+
+    ASSERT(signature == NULL);
+    ASSERT(publicKey == NULL);
+    ASSERT(certificate == NULL);
+
+    r = Fapi_SetAuthCB(context, auth_callback, "");
+    goto_if_error(r, "Error SetPolicyAuthCallback", error);
+
+    signature = NULL;
+    publicKey = NULL;
+    certificate = NULL;
+    r = Fapi_Sign(context, sign_key, NULL,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, &certificate);
+    goto_if_error(r, "Error Fapi_Sign", error);
+    ASSERT(signature != NULL);
+    ASSERT(publicKey != NULL);
+    ASSERT(certificate != NULL);
+    ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
+    ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
+
+    r = Fapi_Delete(context, "/");
+    goto_if_error(r, "Error Fapi_Delete", error);
+
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(certificate);
+    SAFE_FREE(json_policy);
+    return EXIT_SUCCESS;
+
+error:
+    Fapi_Delete(context, "/");
+    SAFE_FREE(signature);
+    SAFE_FREE(publicKey);
+    SAFE_FREE(certificate);
+    SAFE_FREE(json_policy);
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_fapi(FAPI_CONTEXT *context)
+{
+    return test_fapi_key_create_policy_secret_key_sign(context);
+}


### PR DESCRIPTION
 * The wrong context usage during key loading in the callback for object authorization was fixed.
 * An integration test, also with testing wrong authentication was added.

Signed-off-by: Juergen Repp <juergen_repp@web.de>