### PR TITLE
FAPI: Fix return value if policy does not exist.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -166,6 +166,10 @@ ifapi_policy_store_load_async(
         }
     }
 
+    if (!ifapi_io_path_exists(abs_path)) {
+        goto_error(r, TSS2_FAPI_RC_BAD_PATH, "Policy %s does not exist.", cleanup, path);
+    }
+
     /* Prepare read operation */
     r = ifapi_io_read_async(io, abs_path);
 


### PR DESCRIPTION
FAPI returns FAPI_RC_IO_ERROR if a policy does not exist in keystore. The Spec requires the return value FAPI_RC_BAD_PATH.

Signed-off-by: Juergen Repp <juergen_repp@web.de>