### PR TITLE
tests: rm tcti-spi-helper tests when not enabled

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -117,7 +117,6 @@ TESTS_UNIT  = \
     test/unit/tctildr-nodl \
     test/unit/tctildr-tcti \
     test/unit/tctildr-getinfo \
-    test/unit/tcti-spi-helper \
     test/unit/dlopen-fail \
     test/unit/dlopen-UINT8-marshal \
     test/unit/dlopen-TPM2B-marshal \
@@ -153,7 +152,9 @@ endif
 if ENABLE_TCTI_CMD
 TESTS_UNIT += test/unit/tcti-cmd
 endif
-
+if ENABLE_TCTI_SPI_HELPER
+TESTS_UNIT += test/unit/tcti-spi-helper
+endif
 if ESYS
 TESTS_UNIT += \
     test/unit/esys-context-null \
@@ -520,9 +521,11 @@ test_unit_tcti_cmd_SOURCES = test/unit/tcti-cmd.c \
     src/tss2-tcti/tcti-cmd.c src/tss2-tcti/tcti-cmd.h test/unit/tcti-cmd-test.h
 endif
 
+if ENABLE_TCTI_SPI_HELPER
 test_unit_tcti_spi_helper_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tcti_spi_helper_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
 test_unit_tcti_spi_helper_SOURCES = test/unit/tcti-spi-helper.c
+endif
 
 test_unit_tctildr_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
 test_unit_tctildr_LDADD = $(CMOCKA_LIBS) $(libutil)


### PR DESCRIPTION
When configure time flags --disable-tcti-spi-helper and --enable-unit are used in conjunction, the unit tests for the spi tcti helper are built but the code is not, causing undefined references at link. Correct this by guarding the tests in AM conditionals based on if spi helper tcti is enabled.

Corrects Error:
/usr/bin/ld: test/unit/tcti_spi_helper-tcti-spi-helper.o: in function `tcti_spi_no_wait_state_success_test': /.../tpm2-tss/test/unit/tcti-spi-helper.c:215: undefined reference to `Tss2_Tcti_Spi_Helper_Init' /usr/bin/ld: /.../tpm2-tss/test/unit/tcti-spi-helper.c:224: undefined reference to `Tss2_Tcti_Spi_Helper_Init' /usr/bin/ld: test/unit/tcti_spi_helper-tcti-spi-helper.o: in function `tcti_spi_with_wait_state_success_test': /.../tpm2-tss/test/unit/tcti-spi-helper.c:244: undefined reference to `Tss2_Tcti_Spi_Helper_Init' /usr/bin/ld: /.../tpm2-tss/test/unit/tcti-spi-helper.c:253: undefined reference to `Tss2_Tcti_Spi_Helper_Init' collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:16502: test/unit/tcti-spi-helper] Error 1 make[1]: *** Waiting for unfinished jobs....

Fixes: #2489

Signed-off-by: William Roberts <william.c.roberts@intel.com>