### PR TITLE
[RFC] Add tests for vendor

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -31,8 +31,6 @@ check-programs: $(check_PROGRAMS)
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 
-XFAIL_TESTS =
-
 if UNIT
 check_PROGRAMS += test/helper/tpm_cmd_tcti_dummy
 test_helper_tpm_cmd_tcti_dummy_SOURCES = \
@@ -169,9 +167,6 @@ TESTS_UNIT += \
     test/unit/esys-policy-ac-sendselect \
     test/unit/esys-nulltcti \
     test/unit/esys-crypto \
-    test/unit/esys-vendor
-
-XFAIL_TESTS += \
     test/unit/esys-vendor
 
 endif ESYS

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -31,6 +31,8 @@ check-programs: $(check_PROGRAMS)
 check_PROGRAMS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 
+XFAIL_TESTS =
+
 if UNIT
 check_PROGRAMS += test/helper/tpm_cmd_tcti_dummy
 test_helper_tpm_cmd_tcti_dummy_SOURCES = \
@@ -166,7 +168,11 @@ TESTS_UNIT += \
     test/unit/esys-ac-send \
     test/unit/esys-policy-ac-sendselect \
     test/unit/esys-nulltcti \
-    test/unit/esys-crypto
+    test/unit/esys-crypto \
+    test/unit/esys-vendor
+
+XFAIL_TESTS += \
+    test/unit/esys-vendor
 
 endif ESYS
 if FAPI
@@ -725,6 +731,16 @@ test_unit_esys_crypto_SOURCES = test/unit/esys-crypto.c \
                                 src/tss2-esys/esys_iutil.c \
                                 src/tss2-tcti/tctildr.c \
                                 src/tss2-tcti/tctildr-dl.c \
+                                src/tss2-esys/esys_crypto.c \
+                                $(TSS2_ESYS_SRC_CRYPTO)
+
+
+test_unit_esys_vendor_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS) $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_unit_esys_vendor_LDADD = $(CMOCKA_LIBS)  $(TESTS_LDADD) $(LIBADD_DL)
+test_unit_esys_vendor_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_unit_esys_vendor_SOURCES = test/unit/esys-vendor.c \
+                                src/tss2-esys/esys_context.c \
+                                src/tss2-esys/esys_iutil.c \
                                 src/tss2-esys/esys_crypto.c \
                                 $(TSS2_ESYS_SRC_CRYPTO)
 endif # ESYS

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -243,7 +243,7 @@ static TSS2_RC unmarshal_null(uint8_t const buffer[], size_t buffer_size,
  *   type - The type of the TPMU_* being marshaled. This is used to
  *       generate the name of the function and the type of its first
  *       parameter.
- *   The remaining parameters are grouped as 4-tuples. There are 11 of them,
+ *   The remaining parameters are grouped as 4-tuples. There are 12 of them,
  *       each defined as <selector, operator, member, function> where:
  *       selector - The constant value, typically from a table in some TCG
  *           registry, that the generated function will use to select the
@@ -256,13 +256,13 @@ static TSS2_RC unmarshal_null(uint8_t const buffer[], size_t buffer_size,
  *       function - A function capable of marshaling the 'member' from the
  *           TPMU_* being marshaled.
  *
- * This macro takes 11 such 4-tuples. This is the maximum number of members
- * in the TPMU_* types. All parameters after the first 45 parameters (11*4+1)
+ * This macro takes 12 such 4-tuples. This is the maximum number of members
+ * in the TPMU_* types. All parameters after the first 49 parameters (12*4+1)
  * are taken as variadic arguments (...) but they are ignored. The reason for
  * this is documented with the TPMU_MARSHAL2 macro below.
  *
- * NOTE: this macro must be passed 11 4-tuples even when defining TPMU_* types
- * with fewer than 11 members. The extra tuples should be defined as:
+ * NOTE: this macro must be passed 12 4-tuples even when defining TPMU_* types
+ * with fewer than 12 members. The extra tuples should be defined as:
  * <-X, ADDR, m, marshal_null> where:
  *     -X - A unique negative constant value.
  *     ADDR - The macro defined at the top of this file.
@@ -273,7 +273,8 @@ static TSS2_RC unmarshal_null(uint8_t const buffer[], size_t buffer_size,
 #define TPMU_MARSHAL(type, sel, op, m, fn, sel2, op2, m2, fn2, sel3, op3, m3, fn3, \
                      sel4, op4, m4, fn4, sel5, op5, m5, fn5, sel6, op6, m6, fn6, \
                      sel7, op7, m7, fn7, sel8, op8, m8, fn8, sel9, op9, m9, fn9, \
-                     sel10, op10, m10, fn10, sel11, op11, m11, fn11, ...) \
+                     sel10, op10, m10, fn10, sel11, op11, m11, fn11, sel12, op12, \
+                     m12, fn12,  ...) \
 TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buffer[], \
                                  size_t buffer_size, size_t *offset) \
 { \
@@ -319,6 +320,9 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
     case sel11: \
     ret = fn11(op11 src->m11, buffer, buffer_size, offset); \
     break; \
+    case sel12: \
+    ret = fn12(op12 src->m12, buffer, buffer_size, offset); \
+    break; \
     case TPM2_ALG_NULL: \
     LOG_DEBUG("ALG_NULL selector skipping"); \
     ret = TSS2_RC_SUCCESS; \
@@ -333,7 +337,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
 /*
  * The TPMU_MARSHAL2 macro is a thin wrapper around the TPMU_MARSHAL macro.
  * This macro is designed to keep us from having to provide dummy 4-tuples
- * to satisfy the required 45 (11*4+1) parameters required by TPMU_MARSHAL.
+ * to satisfy the required 49 (12*4+1) parameters required by TPMU_MARSHAL.
  *
  * It does this by accepting the tuples describing the variable number of
  * members in a TPMU_* union (except for the first one) as variadic
@@ -342,14 +346,14 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
  * the TPMU_MARSHAL macro.
  *
  * NOTE: Remember that all parameters to the TPMU_MARSHAL macro beyond the
- * first 45 are variadic parameters and are ignored by the macro. This
+ * first 49 are variadic parameters and are ignored by the macro. This
  * allows the TPMU_MARSHAL2 macro to provide the maximum required no-op
  * tuples.
- * e.g. The TPMU_* unions have between 2 and 11 members. A 2 member
+ * e.g. The TPMU_* unions have between 2 and 12 members. A 2 member
  * TPMU_* will require 9 no-op tuples to provide 45 parameters to the
- * TPMU_MARSHAL macro (note the 9 no-op tuples used in the TPMU_MARSHAL2
+ * TPMU_MARSHAL macro (note the 10 no-op tuples used in the TPMU_MARSHAL2
  * macro). The largest TPMU_* with 11 members will need to provide 0 no-op
- * tuples. In this last case the 9 no-op tuples provided by the
+ * tuples. In this last case the 10 no-op tuples provided by the
  * TPMU_MARSHAL2 macro will fall into the variadic parameters accepted by
  * TPMU_MARSHAL and they will be ignored.
  */
@@ -358,7 +362,8 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
                  -2, ADDR, m, marshal_null, -3, ADDR, m, marshal_null, \
                  -4, ADDR, m, marshal_null, -5, ADDR, m, marshal_null, \
                  -6, ADDR, m, marshal_null, -7, ADDR, m, marshal_null, \
-                 -8, ADDR, m, marshal_null, -9, ADDR, m, marshal_null)
+                 -8, ADDR, m, marshal_null, -9, ADDR, m, marshal_null, \
+				 -10, ADDR, m, marshal_null)
 
 /*
  * The TPMU_UNMARSHAL macro functions in the same way as the TPMU_MARSHAL
@@ -370,7 +375,8 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
  */
 #define TPMU_UNMARSHAL(type, sel, m, fn, sel2, m2, fn2, sel3, m3, fn3, \
                        sel4, m4, fn4, sel5, m5, fn5, sel6, m6, fn6, sel7, m7, fn7, \
-                       sel8, m8, fn8, sel9, m9, fn9, sel10, m10, fn10, sel11, m11, fn11, ...) \
+                       sel8, m8, fn8, sel9, m9, fn9, sel10, m10, fn10, sel11, m11, fn11, \
+					   sel12, m12, fn12,...) \
 TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
                                    size_t *offset, uint32_t selector, type *dest) \
 { \
@@ -411,6 +417,9 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     case sel11: \
     ret = fn11(buffer, buffer_size, offset, dest ? &dest->m11 : NULL); \
     break; \
+    case sel12: \
+    ret = fn12(buffer, buffer_size, offset, dest ? &dest->m12 : NULL); \
+    break; \
     case TPM2_ALG_NULL: \
     LOG_DEBUG("ALG_NULL selector skipping"); \
     ret = TSS2_RC_SUCCESS; \
@@ -431,7 +440,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     TPMU_UNMARSHAL(type, sel, m, fn, __VA_ARGS__, -1, m, unmarshal_null, \
             -2, m, unmarshal_null, -3, m, unmarshal_null, -4, m, unmarshal_null, \
             -5, m, unmarshal_null, -6, m, unmarshal_null, -7, m, unmarshal_null, \
-            -8, m, unmarshal_null, -9, m, unmarshal_null)
+            -8, m, unmarshal_null, -9, m, unmarshal_null, -10, m, unmarshal_null)
 
 /*
  * Following are invocations of the TPMU_MARSHAL2 and TPMU_UNMARSHAL2 macros.

--- a/test/unit/esys-vendor.c
+++ b/test/unit/esys-vendor.c
@@ -1,0 +1,201 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_esys.h"
+
+#define LOGMODULE tests
+#include "util/log.h"
+
+typedef struct vendor_tests vendor_tests;
+struct vendor_tests {
+	const char *id;
+	char *resp;
+	TPML_INTEL_PTT_PROPERTY expected;
+};
+
+vendor_tests tests[] = {
+	{
+	    .id = "ptt_property_1_count_1024",
+	    .resp = "8001000000170000000001000001000000000100000003",
+        .expected = {
+        	.count = 1,
+			.property = { 0x3, }
+        },
+	},
+};
+
+#define TEST_MOCK_SETUP will_return_always(tcti_fake_recv, __func__)
+
+static void unhex(const char *hexstr, uint8_t *buf, size_t *len) {
+
+	/* should always be even in length ie bit index 0 unset */
+	size_t l = strlen(hexstr);
+	assert_false(l & 0x1);
+
+	*len = l >> 1;
+
+	size_t i;
+    for (i = 0; i < *len; i++) {
+        char tmp_str[4] = { 0 };
+        tmp_str[0] = hexstr[i * 2];
+        tmp_str[1] = hexstr[i * 2 + 1];
+        buf[i] = strtol(tmp_str, NULL, 16);
+    }
+}
+
+#define get_expected(expected) _get_expected(__func__, (expected))
+static void _get_expected(const char *id, TPML_INTEL_PTT_PROPERTY *expected) {
+
+    size_t i;
+    for(i=0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        vendor_tests *t = &tests[i];
+        if (!strcmp(t->id, id)) {
+            *expected = t->expected;
+            return;
+        }
+    }
+    assert_true(false);
+
+}
+
+
+static void get_response(const char *id, uint8_t *resp_buf, size_t *resp_len) {
+
+    if (!resp_buf) {
+        *resp_len = 4096;
+        return;
+    }
+
+	size_t i;
+	for(i=0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+		vendor_tests *t = &tests[i];
+		if (!strcmp(t->id, id)) {
+			unhex(t->resp, resp_buf, resp_len);
+			return;
+		}
+	}
+	assert_true(false);
+}
+
+
+#define TCTI_FAKE_MAGIC 0x46414b4500000000ULL        /* 'FAKE\0' */
+#define TCTI_FAKE_VERSION 0x1
+
+typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_FAKE;
+
+void
+tcti_fake_finalize(TSS2_TCTI_CONTEXT *tctiContext)
+{
+    UNUSED(tctiContext);
+}
+
+static TSS2_RC tcti_fake_transmit(
+		TSS2_TCTI_CONTEXT *tctiContext,
+	    size_t size,
+	    uint8_t const *command) {
+
+	UNUSED(tctiContext);
+	UNUSED(size);
+	UNUSED(command);
+	return TSS2_RC_SUCCESS;
+}
+
+static TSS2_RC tcti_fake_recv(
+		TSS2_TCTI_CONTEXT *tctiContext,
+	    size_t *size,
+	    uint8_t *response,
+	    int32_t timeout) {
+	UNUSED(tctiContext);
+	UNUSED(timeout);
+
+	const char *id = (const char *)mock();
+
+	get_response(id, response, size);
+	return TSS2_RC_SUCCESS;
+}
+
+
+TSS2_RC
+Tss2_FAKE_TCTI_Initialize (const char *nameConf,
+                                TSS2_TCTI_CONTEXT **tcti)
+{
+    if (tcti == NULL)
+        return TSS2_BASE_RC_GENERAL_FAILURE;
+
+    /* This is to calm down scan-build */
+    TSS2_TCTI_CONTEXT_FAKE **faketcti = (TSS2_TCTI_CONTEXT_FAKE **) tcti;
+
+    *faketcti = calloc(1, sizeof(TSS2_TCTI_CONTEXT_FAKE));
+    TSS2_TCTI_MAGIC(*faketcti) = TCTI_FAKE_MAGIC;
+    TSS2_TCTI_VERSION(*faketcti) = TCTI_FAKE_VERSION;
+    TSS2_TCTI_TRANSMIT(*faketcti) = tcti_fake_transmit;
+    TSS2_TCTI_RECEIVE(*faketcti) = tcti_fake_recv;
+    TSS2_TCTI_FINALIZE(*faketcti) = tcti_fake_finalize;
+    TSS2_TCTI_CANCEL(*faketcti) = NULL;
+    TSS2_TCTI_GET_POLL_HANDLES(*faketcti) = NULL;
+    TSS2_TCTI_SET_LOCALITY(*faketcti) = NULL;
+
+    return TSS2_RC_SUCCESS;
+}
+
+static int test_setup(void **state) {
+	Tss2_FAKE_TCTI_Initialize(NULL,
+			(TSS2_TCTI_CONTEXT **)state);
+	return 0;
+}
+
+static int test_teardown(void **state) {
+	free(*state);
+	*state = NULL;
+	return 0;
+}
+
+
+static void
+ptt_property_1_count_1024(void **state)
+{
+    TSS2_RC r;
+    ESYS_CONTEXT *ectx;
+
+    TEST_MOCK_SETUP;
+
+    r = Esys_Initialize(&ectx, (TSS2_TCTI_CONTEXT*)*state, NULL);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+
+    TPMI_YES_NO more_data;
+    TPMS_CAPABILITY_DATA *cap_data = NULL;
+    r = Esys_GetCapability(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+    		TPM2_CAP_VENDOR_PROPERTY, 1, 1024, &more_data, &cap_data);
+    assert_int_equal(r, TSS2_RC_SUCCESS);
+    assert_int_equal(cap_data->capability, TPM2_CAP_VENDOR_PROPERTY);
+
+    TPML_INTEL_PTT_PROPERTY expected = { 0 };
+    get_expected(&expected);
+    assert_int_equal(cap_data->data.intelPttProperty.count, expected.count);
+    assert_int_equal(cap_data->data.intelPttProperty.property[0], expected.property[0]);
+
+    Esys_Free(cap_data);
+    Esys_Finalize(&ectx);
+}
+
+int
+main(int argc, char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+    		cmocka_unit_test_setup_teardown(ptt_property_1_count_1024,
+    				test_setup, test_teardown),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
@AndreasFuchsTPM for completeness wanted to show the state of the current master:

Unmarshaling a TPMU_CAPABILITIES fails for the last field, which happened to be intelPttProperty. Not sure about marshaling, seems to suffer from the same bug. The bug is that @tstruk can't count :-p. The magic macros work for up to 11 fields, but their was 12. The direct functions Tss2_MU_TPML_INTEL_PTT_PROPERTY_Unmarshal seem to work.

So right now their was no way to call GetCap and get a valid unmarshalled intelPttProperty.

I think we want to merge this, as it keeps it "fixed" for the vendor field even though we marshal that by hand. 

I have some code on another branch I need to clean up, but it does this all with the vendor buffers, and Ill make the tests backwards compat and cherry-pick it before the vendor tpm2b change so we can ensure it's backwards compat.
