### PR TITLE
Makefile: Add tss2-tcti-swtpm.7.in to EXTRA_DIST (3.2.x)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -771,7 +771,7 @@ EXTRA_DIST += \
     man/Tss2_TctiLdr_Initialize.3.in \
     man/tss2-tcti-pcap.7.in \
     man/tss2-tcti-device.7.in \
-    man/man7/tss2-tcti-swtpm.7 \
+    man/tss2-tcti-swtpm.7.in \
     man/tss2-tcti-mssim.7.in \
     man/tss2-tcti-cmd.7.in \
     man/tss2-tctildr.7.in


### PR DESCRIPTION
tss2-tcti-swtpm.7 was added wrongly to EXTRA_DIST, which caused a build fail after make clean.
Fixes: #2557

Signed-off-by: Juergen Repp <juergen_repp@web.de>