### PR TITLE
FAPI:  Add the policy PolicyTemplate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -641,6 +641,7 @@ EXTRA_DIST +=  \
     test/data/fapi/policy/pol_authorize_nv_sha384.json \
     test/data/fapi/policy/pol_cphash_sha384.json \
     test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json \
+    test/data/fapi/policy/pol_template.json \
     test/data/fapi/eventlog/binary_measurements_nuc.b64 \
     test/data/fapi/eventlog/binary_measurements_pc_client.b64 \
     test/data/fapi/eventlog/event.b64 \

--- a/src/tss2-fapi/ifapi_policy_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_deserialize.c
@@ -1061,13 +1061,6 @@ ifapi_json_TPMS_POLICYTEMPLATE_deserialize(json_object *jso,
         out->templatePublic.size = 0;
     }
 
-    if (ifapi_get_sub_object(jso, "templateName", &jso2)) {
-        r = ifapi_json_char_deserialize(jso2, &out->templateName);
-        return_if_error(r, "Bad value for field \"templateName\".");
-    } else {
-        out->templateName = NULL;
-    }
-
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {
         return_error(TSS2_FAPI_RC_BAD_VALUE,

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -811,14 +811,6 @@ ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
 
         json_object_object_add(*jso, "templatePublic", jso2);
     }
-    if (in->templateName) {
-        jso2 = NULL;
-        cond_cnt++;
-        r = ifapi_json_char_serialize(in->templateName, &jso2);
-        return_if_error(r, "Serialize char");
-
-        json_object_object_add(*jso, "templateName", jso2);
-    }
 
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -803,10 +803,10 @@ ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
 
         json_object_object_add(*jso, "templateHash", jso2);
     }
-    if (in->templatePublic.size != 0) {
+    if (in->templatePublic.publicArea.type) {
         jso2 = NULL;
         cond_cnt++;
-        r = ifapi_json_TPM2B_PUBLIC_serialize(&in->templatePublic, &jso2);
+        r = ifapi_json_TPMT_PUBLIC_serialize(&in->templatePublic.publicArea, &jso2);
         return_if_error(r, "Serialize TPM2B_PUBLIC");
 
         json_object_object_add(*jso, "templatePublic", jso2);

--- a/src/tss2-fapi/ifapi_policy_types.h
+++ b/src/tss2-fapi/ifapi_policy_types.h
@@ -174,7 +174,6 @@ typedef struct {
 typedef struct {
     TPM2B_DIGEST                           templateHash;    /**< None */
     TPM2B_PUBLIC                         templatePublic;    /**< None */
-    char                                  *templateName;    /**< None */
 } TPMS_POLICYTEMPLATE;
 
 /** Policy type TPMS_POLICYAUTHORIZENV

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -4323,11 +4323,11 @@ ifapi_json_TPMT_PUBLIC_deserialize(json_object *jso,  TPMT_PUBLIC *out)
     return_if_error(r, "Bad value for field \"parameters\".");
 
     if (!ifapi_get_sub_object(jso, "unique", &jso2)) {
-        LOG_ERROR("Field \"unique\" not found.");
-        return TSS2_FAPI_RC_BAD_VALUE;
+        memset(&out->unique, 0, sizeof(TPMU_PUBLIC_ID));
+    } else {
+        r = ifapi_json_TPMU_PUBLIC_ID_deserialize(out->type, jso2, &out->unique);
+        return_if_error(r, "Bad value for field \"unique\".");
     }
-    r = ifapi_json_TPMU_PUBLIC_ID_deserialize(out->type, jso2, &out->unique);
-    return_if_error(r, "Bad value for field \"unique\".");
 
     LOG_TRACE("true");
     return TSS2_RC_SUCCESS;

--- a/test/data/fapi/policy/pol_template.json
+++ b/test/data/fapi/policy/pol_template.json
@@ -1,0 +1,44 @@
+{
+    "description":"Description pol_template",
+    "policy":[
+        {
+            "type": "POLICYTEMPLATE",
+            "templatePublic": {
+                    "type":"ECC",
+                    "nameAlg":"sha256",
+                    "objectAttributes":{
+                        "fixedTPM":1,
+                        "stClear":0,
+                        "fixedParent":1,
+                        "sensitiveDataOrigin":1,
+                        "userWithAuth":1,
+                        "adminWithPolicy":0,
+                        "noDA":0,
+                        "encryptedDuplication":0,
+                        "restricted":1,
+                        "decrypt":1,
+                        "sign":0
+                    },
+                    "authPolicy":"",
+                    "parameters":{
+                        "symmetric":{
+                            "algorithm":"AES",
+                            "keyBits":128,
+                            "mode":"CFB"
+                        },
+                        "scheme":{
+                            "scheme":"NULL"
+                        },
+                        "curveID":"NIST_P256",
+                        "kdf":{
+                            "scheme":"NULL"
+                        }
+                    },
+                   "unique":{
+                       "x":"",
+                       "y":""
+      }
+            }
+        }
+    ]
+}

--- a/test/data/test-fapi-policies.h
+++ b/test/data/test-fapi-policies.h
@@ -86,5 +86,8 @@ static policy_digests _test_fapi_policy_policies[] = {
     { .path = "/policy/pol_ek_high_range_sha256",
       .sha1 = "23694f69a8f33f588a93879021a294f3ed73b361",
       .sha256 = "ca3d0a99a2b93906f7a3342414efcfb3a385d44cd1fd459089d19b5071c0b7a0" },
+    { .path = "/policy/pol_template",
+      .sha1 = "acfec8114dee366fa5451cfcbfe2111cf324e18d",
+      .sha256 = "4f94fe9a608e6efc376ee1589f43581b8eb1fea60fe6ae94d60f88b67312825d" },
 };
 #endif


### PR DESCRIPTION
* The calculation and execution of PolicyTemplate was added.
* The policy unit tests was extended with an test for PolicyTemplate.
* The deserialization of TPMT_PUBLIC was simplified.
* Fixes #2509.

Signed-off-by: Juergen Repp <juergen_repp@web.de> 