### PR TITLE
headers: use ifndef over if !defined for CFFI

### DIFF
--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -2024,7 +2024,7 @@ Tss2_MU_TPM2B_MAX_CAP_BUFFER_Unmarshal(
         size_t               *offset,
         TPM2B_MAX_CAP_BUFFER *dest);
 
-#if !defined(DISABLE_VENDOR)
+#ifndef DISABLE_VENDOR
 TSS2_RC
 Tss2_MU_TPML_INTEL_PTT_PROPERTY_Marshal(
     TPML_INTEL_PTT_PROPERTY const *src,

--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -2037,7 +2037,7 @@ struct TPML_AC_CAPABILITIES {
     TPMS_AC_OUTPUT acCapabilities[TPM2_MAX_AC_CAPABILITIES]; /* List of AC values */
 };
 
-#if !defined(DISABLE_VENDOR)
+#ifndef DISABLE_VENDOR
 /* Implementation specific structure to hold Intel PTT specific property data. */
 typedef struct TPML_INTEL_PTT_PROPERTY TPML_INTEL_PTT_PROPERTY;
 struct TPML_INTEL_PTT_PROPERTY {

--- a/test/unit/TPML-marshal.c
+++ b/test/unit/TPML-marshal.c
@@ -473,7 +473,7 @@ tpml_unmarshal_invalid_count(void **state)
     assert_int_equal (rc, TSS2_SYS_RC_MALFORMED_RESPONSE);
 }
 
-#if !defined(DISABLE_VENDOR)
+#ifndef DISABLE_VENDOR
 static void
 tpml_intel_ptt_marshal_unmarshal(void **state)
 {
@@ -524,7 +524,7 @@ int main(void) {
         cmocka_unit_test (tpml_unmarshal_dest_null_offset_valid),
         cmocka_unit_test (tpml_unmarshal_buffer_size_lt_data_nad_lt_offset),
         cmocka_unit_test (tpml_unmarshal_invalid_count),
-#if !defined(DISABLE_VENDOR)
+#ifndef DISABLE_VENDOR
         cmocka_unit_test (tpml_intel_ptt_marshal_unmarshal)
 #endif
     };


### PR DESCRIPTION
CFFI doesn't like if !defined(xxx), update all the DISABLE_VENDOR calls and make the style consistent through the source for those macros only.

Fixes:
cffi.CDefError: cannot parse "#if !defined(DISABLE_VENDOR)" <cdef source string>:2193:2: before: if
[end of output]

Signed-off-by: William Roberts <william.c.roberts@intel.com>