### PR TITLE
FAPI: Fix deviation from specification in Fapi_GetDescription.

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -4450,14 +4450,16 @@ ifapi_get_description(IFAPI_OBJECT *object, char **description)
             obj_description = "Hierarchy";
         break;
     default:
-        *description = NULL;
+        *description = strdup("");
+        check_oom(*description);
         return TSS2_RC_SUCCESS;
     }
     if (obj_description) {
         *description = strdup(obj_description);
         check_oom(*description);
     } else {
-        *description = NULL;
+        *description = strdup("");
+        check_oom(*description);
     }
     return TSS2_RC_SUCCESS;
 }


### PR DESCRIPTION
If no description exists Fapi_GetDescription returns NULL. The FAPI specification states:
If no description is present, description SHALL be set to an empty string.

Signed-off-by: Juergen Repp <juergen_repp@web.de>