### PR TITLE
FAPI: Fix usage of management events in event list.

### DIFF
--- a/src/tss2-fapi/ifapi_json_eventlog_serialize.h
+++ b/src/tss2-fapi/ifapi_json_eventlog_serialize.h
@@ -22,6 +22,11 @@ typedef struct {
     size_t recnum_tab[TPM2_MAX_PCRS];
 } callback_data;
 
+bool ifapi_pcr_used(
+    uint32_t pcr,
+    const uint32_t *pcr_list,
+    size_t pcr_list_size);
+
 TSS2_RC ifapi_tcg_eventlog_serialize(
     UINT8 const *eventlog,
     size_t size,


### PR DESCRIPTION
CEL management and advisory only events were added to the event list although PCR0 was not selected.
Now these events will only be added if PCR0 is selected. Fixes: #2454

Signed-off-by: Juergen Repp <juergen_repp@web.de>