### PR TITLE
FAPI: Skip provisioning test for nv ext and profile paths. 3.2.x

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1772,6 +1772,14 @@ ifapi_check_provisioned(
 
     *ok = false;
 
+    /* No profile in path, test can be skipped. */
+    if (ifapi_path_type_p(rel_path, IFAPI_NV_PATH) ||
+        ifapi_path_type_p(rel_path, IFAPI_POLICY_PATH) ||
+        ifapi_path_type_p(rel_path, IFAPI_EXT_PATH)) {
+        *ok = true;
+        return TSS2_RC_SUCCESS;
+    }
+
     /* First expand path in user directory  */
     r = expand_path(keystore, rel_path, &directory);
     goto_if_error(r, "Expand path", cleanup);


### PR DESCRIPTION
The provisioning test in ifapi_check_provisioned will be skipped for ext nv and profile paths. The test did produce inappropriate error messages if the corresponding paths did not exist in keystore. The test is only needed for pathnames starting with the profile. Fixes: #2596

Signed-off-by: Juergen Repp <juergen_repp@web.de>