### PR TITLE
FAPI: Fix double free if keystore is corrupted.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -644,6 +644,7 @@ ifapi_keystore_load_finish(
     if (jso)
         json_object_put(jso);
     LOG_TRACE("Return %x", r);
+    object->rel_path = NULL;
     SAFE_FREE(keystore->rel_path);
     return r;
 }


### PR DESCRIPTION
If the keystore contains invalid JSON data for an object a double free during the object cleanup occurs.
The corresponding value in the object is now set to NULL after the first free.

Signed-off-by: Juergen Repp <juergen_repp@web.de>
Signed-off-by: William Roberts <william.c.roberts@intel.com>