### PR TITLE
src: Check if NID_sm2 is defined

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -919,7 +919,7 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC *key,
         curveId = NID_secp521r1;
         key_size = 66;
         break;
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#ifdef NID_sm2
     case TPM2_ECC_SM2_P256:
         curveId = NID_sm2;
         key_size = 32;

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -544,7 +544,7 @@ ossl_ecc_pub_from_tpm(const TPM2B_PUBLIC *tpmPublicKey, EVP_PKEY **evpPublicKey)
     case TPM2_ECC_NIST_P521:
         curveId = NID_secp521r1;
         break;
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#ifdef NID_sm2
     case TPM2_ECC_SM2_P256:
         curveId = NID_sm2;
         break;
@@ -1195,7 +1195,7 @@ get_ecc_tpm2b_public_from_evp(
     case NID_secp521r1:
         tpmCurveId = TPM2_ECC_NIST_P521;
         break;
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#ifdef NID_sm2
     case NID_sm2:
         tpmCurveId = TPM2_ECC_SM2_P256;
         break;


### PR DESCRIPTION
The NID_sm2 algorithm is not currently supported by LibreSSL which causes build failures. However instead of checking the OpenSSL version number it is possible to just check if NID_sm2 is defined instead. This way it will be automatically enabled when LibreSSL does support it and disabled in the event the OpenSSL stops supporting it.

LibreSSL issue: https://github.com/libressl/portable/issues/841

I am splitting this off from PR https://github.com/tpm2-software/tpm2-tss/pull/2380 since it is more general.