### PR TITLE
Esys_PCR_SetAuthValue: use correct union selection

### DIFF
--- a/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
+++ b/src/tss2-esys/api/Esys_PCR_SetAuthValue.c
@@ -321,7 +321,7 @@ Esys_PCR_SetAuthValue_Finish(
     r = esys_GetResourceObject(esysContext, pcrHandle, &pcrHandleNode);
     return_if_error(r, "get resource");
 
-    pcrHandleNode->auth = esysContext->in.NV.authData;
+    pcrHandleNode->auth = esysContext->in.PCR.authData;
 
     iesys_compute_session_value(esysContext->session_tab[0],
                                 &pcrHandleNode->rsrc.name, &pcrHandleNode->auth);


### PR DESCRIPTION
Use in.PCR not in.NV when getting the stored authValue. This worked, coincidentally, becuase the unions overlapped.

Signed-off-by: William Roberts <william.c.roberts@intel.com>