### PR TITLE
fapi: fix curl curl_url_strerror not found error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,7 @@ AS_IF([test "x$enable_fapi" = xyes -o "x$enable_policy" = xyes ],
 
 AS_IF([test "x$enable_fapi" = xyes ],
       [PKG_CHECK_MODULES([CURL], [libcurl])])
+AC_CHECK_LIB([curl], [curl_url_strerror], [AC_DEFINE([HAVE_CURL_URL_STRERROR],[1], [If lib curl has curl_url_strerror function])])
 
 AS_IF([test "x$enable_fapi" = xyes -o "x$enable_policy" = xyes ],
       [PKG_CHECK_MODULES([UUID], [uuid])])

--- a/src/tss2-fapi/ifapi_curl.c
+++ b/src/tss2-fapi/ifapi_curl.c
@@ -381,8 +381,12 @@ ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
     CURLUcode url_rc;
     url_rc = curl_url_set(urlp, CURLUPART_URL, (const char *)url, CURLU_ALLOW_SPACE | CURLU_URLENCODE);
     if (url_rc) {
+#ifdef HAVE_CURL_URL_STRERROR
         LOG_ERROR("curl_url_set for CURUPART_URL failed: %s",
                   curl_url_strerror(url_rc));
+#else
+        LOG_ERROR("curl_url_set for CURUPART_URL failed: %u", url_rc);
+#endif
         goto out_easy_cleanup;
     }
     rc = curl_easy_setopt(curl, CURLOPT_CURLU, urlp);


### PR DESCRIPTION
Fix undefined reference to curl_url_strerror for libcurl versions prior to 7.80.0, see:
  - https://curl.se/libcurl/c/curl_url_strerror.html

Signed-off-by: William Roberts <william.c.roberts@intel.com>