### PR TITLE
tcti: fix get_poll_handles for mssim TCTI

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -284,7 +284,12 @@ tcti_mssim_get_poll_handles (
     *num_handles = 1;
     if (handles != NULL) {
 #ifdef _WIN32
-        *handles = tcti_mssim->tpm_sock;
+        HANDLE hEvent = WSACreateEvent();
+        if (WSAEventSelect(tcti_mssim->tpm_sock, hEvent, FD_READ | FD_WRITE)) {
+            WSACloseEvent(hEvent);
+            return TSS2_TCTI_RC_BAD_VALUE;
+        }
+        *handles = hEvent;
 #else
         handles->fd = tcti_mssim->tpm_sock;
         handles->events = POLLIN | POLLOUT;


### PR DESCRIPTION
The get_poll_handles function for the mssim TCTI returns a windows HANDLE object. Current code was returning a SOCKET which was an integer type. To fix this use an event HANDLE and set up the events to listen to.

Fixes: #2520

Signed-off-by: robedpixel <3531281-robedpixel@users.noreply.gitlab.com>
Signed-off-by: William Roberts <william.c.roberts@intel.com>