### PR TITLE
tcti_spi_helper_transmit: ensure FIFO is accessed only after TPM repo…

### DIFF
--- a/src/tss2-tcti/tcti-spi-helper.c
+++ b/src/tss2-tcti/tcti-spi-helper.c
@@ -619,6 +619,14 @@ TSS2_RC tcti_spi_helper_transmit (TSS2_TCTI_CONTEXT *tcti_ctx, size_t size, cons
     // Tell TPM to expect command
     spi_tpm_helper_write_sts_reg(ctx, TCTI_SPI_HELPER_TPM_STS_COMMAND_READY);
 
+    // Wait until ready bit is set by TPM device
+    uint32_t expected_status_bits = TCTI_SPI_HELPER_TPM_STS_COMMAND_READY;
+    rc = spi_tpm_helper_wait_for_status(ctx, expected_status_bits, expected_status_bits, 200);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Failed waiting for TPM to become ready");
+        return rc;
+    }
+
     // Send command
     spi_tpm_helper_fifo_transfer(ctx, (void*)cmd_buf, size, TCTI_SPI_HELPER_FIFO_TRANSMIT);
 


### PR DESCRIPTION
tcti_spi_helper_transmit: ensure TPM FIFO is only accessed after TPM reports commandReady is set to 1 in the TPM_STS register. 

The current implementation is accessing the FIFO with the commandReady not set to 1 which leads to problems that manifest as unrelated SPI timings issues.
![image](https://user-images.githubusercontent.com/3757261/214254711-8105e8ec-37ef-4b48-a810-f4a22b67c5fd.png)
