### PR TITLE
FAPI: Fix wrong allocation of pcr policy 3.2.x

### DIFF
--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -1343,7 +1343,7 @@ copy_policy_element(const TPMT_POLICYELEMENT *from_policy, TPMT_POLICYELEMENT *t
     case POLICYPCR:
         to_policy->element.PolicyPCR.pcrs =
             calloc(1, sizeof(TPML_PCRVALUES) +
-                   from_policy->element.PolicyPCR.pcrs->count + sizeof(TPMS_PCRVALUE));
+                   from_policy->element.PolicyPCR.pcrs->count * sizeof(TPMS_PCRVALUE));
         goto_if_null2(to_policy->element.PolicyPCR.pcrs, "Out of memory.",
                       r, TSS2_FAPI_RC_MEMORY, error);
         to_policy->element.PolicyPCR.pcrs->count


### PR DESCRIPTION
The list of pcr registers was was allocated with the wrong size in the function copy_policy_element which caused a segfault if more than one pcr was used.

Signed-off-by: Juergen Repp <juergen_repp@web.de>