### PR TITLE
FAPI: Fix json syntax in FAPI profiles.

### DIFF
--- a/dist/fapi-profiles/P_ECCP256SHA256.json
+++ b/dist/fapi-profiles/P_ECCP256SHA256.json
@@ -33,7 +33,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/dist/fapi-profiles/P_RSA2048SHA256.json
+++ b/dist/fapi-profiles/P_RSA2048SHA256.json
@@ -46,7 +46,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_ECC.json
+++ b/test/data/fapi/P_ECC.json
@@ -33,7 +33,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_ECC_error.json
+++ b/test/data/fapi/P_ECC_error.json
@@ -33,7 +33,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_ECC_sh_eh_policy.json
+++ b/test/data/fapi/P_ECC_sh_eh_policy.json
@@ -31,7 +31,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     },

--- a/test/data/fapi/P_ECC_system.json
+++ b/test/data/fapi/P_ECC_system.json
@@ -33,7 +33,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_RSA.json
+++ b/test/data/fapi/P_RSA.json
@@ -46,7 +46,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_RSA2.json
+++ b/test/data/fapi/P_RSA2.json
@@ -46,7 +46,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     }

--- a/test/data/fapi/P_RSA_sh_policy.json
+++ b/test/data/fapi/P_RSA_sh_policy.json
@@ -46,7 +46,7 @@
         "policy":[
             {
                 "type":"POLICYSECRET",
-                "objectName": "4000000b",
+                "objectName": "4000000b"
             }
         ]
     },


### PR DESCRIPTION
An unnecessary comma was used in the definition of the EK policy. The comma was ignored by json-c but did cause errors in other tools (e.g. jq).

Signed-off-by: Juergen Repp <juergen_repp@web.de>