### PR TITLE
FAPI: Fix test provisioning with template.

### DIFF
--- a/test/integration/fapi-provisioning-with-template.int.c
+++ b/test/integration/fapi-provisioning-with-template.int.c
@@ -34,6 +34,9 @@
 int
 test_fapi_provision_template(FAPI_CONTEXT *context)
 {
+#ifndef SELF_GENERATED_CERTIFICATE
+    return EXIT_SKIP;
+#endif
     size_t offset = 0;
     UINT16 offset_nv = 0;
      TSS2_TCTI_CONTEXT *tcti;


### PR DESCRIPTION
This tests works only if for builds with --enable-self-generated-certificate. The test is now skipped if this option is disabled.