### PR TITLE
TCTI: Add USB TPM (FTDI MPSSE USB to SPI bridge) TCTI module

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ task:
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive
     - pkg install -y automake openssl json-c cmocka uthash wget curl git util-linux
+    - pkg install -y libftdi1
     - wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
     - shasum -a256 $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
     - mkdir -p $ibmtpm_name

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,8 @@ jobs:
               libcurl4-openssl-dev \
               uuid-dev \
               libltdl-dev \
-              libusb-1.0-0-dev
+              libusb-1.0-0-dev \
+              libftdi-dev
 
       - name: After Prepare (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,8 @@ $ sudo apt -y install \
   libcurl4-openssl-dev \
   uuid-dev \
   libltdl-dev \
-  libusb-1.0-0-dev
+  libusb-1.0-0-dev \
+  libftdi-dev
 ```
 Note: In some Ubuntu versions, the lcov and autoconf-archive packages are incompatible with each other. It is recommended to download autoconf-archive directly from upstream and copy `ax_code_coverage.m4` and `ax_prog_doxygen.m4` to the `m4/` subdirectory of your tpm2-tss directory.
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -158,6 +158,9 @@ endif
 if ENABLE_TCTI_SPI_LT2GO
 TESTS_UNIT += test/unit/tcti-spi-lt2go
 endif
+if ENABLE_TCTI_SPI_FTDI
+TESTS_UNIT += test/unit/tcti-spi-ftdi
+endif
 if ESYS
 TESTS_UNIT += \
     test/unit/esys-context-null \
@@ -557,6 +560,20 @@ test_unit_tcti_spi_lt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
                                    -Wl,--wrap=libusb_strerror
 test_unit_tcti_spi_lt2go_SOURCES = test/unit/tcti-spi-lt2go.c \
                                    src/tss2-tcti/tcti-spi-lt2go.c
+endif
+
+if ENABLE_TCTI_SPI_FTDI
+test_unit_tcti_spi_ftdi_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_spi_ftdi_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
+test_unit_tcti_spi_ftdi_LDFLAGS = -Wl,--wrap=Close \
+                                  -Wl,--wrap=MPSSE \
+                                  -Wl,--wrap=PinHigh \
+                                  -Wl,--wrap=PinLow \
+                                  -Wl,--wrap=Start \
+                                  -Wl,--wrap=Stop \
+                                  -Wl,--wrap=Transfer
+test_unit_tcti_spi_ftdi_SOURCES = test/unit/tcti-spi-ftdi.c \
+                                  src/tss2-tcti/tcti-spi-ftdi.c
 endif
 
 test_unit_tctildr_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -444,6 +444,31 @@ endif # ENABLE_TCTI_SPI_LT2GO
 EXTRA_DIST += lib/tss2-tcti-spi-lt2go.map \
               lib/tss2-tcti-spi-lt2go.def
 
+# tcti library for ftdi connected tpm
+if ENABLE_TCTI_SPI_FTDI
+libtss2_tcti_spi_ftdi = src/tss2-tcti/libtss2-tcti-spi-ftdi.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_spi_ftdi.h
+lib_LTLIBRARIES += $(libtss2_tcti_spi_ftdi)
+pkgconfig_DATA += lib/tss2-tcti-spi-ftdi.pc
+EXTRA_DIST += lib/tss2-tcti-spi-ftdi.map \
+              lib/tss2-tcti-spi-ftdi.def
+
+src_tss2_tcti_libtss2_tcti_spi_ftdi_la_CFLAGS  = $(AM_CFLAGS) $(LIBFTDI_CFLAGS) -Wno-deprecated-declarations
+src_tss2_tcti_libtss2_tcti_spi_ftdi_la_LDFLAGS  = $(LIBFTDI_LIBS)
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_spi_ftdi_la_LDFLAGS  += -Wl,--version-script=$(srcdir)/lib/tss2-tcti-spi-ftdi.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_spi_ftdi_la_LIBADD   = $(libutil) $(libtss2_mu) $(libtss2_tcti_spi_helper)
+src_tss2_tcti_libtss2_tcti_spi_ftdi_la_SOURCES  = \
+    src/tss2-tcti/mpsse/support.c \
+    src/tss2-tcti/mpsse/support.h \
+    src/tss2-tcti/mpsse/mpsse.c \
+    src/tss2-tcti/mpsse/mpsse.h \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-spi-ftdi.c \
+    src/tss2-tcti/tcti-spi-ftdi.h
+endif # ENABLE_TCTI_SPI_FTDI
+
 ### TCG TSS SYS spec library ###
 libtss2_sys = src/tss2-sys/libtss2-sys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_sys.h
@@ -828,6 +853,7 @@ man7_MANS = \
     man/man7/tss2-tcti-cmd.7 \
     man/man7/tss2-tcti-spi-helper.7 \
     man/man7/tss2-tcti-spi-lt2go.7 \
+    man/man7/tss2-tcti-spi-ftdi.7 \
     man/man7/tss2-tctildr.7
 
 if FAPI
@@ -908,6 +934,7 @@ EXTRA_DIST += \
     man/tss2-tcti-cmd.7.in \
     man/tss2-tcti-spi-helper.7.in \
     man/tss2-tcti-spi-lt2go.7.in \
+    man/tss2-tcti-spi-ftdi.7.in \
     man/tss2-tctildr.7.in
 
 CLEANFILES += \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc lib/tss2-tcti-spi-ftdi.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -320,6 +320,33 @@ AM_CONDITIONAL([ENABLE_TCTI_SPI_LT2GO], [test "x$enable_tcti_spi_lt2go" != xno])
 
 AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
     AC_DEFINE([TCTI_SPI_LT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
+
+AC_ARG_ENABLE([tcti-spi-ftdi],
+              [AS_HELP_STRING([--disable-tcti-spi-ftdi],
+                              [don't build the tcti-spi-ftdi module])],
+              [AS_IF([test "x$enable_tcti_spi_ftdi" = "xyes"],
+                     [PKG_CHECK_MODULES([LIBFTDI],
+                                        [libftdi],
+                                        [AC_DEFINE(LIBFTDI_VERSION, [0], [libftdi version 0.x])],
+                                        [PKG_CHECK_MODULES([LIBFTDI],
+                                                           [libftdi1],
+                                                           [AC_DEFINE(LIBFTDI_VERSION, [1], [libftdi version 1.x])],
+                                                           [AC_MSG_ERROR([libftdi/libftdi1 library is missing.])])])])],
+              [PKG_CHECK_MODULES([LIBFTDI],
+                                 [libftdi],
+                                 [enable_tcti_spi_ftdi=yes]
+                                 [AC_DEFINE(LIBFTDI_VERSION, [0], [libftdi version 0.x])],
+                                 [PKG_CHECK_MODULES([LIBFTDI],
+                                                    [libftdi1],
+                                                    [enable_tcti_spi_ftdi=yes]
+                                                    [AC_DEFINE(LIBFTDI_VERSION, [1], [libftdi version 1.x])],
+                                                    [enable_tcti_spi_ftdi=no]
+                                                    [AC_MSG_ERROR([libftdi/libftdi1 library is missing.])])])])
+
+AM_CONDITIONAL([ENABLE_TCTI_SPI_FTDI], [test "x$enable_tcti_spi_ftdi" != xno])
+
+AS_IF([test "x$enable_tcti_spi_ftdi" = "xyes"],
+    AC_DEFINE([TCTI_SPI_FTDI],[1], [TCTI FOR USB BASED ACCESS TO SPI BASED TPM OVER THE FTDI MPSSE USB TO SPI BRIDGE]))
 
 AC_ARG_ENABLE([tcti-fuzzing],
             [AS_HELP_STRING([--enable-tcti-fuzzing],
@@ -668,4 +695,5 @@ AC_MSG_RESULT([
     sysmeasurements:    $sysmeasurements
     imameasurements:    $imameasurements
     tcti_spi_lt2go      $enable_tcti_spi_lt2go
+    tcti_spi_ftdi       $enable_tcti_spi_ftdi
 ])

--- a/doc/tcti-spi-ftdi.md
+++ b/doc/tcti-spi-ftdi.md
@@ -1,0 +1,60 @@
+# SPI TCTI FTDI
+
+The SPI TCTI FTDI can be used for communication with a SPI-based TPM over the FTDI MPSSE
+USB to SPI bridge. The FTDI module utilizes the `tcti-spi-helper` library for handling the
+PTP SPI protocol and the `libftdi-dev` library for handling the USB to SPI communication.
+
+Example of a FTDI MPSSE USB to SPI bridge is the product "USB 2.0 Hi-Speed to MPSSE
+Cable (SPI/I2C/JTAG master) with +3.3V digital level signals", part no: C232HM-DDHSL-0.
+Connect the cable to your TPM as specified in the table below:
+
+|    C232HM-DDHSL-0   | Description |
+|---------------------|-------------|
+|  VCC, red, pin 1    |     VCC     |
+|  SK, orange, pin 2  |     SCLK    |
+|  DO, yellow, pin 3  |     MOSI    |
+|  DI, green, pin 4   |     MISO    |
+|  CS, brown, pin 5   |     CS      |
+|  GND, black, pin 10 |     GND     |
+
+# EXAMPLES
+
+Set udev rules for the C232HM-DDHSL-0 cable by creating a file `/etc/udev/rules.d/60-c232hm.rules`:
+```
+ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6014", TAG+="uaccess"
+```
+
+Activate the udev rules:
+```console
+sudo udevadm control --reload
+```
+
+You should see the following after plugging in the C232HM-DDHSL-0 cable:
+```
+dmesg
+ [74386.091721] usb 3-2: new high-speed USB device number 18 using xhci_hcd
+ [74386.439103] usb 3-2: New USB device found, idVendor=0403, idProduct=6014, bcdDevice= 9.00
+ [74386.439117] usb 3-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+ [74386.439129] usb 3-2: Product: C232HM-DDHSL-0
+ [74386.439140] usb 3-2: Manufacturer: FTDI
+ [74386.439151] usb 3-2: SerialNumber: FT1UGJKF
+ [74386.443996] ftdi_sio 3-2:1.0: FTDI USB Serial Device converter detected
+ [74386.444030] usb 3-2: Detected FT232H
+ [74386.446370] usb 3-2: FTDI USB Serial Device converter now attached to ttyUSB0
+```
+
+Use tcti-spi-ftdi to communicate with a SPI-based TPM:
+```console
+tpm2_startup -Tspi-ftdi -c
+tpm2_getrandom -Tspi-ftdi 8 --hex
+```
+
+Enable abrmd:
+```console
+export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork`
+tpm2-abrmd --allow-root --session --tcti=spi-ftdi &
+
+export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
+tpm2_startup -c
+tpm2_getrandom 8 --hex
+```

--- a/include/tss2/tss2_tcti_spi_ftdi.h
+++ b/include/tss2/tss2_tcti_spi_ftdi.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TSS2_TCTI_SPI_FTDI_H
+#define TSS2_TCTI_SPI_FTDI_H
+
+#include <stdbool.h>
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Spi_Ftdi_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_SPI_FTDI_H */

--- a/lib/tss2-tcti-spi-ftdi.def
+++ b/lib/tss2-tcti-spi-ftdi.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-spi-ftdi
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Spi_Ftdi_Init

--- a/lib/tss2-tcti-spi-ftdi.map
+++ b/lib/tss2-tcti-spi-ftdi.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Spi_Ftdi_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-spi-ftdi.pc.in
+++ b/lib/tss2-tcti-spi-ftdi.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-spi-ftdi
+Description: TCTI library for communicating with a TPM over USB-FTDI-SPI converter.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Cflags: -I${includedir} -I${includedir}/tss
+Libs: -ltss2-tcti-spi-helper -ltss2-tcti-spi-ftdi -L${libdir} -lftdi

--- a/man/tss2-tcti-spi-ftdi.7.in
+++ b/man/tss2-tcti-spi-ftdi.7.in
@@ -1,0 +1,14 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-SPI 7 "NOVEMBER 2022" "TPM2 Software Stack"
+.SH NAME
+tcti-spi-ftdi \- USB to SPI-based TPM TCTI library
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for interaction with
+a SPI-based TPM over the FTDI MPSSE USB to SPI bridge.
+.SH DESCRIPTION
+tcti-spi-ftdi is a library that abstracts the details of communication
+with a SPI-based TPM over the FTDI MPSSE USB to SPI bridge. The interface
+exposed by this library is defined in the \*(lqTSS System Level API and
+and TPM Command Transmission Interface Specification\*(rq specification.

--- a/src/tss2-tcti/mpsse/mpsse.c
+++ b/src/tss2-tcti/mpsse/mpsse.c
@@ -1,0 +1,1278 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+/*
+ * This file was copied from https://github.com/devttys0/libmpsse.git (sha1: a2eafa2)
+ * and modified accordingly.
+ *
+ * Copyright (c) 2015, Craig Heffner
+ * All rights reserved.
+ * SPDX short identifier: BSD-2-Clause
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/time.h>
+
+#include "mpsse.h"
+#include "support.h"
+#include "config.h"
+
+/* List of known FT2232-based devices */
+struct vid_pid supported_devices[] = {
+    { 0x0403, 0x6014, "FT232H Future Technology Devices International, Ltd" },
+    { 0x0403, 0x6010, "FT2232 Future Technology Devices International, Ltd" },
+    { 0x0403, 0x6011, "FT4232 Future Technology Devices International, Ltd" },
+
+    /* These devices are based on FT2232 chips, but have not been tested. */
+    { 0x0403, 0x8878, "Bus Blaster v2 (channel A)" },
+    { 0x0403, 0x8879, "Bus Blaster v2 (channel B)" },
+    { 0x0403, 0xBDC8, "Turtelizer JTAG/RS232 Adapter A" },
+    { 0x0403, 0xCFF8, "Amontec JTAGkey" },
+    { 0x0403, 0x8A98, "TIAO Multi Protocol Adapter"},
+    { 0x15BA, 0x0003, "Olimex Ltd. OpenOCD JTAG" },
+    { 0x15BA, 0x0004, "Olimex Ltd. OpenOCD JTAG TINY" },
+
+    { 0, 0, NULL }
+};
+
+/*
+ * Opens and initializes the first FTDI device found.
+ *
+ * @mode      - Mode to open the device in. One of enum modes.
+ * @freq      - Clock frequency to use for the specified mode.
+ * @endianess - Specifies how data is clocked in/out (MSB, LSB).
+ *
+ * Returns a pointer to an MPSSE context structure.
+ * On success, mpsse->open will be set to 1.
+ * On failure, mpsse->open will be set to 0.
+ */
+struct mpsse_context *MPSSE (enum modes mode, int freq, int endianess)
+{
+    int i = 0;
+    struct mpsse_context *mpsse = NULL;
+
+    for (i=0; supported_devices[i].vid != 0; i++)
+    {
+        if ((mpsse = Open (supported_devices[i].vid, supported_devices[i].pid, mode, freq, endianess, IFACE_A, NULL, NULL)) != NULL)
+        {
+            if (mpsse->open)
+            {
+                mpsse->description = supported_devices[i].description;
+                break;
+            }
+            /* If there is another device still left to try, free the context pointer and try again */
+            else if (supported_devices[i+1].vid != 0)
+            {
+                Close (mpsse);
+                mpsse = NULL;
+            }
+        }
+    }
+
+    return mpsse;
+}
+
+/*
+ * Open device by VID/PID
+ *
+ * @vid         - Device vendor ID.
+ * @pid         - Device product ID.
+ * @mode        - MPSSE mode, one of enum modes.
+ * @freq        - Clock frequency to use for the specified mode.
+ * @endianess   - Specifies how data is clocked in/out (MSB, LSB).
+ * @interface   - FTDI interface to use (IFACE_A - IFACE_D).
+ * @description - Device product description (set to NULL if not needed).
+ * @serial      - Device serial number (set to NULL if not needed).
+ *
+ * Returns a pointer to an MPSSE context structure.
+ * On success, mpsse->open will be set to 1.
+ * On failure, mpsse->open will be set to 0.
+ */
+struct mpsse_context *Open (int vid, int pid, enum modes mode, int freq, int endianess, int interface, const char *description, const char *serial)
+{
+    return OpenIndex (vid, pid, mode, freq, endianess, interface, description, serial, 0);
+}
+
+/*
+ * Open device by VID/PID/index
+ *
+ * @vid         - Device vendor ID.
+ * @pid         - Device product ID.
+ * @mode        - MPSSE mode, one of enum modes.
+ * @freq        - Clock frequency to use for the specified mode.
+ * @endianess   - Specifies how data is clocked in/out (MSB, LSB).
+ * @interface   - FTDI interface to use (IFACE_A - IFACE_D).
+ * @description - Device product description (set to NULL if not needed).
+ * @serial      - Device serial number (set to NULL if not needed).
+ * @index       - Device index (set to 0 if not needed).
+ *
+ * Returns a pointer to an MPSSE context structure.
+ * On success, mpsse->open will be set to 1.
+ * On failure, mpsse->open will be set to 0.
+ */
+struct mpsse_context *OpenIndex (int vid, int pid, enum modes mode, int freq, int endianess, int interface, const char *description, const char *serial, int index)
+{
+    int status = 0;
+    struct mpsse_context *mpsse = NULL;
+
+    mpsse = malloc (sizeof(struct mpsse_context));
+    if (mpsse)
+    {
+        memset (mpsse, 0, sizeof (struct mpsse_context));
+
+        /* Legacy; flushing is no longer needed, so disable it by default. */
+        FlushAfterRead (mpsse, 0);
+
+        /* ftdilib initialization */
+        if (ftdi_init (&mpsse->ftdi) == 0)
+        {
+            /* Set the FTDI interface  */
+            ftdi_set_interface (&mpsse->ftdi, interface);
+
+            /* Open the specified device */
+            if (ftdi_usb_open_desc_index (&mpsse->ftdi, vid, pid, description, serial, index) == 0)
+            {
+                mpsse->mode = mode;
+                mpsse->vid = vid;
+                mpsse->pid = pid;
+                mpsse->status = STOPPED;
+                mpsse->endianess = endianess;
+
+                /* Set the appropriate transfer size for the requested protocol */
+                if (mpsse->mode == I2C)
+                {
+                    mpsse->xsize = I2C_TRANSFER_SIZE;
+                }
+                else
+                {
+                    mpsse->xsize = SPI_RW_SIZE;
+                }
+
+                status |= ftdi_usb_reset (&mpsse->ftdi);
+                status |= ftdi_set_latency_timer (&mpsse->ftdi, LATENCY_MS);
+                status |= ftdi_write_data_set_chunksize (&mpsse->ftdi, CHUNK_SIZE);
+                status |= ftdi_read_data_set_chunksize (&mpsse->ftdi, CHUNK_SIZE);
+                status |= ftdi_set_bitmode (&mpsse->ftdi, 0, BITMODE_RESET);
+
+                if (status == 0)
+                {
+                    /* Set the read and write timeout periods */
+                    set_timeouts (mpsse, USB_TIMEOUT);
+
+                    if (mpsse->mode != BITBANG)
+                    {
+                        ftdi_set_bitmode (&mpsse->ftdi, 0, BITMODE_MPSSE);
+
+                        if (SetClock (mpsse, freq) == MPSSE_OK)
+                        {
+                            if (SetMode (mpsse, endianess) == MPSSE_OK)
+                            {
+                                int32_t ms = SETUP_DELAY/1000;
+                                struct timeval tv = {ms/1000, (ms%1000)*1000};
+
+                                mpsse->open = 1;
+
+                                /* Give the chip a few mS to initialize */
+                                select (0, NULL, NULL, NULL, &tv);
+
+                                /*
+                                 * Not all FTDI chips support all the commands that SetMode may have sent.
+                                 * This clears out any errors from unsupported commands that might have been sent during set up.
+                                 */
+                                ftdi_usb_purge_buffers (&mpsse->ftdi);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        /* Skip the setup functions if we're just operating in BITBANG mode */
+                        if (ftdi_set_bitmode (&mpsse->ftdi, 0xFF, BITMODE_BITBANG) == 0)
+                        {
+                            mpsse->open = 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return mpsse;
+}
+
+/*
+ * Closes the device, deinitializes libftdi, and frees the MPSSE context pointer.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns void.
+ */
+void Close (struct mpsse_context *mpsse)
+{
+    if (mpsse)
+    {
+        if (mpsse->open)
+        {
+            ftdi_set_bitmode (&mpsse->ftdi, 0, BITMODE_RESET);
+            ftdi_usb_close (&mpsse->ftdi);
+            ftdi_deinit (&mpsse->ftdi);
+        }
+
+        free (mpsse);
+        mpsse = NULL;
+    }
+
+    return;
+}
+
+/* Enables bit-wise data transfers.
+ * Must be called after MPSSE() / Open() / OpenIndex().
+ *
+ * Returns void.
+ */
+void EnableBitmode (struct mpsse_context *mpsse, int tf)
+{
+    if (is_valid_context (mpsse))
+    {
+        if (tf)
+        {
+            mpsse->tx |= MPSSE_BITMODE;
+            mpsse->rx |= MPSSE_BITMODE;
+            mpsse->txrx |= MPSSE_BITMODE;
+        }
+        else
+        {
+            mpsse->tx &= ~MPSSE_BITMODE;
+            mpsse->rx &= ~MPSSE_BITMODE;
+            mpsse->txrx &= ~MPSSE_BITMODE;
+        }
+    }
+}
+
+/*
+ * Sets the appropriate transmit and receive commands based on the requested mode and byte order.
+ *
+ * @mpsse     - MPSSE context pointer.
+ * @endianess - MPSSE_MSB or MPSSE_LSB.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int SetMode (struct mpsse_context *mpsse, int endianess)
+{
+    int retval = MPSSE_OK, i = 0, setup_commands_size = 0;
+    unsigned char buf[CMD_SIZE] = { 0 };
+    unsigned char setup_commands[CMD_SIZE*MAX_SETUP_COMMANDS] = { 0 };
+
+    /* Do not call is_valid_context() here, as the FTDI chip may not be completely configured when SetMode is called */
+    if (mpsse)
+    {
+        /* Read and write commands need to include endianess */
+        mpsse->tx   = MPSSE_DO_WRITE | endianess;
+        mpsse->rx   = MPSSE_DO_READ  | endianess;
+        mpsse->txrx = MPSSE_DO_WRITE | MPSSE_DO_READ | endianess;
+
+        /* Clock, data out, chip select pins are outputs; all others are inputs. */
+        mpsse->tris = DEFAULT_TRIS;
+
+        /* Clock and chip select pins idle high; all others are low */
+        mpsse->pidle = mpsse->pstart = mpsse->pstop = DEFAULT_PORT;
+
+        /* During reads and writes the chip select pin is brought low */
+        mpsse->pstart &= ~TMS;
+
+        /* Disable FTDI internal loopback */
+        SetLoopback (mpsse, 0);
+
+        /* Send ACKs by default */
+        SetAck (mpsse, ACK);
+
+        /* Ensure adaptive clock is disabled */
+        setup_commands[setup_commands_size++] = DISABLE_ADAPTIVE_CLOCK;
+
+        switch (mpsse->mode)
+        {
+            case SPI0:
+                /* SPI mode 0 clock idles low */
+                mpsse->pidle &= ~SK;
+                mpsse->pstart &= ~SK;
+                mpsse->pstop &= ~SK;
+                /* SPI mode 0 propogates data on the falling edge and read data on the rising edge of the clock */
+                mpsse->tx |= MPSSE_WRITE_NEG;
+                mpsse->rx &= ~MPSSE_READ_NEG;
+                mpsse->txrx |= MPSSE_WRITE_NEG;
+                mpsse->txrx &= ~MPSSE_READ_NEG;
+                break;
+            case SPI3:
+                /* SPI mode 3 clock idles high */
+                mpsse->pidle |= SK;
+                mpsse->pstart |= SK;
+                /* Keep the clock low while the CS pin is brought high to ensure we don't accidentally clock out an extra bit */
+                mpsse->pstop &= ~SK;
+                /* SPI mode 3 propogates data on the falling edge and read data on the rising edge of the clock */
+                mpsse->tx |= MPSSE_WRITE_NEG;
+                mpsse->rx &= ~MPSSE_READ_NEG;
+                mpsse->txrx |= MPSSE_WRITE_NEG;
+                mpsse->txrx &= ~MPSSE_READ_NEG;
+                break;
+            case SPI1:
+                /* SPI mode 1 clock idles low */
+                mpsse->pidle &= ~SK;
+                /* Since this mode idles low, the start condition should ensure that the clock is low */
+                mpsse->pstart &= ~SK;
+                /* Even though we idle low in this mode, we need to keep the clock line high when we set the CS pin high to prevent
+                 * an unintended clock cycle from being sent by the FT2232. This way, the clock goes high, but does not go low until
+                 * after the CS pin goes high.
+                 */
+                mpsse->pstop |= SK;
+                /* Data read on falling clock edge */
+                mpsse->rx |= MPSSE_READ_NEG;
+                mpsse->tx &= ~MPSSE_WRITE_NEG;
+                mpsse->txrx |= MPSSE_READ_NEG;
+                mpsse->txrx &= ~MPSSE_WRITE_NEG;
+                break;
+            case SPI2:
+                /* SPI 2 clock idles high */
+                mpsse->pidle |= SK;
+                mpsse->pstart |= SK;
+                mpsse->pstop |= SK;
+                /* Data read on falling clock edge */
+                mpsse->rx |= MPSSE_READ_NEG;
+                mpsse->tx &= ~MPSSE_WRITE_NEG;
+                mpsse->txrx |= MPSSE_READ_NEG;
+                mpsse->txrx &= ~MPSSE_WRITE_NEG;
+                break;
+            case I2C:
+                /* I2C propogates data on the falling clock edge and reads data on the falling (or rising) clock edge */
+                mpsse->tx |= MPSSE_WRITE_NEG;
+                mpsse->rx &= ~MPSSE_READ_NEG;
+                /* In I2C, both the clock and the data lines idle high */
+                mpsse->pidle |= DO | DI;
+                /* I2C start bit == data line goes from high to low while clock line is high */
+                mpsse->pstart &= ~DO & ~DI;
+                /* I2C stop bit == data line goes from low to high while clock line is high - set data line low here, so the transition to the idle state triggers the stop condition. */
+                mpsse->pstop &= ~DO & ~DI;
+                /* Enable three phase clock to ensure that I2C data is available on both the rising and falling clock edges */
+                setup_commands[setup_commands_size++] = ENABLE_3_PHASE_CLOCK;
+                break;
+            case GPIO:
+                break;
+            default:
+                retval = MPSSE_FAIL;
+        }
+
+        /* Send any setup commands to the chip */
+        if (retval == MPSSE_OK)
+        {
+            retval = raw_write (mpsse, setup_commands, setup_commands_size);
+        }
+
+        if (retval == MPSSE_OK)
+        {
+            /* Set the idle pin states */
+            set_bits_low (mpsse, mpsse->pidle);
+
+            /* All GPIO pins are outputs, set low */
+            mpsse->trish = 0xFF;
+            mpsse->gpioh = 0x00;
+
+            buf[i++] = SET_BITS_HIGH;
+            buf[i++] = mpsse->gpioh;
+            buf[i++] = mpsse->trish;
+
+            retval = raw_write (mpsse, buf, i);
+        }
+    }
+    else
+    {
+        retval = MPSSE_FAIL;
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the appropriate divisor for the desired clock frequency.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @freq  - Desired clock frequency in hertz.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int SetClock (struct mpsse_context *mpsse, uint32_t freq)
+{
+    int retval = MPSSE_FAIL;
+    uint32_t system_clock = 0;
+    uint16_t divisor = 0;
+    unsigned char buf[CMD_SIZE] = { 0 };
+
+    /* Do not call is_valid_context() here, as the FTDI chip may not be completely configured when SetClock is called */
+    if (mpsse)
+    {
+        if (freq > SIX_MHZ)
+        {
+            buf[0] = TCK_X5;
+            system_clock = SIXTY_MHZ;
+        }
+        else
+        {
+            buf[0] = TCK_D5;
+            system_clock = TWELVE_MHZ;
+        }
+
+        if (raw_write (mpsse, buf, 1) == MPSSE_OK)
+        {
+            if (freq <= 0)
+            {
+                divisor = 0xFFFF;
+            }
+            else
+            {
+                divisor = freq2div (system_clock, freq);
+            }
+
+            buf[0] = TCK_DIVISOR;
+            buf[1] = (divisor & 0xFF);
+            buf[2] = ((divisor >> 8) & 0xFF);
+
+            if (raw_write (mpsse, buf, 3) == MPSSE_OK)
+            {
+                mpsse->clock = div2freq (system_clock, divisor);
+                retval = MPSSE_OK;
+            }
+        }
+    }
+
+    return retval;
+}
+
+/*
+ * Retrieves the last error string from libftdi.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns a pointer to the last error string.
+ */
+const char *ErrorString (struct mpsse_context *mpsse)
+{
+    if (mpsse != NULL)
+    {
+        return ftdi_get_error_string (&mpsse->ftdi);
+    }
+
+    return NULL_CONTEXT_ERROR_MSG;
+}
+
+/*
+ * Gets the currently configured clock rate.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns the existing clock rate in hertz.
+ */
+int GetClock (struct mpsse_context *mpsse)
+{
+    int clock = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        clock = mpsse->clock;
+    }
+
+    return clock;
+}
+
+/*
+ * Returns the vendor ID of the FTDI chip.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns the integer value of the vendor ID.
+ */
+int GetVid (struct mpsse_context *mpsse)
+{
+    int vid = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        vid = mpsse->vid;
+    }
+
+    return vid;
+}
+
+/*
+ * Returns the product ID of the FTDI chip.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns the integer value of the product ID.
+ */
+int GetPid (struct mpsse_context *mpsse)
+{
+    int pid = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        pid = mpsse->pid;
+    }
+
+    return pid;
+}
+
+/*
+ * Returns the description of the FTDI chip, if any.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns the description of the FTDI chip.
+ */
+const char *GetDescription (struct mpsse_context *mpsse)
+{
+    char *description = NULL;
+
+    if (is_valid_context (mpsse))
+    {
+        description = mpsse->description;
+    }
+
+    return description;
+}
+
+/*
+ * Enable / disable internal loopback.
+ *
+ * @mpsse  - MPSSE context pointer.
+ * @enable - Zero to disable loopback, 1 to enable loopback.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int SetLoopback (struct mpsse_context *mpsse, int enable)
+{
+    unsigned char buf[1] = { 0 };
+    int retval = MPSSE_FAIL;
+
+    if (is_valid_context (mpsse))
+    {
+        if (enable)
+        {
+            buf[0] = LOOPBACK_START;
+        }
+        else
+        {
+            buf[0] = LOOPBACK_END;
+        }
+
+        retval = raw_write (mpsse, buf, 1);
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the idle state of the chip select pin. CS idles high by default.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @idle  - Set to 1 to idle high, 0 to idle low.
+ *
+ * Returns void.
+ */
+void SetCSIdle (struct mpsse_context *mpsse, int idle)
+{
+    if (is_valid_context (mpsse))
+    {
+        if (idle > 0)
+        {
+            /* Chip select idles high, active low */
+            mpsse->pidle |= TMS;
+            mpsse->pstop |= TMS;
+            mpsse->pstart &= ~TMS;
+        }
+        else
+        {
+            /* Chip select idles low, active high */
+            mpsse->pidle &= ~TMS;
+            mpsse->pstop &= ~TMS;
+            mpsse->pstart |= TMS;
+        }
+    }
+
+    return;
+}
+
+/*
+ * Enables or disables flushing of the FTDI chip's RX buffers after each read operation.
+ * Flushing is disable by default.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @tf    - Set to 1 to enable flushing, or 0 to disable flushing.
+ *
+ * Returns void.
+ */
+void FlushAfterRead (struct mpsse_context *mpsse, int tf)
+{
+    mpsse->flush_after_read = tf;
+    return;
+}
+
+/*
+ * Send data start condition.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int Start (struct mpsse_context *mpsse)
+{
+    int status = MPSSE_OK;
+
+    if (is_valid_context (mpsse))
+    {
+
+        if (mpsse->mode == I2C && mpsse->status == STARTED)
+        {
+            /* Set the default pin states while the clock is low since this is an I2C repeated start condition */
+            status |= set_bits_low (mpsse, (mpsse->pidle & ~SK));
+
+            /* Make sure the pins are in their default idle state */
+            status |= set_bits_low (mpsse, mpsse->pidle);
+        }
+
+        /* Set the start condition */
+        status |= set_bits_low (mpsse, mpsse->pstart);
+
+        /*
+         * Hackish work around to properly support SPI mode 3.
+         * SPI3 clock idles high, but needs to be set low before sending out
+         * data to prevent unintenteded clock glitches from the FT2232.
+         */
+        if (mpsse->mode == SPI3)
+        {
+            status |= set_bits_low (mpsse, (mpsse->pstart & ~SK));
+        }
+        /*
+         * Hackish work around to properly support SPI mode 1.
+         * SPI1 clock idles low, but needs to be set high before sending out
+         * data to preven unintended clock glitches from the FT2232.
+         */
+        else if (mpsse->mode == SPI1)
+        {
+            status |= set_bits_low (mpsse, (mpsse->pstart | SK));
+        }
+
+        mpsse->status = STARTED;
+    }
+    else
+    {
+        status = MPSSE_FAIL;
+        mpsse->status = STOPPED;
+    }
+
+    return status;
+}
+
+/*
+ * Performs a bit-wise write of up to 8 bits at a time.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @bits  - A byte containing the desired bits to write.
+ * @size  - The number of bits from the 'bits' byte to write.
+ *
+ * Returns MPSSE_OK on success, MPSSE_FAIL on failure.
+ */
+int WriteBits (struct mpsse_context *mpsse, char bits, int size)
+{
+    char data[8] = { 0 };
+    int i = 0, retval = MPSSE_OK;
+
+    if (size > (int)sizeof(data))
+    {
+        size = sizeof(data);
+    }
+
+    /* Convert each bit in bits to an array of bytes */
+    for (i=0; i<size; i++)
+    {
+        if (bits & (1 << i))
+        {
+            /* Be sure to honor endianess */
+            if (mpsse->endianess == LSB)
+            {
+                data[i] = '\xFF';
+            }
+            else
+            {
+                data[size-i-1] = '\xFF';
+            }
+        }
+    }
+
+    /* Enable bit mode before writing, then disable it afterwards. */
+    EnableBitmode (mpsse, 1);
+    retval = Write (mpsse, data, size);
+    EnableBitmode (mpsse, 0);
+
+    return retval;
+}
+
+/*
+ * Send data out via the selected serial protocol.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @data  - Buffer of data to send.
+ * @size  - Size of data.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int Write (struct mpsse_context *mpsse, char *data, int size)
+{
+    unsigned char *buf = NULL;
+    int retval = MPSSE_FAIL, buf_size = 0, txsize = 0, n = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        if (mpsse->mode)
+        {
+            while(n < size)
+            {
+                txsize = size - n;
+                if (txsize > mpsse->xsize)
+                {
+                    txsize = mpsse->xsize;
+                }
+
+                /*
+                 * For I2C we need to send each byte individually so that we can
+                 * read back each individual ACK bit, so set the transmit size to 1.
+                 */
+                if (mpsse->mode == I2C)
+                {
+                    txsize = 1;
+                }
+
+                buf = build_block_buffer (mpsse, mpsse->tx, (unsigned char *) (data + n), txsize, &buf_size);
+                if (buf)
+                {
+                    retval = raw_write (mpsse, buf, buf_size);
+                    n += txsize;
+                    free(buf);
+
+                    if (retval == MPSSE_FAIL)
+                    {
+                        break;
+                    }
+
+                    /* Read in the ACK bit and store it in mpsse->rack */
+                    if (mpsse->mode == I2C)
+                    {
+                        raw_read (mpsse, (unsigned char *) &mpsse->rack, 1);
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        if (retval == MPSSE_OK && n == size)
+        {
+            retval = MPSSE_OK;
+        }
+    }
+
+    return retval;
+}
+
+/* Performs a read. For internal use only; see Read() and ReadBits(). */
+char *InternalRead (struct mpsse_context *mpsse, int size)
+{
+    unsigned char *data = NULL, *buf = NULL;
+    unsigned char sbuf[SPI_RW_SIZE] = { 0 };
+    int n = 0, rxsize = 0, data_size = 0, retval = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        if (mpsse->mode)
+        {
+            buf = malloc (size);
+            if (buf)
+            {
+                memset (buf, 0, size);
+
+                while(n < size)
+                {
+                    rxsize = size - n;
+                    if (rxsize > mpsse->xsize)
+                    {
+                        rxsize = mpsse->xsize;
+                    }
+
+                    data = build_block_buffer (mpsse, mpsse->rx, sbuf, rxsize, &data_size);
+                    if (data)
+                    {
+                        retval = raw_write (mpsse, data, data_size);
+                        free (data);
+
+                        if (retval == MPSSE_OK)
+                        {
+                            n += raw_read (mpsse, buf+n, rxsize);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    return (char *) buf;
+}
+
+/*
+ * Reads data over the selected serial protocol.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @size  - Number of bytes to read.
+ *
+ * Returns a pointer to the read data on success.
+ * Returns NULL on failure.
+ */
+#ifdef SWIGPYTHON
+swig_string_data Read (struct mpsse_context *mpsse, int size)
+#else
+char *Read (struct mpsse_context *mpsse, int size)
+#endif
+{
+    char *buf = NULL;
+
+    buf = InternalRead (mpsse, size);
+
+#ifdef SWIGPYTHON
+    swig_string_data sdata = { 0 };
+    sdata.size = size;
+    sdata.data = buf;
+    return sdata;
+#else
+    return buf;
+#endif
+}
+
+/*
+ * Performs a bit-wise read of up to 8 bits.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @size  - Number of bits to read.
+ *
+ * Returns an 8-bit byte containing the read bits.
+ */
+char ReadBits (struct mpsse_context *mpsse, int size)
+{
+    char bits = 0;
+    char *rdata = NULL;
+
+    if (size > 8)
+    {
+        size = 8;
+    }
+
+    EnableBitmode (mpsse, 1);
+    rdata = InternalRead (mpsse, size);
+    EnableBitmode (mpsse, 0);
+
+    if (rdata)
+    {
+        /* The last byte in rdata will have all the read bits set or unset as needed. */
+        bits = rdata[size-1];
+
+        if (mpsse->endianess == MSB)
+        {
+            /*
+             * In MSB mode, bits are sifted in from the left. If less than 8 bits were
+             * read, we need to shift them left accordingly.
+             */
+            bits = bits << (8-size);
+        }
+        else if (mpsse->endianess == LSB)
+        {
+            /*
+             * In LSB mode, bits are shifted in from the right. If less than 8 bits were
+             * read, we need to shift them right accordingly.
+             */
+            bits = bits >> (8-size);
+        }
+
+        free (rdata);
+    }
+
+    return bits;
+}
+
+/*
+ * Reads and writes data over the selected serial protocol (SPI only).
+ *
+ * @mpsse - MPSSE context pointer.
+ * @data  - Buffer containing bytes to write.
+ * @size  - Number of bytes to transfer.
+ *
+ * Returns a pointer to the read data on success.
+ * Returns NULL on failure.
+ */
+#ifdef SWIGPYTHON
+swig_string_data Transfer (struct mpsse_context *mpsse, char *data, int size)
+#else
+char *Transfer (struct mpsse_context *mpsse, char *data, int size)
+#endif
+{
+    unsigned char *txdata = NULL, *buf = NULL;
+    int n = 0, data_size = 0, rxsize = 0, retval = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        /* Make sure we're configured for one of the SPI modes */
+        if (mpsse->mode >= SPI0 && mpsse->mode <= SPI3)
+        {
+            buf = malloc (size);
+            if (buf)
+            {
+                memset (buf, 0, size);
+
+                while(n < size)
+                {
+                    /* When sending and recieving, FTDI chips don't seem to like large data blocks. Limit the size of each block to SPI_TRANSFER_SIZE */
+                    rxsize = size - n;
+                    if (rxsize > SPI_TRANSFER_SIZE)
+                    {
+                        rxsize = SPI_TRANSFER_SIZE;
+                    }
+
+                    txdata = build_block_buffer (mpsse, mpsse->txrx, (unsigned char *) (data + n), rxsize, &data_size);
+                    if (txdata)
+                    {
+                        retval = raw_write (mpsse, txdata, data_size);
+                        free (txdata);
+
+                        if (retval == MPSSE_OK)
+                        {
+                            n += raw_read (mpsse, (buf + n), rxsize);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+#ifdef SWIGPYTHON
+    swig_string_data sdata = { 0 };
+    sdata.size = n;
+    sdata.data = (char *) buf;
+    return sdata;
+#else
+    return (char *) buf;
+#endif
+}
+
+/*
+ * Returns the last received ACK bit.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns either an ACK (0) or a NACK (1).
+ */
+int GetAck (struct mpsse_context *mpsse)
+{
+    int ack = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        ack = (mpsse->rack & 0x01);
+    }
+
+    return ack;
+}
+
+/*
+ * Sets the transmitted ACK bit.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @ack   - 0 to send ACKs, 1 to send NACKs.
+ *
+ * Returns void.
+ */
+void SetAck (struct mpsse_context *mpsse, int ack)
+{
+    if (is_valid_context (mpsse))
+    {
+        if (ack == NACK)
+        {
+            mpsse->tack = 0xFF;
+        }
+        else
+        {
+            mpsse->tack = 0x00;
+        }
+    }
+
+    return;
+}
+
+/*
+ * Causes libmpsse to send ACKs after each read byte in I2C mode.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns void.
+ */
+void SendAcks (struct mpsse_context *mpsse)
+{
+    return SetAck (mpsse, ACK);
+}
+
+/*
+ * Causes libmpsse to send NACKs after each read byte in I2C mode.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns void.
+ */
+void SendNacks (struct mpsse_context *mpsse)
+{
+    return SetAck (mpsse, NACK);
+}
+
+/*
+ * Send data stop condition.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int Stop (struct mpsse_context *mpsse)
+{
+    int retval = MPSSE_OK;
+
+    if (is_valid_context (mpsse))
+    {
+        /* In I2C mode, we need to ensure that the data line goes low while the clock line is low to avoid sending an inadvertent start condition */
+        if (mpsse->mode == I2C)
+        {
+            retval |= set_bits_low (mpsse, (mpsse->pidle & ~DO & ~SK));
+        }
+
+        /* Send the stop condition */
+        retval |= set_bits_low (mpsse, mpsse->pstop);
+
+        if (retval == MPSSE_OK)
+        {
+            /* Restore the pins to their idle states */
+            retval |= set_bits_low (mpsse, mpsse->pidle);
+        }
+
+        mpsse->status = STOPPED;
+    }
+    else
+    {
+        retval = MPSSE_FAIL;
+        mpsse->status = STOPPED;
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the specified pin high.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @pin   - Pin number to set high.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int PinHigh (struct mpsse_context *mpsse, int pin)
+{
+    int retval = MPSSE_FAIL;
+
+    if (is_valid_context (mpsse))
+    {
+        retval = gpio_write (mpsse, pin, HIGH);
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the specified pin low.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @pin   - Pin number to set low.
+ *
+ * Returns MPSSE_OK on success.
+ * Returns MPSSE_FAIL on failure.
+ */
+int PinLow (struct mpsse_context *mpsse, int pin)
+{
+    int retval = MPSSE_FAIL;
+
+    if (is_valid_context (mpsse))
+    {
+        retval = gpio_write (mpsse, pin, LOW);
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the input/output direction of all pins. For use in BITBANG mode only.
+ *
+ * @mpsse     - MPSSE context pointer.
+ * @direction - Byte indicating input/output direction of each bit.  1 is out.
+ *
+ * Returns MPSSE_OK if direction could be set, MPSSE_FAIL otherwise.
+ */
+int SetDirection (struct mpsse_context *mpsse, uint8_t direction)
+{
+    int retval = MPSSE_FAIL;
+
+    if (is_valid_context (mpsse))
+    {
+        if (mpsse->mode == BITBANG)
+        {
+            if (ftdi_set_bitmode (&mpsse->ftdi, direction, BITMODE_BITBANG) == 0)
+            {
+                retval = MPSSE_OK;
+            }
+        }
+    }
+
+    return retval;
+}
+
+/*
+ * Sets the input/output value of all pins. For use in BITBANG mode only.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @data  - Byte indicating bit hi/low value of each bit.
+ *
+ * Returns MPSSE_OK if direction could be set, MPSSE_FAIL otherwise.
+ */
+int WritePins (struct mpsse_context *mpsse, uint8_t data)
+{
+    int retval = MPSSE_FAIL;
+
+    if (is_valid_context (mpsse))
+    {
+        if (mpsse->mode == BITBANG)
+        {
+            if (ftdi_write_data (&mpsse->ftdi, &data, 1) == 0)
+            {
+                retval = MPSSE_OK;
+            }
+        }
+    }
+
+    return retval;
+}
+
+/*
+ * Reads the state of the chip's pins. For use in BITBANG mode only.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns a byte with the corresponding pin's bits set to 1 or 0.
+ */
+int ReadPins (struct mpsse_context *mpsse)
+{
+    uint8_t val = 0;
+
+    if (is_valid_context (mpsse))
+    {
+        ftdi_read_pins ((struct ftdi_context *)&mpsse->ftdi, (unsigned char *)&val);
+    }
+
+    return (int) val;
+}
+
+/*
+ * Checks if a specific pin is high or low. For use in BITBANG mode only.
+ *
+ * @mpsse - MPSSE context pointer.
+ * @pin   - The pin number.
+ * @state - The state of the pins, as returned by ReadPins.
+ *          If set to -1, ReadPins will automatically be called.
+ *
+ * Returns a 1 if the pin is high, 0 if the pin is low.
+ */
+int PinState (struct mpsse_context *mpsse, int pin, int state)
+{
+    if (state == -1)
+    {
+        state = ReadPins (mpsse);
+    }
+
+    /* If not in bitbang mode, the specified pin should be one of GPIOLx. Convert these defines into an absolute pin number. */
+    if (mpsse->mode != BITBANG)
+    {
+        pin += NUM_GPIOL_PINS;
+    }
+
+    return ((state & (1 << pin)) >> pin);
+}
+
+/*
+ * Places all I/O pins into a tristate mode.
+ *
+ * @mpsse - MPSSE context pointer.
+ *
+ * Returns MPSSE_OK on success, MPSSE_FAIL on failure.
+ */
+int Tristate (struct mpsse_context *mpsse)
+{
+    unsigned char cmd[CMD_SIZE] = { 0 };
+
+    /* Tristate the all I/O pins (FT232H only) */
+    cmd[0] = TRISTATE_IO;
+    cmd[1] = 0xFF;
+    cmd[2] = 0xFF;
+
+    return raw_write (mpsse, cmd, sizeof (cmd));
+}

--- a/src/tss2-tcti/mpsse/mpsse.h
+++ b/src/tss2-tcti/mpsse/mpsse.h
@@ -1,0 +1,259 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+/*
+ * This file was copied from https://github.com/devttys0/libmpsse.git (sha1: a2eafa2)
+ * and modified accordingly.
+ *
+ * Copyright (c) 2015, Craig Heffner
+ * All rights reserved.
+ * SPDX short identifier: BSD-2-Clause
+ */
+#ifndef _LIBMPSSE_H_
+#define _LIBMPSSE_H_
+
+#include <stdint.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if LIBFTDI_VERSION == 1
+#include <libftdi1/ftdi.h>
+#else
+#include <ftdi.h>
+#endif
+
+#define MPSSE_OK            0
+#define MPSSE_FAIL          -1
+
+#define MSB                 0x00
+#define LSB                 0x08
+
+#define CHUNK_SIZE          65535
+#define SPI_RW_SIZE         (63 * 1024)
+#define SPI_TRANSFER_SIZE   512
+#define I2C_TRANSFER_SIZE   64
+
+#define LATENCY_MS          2
+#define TIMEOUT_DIVISOR     1000000
+#define USB_TIMEOUT         120000
+#define SETUP_DELAY         25000
+
+#define BITMODE_RESET       0
+#define BITMODE_MPSSE       2
+
+#define CMD_SIZE            3
+#define MAX_SETUP_COMMANDS  10
+#define SS_TX_COUNT         3
+
+#define LOW                 0
+#define HIGH                1
+#define NUM_GPIOL_PINS      4
+#define NUM_GPIO_PINS       12
+
+#define NULL_CONTEXT_ERROR_MSG    "NULL MPSSE context pointer!"
+
+/* FTDI interfaces */
+enum interface
+{
+    IFACE_ANY    = INTERFACE_ANY,
+    IFACE_A     = INTERFACE_A,
+    IFACE_B        = INTERFACE_B,
+    IFACE_C        = INTERFACE_C,
+    IFACE_D        = INTERFACE_D
+};
+
+/* Common clock rates */
+enum clock_rates
+{
+    ONE_HUNDRED_KHZ  = 100000,
+    FOUR_HUNDRED_KHZ = 400000,
+    ONE_MHZ          = 1000000,
+    TWO_MHZ          = 2000000,
+    FIVE_MHZ         = 5000000,
+    SIX_MHZ          = 6000000,
+    TEN_MHZ          = 10000000,
+    TWELVE_MHZ       = 12000000,
+    FIFTEEN_MHZ      = 15000000,
+    THIRTY_MHZ       = 30000000,
+    SIXTY_MHZ        = 60000000
+};
+
+/* Supported MPSSE modes */
+enum modes
+{
+    SPI0    = 1,
+    SPI1    = 2,
+    SPI2    = 3,
+    SPI3    = 4,
+    I2C     = 5,
+    GPIO    = 6,
+    BITBANG = 7,
+};
+
+enum pins
+{
+    SK       = 1,
+    DO       = 2,
+    DI       = 4,
+    TMS      = 8 ,
+    GPIO0    = 16,
+    GPIO1    = 32,
+    GPIO2    = 64,
+    GPIO3    = 128
+};
+
+enum gpio_pins
+{
+    GPIOL0 = 0,
+    GPIOL1 = 1,
+    GPIOL2 = 2,
+    GPIOL3 = 3,
+    GPIOH0 = 4,
+    GPIOH1 = 5,
+    GPIOH2 = 6,
+    GPIOH3 = 7,
+    GPIOH4 = 8,
+    GPIOH5 = 9,
+    GPIOH6 = 10,
+    GPIOH7 = 11
+};
+
+enum i2c_ack
+{
+    ACK  = 0,
+    NACK = 1
+};
+
+#define DEFAULT_TRIS    (SK | DO | TMS | GPIO0 | GPIO1 | GPIO2 | GPIO3)    /* SK/DO/CS and GPIOs are outputs, DI is an input */
+#define DEFAULT_PORT    (SK | TMS)    /* SK and CS are high, all others low */
+
+enum mpsse_commands
+{
+    INVALID_COMMAND         = 0xAB,
+    ENABLE_ADAPTIVE_CLOCK   = 0x96,
+    DISABLE_ADAPTIVE_CLOCK  = 0x97,
+    ENABLE_3_PHASE_CLOCK    = 0x8C,
+    DISABLE_3_PHASE_CLOCK   = 0x8D,
+    TCK_X5                  = 0x8A,
+    TCK_D5                  = 0x8B,
+    CLOCK_N_CYCLES          = 0x8E,
+    CLOCK_N8_CYCLES         = 0x8F,
+    PULSE_CLOCK_IO_HIGH     = 0x94,
+    PULSE_CLOCK_IO_LOW      = 0x95,
+    CLOCK_N8_CYCLES_IO_HIGH = 0x9C,
+    CLOCK_N8_CYCLES_IO_LOW  = 0x9D,
+    TRISTATE_IO             = 0x9E,
+};
+
+enum low_bits_status
+{
+    STARTED,
+    STOPPED
+};
+
+struct vid_pid
+{
+    int vid;
+    int pid;
+    char *description;
+};
+
+struct mpsse_context
+{
+    char *description;
+    struct ftdi_context ftdi;
+    enum modes mode;
+    enum low_bits_status status;
+    int flush_after_read;
+    int vid;
+    int pid;
+    int clock;
+    int xsize;
+    int open;
+    int endianess;
+    uint8_t tris;
+    uint8_t pstart;
+    uint8_t pstop;
+    uint8_t pidle;
+    uint8_t gpioh;
+    uint8_t trish;
+    uint8_t bitbang;
+    uint8_t tx;
+    uint8_t rx;
+    uint8_t txrx;
+    uint8_t tack;
+    uint8_t rack;
+};
+
+struct mpsse_context *MPSSE (enum modes mode, int freq, int endianess);
+struct mpsse_context *Open (int vid, int pid, enum modes mode, int freq, int endianess, int interface, const char *description, const char *serial);
+struct mpsse_context *OpenIndex (int vid, int pid, enum modes mode, int freq, int endianess, int interface, const char *description, const char *serial, int index);
+void Close (struct mpsse_context *mpsse);
+const char *ErrorString (struct mpsse_context *mpsse);
+int SetMode (struct mpsse_context *mpsse, int endianess);
+void EnableBitmode (struct mpsse_context *mpsse, int tf);
+int SetClock (struct mpsse_context *mpsse, uint32_t freq);
+int GetClock (struct mpsse_context *mpsse);
+int GetVid (struct mpsse_context *mpsse);
+int GetPid (struct mpsse_context *mpsse);
+const char *GetDescription (struct mpsse_context *mpsse);
+int SetLoopback (struct mpsse_context *mpsse, int enable);
+void SetCSIdle (struct mpsse_context *mpsse, int idle);
+int Start (struct mpsse_context *mpsse);
+int Write (struct mpsse_context *mpsse, char *data, int size);
+int Stop (struct mpsse_context *mpsse);
+int GetAck (struct mpsse_context *mpsse);
+void SetAck (struct mpsse_context *mpsse, int ack);
+void SendAcks (struct mpsse_context *mpsse);
+void SendNacks (struct mpsse_context *mpsse);
+void FlushAfterRead (struct mpsse_context *mpsse, int tf);
+int PinHigh (struct mpsse_context *mpsse, int pin);
+int PinLow (struct mpsse_context *mpsse, int pin);
+int SetDirection (struct mpsse_context *mpsse, uint8_t direction);
+int WriteBits (struct mpsse_context *mpsse, char bits, int size);
+char ReadBits (struct mpsse_context *mpsse, int size);
+int WritePins (struct mpsse_context *mpsse, uint8_t data);
+int ReadPins (struct mpsse_context *mpsse);
+int PinState (struct mpsse_context *mpsse, int pin, int state);
+int Tristate (struct mpsse_context *mpsse);
+
+#ifdef SWIGPYTHON
+typedef struct swig_string_data
+{
+    int size;
+    char *data;
+} swig_string_data;
+
+swig_string_data Read (struct mpsse_context *mpsse, int size);
+swig_string_data Transfer (struct mpsse_context *mpsse, char *data, int size);
+#else
+char *Read (struct mpsse_context *mpsse, int size);
+char *Transfer (struct mpsse_context *mpsse, char *data, int size);
+
+int FastWrite (struct mpsse_context *mpsse, char *data, int size);
+int FastRead (struct mpsse_context *mpsse, char *data, int size);
+int FastTransfer (struct mpsse_context *mpsse, char *wdata, char *rdata, int size);
+#endif
+
+#endif

--- a/src/tss2-tcti/mpsse/support.c
+++ b/src/tss2-tcti/mpsse/support.c
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+/*
+ * This file was copied from https://github.com/devttys0/libmpsse.git (sha1: a2eafa2)
+ * and modified accordingly.
+ *
+ * Copyright (c) 2015, Craig Heffner
+ * All rights reserved.
+ * SPDX short identifier: BSD-2-Clause
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mpsse.h"
+#include "support.h"
+
+/* Write data to the FTDI chip */
+int raw_write (struct mpsse_context *mpsse, unsigned char *buf, int size)
+{
+    int retval = MPSSE_FAIL;
+
+    if (mpsse->mode)
+    {
+        if (ftdi_write_data (&mpsse->ftdi, buf, size) == size)
+        {
+            retval = MPSSE_OK;
+        }
+    }
+
+    return retval;
+}
+
+/* Read data from the FTDI chip */
+int raw_read (struct mpsse_context *mpsse, unsigned char *buf, int size)
+{
+    int n = 0, r = 0;
+
+    if (mpsse->mode)
+    {
+        while (n < size)
+        {
+            r = ftdi_read_data (&mpsse->ftdi, buf, size);
+            if (r < 0) break;
+            n += r;
+        }
+
+        if (mpsse->flush_after_read)
+        {
+            /*
+             * Make sure the buffers are cleared after a read or subsequent reads may fail.
+             *
+             * Is this needed anymore? It slows down repetitive read operations by ~8%.
+             */
+            ftdi_usb_purge_rx_buffer (&mpsse->ftdi);
+        }
+    }
+
+    return n;
+}
+
+/* Sets the read and write timeout periods for bulk usb data transfers. */
+void set_timeouts (struct mpsse_context *mpsse, int timeout)
+{
+    if (mpsse->mode)
+    {
+        mpsse->ftdi.usb_read_timeout = timeout;
+        mpsse->ftdi.usb_write_timeout = timeout;
+    }
+
+    return;
+}
+
+/* Convert a frequency to a clock divisor */
+uint16_t freq2div (uint32_t system_clock, uint32_t freq)
+{
+    return (((system_clock / freq) / 2) - 1);
+}
+
+/* Convert a clock divisor to a frequency */
+uint32_t div2freq (uint32_t system_clock, uint16_t div)
+{
+    return (system_clock / ((1 + (uint32_t)div) * 2));
+}
+
+/* Builds a buffer of commands + data blocks */
+unsigned char *build_block_buffer (struct mpsse_context *mpsse, uint8_t cmd, unsigned char *data, int size, int *buf_size)
+{
+    unsigned char *buf = NULL;
+    int i = 0, j = 0, k = 0, dsize = 0, num_blocks = 0, total_size = 0, xfer_size = 0;
+    uint16_t rsize = 0;
+
+    *buf_size = 0;
+
+    /* Data block size is 1 in I2C, or when in bitmode */
+    if (mpsse->mode == I2C || (cmd & MPSSE_BITMODE))
+    {
+        xfer_size = 1;
+    }
+    else
+    {
+        xfer_size = mpsse->xsize;
+    }
+
+    num_blocks = (size / xfer_size);
+    if (size % xfer_size)
+    {
+        num_blocks++;
+    }
+
+    /* The total size of the data will be the data size + the write command */
+    total_size = size + (CMD_SIZE * num_blocks);
+
+    /* In I2C we have to add 3 additional commands per data block */
+    if (mpsse->mode == I2C)
+    {
+        total_size += (CMD_SIZE * 3 * num_blocks);
+    }
+
+    buf = malloc (total_size);
+    if (buf)
+    {
+        memset (buf, 0, total_size);
+
+        for(j=0; j<num_blocks; j++)
+        {
+            dsize = size - k;
+            if (dsize > xfer_size)
+            {
+                dsize = xfer_size;
+            }
+
+            /* The reported size of this block is block size - 1 */
+            rsize = dsize - 1;
+
+            /* For I2C we need to ensure that the clock pin is set low prior to clocking out data */
+            if (mpsse->mode == I2C)
+            {
+                buf[i++] = SET_BITS_LOW;
+                buf[i++] = mpsse->pstart & ~SK;
+
+                /* On receive, we need to ensure that the data out line is set as an input to avoid contention on the bus */
+                if (cmd == mpsse->rx)
+                {
+                    buf[i++] = mpsse->tris & ~DO;
+                }
+                else
+                {
+                    buf[i++] = mpsse->tris;
+                }
+            }
+
+            /* Copy in the command for this block */
+            buf[i++] = cmd;
+            buf[i++] = (rsize & 0xFF);
+            if (!(cmd & MPSSE_BITMODE))
+            {
+                buf[i++] = ((rsize >> 8) & 0xFF);
+            }
+
+            /* On a write, copy the data to transmit after the command */
+            if (cmd == mpsse->tx || cmd == mpsse->txrx)
+            {
+                memcpy (buf+i, data+k, dsize);
+
+                /* i == offset into buf */
+                i += dsize;
+                /* k == offset into data */
+                k += dsize;
+            }
+
+            /* In I2C mode we need to clock one ACK bit after each byte */
+            if (mpsse->mode == I2C)
+            {
+                /* If we are receiving data, then we need to clock out an ACK for each byte */
+                if (cmd == mpsse->rx)
+                {
+                    buf[i++] = SET_BITS_LOW;
+                    buf[i++] = mpsse->pstart & ~SK;
+                    buf[i++] = mpsse->tris;
+
+                    buf[i++] = mpsse->tx | MPSSE_BITMODE;
+                    buf[i++] = 0;
+                    buf[i++] = mpsse->tack;
+                }
+                /* If we are sending data, then we need to clock in an ACK for each byte */
+                else if (cmd == mpsse->tx)
+                {
+                    /* Need to make data out an input to avoid contention on the bus when the slave sends an ACK */
+                    buf[i++] = SET_BITS_LOW;
+                    buf[i++] = mpsse->pstart & ~SK;
+                    buf[i++] = mpsse->tris & ~DO;
+
+                    buf[i++] = mpsse->rx | MPSSE_BITMODE;
+                    buf[i++] = 0;
+                    buf[i++] = SEND_IMMEDIATE;
+                }
+            }
+        }
+
+        *buf_size = i;
+    }
+
+    return buf;
+}
+
+/* Set the low bit pins high/low */
+int set_bits_low (struct mpsse_context *mpsse, int port)
+{
+    char buf[CMD_SIZE] = { 0 };
+
+    buf[0] = SET_BITS_LOW;
+    buf[1] = port;
+    buf[2] = mpsse->tris;
+
+    return raw_write (mpsse, (unsigned char *) &buf, sizeof (buf));
+}
+
+/* Set the high bit pins high/low */
+int set_bits_high (struct mpsse_context *mpsse, int port)
+{
+    char buf[CMD_SIZE] = { 0 };
+
+    buf[0] = SET_BITS_HIGH;
+    buf[1] = port;
+    buf[2] = mpsse->trish;
+
+    return raw_write (mpsse, (unsigned char *)&buf, sizeof (buf));
+}
+
+/* Set the GPIO pins high/low */
+int gpio_write (struct mpsse_context *mpsse, int pin, int direction)
+{
+    int retval = MPSSE_FAIL;
+
+    if (mpsse->mode == BITBANG)
+    {
+        if (direction == HIGH)
+        {
+            mpsse->bitbang |= (1 << pin);
+        }
+        else
+        {
+            mpsse->bitbang &= ~(1 << pin);
+        }
+
+        if (set_bits_high (mpsse, mpsse->bitbang) == MPSSE_OK)
+        {
+            retval = raw_write (mpsse, (unsigned char *)&mpsse->bitbang, 1);
+        }
+    }
+    else
+    {
+        /* The first four pins can't be changed unless we are in a stopped status */
+        if (pin < NUM_GPIOL_PINS && mpsse->status == STOPPED)
+        {
+            /* Convert pin number (0-3) to the corresponding pin bit */
+            pin = (GPIO0 << pin);
+
+            if (direction == HIGH)
+            {
+                mpsse->pstart |= pin;
+                mpsse->pidle |= pin;
+                mpsse->pstop |= pin;
+            }
+            else
+            {
+                mpsse->pstart &= ~pin;
+                mpsse->pidle &= ~pin;
+                mpsse->pstop &= ~pin;
+            }
+
+            retval = set_bits_low (mpsse, mpsse->pstart);
+        }
+        else if (pin >= NUM_GPIOL_PINS && pin < NUM_GPIO_PINS)
+        {
+            /* Convert pin number (4 - 11) to the corresponding pin bit */
+            pin -= NUM_GPIOL_PINS;
+
+            if (direction == HIGH)
+            {
+                mpsse->gpioh |= (1 << pin);
+            }
+            else
+            {
+                mpsse->gpioh &= ~(1 << pin);
+            }
+            retval = set_bits_high (mpsse, mpsse->gpioh);
+        }
+    }
+
+    return retval;
+}
+
+/* Checks if a given MPSSE context is valid. */
+int is_valid_context (struct mpsse_context *mpsse)
+{
+    int retval = 0;
+
+    if (mpsse != NULL && mpsse->open)
+    {
+        retval = 1;
+    }
+
+    return retval;
+}

--- a/src/tss2-tcti/mpsse/support.h
+++ b/src/tss2-tcti/mpsse/support.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+/*
+ * This file was copied from https://github.com/devttys0/libmpsse.git (sha1: a2eafa2)
+ * and modified accordingly.
+ *
+ * Copyright (c) 2015, Craig Heffner
+ * All rights reserved.
+ * SPDX short identifier: BSD-2-Clause
+ */
+#ifndef _SUPPORT_H_
+#define _SUPPORT_H_
+
+#include "mpsse.h"
+
+int raw_write (struct mpsse_context *mpsse, unsigned char *buf, int size);
+int raw_read (struct mpsse_context *mpsse, unsigned char *buf, int size);
+void set_timeouts (struct mpsse_context *mpsse, int timeout);
+uint16_t freq2div (uint32_t system_clock, uint32_t freq);
+uint32_t div2freq (uint32_t system_clock, uint16_t div);
+unsigned char *build_block_buffer (struct mpsse_context *mpsse, uint8_t cmd, unsigned char *data, int size, int *buf_size);
+int set_bits_high (struct mpsse_context *mpsse, int port);
+int set_bits_low (struct mpsse_context *mpsse, int port);
+int gpio_write (struct mpsse_context *mpsse, int pin, int direction);
+int is_valid_context (struct mpsse_context *mpsse);
+
+#endif

--- a/src/tss2-tcti/tcti-spi-ftdi.c
+++ b/src/tss2-tcti/tcti-spi-ftdi.c
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "tss2_tcti.h"
+#include "tcti-spi-ftdi.h"
+#include "tss2_tcti_spi_ftdi.h"
+#include "tcti-spi-helper.h"
+#include "tss2_mu.h"
+#include "util/io.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+TSS2_RC
+platform_sleep_ms (void *user_data, int32_t milliseconds)
+{
+    (void) user_data;
+    struct timeval tv = {milliseconds/1000, (milliseconds%1000)*1000};
+    select (0, NULL, NULL, NULL, &tv);
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_start_timeout (void *user_data, int32_t milliseconds)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    memset (&platform_data->timeout, 0, sizeof (struct timeval));
+
+    if (gettimeofday (&platform_data->timeout, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    platform_data->timeout.tv_sec += (milliseconds/1000);
+    platform_data->timeout.tv_usec += (milliseconds%1000)*1000;
+    if (platform_data->timeout.tv_usec > 999999) {
+        platform_data->timeout.tv_sec++;
+        platform_data->timeout.tv_usec -= 1000000;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_timeout_expired (void *user_data, bool *is_timeout_expired)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    struct timeval now;
+    if (gettimeofday (&now, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    if (now.tv_sec > platform_data->timeout.tv_sec) {
+        *is_timeout_expired = true;
+    } else if ((now.tv_sec == platform_data->timeout.tv_sec)
+               && (now.tv_usec > platform_data->timeout.tv_usec)) {
+        *is_timeout_expired = true;
+    } else {
+        *is_timeout_expired = false;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_spi_transfer (void *user_data, const void *data_out, void *data_in, size_t cnt)
+{
+    int length = cnt;
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    struct mpsse_context *mpsse = platform_data->mpsse;
+    char *data = NULL;
+
+    if (Start (mpsse) != MPSSE_OK) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    if ((data = Transfer (mpsse, (char *)data_out, length)) == NULL) {
+        Stop (mpsse);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    if (data_in != NULL) {
+        memcpy (data_in, (unsigned char *)data, length);
+    }
+
+    free (data);
+
+    if (Stop (mpsse) != MPSSE_OK) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+void
+platform_finalize (void *user_data)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    struct mpsse_context *mpsse = platform_data->mpsse;
+
+    if (mpsse != NULL) {
+        Close (mpsse);
+    }
+
+    free (platform_data);
+}
+
+TSS2_RC
+create_tcti_spi_ftdi_platform (TSS2_TCTI_SPI_HELPER_PLATFORM *platform)
+{
+    PLATFORM_USERDATA *platform_data = malloc (sizeof (PLATFORM_USERDATA));
+    struct mpsse_context **mpsse = &platform_data->mpsse;
+
+    if (platform_data == NULL) {
+        return TSS2_BASE_RC_MEMORY;
+    }
+
+    memset (platform_data, 0, sizeof (PLATFORM_USERDATA));
+
+    if ((*mpsse = MPSSE (SPI0, FIFTEEN_MHZ, MSB)) == NULL )
+    {
+        goto error;
+    }
+
+    platform->user_data = platform_data;
+    platform->sleep_ms = platform_sleep_ms;
+    platform->start_timeout = platform_start_timeout;
+    platform->timeout_expired = platform_timeout_expired;
+    platform->spi_acquire = NULL;
+    platform->spi_release = NULL;
+    platform->spi_transfer = platform_spi_transfer;
+    platform->finalize = platform_finalize;
+
+    return TSS2_RC_SUCCESS;
+
+error:
+    platform_finalize ((void *) platform_data);
+    return TSS2_BASE_RC_IO_ERROR;
+}
+
+TSS2_RC
+Tss2_Tcti_Spi_Ftdi_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const char* config)
+{
+    (void) config;
+    TSS2_RC ret = 0;
+    TSS2_TCTI_SPI_HELPER_PLATFORM tcti_platform = {0};
+
+    if (tcti_context == NULL) {
+        return Tss2_Tcti_Spi_Helper_Init (NULL, size, NULL);
+    }
+
+    if ((ret = create_tcti_spi_ftdi_platform (&tcti_platform))) {
+        return ret;
+    }
+
+    return Tss2_Tcti_Spi_Helper_Init (tcti_context, size, &tcti_platform);
+}
+
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-spi-ftdi",
+    .description = "TCTI for communicating with TPM through the USB-FTDI-SPI converter.",
+    .config_help = "Takes no configuration.",
+    .init = Tss2_Tcti_Spi_Ftdi_Init
+};
+
+const TSS2_TCTI_INFO *
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-spi-ftdi.h
+++ b/src/tss2-tcti/tcti-spi-ftdi.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TCTI_SPI_FTDI_H
+#define TCTI_SPI_FTDI_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdint.h>
+#include <sys/time.h>
+
+#include "tcti-common.h"
+#include "tss2_tcti_spi_helper.h"
+#include "mpsse/mpsse.h"
+
+typedef struct {
+    struct timeval timeout;
+    struct mpsse_context *mpsse;
+} PLATFORM_USERDATA;
+
+#endif /* TCTI_SPI_FTDI_H */

--- a/test/unit/tcti-spi-ftdi.c
+++ b/test/unit/tcti-spi-ftdi.c
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/***********************************************************************;
+ * Copyright (c) 2023, Infineon Technologies AG
+ * All rights reserved.
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_spi_ftdi.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-spi-ftdi.h"
+#include "tss2-tcti/tcti-spi-helper.h"
+#include "util/key-value-parse.h"
+
+typedef enum {
+    TPM_DID_VID = 0,
+    TPM_ACCESS,
+    TPM_STS_CMD_NOT_READY,
+    TPM_STS_CMD_READY,
+    TPM_RID,
+} tpm_state_t;
+
+static const unsigned char TPM_DID_VID_0[] = {0x83, 0xd4, 0x0f, 0x00, 0xd1, 0x15, 0x1b, 0x00};
+static const unsigned char TPM_ACCESS_0[] = {0x80, 0xd4, 0x00, 0x00, 0xa1};
+static const unsigned char TPM_STS_0_CMD_NOT_READY[] = {0x83, 0xd4, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00};
+static const unsigned char TPM_STS_0_CMD_READY[] = {0x83, 0xd4, 0x00, 0x18, 0x40, 0x00, 0x00, 0x00};
+static const unsigned char TPM_RID_0[] = {0x80, 0xd4, 0x0f, 0x04, 0x00};
+
+static struct mpsse_context *_mpsse;
+
+/*
+ * Mock function MPSSE
+ */
+struct mpsse_context *__wrap_MPSSE (enum modes mode, int freq, int endianess)
+{
+    assert_int_equal (mode, SPI0);
+    assert_int_equal (freq, FIFTEEN_MHZ);
+    assert_int_equal (endianess, MSB);
+
+    _mpsse = malloc (sizeof (struct mpsse_context));
+
+    return _mpsse;
+}
+
+/*
+ * Mock function PinLow
+ */
+int __wrap_PinLow (struct mpsse_context *mpsse, int pin)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    assert_int_equal (pin, GPIOL0);
+
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function PinHigh
+ */
+int __wrap_PinHigh (struct mpsse_context *mpsse, int pin)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    assert_int_equal (pin, GPIOL0);
+
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function Start
+ */
+int __wrap_Start (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function Transfer
+ */
+char *__wrap_Transfer (struct mpsse_context *mpsse, char *data, int size)
+{
+
+    static tpm_state_t tpm_state = TPM_DID_VID;
+    char *ret = malloc (size);
+
+    assert_non_null (ret);
+    assert_ptr_equal (mpsse, _mpsse);
+
+    switch (tpm_state++) {
+    case TPM_DID_VID:
+        assert_int_equal (size, 8);
+        assert_true (!memcmp (data, TPM_DID_VID_0, 4));
+        memcpy (ret, TPM_DID_VID_0, sizeof (TPM_DID_VID_0));
+        break;
+    case TPM_ACCESS:
+        assert_int_equal (size, 5);
+        assert_true (!memcmp (data, TPM_ACCESS_0, 4));
+        memcpy (ret, TPM_ACCESS_0, sizeof (TPM_ACCESS_0));
+        break;
+    case TPM_STS_CMD_NOT_READY:
+        assert_int_equal (size, 8);
+        assert_true (!memcmp (data, TPM_STS_0_CMD_NOT_READY, 4));
+        memcpy (ret, TPM_STS_0_CMD_NOT_READY, sizeof (TPM_STS_0_CMD_NOT_READY));
+        break;
+    case TPM_STS_CMD_READY:
+        assert_int_equal (size, 8);
+        assert_true (!memcmp (data, TPM_STS_0_CMD_READY, 4));
+        memcpy (ret, TPM_STS_0_CMD_READY, sizeof (TPM_STS_0_CMD_READY));
+        break;
+    case TPM_RID:
+        assert_int_equal (size, 5);
+        assert_true (!memcmp (data, TPM_RID_0, 4));
+        memcpy (ret, TPM_RID_0, sizeof (TPM_RID_0));
+        break;
+    default:
+        assert_true (false);
+    }
+
+    return ret;
+}
+
+/*
+ * Mock function Stop
+ */
+int __wrap_Stop (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function Close
+ */
+void __wrap_Close (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    free (_mpsse);
+    _mpsse = NULL;
+}
+
+/*
+ * The test will invoke Tss2_Tcti_Spi_Ftdi_Init() and subsequently
+ * it will start reading TPM_DID_VID, claim locality, read TPM_STS,
+ * and finally read TPM_RID before exiting the Init function.
+ * For testing purpose, the TPM responses are hardcoded.
+ * SPI wait state is not supported in this test.
+ */
+static void
+tcti_spi_no_wait_state_success_test (void **state)
+{
+    TSS2_RC rc;
+    size_t size;
+    TSS2_TCTI_CONTEXT* tcti_ctx;
+
+    // Get requested TCTI context size
+    rc = Tss2_Tcti_Spi_Ftdi_Init (NULL, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    // Allocate TCTI context size
+    tcti_ctx = (TSS2_TCTI_CONTEXT*) calloc (1, size);
+    assert_non_null (tcti_ctx);
+
+    // Initialize TCTI context
+    rc = Tss2_Tcti_Spi_Ftdi_Init (tcti_ctx, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    // Finalize
+    TSS2_TCTI_FINALIZE(tcti_ctx)(tcti_ctx);
+
+    free (tcti_ctx);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (tcti_spi_no_wait_state_success_test),
+    };
+
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
Bringing up a TCTI module to support the FTDI MPSSE USB to SPI bridge for communication with a SPI-based TPM. Example of a FTDI MPSSE USB to SPI bridge is the product "USB 2.0 Hi-Speed to MPSSE Cable (SPI/I2C/JTAG master) with +3.3V digital level signals", part no: C232HM-DDHSL-0. It is used for current development and testing.

A little background about the dependencies and options:
- **[current implementation]** Option 1:<br>tcti-spi-ftdi -> libmpsse from [devttys0](https://github.com/devttys0/libmpsse) -> [libftdi](http://www.intra2net.com/en/developer/libftdi/).
  - libmpsse from devttys0: BSD-2-Clause; maintainer inactive since 2016
  - libftdi: GNU Lesser General Public License (LGPL); open source USB driver library; easy to install via package managers
- Option 2:<br>tcti-spi-ftdi -> libmpsse from [ftdi](https://ftdichip.com/software-examples/mpsse-projects/libmpsse-spi-examples/) -> [libftd2xx](https://ftdichip.com/drivers/d2xx-drivers/)
  - libmpsse from ftdi: License for distribution is not explicitly mentioned, at least I cannot identify it yet
  - libftd2xx: "FTDI drivers may be distributed in any form as long as license information is not modified" according to [here](https://ftdichip.com/drivers/d2xx-drivers/), more details [here](https://ftdichip.com/driver-licence-terms/) and [here](https://ftdichip.com/driver-licence-terms-details/); FTD2XX is a closed-source library; has to be manually installed, more info [here](https://ftdichip.com/wp-content/uploads/2020/08/AN_220_FTDI_Drivers_Installation_Guide_for_Linux-1.pdf)

The CI is expected to fail at this stage since the library `libftdi` is missing from CI container images.
