### PR TITLE
CI: Fix usage of sanitizer 3.2.x.

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -63,7 +63,7 @@ if [ "$CC" == "gcc" ]; then
   export CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage";
 fi
 
-if [ ldconfig -p 2>/dev/null| grep libasan > /dev/null && ldconfig -p 2>/dev/null| grep libubsan > /dev/null ]; then
+if ldconfig -p 2>/dev/null| grep libasan > /dev/null && ldconfig -p 2>/dev/null| grep libubsan > /dev/null; then
   SANITIZER_OPTION="--with-sanitizer=undefined,address"
 fi
 

--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -313,6 +313,8 @@ Fapi_ChangeAuth_Finish(
                                             &command->numPaths);
                 goto_if_error(r, "get entities.", error_cleanup);
 
+                command->numPathsCleanup = command->numPaths;
+
                 /* Load the hierarchy's metadata from the keystore. */
                 r = ifapi_keystore_load_async(&context->keystore, &context->io,
                         command->entityPath);
@@ -600,7 +602,7 @@ error_cleanup:
     SAFE_FREE(command->entityPath);
     SAFE_FREE(command->authValue);
     if (command->pathlist) {
-        for (size_t i = 0; i < command->numPaths; i++) {
+        for (size_t i = 0; i < command->numPathsCleanup; i++) {
             SAFE_FREE(command->pathlist[i]);
         }
         SAFE_FREE(command->pathlist);

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -487,6 +487,7 @@ typedef struct {
     ESYS_TR hierarchy_handle;       /**< NV handle of the hierarchy to be changed */
     char **pathlist;                /**< The array with all keystore objects */
     size_t numPaths;                /**< Size of array with all keystore objects */
+    size_t numPathsCleanup;         /**< Size of array with all keystore objects */
 } IFAPI_Entity_ChangeAuth;
 
 /** The data structure holding internal state of Fapi_AuthorizePolicy.


### PR DESCRIPTION
* The check in docker.run whether libasan and libubsan are available
   did not work. Thus the sanitizer was not used in the CI.
* All leaks which were not detected are now fixed.
* Fixes #2470.
 
 Signed-off-by: Juergen Repp <juergen_repp@web.de>
