### PR TITLE
Fix broken GetPollHandles interface for windows in tcti-mssim.c

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -285,12 +285,11 @@ tcti_mssim_get_poll_handles (
     if (handles != NULL) {
 #ifdef _WIN32
         HANDLE hEvent = WSACreateEvent();
-        if (WSAEventSelect(tcti_mssim->tpm_sock, hEvent, FD_READ | FD_WRITE) == 0){
-            *handles = hEvent;
-        } else {
+        if (WSAEventSelect(tcti_mssim->tpm_sock, hEvent, FD_READ | FD_WRITE)) {
             WSACloseEvent(hEvent);
             return TSS2_TCTI_RC_BAD_VALUE;
         }
+        *handles = hEvent
 #else
         handles->fd = tcti_mssim->tpm_sock;
         handles->events = POLLIN | POLLOUT;

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -284,7 +284,13 @@ tcti_mssim_get_poll_handles (
     *num_handles = 1;
     if (handles != NULL) {
 #ifdef _WIN32
-        *handles = (TSS2_TCTI_POLL_HANDLE)(tcti_mssim->tpm_sock);
+        HANDLE hEvent = WSACreateEvent();
+        if (WSAEventSelect(tcti_mssim->tpm_sock, hEvent, FD_READ | FD_WRITE) == 0){
+            *handles = hEvent;
+        } else {
+            WSACloseEvent(hEvent);
+            return TSS2_TCTI_RC_BAD_VALUE;
+        }
 #else
         handles->fd = tcti_mssim->tpm_sock;
         handles->events = POLLIN | POLLOUT;

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -284,7 +284,7 @@ tcti_mssim_get_poll_handles (
     *num_handles = 1;
     if (handles != NULL) {
 #ifdef _WIN32
-        *handles = tcti_mssim->tpm_sock;
+        *handles = (TSS2_TCTI_POLL_HANDLE)(tcti_mssim->tpm_sock);
 #else
         handles->fd = tcti_mssim->tpm_sock;
         handles->events = POLLIN | POLLOUT;


### PR DESCRIPTION
This change will stop the latest clang from throwing an int-to-pointer error when compiling the library on windows