### PR TITLE
TCTI: Add USB TPM (LetsTrust-TPM2Go) TCTI module

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,7 @@ task:
     CFLAGS: "-I/usr/local/include -I/usr/local/openssl/include"
     LDFLAGS: -L/usr/local/lib
     ibmtpm_name: ibmtpm1637
+    libusb_version: v1.0.26
   freebsd_instance:
     matrix:
       image_family: freebsd-13-1
@@ -21,6 +22,9 @@ task:
     - gmake -j && cp tpm_server /usr/bin/
     - cd -
     - rm -fr $ibmtpm_name $ibmtpm_name.tar.gz
+    - git clone --depth 1 -b $libusb_version https://github.com/libusb/libusb
+    - cd libusb && ./bootstrap.sh && ./configure && gmake -j install
+    - cd - && rm -fr libusb
   script:
     ./bootstrap &&
     ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=no --enable-tcti-libtpms=no --enable-tcti-mssim=yes --disable-dependency-tracking &&

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,8 @@ jobs:
               libini-config-dev \
               libcurl4-openssl-dev \
               uuid-dev \
-              libltdl-dev
+              libltdl-dev \
+              libusb-1.0-0-dev
 
       - name: After Prepare (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,8 @@ following sections describe them for the supported platforms.
 * libcurl development libraries
 * Access Control List utility (acl)
 * JSON C Development library
+* Package libusb-1.0-0-dev
+
 
 The following are dependencies only required when building test suites.
 * Integration test suite (see ./configure option --enable-integration):
@@ -55,7 +57,8 @@ $ sudo apt -y install \
   libini-config-dev \
   libcurl4-openssl-dev \
   uuid-dev \
-  libltdl-dev
+  libltdl-dev \
+  libusb-1.0-0-dev
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -155,6 +155,9 @@ endif
 if ENABLE_TCTI_SPI_HELPER
 TESTS_UNIT += test/unit/tcti-spi-helper
 endif
+if ENABLE_TCTI_SPI_LT2GO
+TESTS_UNIT += test/unit/tcti-spi-lt2go
+endif
 if ESYS
 TESTS_UNIT += \
     test/unit/esys-context-null \
@@ -532,6 +535,28 @@ if ENABLE_TCTI_SPI_HELPER
 test_unit_tcti_spi_helper_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_spi_helper_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
 test_unit_tcti_spi_helper_SOURCES = test/unit/tcti-spi-helper.c
+endif
+
+if ENABLE_TCTI_SPI_LT2GO
+test_unit_tcti_spi_lt2go_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_spi_lt2go_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
+test_unit_tcti_spi_lt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
+                                   -Wl,--wrap=libusb_claim_interface \
+                                   -Wl,--wrap=libusb_close \
+                                   -Wl,--wrap=libusb_control_transfer \
+                                   -Wl,--wrap=libusb_dev_mem_alloc \
+                                   -Wl,--wrap=libusb_dev_mem_free \
+                                   -Wl,--wrap=libusb_exit \
+                                   -Wl,--wrap=libusb_free_config_descriptor \
+                                   -Wl,--wrap=libusb_get_config_descriptor \
+                                   -Wl,--wrap=libusb_get_device \
+                                   -Wl,--wrap=libusb_init \
+                                   -Wl,--wrap=libusb_open_device_with_vid_pid \
+                                   -Wl,--wrap=libusb_release_interface \
+                                   -Wl,--wrap=libusb_set_auto_detach_kernel_driver \
+                                   -Wl,--wrap=libusb_strerror
+test_unit_tcti_spi_lt2go_SOURCES = test/unit/tcti-spi-lt2go.c \
+                                   src/tss2-tcti/tcti-spi-lt2go.c
 endif
 
 test_unit_tctildr_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -423,6 +423,27 @@ src_tss2_tcti_libtss2_tcti_spi_helper_la_SOURCES  = \
     src/tss2-tcti/tcti-spi-helper.h
 endif # ENABLE_TCTI_SPI_HELPER
 
+# tcti library for letstrust-tpm2go usb tpm
+if ENABLE_TCTI_SPI_LT2GO
+libtss2_tcti_spi_lt2go = src/tss2-tcti/libtss2-tcti-spi-lt2go.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_spi_lt2go.h
+lib_LTLIBRARIES += $(libtss2_tcti_spi_lt2go)
+pkgconfig_DATA += lib/tss2-tcti-spi-lt2go.pc
+
+src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LDFLAGS  = -lusb-1.0
+
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LDFLAGS  += -Wl,--version-script=$(srcdir)/lib/tss2-tcti-spi-lt2go.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LIBADD   = $(libutil) $(libtss2_mu) $(libtss2_tcti_spi_helper)
+src_tss2_tcti_libtss2_tcti_spi_lt2go_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-spi-lt2go.c \
+    src/tss2-tcti/tcti-spi-lt2go.h
+endif # ENABLE_TCTI_SPI_LT2GO
+EXTRA_DIST += lib/tss2-tcti-spi-lt2go.map \
+              lib/tss2-tcti-spi-lt2go.def
+
 ### TCG TSS SYS spec library ###
 libtss2_sys = src/tss2-sys/libtss2-sys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_sys.h
@@ -805,6 +826,8 @@ man7_MANS = \
     man/man7/tss2-tcti-swtpm.7 \
     man/man7/tss2-tcti-mssim.7 \
     man/man7/tss2-tcti-cmd.7 \
+    man/man7/tss2-tcti-spi-helper.7 \
+    man/man7/tss2-tcti-spi-lt2go.7 \
     man/man7/tss2-tctildr.7
 
 if FAPI
@@ -883,6 +906,8 @@ EXTRA_DIST += \
     man/man7/tss2-tcti-swtpm.7 \
     man/tss2-tcti-mssim.7.in \
     man/tss2-tcti-cmd.7.in \
+    man/tss2-tcti-spi-helper.7.in \
+    man/tss2-tcti-spi-lt2go.7.in \
     man/tss2-tctildr.7.in
 
 CLEANFILES += \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -297,6 +297,20 @@ AC_ARG_ENABLE([tcti-spi-helper],
 AM_CONDITIONAL([ENABLE_TCTI_SPI_HELPER], [test "x$enable_tcti_spi_helper" != xno])
 AS_IF([test "x$enable_tcti_spi_helper" = "xyes"],
 	[AC_DEFINE([TCTI_SPI_HELPER],[1], [TCTI HELPER FOR SPI BASED ACCESS TO TPM2 DEVICE])])
+
+AC_ARG_ENABLE([tcti-spi-lt2go],
+            [AS_HELP_STRING([--disable-tcti-spi-lt2go],
+                            [don't build the tcti-spi-lt2go module])],,
+            [enable_tcti_spi_lt2go=yes])
+
+AM_CONDITIONAL([ENABLE_TCTI_SPI_LT2GO], [test "x$enable_tcti_spi_lt2go" != xno])
+AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
+    AC_DEFINE([TCTI_SPI_LT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
+
+AS_IF([test "x$enable_tcti_spi_lt2go" = xyes ],
+      [PKG_CHECK_MODULES([LIBUSB],
+                         [libusb-1.0],,
+                         [AC_MSG_ERROR([libusb-1.0 library is missing.])])])
 
 AC_ARG_ENABLE([tcti-fuzzing],
             [AS_HELP_STRING([--enable-tcti-fuzzing],

--- a/doc/tcti-spi-lt2go.md
+++ b/doc/tcti-spi-lt2go.md
@@ -1,0 +1,48 @@
+# SPI TCTI LT2GO
+The SPI TCTI LT2GO can be used for communication with LetsTrust-TPM2Go USB TPM.
+The LT2GO module utilizes the `tcti-spi-helper` library for PTP SPI protocol handling
+and the `libusb-1.0-0-dev` library for USB communication.
+
+# EXAMPLES
+
+Set udev rules for LetsTrust-TPM2Go by creating a file `/etc/udev/rules.d/60-tpm2go.rules`:
+```
+ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0004", TAG+="uaccess"
+```
+
+Activate the udev rules:
+```console
+sudo udevadm control --reload
+```
+
+You should see the following after plugging in the LetsTrust-TPM2Go:
+```
+dmesg
+ [ 1019.115823] usb 3-2: new full-speed USB device number 5 using xhci_hcd
+ [ 1019.480333] usb 3-2: New USB device found, idVendor=04b4, idProduct=0004, bcdDevice= 0.00
+ [ 1019.480360] usb 3-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+ [ 1019.480382] usb 3-2: Product: LetsTrust-TPM2Go
+ [ 1019.480405] usb 3-2: Manufacturer: www.pi3g.com
+ [ 1019.480426] usb 3-2: SerialNumber: 000010
+
+sudo udevadm info -e | grep LetsTrust
+ E: ID_MODEL=LetsTrust-TPM2Go
+ E: ID_MODEL_ENC=LetsTrust-TPM2Go
+ E: ID_SERIAL=www.pi3g.com_LetsTrust-TPM2Go_000010
+```
+
+Use tcti-spi-lt2go to communicate with LetsTrust-TPM2Go:
+```console
+tpm2_startup -Tspi-lt2go -c
+tpm2_getrandom -Tspi-lt2go 8 --hex
+```
+
+Enable abrmd:
+```console
+export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork`
+tpm2-abrmd --allow-root --session --tcti=spi-lt2go &
+
+export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
+tpm2_startup -c
+tpm2_getrandom 8 --hex
+```

--- a/include/tss2/tss2_tcti_spi_lt2go.h
+++ b/include/tss2/tss2_tcti_spi_lt2go.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 Peter Huewe
+ */
+#ifndef TSS2_TCTI_SPI_LT2GO_H
+#define TSS2_TCTI_SPI_LT2GO_H
+
+#include <stdbool.h>
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Spi_Lt2go_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *config);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_SPI_LT2GO_H */

--- a/lib/tss2-tcti-spi-lt2go.def
+++ b/lib/tss2-tcti-spi-lt2go.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-spi-lt2go
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Spi_Lt2go_Init

--- a/lib/tss2-tcti-spi-lt2go.map
+++ b/lib/tss2-tcti-spi-lt2go.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Spi_Lt2go_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-spi-lt2go.pc.in
+++ b/lib/tss2-tcti-spi-lt2go.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-spi-lt2go
+Description: TCTI library for communicating with the LetsTrust-TPM2Go over USB.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Cflags: -I${includedir} -I${includedir}/tss
+Libs: -ltss2-tcti-spi-helper -ltss2-tcti-spi-lt2go -L${libdir} -lusb-1.0

--- a/man/tss2-tcti-spi-lt2go.7.in
+++ b/man/tss2-tcti-spi-lt2go.7.in
@@ -1,0 +1,14 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-SPI 7 "NOVEMBER 2022" "TPM2 Software Stack"
+.SH NAME
+tcti-spi-lt2go \- LetsTrust-TPM2Go USB TPM TCTI library
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for interaction with
+the LetsTrust-TPM2Go USB TPM.
+.SH DESCRIPTION
+tcti-spi-lt2go is a library that abstracts the details of communication
+with the LetsTrust-TPM2Go USB TPM. The interface exposed by this library
+is defined in the \*(lqTSS System Level API and TPM Command Transmission
+Interface Specification\*(rq specification.

--- a/src/tss2-tcti/tcti-spi-helper.c
+++ b/src/tss2-tcti/tcti-spi-helper.c
@@ -666,6 +666,10 @@ TSS2_RC Tss2_Tcti_Spi_Helper_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size
         return TSS2_RC_SUCCESS;
     }
 
+    if (!platform_conf) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
     if (*size < sizeof (TSS2_TCTI_SPI_HELPER_CONTEXT)) {
         return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
     }

--- a/src/tss2-tcti/tcti-spi-lt2go.c
+++ b/src/tss2-tcti/tcti-spi-lt2go.c
@@ -1,0 +1,330 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 Peter Huewe
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "tss2_tcti.h"
+#include "tcti-spi-lt2go.h"
+#include "tss2_tcti_spi_lt2go.h"
+#include "tcti-spi-helper.h"
+#include "tss2_mu.h"
+#include "util/io.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+#define VID_CYPRESS 0x04b4u
+#define PID_CYUSBSPI 0x0004u
+#define TIMEOUT 1000
+#define CTRL_SET 0xC0u
+#define CTRL_GET 0x40u
+#define CY_CMD_SPI 0xCAu
+#define CY_CMD_GPIO_SET 0xDBu
+#define CY_SPI_WRITEREAD 0x03u
+#define EP_OUT 0x01u
+#define EP_IN 0x82u
+
+#define SPI_MAX_TRANSFER (4 + 64)
+
+TSS2_RC
+platform_spi_transfer (void *user_data, const void *data_out, void *data_in, size_t cnt)
+{
+    int act_len = 0;
+    int retry = 0;
+    int ret = 0;
+    size_t transfered = 0;
+    size_t length = cnt;
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    uint8_t *spi_dma_buffer = platform_data->spi_dma_buffer;
+    libusb_device_handle *dev_handle = platform_data->dev_handle;
+
+    memset (spi_dma_buffer, 0, SPI_MAX_TRANSFER);
+
+    /* Maximum transfer size is 64 bytes */
+    if (cnt > SPI_MAX_TRANSFER) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    /* At least one of the buffers has to be set */
+    if (data_out == NULL && data_in == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    /* Clear receive buffer */
+    if (data_in != NULL && data_in !=  data_out) {
+        memset (data_in, 0, cnt);
+    }
+
+    if (data_out != NULL){
+        memcpy (spi_dma_buffer, data_out, length);
+    }
+
+    ret = libusb_control_transfer (dev_handle, CTRL_SET, CY_CMD_SPI, CY_SPI_WRITEREAD, length, NULL, 0, TIMEOUT);
+    if (ret) {
+        LOG_ERROR ("libusb_control_transfer failed with error: %s.", libusb_strerror(ret));
+        ret = TSS2_TCTI_RC_IO_ERROR;
+        goto out;
+    }
+
+    while (transfered != cnt){
+        ret = libusb_bulk_transfer (dev_handle, EP_OUT, spi_dma_buffer+transfered, length, &act_len, TIMEOUT);
+        if (ret) {
+            LOG_ERROR ("libusb_bulk_transfer write failed with error: %s.", libusb_strerror(ret));
+            ret = TSS2_TCTI_RC_IO_ERROR;
+            goto out;
+        }
+        transfered += act_len;
+        length -= act_len;
+    }
+
+    transfered = 0;
+    length = cnt;
+    while(transfered != cnt){
+        ret = libusb_bulk_transfer (dev_handle, EP_IN, spi_dma_buffer+transfered, length, &act_len, TIMEOUT);
+        if (ret) {
+            if (retry++ > 5) {
+                LOG_ERROR ("libusb_bulk_transfer read failed with error: %s.", libusb_strerror(ret));
+                ret = TSS2_TCTI_RC_IO_ERROR;
+                goto out;
+            }
+            continue;
+        }
+        transfered += act_len;
+        length -= act_len;
+    }
+
+    if (data_in != NULL) {
+        memcpy(data_in, spi_dma_buffer, cnt);
+    }
+
+out:
+    memset (spi_dma_buffer, 0, SPI_MAX_TRANSFER);
+    return ret;
+}
+
+TSS2_RC
+platform_sleep_ms (void *user_data, int32_t milliseconds)
+{
+    (void) user_data;
+    struct timeval tv = {milliseconds/1000, (milliseconds%1000)*1000};
+    select (0, NULL, NULL, NULL, &tv);
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_start_timeout (void *user_data, int32_t milliseconds)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    memset (&platform_data->timeout, 0, sizeof (struct timeval));
+
+    if (gettimeofday (&platform_data->timeout, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    platform_data->timeout.tv_sec += (milliseconds/1000);
+    platform_data->timeout.tv_usec += (milliseconds%1000)*1000;
+    if (platform_data->timeout.tv_usec > 999999) {
+        platform_data->timeout.tv_sec++;
+        platform_data->timeout.tv_usec -= 1000000;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_timeout_expired (void *user_data, bool *is_timeout_expired)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    struct timeval now;
+    if (gettimeofday (&now, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    if (now.tv_sec > platform_data->timeout.tv_sec) {
+        *is_timeout_expired = true;
+    } else if ((now.tv_sec == platform_data->timeout.tv_sec)
+               && (now.tv_usec > platform_data->timeout.tv_usec)) {
+        *is_timeout_expired = true;
+    } else {
+        *is_timeout_expired = false;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+void
+platform_finalize(void *user_data)
+{
+    int ret = 0;
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    if (platform_data->spi_dma_buffer)
+        libusb_dev_mem_free (platform_data->dev_handle, platform_data->spi_dma_buffer, SPI_MAX_TRANSFER);
+
+    if (platform_data->dev_handle) {
+        /* Release the interface we claimed */
+        ret = libusb_release_interface (platform_data->dev_handle, 0);
+        if (ret) {
+            LOG_WARNING ("libusb_release_interface failed: %s.", libusb_strerror (ret));
+        }
+
+        /* Close the device we opened */
+        libusb_close (platform_data->dev_handle);
+    }
+
+    if (platform_data->ctx) {
+        /* Needs to be called after closing all open devices
+           and before your application terminates */
+        libusb_exit (platform_data->ctx);
+    }
+
+    free(platform_data);
+}
+
+TSS2_RC
+create_tcti_spi_lt2go_platform (TSS2_TCTI_SPI_HELPER_PLATFORM *platform)
+{
+    int ret = 0;
+    int nb_ifaces = 0;
+    libusb_device *dev = NULL;
+    struct libusb_config_descriptor *conf_desc = NULL;
+
+    /* Create required platform user data */
+    PLATFORM_USERDATA *platform_data = calloc (1, sizeof (PLATFORM_USERDATA));
+
+    if (platform_data == NULL) {
+        return TSS2_BASE_RC_MEMORY;
+    }
+
+    ret = libusb_init (&platform_data->ctx);
+    if (ret) {
+        LOG_ERROR ("libusb init failed: %s.", libusb_strerror (ret));
+        goto out;
+    }
+
+    platform_data->dev_handle = libusb_open_device_with_vid_pid (platform_data->ctx, VID_CYPRESS, PID_CYUSBSPI);
+    if (!platform_data->dev_handle) {
+        LOG_ERROR ("LetsTrust-TPM2Go not found.");
+        goto out;
+    }
+
+    dev = libusb_get_device (platform_data->dev_handle);
+    if (dev == NULL) {
+        LOG_ERROR ("libusb_get_device failed.");
+        goto out;
+    }
+
+    ret = libusb_get_config_descriptor (dev, 0, &conf_desc);
+    if (ret) {
+        LOG_ERROR ("libusb_get_config_descriptor failed: %s.", libusb_strerror (ret));
+        goto out;
+    }
+
+    nb_ifaces = conf_desc->bNumInterfaces;
+    libusb_free_config_descriptor(conf_desc);
+    if (!nb_ifaces) {
+        LOG_ERROR ("libusb no interface found.");
+        goto out;
+    }
+
+    ret = libusb_set_auto_detach_kernel_driver (platform_data->dev_handle, 1);
+    if (ret) {
+        LOG_ERROR ("libusb_set_auto_detach_kernel_driver failed: %s.", libusb_strerror (ret));
+        goto out;
+    }
+
+    ret = libusb_claim_interface (platform_data->dev_handle, 0);
+    if (ret) {
+        LOG_ERROR ("libusb_claim_interface failed: %s.", libusb_strerror (ret));
+        goto out;
+    }
+
+    platform_data->spi_dma_buffer = libusb_dev_mem_alloc (platform_data->dev_handle, SPI_MAX_TRANSFER);
+    if (!platform_data->spi_dma_buffer){
+        LOG_ERROR ("libusb_dev_mem_alloc failed.");
+        goto out;
+    }
+
+    /* Create TCTI SPI platform struct with custom platform methods */
+    platform->user_data = platform_data;
+    platform->sleep_ms = platform_sleep_ms;
+    platform->start_timeout = platform_start_timeout;
+    platform->timeout_expired = platform_timeout_expired;
+    platform->spi_acquire = NULL;
+    platform->spi_release = NULL;
+    platform->spi_transfer = platform_spi_transfer;
+    platform->finalize = platform_finalize;
+
+    return TSS2_RC_SUCCESS;
+
+out:
+    if (platform_data->spi_dma_buffer)
+        libusb_dev_mem_free (platform_data->dev_handle, platform_data->spi_dma_buffer, SPI_MAX_TRANSFER);
+
+    if (platform_data->dev_handle) {
+        /* Release the interface we claimed */
+        ret = libusb_release_interface(platform_data->dev_handle, 0);
+        if (ret) {
+            LOG_WARNING ("libusb_release_interface failed: %s.", libusb_strerror (ret));
+        }
+
+        /* Close the device we opened */
+        libusb_close (platform_data->dev_handle);
+    }
+
+    if (platform_data->ctx) {
+        /* Needs to be called after closing all open devices
+           and before your application terminates */
+        libusb_exit (platform_data->ctx);
+    }
+
+    return TSS2_BASE_RC_IO_ERROR;
+}
+
+TSS2_RC
+Tss2_Tcti_Spi_Lt2go_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const char* config)
+{
+    (void) config;
+    TSS2_RC ret = 0;
+    TSS2_TCTI_SPI_HELPER_PLATFORM tcti_platform = {0};
+
+    /* Check if context size is requested */
+    if (tcti_context == NULL) {
+        return Tss2_Tcti_Spi_Helper_Init (NULL, size, NULL);
+    }
+
+    if ((ret = create_tcti_spi_lt2go_platform (&tcti_platform))) {
+        return ret;
+    }
+
+    /* Initialize TCTI context */
+    return Tss2_Tcti_Spi_Helper_Init (tcti_context, size, &tcti_platform);
+}
+
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-spi-lt2go",
+    .description = "TCTI for communicating with LetsTrust-TPM2Go.",
+    .config_help = "Takes no configuration.",
+    .init = Tss2_Tcti_Spi_Lt2go_Init
+};
+
+const TSS2_TCTI_INFO *
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-spi-lt2go.h
+++ b/src/tss2-tcti/tcti-spi-lt2go.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 Peter Huewe
+ */
+#ifndef TCTI_SPI_LT2GO_H
+#define TCTI_SPI_LT2GO_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdint.h>
+#include <libusb-1.0/libusb.h>
+
+#include "tcti-common.h"
+#include "tss2_tcti_spi_helper.h"
+
+typedef struct {
+    struct timeval timeout;
+    libusb_device_handle *dev_handle;
+    libusb_context *ctx;
+    uint8_t *spi_dma_buffer;
+} PLATFORM_USERDATA;
+
+#endif /* TCTI_SPI_LT2GO_H */

--- a/test/unit/tcti-spi-lt2go.c
+++ b/test/unit/tcti-spi-lt2go.c
@@ -1,0 +1,345 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/***********************************************************************;
+ * Copyright (c) 2022, Infineon Technologies AG
+ * All rights reserved.
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_spi_lt2go.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-spi-lt2go.h"
+#include "tss2-tcti/tcti-spi-helper.h"
+#include "util/key-value-parse.h"
+
+#define VID_CYPRESS 0x04b4u
+#define PID_CYUSBSPI 0x0004u
+#define CTRL_SET 0xC0u
+#define CY_CMD_SPI 0xCAu
+#define CY_SPI_WRITEREAD 0x03u
+#define TIMEOUT 1000
+#define EP_OUT 0x01u
+#define EP_IN 0x82u
+
+typedef enum {
+    TPM_DID_VID_HEAD_RX = 0,
+    TPM_DID_VID_HEAD_TX,
+    TPM_ACCESS_HEAD_RX,
+    TPM_ACCESS_HEAD_TX,
+    TPM_STS_HEAD_RX,
+    TPM_STS_HEAD_TX,
+    TPM_RID_HEAD_RX,
+    TPM_RID_HEAD_TX,
+} tpm_state_t;
+
+static const unsigned char TPM_DID_VID_0[] = {0x83, 0xd4, 0x0f, 0x00, 0xd1, 0x15, 0x1b, 0x00};
+static const unsigned char TPM_ACCESS_0[] = {0x80, 0xd4, 0x00, 0x00, 0xa1};
+static const unsigned char TPM_STS_0[] = {0x83, 0xd4, 0x00, 0x18, 0x40, 0x00, 0x00, 0x00};
+static const unsigned char TPM_RID_0[] = {0x80, 0xd4, 0x0f, 0x04, 0x00};
+
+static libusb_device_handle *device_handle;
+static libusb_context *context;
+struct libusb_config_descriptor *config_descriptor;
+static libusb_device *usb_device;
+static unsigned char *device_mem_alloc;
+static size_t device_mem_alloc_length;
+static uint16_t transfer_length;
+
+/*
+ * Mock function libusb_get_device.
+ */
+libusb_device * __wrap_libusb_get_device (libusb_device_handle *dev_handle)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    usb_device = malloc (1);
+    return usb_device;
+}
+
+/*
+ * Mock function libusb_get_config_descriptor.
+ */
+int __wrap_libusb_get_config_descriptor (libusb_device *dev,
+    uint8_t config_index, struct libusb_config_descriptor **config)
+{
+    assert_ptr_equal (dev, usb_device);
+    assert_int_equal (config_index, 0);
+    config_descriptor = malloc (sizeof (struct libusb_config_descriptor));
+    config_descriptor->bNumInterfaces = 2;
+    *config = config_descriptor;
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_free_config_descriptor.
+ */
+void __wrap_libusb_free_config_descriptor (
+     struct libusb_config_descriptor *config)
+{
+    assert_ptr_equal (config, config_descriptor);
+    free (config);
+}
+
+/*
+ * Mock function libusb_set_auto_detach_kernel_driver.
+ */
+int __wrap_libusb_set_auto_detach_kernel_driver (
+    libusb_device_handle *dev_handle, int enable)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_int_equal (enable, 1);
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_claim_interface.
+ */
+int __wrap_libusb_claim_interface (libusb_device_handle *dev_handle,
+    int interface_number)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_int_equal (interface_number, 0);
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_release_interface.
+ */
+int __wrap_libusb_release_interface (libusb_device_handle *dev_handle,
+    int interface_number)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_int_equal (interface_number, 0);
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_control_transfer.
+ */
+int __wrap_libusb_control_transfer (libusb_device_handle *dev_handle,
+    uint8_t request_type, uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
+    unsigned char *data, uint16_t wLength, unsigned int timeout)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_int_equal (request_type, CTRL_SET);
+    assert_int_equal (bRequest, CY_CMD_SPI);
+    assert_int_equal (wValue, CY_SPI_WRITEREAD);
+    assert_null (data);
+    assert_int_equal (wLength, 0);
+    assert_int_equal (timeout, TIMEOUT);
+
+    transfer_length = wIndex;
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_bulk_transfer.
+ *
+ * Here we are imitating the best case scenario where the
+ * actual_length is always equal to length. In actual world,
+ * the transmission can be fragmented hence the actual_length < length,
+ * and multiple retries can happen to process the remaining length.
+ */
+int __wrap_libusb_bulk_transfer (libusb_device_handle *dev_handle,
+    unsigned char endpoint, unsigned char *data, int length,
+    int *actual_length, unsigned int timeout)
+{
+    static tpm_state_t tpm_state = TPM_DID_VID_HEAD_RX;
+
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_int_equal (timeout, TIMEOUT);
+    assert_int_equal (length, transfer_length);
+
+    switch (tpm_state) {
+    case TPM_DID_VID_HEAD_RX:
+        assert_true (endpoint == EP_OUT);
+        assert_int_equal (length, 8);
+        assert_true (!memcmp (data, TPM_DID_VID_0, 4));
+        break;
+    case TPM_DID_VID_HEAD_TX:
+        assert_true (endpoint == EP_IN);
+        assert_int_equal (length, 8);
+        memcpy (data, TPM_DID_VID_0, sizeof (TPM_DID_VID_0));
+        break;
+    case TPM_ACCESS_HEAD_RX:
+        assert_true (endpoint == EP_OUT);
+        assert_int_equal (length, 5);
+        assert_true (!memcmp (data, TPM_ACCESS_0, 4));
+        break;
+    case TPM_ACCESS_HEAD_TX:
+        assert_true (endpoint == EP_IN);
+        assert_int_equal (length, 5);
+        memcpy (data, TPM_ACCESS_0, sizeof (TPM_ACCESS_0));
+        break;
+    case TPM_STS_HEAD_RX:
+        assert_true (endpoint == EP_OUT);
+        assert_int_equal (length, 8);
+        assert_true (!memcmp (data, TPM_STS_0, 4));
+        break;
+    case TPM_STS_HEAD_TX:
+        assert_true (endpoint == EP_IN);
+        assert_int_equal (length, 8);
+        memcpy (data, TPM_STS_0, sizeof (TPM_STS_0));
+        break;
+    case TPM_RID_HEAD_RX:
+        assert_true (endpoint == EP_OUT);
+        assert_int_equal (length, 5);
+        assert_true (!memcmp (data, TPM_RID_0, 4));
+        break;
+    case TPM_RID_HEAD_TX:
+        assert_true (endpoint == EP_IN);
+        assert_int_equal (length, 5);
+        memcpy (data, TPM_RID_0, sizeof (TPM_RID_0));
+        break;
+    default:
+        assert_true (false);
+    }
+
+    tpm_state += 1;
+    *actual_length = length;
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_close.
+ */
+void __wrap_libusb_close (libusb_device_handle *dev_handle)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    free (usb_device);
+    free (dev_handle);
+}
+
+/*
+ * Mock function libusb_exit.
+ */
+void __wrap_libusb_exit (libusb_context *ctx)
+{
+    assert_ptr_equal (ctx, context);
+    free (ctx);
+}
+
+/*
+ * Mock function libusb_init.
+ */
+int __wrap_libusb_init (libusb_context **ctx)
+{
+    context = malloc (1);
+    *ctx = context;
+
+    return 0;
+}
+
+/*
+ * Mock function libusb_strerror.
+ */
+const char * __wrap_libusb_strerror (int errcode)
+{
+    return NULL;
+}
+
+/*
+ * Mock function libusb_open_device_with_vid_pid.
+ */
+libusb_device_handle * __wrap_libusb_open_device_with_vid_pid (
+    libusb_context *ctx, uint16_t vendor_id, uint16_t product_id)
+{
+    assert_ptr_equal (ctx, context);
+    assert_int_equal (vendor_id, VID_CYPRESS);
+    assert_int_equal (product_id, PID_CYUSBSPI);
+
+    device_handle = malloc (1);
+
+    return device_handle;
+}
+
+/*
+ * Mock function libusb_dev_mem_alloc.
+ */
+unsigned char * __wrap_libusb_dev_mem_alloc (libusb_device_handle *dev_handle,
+    size_t length)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+
+    device_mem_alloc_length = length;
+    device_mem_alloc = malloc (length);
+
+    return device_mem_alloc;
+}
+
+/*
+ * Mock function libusb_dev_mem_free.
+ */
+int __wrap_libusb_dev_mem_free (libusb_device_handle *dev_handle,
+    unsigned char *buffer, size_t length)
+{
+    assert_ptr_equal (dev_handle, device_handle);
+    assert_ptr_equal (buffer, device_mem_alloc);
+    assert_int_equal (length, device_mem_alloc_length);
+
+    free (dev_handle);
+    free (buffer);
+
+    return 0;
+}
+
+/*
+ * The test will invoke Tss2_Tcti_Spi_Lt2go_Init() and subsequently
+ * it will start reading TPM_DID_VID, claim locality, read TPM_STS,
+ * and finally read TPM_RID before exiting the Init function.
+ * For testing purpose, the TPM responses are hardcoded.
+ * SPI wait state is not supported in this test.
+ */
+static void
+tcti_spi_no_wait_state_success_test (void **state)
+{
+    TSS2_RC rc;
+    size_t size;
+    TSS2_TCTI_CONTEXT* tcti_ctx;
+
+    /* Get requested TCTI context size */
+    rc = Tss2_Tcti_Spi_Lt2go_Init (NULL, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Allocate TCTI context size */
+    tcti_ctx = (TSS2_TCTI_CONTEXT*) calloc (1, size);
+    assert_non_null (tcti_ctx);
+
+    /* Initialize TCTI context */
+    rc = Tss2_Tcti_Spi_Lt2go_Init (tcti_ctx, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    TSS2_TCTI_SPI_HELPER_PLATFORM platform = ((TSS2_TCTI_SPI_HELPER_CONTEXT *) tcti_ctx)->platform;
+    free (platform.user_data);
+    free (tcti_ctx);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (tcti_spi_no_wait_state_success_test),
+    };
+
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
Bringing up a TCTI module to support the LetsTrust-TPM2Go, a USB TPM from @PaulKissinger. It's a combined effort and resources are taken from:
- @PeterHuewe: https://github.com/PeterHuewe/tpm2-tss/tree/letstrust2go, https://github.com/PeterHuewe/tpm2-tss/tree/letstrust2go-wo-waitstates
- @tobyp: https://gist.github.com/tobyp/aed5598188088f4abbeb737b408e5287

The CI is expected to fail at this stage since the library `libusb-1.0-0-dev` is missing from the CI container image.