### PR TITLE
tcti: only enable tcti-spi-lt2go if libusb is installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -299,18 +299,15 @@ AS_IF([test "x$enable_tcti_spi_helper" = "xyes"],
 	[AC_DEFINE([TCTI_SPI_HELPER],[1], [TCTI HELPER FOR SPI BASED ACCESS TO TPM2 DEVICE])])
 
 AC_ARG_ENABLE([tcti-spi-lt2go],
-            [AS_HELP_STRING([--disable-tcti-spi-lt2go],
-                            [don't build the tcti-spi-lt2go module])],,
-            [enable_tcti_spi_lt2go=yes])
+            [AS_HELP_STRING([--disable-tcti-libtpms],
+                            [don't build the tcti-spi-lt2go module])],
+            [AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
+                   [PKG_CHECK_MODULES([LIBUSB], [libusb-1.0], [AC_MSG_ERROR([libusb-1.0 library is missing])])])],
+            [PKG_CHECK_MODULES([LIBUSB], [libusb-1.0], [enable_tcti_spi_lt2go=yes],
+                                                       [enable_tcti_spi_lt2go=no]
+                                                       [AC_MSG_WARN([libusb-1.0 library is missing])])])
 
 AM_CONDITIONAL([ENABLE_TCTI_SPI_LT2GO], [test "x$enable_tcti_spi_lt2go" != xno])
-AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
-    AC_DEFINE([TCTI_SPI_LT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
-
-AS_IF([test "x$enable_tcti_spi_lt2go" = xyes ],
-      [PKG_CHECK_MODULES([LIBUSB],
-                         [libusb-1.0],,
-                         [AC_MSG_ERROR([libusb-1.0 library is missing.])])])
 
 AC_ARG_ENABLE([tcti-fuzzing],
             [AS_HELP_STRING([--enable-tcti-fuzzing],


### PR DESCRIPTION
Make support for tcti-spi-lt2go behave as tcti-libtpms in the sense that it should only be enabled by default if the dependencies are installed.