### PR TITLE
ESYS: Allow usage of sha512 for mbedtls.

### DIFF
--- a/src/tss2-esys/esys_crypto_mbed.c
+++ b/src/tss2-esys/esys_crypto_mbed.c
@@ -87,6 +87,9 @@ iesys_cryptmbed_hash_start(ESYS_CRYPTO_CONTEXT_BLOB ** context,
       case TPM2_ALG_SHA384:
           md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
           break;
+    case TPM2_ALG_SHA512:
+          md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
+          break;
     }
 
     if (md_info == NULL) {

--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -43,17 +43,10 @@ check_hash_functions(void **state)
     rc = iesys_crypto_hash_start(&crypto_cb, NULL, TPM2_ALG_SHA384);
     assert_int_equal (rc, TSS2_ESYS_RC_BAD_REFERENCE);
 
-#ifndef OSSL
-    context = NULL;
-    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA512);
-    assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
-    assert_null (context);
-#endif
-
     rc = iesys_crypto_hash_start(&crypto_cb, &context, 0);
     assert_int_equal (rc, TSS2_ESYS_RC_NOT_IMPLEMENTED);
 
-    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA384);
+    rc = iesys_crypto_hash_start(&crypto_cb, &context, TPM2_ALG_SHA512);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
     rc = iesys_crypto_hash_finish(&crypto_cb, NULL, &buffer[0], &size);


### PR DESCRIPTION
* sha512 now is possible in iesys_cryptmbed_hash_start.
* The corresponding unit test was adapted.

Fixes: #2490

Signed-off-by: Juergen Repp <juergen_repp@web.de>