### PR TITLE
test/fapi: test Fapi_SetBranchCB NULL

### DIFF
--- a/test/integration/fapi-key-create-policy-or-sign.int.c
+++ b/test/integration/fapi-key-create-policy-or-sign.int.c
@@ -160,6 +160,19 @@ test_fapi_key_create_policy_or_sign(FAPI_CONTEXT *context)
     ASSERT(strstr(publicKey, "BEGIN PUBLIC KEY"));
     ASSERT(strstr(certificate, "BEGIN CERTIFICATE"));
 
+
+    /* Test that a NULL branch causes an error */
+    r = Fapi_SetBranchCB(context, NULL, NULL);
+    goto_if_error(r, "Error SetPolicybranchselectioncallback", error);
+
+    r = Fapi_Sign(context, "/HS/SRK/mySignKey", NULL,
+                  &digest.buffer[0], digest.size, &signature, &signatureSize,
+                  &publicKey, &certificate);
+    if (r == TSS2_RC_SUCCESS) {
+        LOG_ERROR("Fapi_Sign should fail with a NULL callback");
+        goto error;
+    }
+
     r = Fapi_Delete(context, "/");
     goto_if_error(r, "Error Fapi_Delete", error);
 


### PR DESCRIPTION
Somewhere between 3.0.0 and 3.1.0 we fixed double free but, but we did not maintain commit atomicity and therfore my efforts to bisect were thwarted. I checked a few patches by hand and couldn't find the source of the fix. However, add a regression test.

Signed-off-by: William Roberts <william.c.roberts@intel.com>