### PR TITLE
FAPI: Fix event logging for big endian machines.

### DIFF
--- a/afl-fuzzing/fuzz-ima.sh
+++ b/afl-fuzzing/fuzz-ima.sh
@@ -7,8 +7,13 @@ function stop() {
     killall afl-fuzz
     }
 
-
 trap stop
+
+test_endian=$(echo -n I | od -to2 | awk 'FNR==1{ print substr($2,6,1)}')
+if [ $test_endian == 0 ]; then
+    echo "Little endian test files can't be used on big endian architecture"
+    exit 1
+fi
 
 mkdir -p afl-fuzzing/ima-sml
 for x in sml-ima-ng-sha1.b64  sml-ima-sha1.b64  sml-ima-sha1-invalidated.b64  sml-ima-sig-sha256.b64  sml-ima-sig-sha256-invalidated.b64

--- a/afl-fuzzing/fuzz-system.sh
+++ b/afl-fuzzing/fuzz-system.sh
@@ -5,6 +5,12 @@ export srcdir=$(pwd)
 
 trap killall afl-fuzz
 
+test_endian=$(echo -n I | od -to2 | awk 'FNR==1{ print substr($2,6,1)}')
+if [ $test_endian == 0 ]; then
+    echo "Little endian test files can't be used on big endian architecture"
+    exit 1
+fi
+
 mkdir -p afl-fuzzing/system-events
 for x in binary_measurements_nuc.b64  binary_measurements_pc_client.b64
 do

--- a/src/tss2-fapi/ifapi_ima_eventlog.h
+++ b/src/tss2-fapi/ifapi_ima_eventlog.h
@@ -25,6 +25,11 @@ typedef UINT32 IFAPI_IMA_EVENT_TYPE;
 
 /* Structure to store event header and data of IMA template */
 typedef struct {
+    /* Switch whether conversion from little endian to big endian
+       is needed if on a big endian machine with the option
+       --ima_canonical_fmt ima is forced to produce a little endian log. */
+    bool convert_to_big_endian;
+
     /* header is the First part of the template which will be read
        beforte the rest of the event will be read and parsed. */
     struct {

--- a/test/integration/fapi-quote-destructive.int.c
+++ b/test/integration/fapi-quote-destructive.int.c
@@ -23,6 +23,17 @@
 
 #define EVENT_SIZE 10
 
+static bool big_endian(void) {
+
+    uint32_t test_word;
+    uint8_t *test_byte;
+
+    test_word = 0xFF000000;
+    test_byte = (uint8_t *) (&test_word);
+
+    return test_byte[0] == 0xFF;
+}
+
 /** Test the FAPI functions for quote commands.
  *
  * Tested FAPI commands:
@@ -55,6 +66,10 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
     uint8_t data[EVENT_SIZE] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     size_t signatureSize = 0;
     uint32_t pcrList[2] = { 11, 16 };
+
+    if (big_endian()) {
+        return EXIT_SKIP;
+    }
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
 

--- a/test/unit/fapi-check-ima-log.c
+++ b/test/unit/fapi-check-ima-log.c
@@ -29,6 +29,15 @@
 #define LOGMODULE tests
 #include "util/log.h"
 
+static bool big_endian_arch(void) {
+
+    uint32_t test_word;
+    uint8_t *test_byte;
+
+    test_word = 0xFF000000;
+    test_byte = (uint8_t *) (&test_word);
+    return test_byte[0] == 0xFF;
+}
 
 static void
 check_eventlog(const char *file)
@@ -127,6 +136,9 @@ check_sml_ima_sig_sha256(void **state)
 static void
 check_sml_ima_sig_sha256_invalidated(void **state)
 {
+    if (big_endian_arch())
+        skip();
+
     check_eventlog("test/data/fapi/eventlog/sml-ima-sig-sha256-invalidated.bin");
 }
 

--- a/test/unit/fapi-eventlog.c
+++ b/test/unit/fapi-eventlog.c
@@ -34,6 +34,19 @@
 #define LOGMODULE tests
 #include "util/log.h"
 
+#define EXIT_SKIP 77
+
+static bool big_endian(void) {
+
+    uint32_t test_word;
+    uint8_t *test_byte;
+
+    test_word = 0xFF000000;
+    test_byte = (uint8_t *) (&test_word);
+
+    return test_byte[0] == 0xFF;
+}
+
 static uint8_t *file_to_buffer(const char *filename, size_t *size)
 {
     uint8_t *eventlog = NULL;
@@ -167,6 +180,10 @@ check_specid_vendordata(void **state)
 int
 main(int argc, char *argv[])
 {
+    if (big_endian()) {
+        return EXIT_SKIP;
+    }
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(check_bios_nuc),
         cmocka_unit_test(check_bios_pc_client),


### PR DESCRIPTION
* For eventlogs in little endian format on big endian machines the data will be converted to big endian. That can occur if the option --ima_canonical_fmt is used.
* The tests with system events are skipped because the test data uses little endian.
* For the IMA test files in little endian format the little endian numbers are converted to big endian. The tests with little endian data in the json fields are skipped.

Addresses: #2521

Signed-off-by: Juergen Repp <juergen_repp@web.de>