### PR TITLE
FAPI: Fix usage of persistent handles 3.2.x.

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -4742,6 +4742,7 @@ ifapi_create_primary(
 
     statecase(context->cmd.Key_Create.state, KEY_CREATE_PRIMARY_WAIT_FOR_AUTHORIZE2);
         if (template->persistent_handle) {
+            object->misc.key.persistent_handle = template->persistent_handle;
             r = ifapi_authorize_object(context, hierarchy, &auth_session);
             FAPI_SYNC(r, "Authorize hierarchy.", error_cleanup);
 


### PR DESCRIPTION
* Evict control for persistent keys created with Fapi_CreateKey was called with the wrong handle.
* If Fapi_Quote was executed with a primary key for this key flush context was called.

Signed-off-by: Juergen Repp <juergen_repp@web.de>