### PR TITLE
TCTI: Implement tcti-i2c-helper and tcti-i2c-ftdi

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -161,6 +161,12 @@ endif
 if ENABLE_TCTI_SPI_FTDI
 TESTS_UNIT += test/unit/tcti-spi-ftdi
 endif
+if ENABLE_TCTI_I2C_HELPER
+TESTS_UNIT += test/unit/tcti-i2c-helper
+endif
+if ENABLE_TCTI_I2C_FTDI
+TESTS_UNIT += test/unit/tcti-i2c-ftdi
+endif
 if ESYS
 TESTS_UNIT += \
     test/unit/esys-context-null \
@@ -578,6 +584,30 @@ test_unit_tcti_spi_ftdi_LDFLAGS = -Wl,--wrap=Close \
                                   -Wl,--wrap=gettimeofday
 test_unit_tcti_spi_ftdi_SOURCES = test/unit/tcti-spi-ftdi.c \
                                   src/tss2-tcti/tcti-spi-ftdi.c
+endif
+
+if ENABLE_TCTI_I2C_HELPER
+test_unit_tcti_i2c_helper_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_i2c_helper_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_i2c_helper)
+test_unit_tcti_i2c_helper_SOURCES = test/unit/tcti-i2c-helper.c
+endif
+
+if ENABLE_TCTI_I2C_FTDI
+test_unit_tcti_i2c_ftdi_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_i2c_ftdi_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_i2c_helper)
+test_unit_tcti_i2c_ftdi_LDFLAGS = -Wl,--wrap=MPSSE \
+                                  -Wl,--wrap=Start \
+                                  -Wl,--wrap=Stop \
+                                  -Wl,--wrap=Close \
+                                  -Wl,--wrap=Read \
+                                  -Wl,--wrap=Write \
+                                  -Wl,--wrap=GetAck \
+                                  -Wl,--wrap=SendAcks \
+                                  -Wl,--wrap=SendNacks \
+                                  -Wl,--wrap=select \
+                                  -Wl,--wrap=gettimeofday
+test_unit_tcti_i2c_ftdi_SOURCES = test/unit/tcti-i2c-ftdi.c \
+                                  src/tss2-tcti/tcti-i2c-ftdi.c
 endif
 
 test_unit_tctildr_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -469,6 +469,52 @@ src_tss2_tcti_libtss2_tcti_spi_ftdi_la_SOURCES  = \
     src/tss2-tcti/tcti-spi-ftdi.h
 endif # ENABLE_TCTI_SPI_FTDI
 
+# tcti library for i2c connected tpms
+if ENABLE_TCTI_I2C_HELPER
+libtss2_tcti_i2c_helper = src/tss2-tcti/libtss2-tcti-i2c-helper.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_i2c_helper.h
+lib_LTLIBRARIES += $(libtss2_tcti_i2c_helper)
+pkgconfig_DATA += lib/tss2-tcti-i2c-helper.pc
+EXTRA_DIST += lib/tss2-tcti-i2c-helper.map \
+              lib/tss2-tcti-i2c-helper.def
+
+if HAVE_LD_VERSION_SCRIPT
+if !UNIT
+src_tss2_tcti_libtss2_tcti_i2c_helper_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-i2c-helper.map
+endif # UNIT
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_i2c_helper_la_LIBADD   = $(libutil) $(libtss2_mu)
+src_tss2_tcti_libtss2_tcti_i2c_helper_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-i2c-helper.c \
+    src/tss2-tcti/tcti-i2c-helper.h
+endif # ENABLE_TCTI_I2C_HELPER
+
+# tcti library for ftdi connected tpm
+if ENABLE_TCTI_I2C_FTDI
+libtss2_tcti_i2c_ftdi = src/tss2-tcti/libtss2-tcti-i2c-ftdi.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_i2c_ftdi.h
+lib_LTLIBRARIES += $(libtss2_tcti_i2c_ftdi)
+pkgconfig_DATA += lib/tss2-tcti-i2c-ftdi.pc
+EXTRA_DIST += lib/tss2-tcti-i2c-ftdi.map \
+              lib/tss2-tcti-i2c-ftdi.def
+
+src_tss2_tcti_libtss2_tcti_i2c_ftdi_la_CFLAGS  = $(AM_CFLAGS) $(LIBFTDI_CFLAGS) -Wno-deprecated-declarations
+src_tss2_tcti_libtss2_tcti_i2c_ftdi_la_LDFLAGS  = $(LIBFTDI_LIBS)
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_i2c_ftdi_la_LDFLAGS  += -Wl,--version-script=$(srcdir)/lib/tss2-tcti-i2c-ftdi.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_i2c_ftdi_la_LIBADD   = $(libutil) $(libtss2_mu) $(libtss2_tcti_i2c_helper)
+src_tss2_tcti_libtss2_tcti_i2c_ftdi_la_SOURCES  = \
+    src/tss2-tcti/mpsse/support.c \
+    src/tss2-tcti/mpsse/support.h \
+    src/tss2-tcti/mpsse/mpsse.c \
+    src/tss2-tcti/mpsse/mpsse.h \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-i2c-ftdi.c \
+    src/tss2-tcti/tcti-i2c-ftdi.h
+endif # ENABLE_TCTI_I2C_FTDI
+
 ### TCG TSS SYS spec library ###
 libtss2_sys = src/tss2-sys/libtss2-sys.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_sys.h
@@ -854,6 +900,8 @@ man7_MANS = \
     man/man7/tss2-tcti-spi-helper.7 \
     man/man7/tss2-tcti-spi-lt2go.7 \
     man/man7/tss2-tcti-spi-ftdi.7 \
+    man/man7/tss2-tcti-i2c-helper.7 \
+    man/man7/tss2-tcti-i2c-ftdi.7 \
     man/man7/tss2-tctildr.7
 
 if FAPI
@@ -935,6 +983,8 @@ EXTRA_DIST += \
     man/tss2-tcti-spi-helper.7.in \
     man/tss2-tcti-spi-lt2go.7.in \
     man/tss2-tcti-spi-ftdi.7.in \
+    man/tss2-tcti-i2c-helper.7.in \
+    man/tss2-tcti-i2c-ftdi.7.in \
     man/tss2-tctildr.7.in
 
 CLEANFILES += \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc lib/tss2-tcti-spi-ftdi.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc lib/tss2-tcti-spi-ftdi.pc lib/tss2-tcti-i2c-helper.pc lib/tss2-tcti-i2c-ftdi.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -321,31 +321,54 @@ AM_CONDITIONAL([ENABLE_TCTI_SPI_LT2GO], [test "x$enable_tcti_spi_lt2go" != xno])
 AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
     AC_DEFINE([TCTI_SPI_LT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
 
+PKG_CHECK_MODULES([LIBFTDI],
+                  [libftdi],
+                  [AC_DEFINE(LIBFTDI_VERSION, [0], [libftdi version 0.x])]
+                  [have_libftdi=yes],
+                  [PKG_CHECK_MODULES([LIBFTDI],
+                                     [libftdi1],
+                                     [AC_DEFINE(LIBFTDI_VERSION, [1], [libftdi version 1.x])]
+                                     [have_libftdi=yes],
+                                     [have_libftdi=no])])
+
 AC_ARG_ENABLE([tcti-spi-ftdi],
               [AS_HELP_STRING([--disable-tcti-spi-ftdi],
                               [don't build the tcti-spi-ftdi module])],
               [AS_IF([test "x$enable_tcti_spi_ftdi" = "xyes"],
-                     [PKG_CHECK_MODULES([LIBFTDI],
-                                        [libftdi],
-                                        [AC_DEFINE(LIBFTDI_VERSION, [0], [libftdi version 0.x])],
-                                        [PKG_CHECK_MODULES([LIBFTDI],
-                                                           [libftdi1],
-                                                           [AC_DEFINE(LIBFTDI_VERSION, [1], [libftdi version 1.x])],
-                                                           [AC_MSG_ERROR([libftdi/libftdi1 library is missing.])])])])],
-              [PKG_CHECK_MODULES([LIBFTDI],
-                                 [libftdi],
-                                 [enable_tcti_spi_ftdi=yes]
-                                 [AC_DEFINE(LIBFTDI_VERSION, [0], [libftdi version 0.x])],
-                                 [PKG_CHECK_MODULES([LIBFTDI],
-                                                    [libftdi1],
-                                                    [enable_tcti_spi_ftdi=yes]
-                                                    [AC_DEFINE(LIBFTDI_VERSION, [1], [libftdi version 1.x])],
-                                                    [enable_tcti_spi_ftdi=no])])])
+                     [AS_IF([test "x$have_libftdi" != "xyes"],
+                            [AC_MSG_ERROR([libftdi/libftdi1 library is missing.])])])],
+              [AS_IF([test "x$have_libftdi" = "xyes"],
+                     [enable_tcti_spi_ftdi=yes],
+                     [enable_tcti_spi_ftdi=no])])
 
 AM_CONDITIONAL([ENABLE_TCTI_SPI_FTDI], [test "x$enable_tcti_spi_ftdi" != xno])
 
 AS_IF([test "x$enable_tcti_spi_ftdi" = "xyes"],
     AC_DEFINE([TCTI_SPI_FTDI],[1], [TCTI FOR USB BASED ACCESS TO SPI BASED TPM OVER THE FTDI MPSSE USB TO SPI BRIDGE]))
+
+AC_ARG_ENABLE([tcti-i2c-helper],
+            [AS_HELP_STRING([--disable-tcti-i2c-helper],
+                            [don't build the tcti-i2c-helper module])],,
+            [enable_tcti_i2c_helper=yes])
+
+AM_CONDITIONAL([ENABLE_TCTI_I2C_HELPER], [test "x$enable_tcti_i2c_helper" != xno])
+AS_IF([test "x$enable_tcti_i2c_helper" = "xyes"],
+	[AC_DEFINE([TCTI_I2C_HELPER],[1], [TCTI HELPER FOR I2C BASED ACCESS TO TPM2 DEVICE])])
+
+AC_ARG_ENABLE([tcti-i2c-ftdi],
+              [AS_HELP_STRING([--disable-tcti-i2c-ftdi],
+                              [don't build the tcti-i2c-ftdi module])],
+              [AS_IF([test "x$enable_tcti_i2c_ftdi" = "xyes"],
+                     [AS_IF([test "x$have_libftdi" != "xyes"],
+                            [AC_MSG_ERROR([libftdi/libftdi1 library is missing.])])])],
+              [AS_IF([test "x$have_libftdi" = "xyes"],
+                     [enable_tcti_i2c_ftdi=yes],
+                     [enable_tcti_i2c_ftdi=no])])
+
+AM_CONDITIONAL([ENABLE_TCTI_I2C_FTDI], [test "x$enable_tcti_i2c_ftdi" != xno])
+
+AS_IF([test "x$enable_tcti_i2c_ftdi" = "xyes"],
+    AC_DEFINE([TCTI_I2C_FTDI],[1], [TCTI FOR USB BASED ACCESS TO I2C BASED TPM OVER THE FTDI MPSSE USB TO I2C BRIDGE]))
 
 AC_ARG_ENABLE([tcti-fuzzing],
             [AS_HELP_STRING([--enable-tcti-fuzzing],
@@ -695,4 +718,5 @@ AC_MSG_RESULT([
     imameasurements:    $imameasurements
     tcti_spi_lt2go      $enable_tcti_spi_lt2go
     tcti_spi_ftdi       $enable_tcti_spi_ftdi
+    tcti_i2c_ftdi       $enable_tcti_i2c_ftdi
 ])

--- a/doc/tcti-i2c-ftdi.md
+++ b/doc/tcti-i2c-ftdi.md
@@ -1,0 +1,61 @@
+# I2C TCTI FTDI
+
+The I2C TCTI FTDI can be used for communication with an I2C-based TPM over the FTDI MPSSE
+USB to I2C bridge. The FTDI module utilizes the `tcti-i2c-helper` library for handling the
+PTP I2C protocol and the `libftdi-dev` library for handling the USB to I2C communication.
+
+Example of a FTDI MPSSE USB to I2C bridge is the product "USB 2.0 Hi-Speed to MPSSE
+Cable (SPI/I2C/JTAG master) with +3.3V digital level signals", part no: C232HM-DDHSL-0.
+Connect the cable to your TPM as specified in the table below:
+
+|   C232HM-DDHSL-0   | Description |
+|--------------------|-------------|
+| pin 1, red, VCC    |     VCC     |
+| pin 2, orange, SCL |     SCL     |
+| pin 3, yellow, SDA |     SDA     |
+| pin 4, green, SDA  |     SDA     |
+| pin 10, black, GND |     GND     |
+
+**Important: both yellow and green wires need to be shorted together to create bidirectional data.**
+
+# EXAMPLES
+
+Set udev rules for the C232HM-DDHSL-0 cable by creating a file `/etc/udev/rules.d/60-c232hm.rules`:
+```
+ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6014", TAG+="uaccess"
+```
+
+Activate the udev rules:
+```console
+sudo udevadm control --reload
+```
+
+You should see the following after plugging in the C232HM-DDHSL-0 cable:
+```
+dmesg
+ [74386.091721] usb 3-2: new high-speed USB device number 18 using xhci_hcd
+ [74386.439103] usb 3-2: New USB device found, idVendor=0403, idProduct=6014, bcdDevice= 9.00
+ [74386.439117] usb 3-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+ [74386.439129] usb 3-2: Product: C232HM-DDHSL-0
+ [74386.439140] usb 3-2: Manufacturer: FTDI
+ [74386.439151] usb 3-2: SerialNumber: FT1UGJKF
+ [74386.443996] ftdi_sio 3-2:1.0: FTDI USB Serial Device converter detected
+ [74386.444030] usb 3-2: Detected FT232H
+ [74386.446370] usb 3-2: FTDI USB Serial Device converter now attached to ttyUSB0
+```
+
+Use tcti-i2c-ftdi to communicate with a I2C-based TPM:
+```console
+tpm2_startup -Ti2c-ftdi -c
+tpm2_getrandom -Ti2c-ftdi 8 --hex
+```
+
+Enable abrmd:
+```console
+export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork`
+tpm2-abrmd --allow-root --session --tcti=i2c-ftdi &
+
+export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
+tpm2_startup -c
+tpm2_getrandom 8 --hex
+```

--- a/doc/tcti-i2c-helper.md
+++ b/doc/tcti-i2c-helper.md
@@ -1,0 +1,11 @@
+# I2C TCTI Helper
+
+The I2C TCTI helper can be used for TPM communication over I2C e.g. in embedded systems.
+It uses user supplied methods for I2C and timing operations in order to be platform independent.
+These methods are supplied to `Tss2_Tcti_I2c_Helper_Init` via the `TSS2_TCTI_I2C_HELPER_PLATFORM` struct.
+
+## Platform methods
+
+Documentation detailing the implementation of platform methods can be found in `tss2_tcti_i2c_helper.h`.
+For an example implementation that uses the I2C TCTI helper to communicate with an I2C-based TPM over the
+FTDI MPSSE USB to I2C bridge, refer to the `tcti-i2c-ftdi` module.

--- a/include/tss2/tss2_tcti_i2c_ftdi.h
+++ b/include/tss2/tss2_tcti_i2c_ftdi.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TSS2_TCTI_I2C_FTDI_H
+#define TSS2_TCTI_I2C_FTDI_H
+
+#include <stdbool.h>
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_I2c_Ftdi_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_I2C_FTDI_H */

--- a/include/tss2/tss2_tcti_i2c_helper.h
+++ b/include/tss2/tss2_tcti_i2c_helper.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TSS2_TCTI_I2C_HELPER_HELPER_H
+#define TSS2_TCTI_I2C_HELPER_HELPER_H
+
+#include <stdbool.h>
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Forward declaration
+ */
+typedef struct TSS2_TCTI_I2C_HELPER_PLATFORM TSS2_TCTI_I2C_HELPER_PLATFORM;
+
+/*
+ * Sleeps for the specified amount of microseconds
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_SLEEP_US_FUNC) (void* user_data, int microseconds);
+
+/*
+ * Sleeps for the specified amount of milliseconds
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_SLEEP_MS_FUNC) (void* user_data, int milliseconds);
+
+/*
+ * Starts a timeout timer which expires in the specified amount of milliseconds.
+ * This can be done by storing the expire time (now + milliseconds) in the userdata.
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_START_TIMEOUT_FUNC) (void* user_data, int milliseconds);
+
+/*
+ * Returns true if the timeout started previously by START_TIMEOUT_FUNC already has expired, false otherwise.
+ * This can be done e.g. by comparing the current time and the stored timer expire time.
+ * This method will be called often when waiting for timeouts and should be fast.
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_TIMEOUT_EXPIRED_FUNC) (void* user_data, bool *result);
+
+/*
+ * Writes cnt bytes from data buffer to the I2C slave.
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_I2C_WRITE_FUNC) (void* user_data, uint8_t reg_addr, const void *data, size_t cnt);
+
+/*
+ * Reads cnt bytes from the I2C slave to data buffer.
+ */
+typedef TSS2_RC (*TSS2_TCTI_I2C_HELPER_PLATFORM_I2C_READ_FUNC) (void* user_data, uint8_t reg_addr, void *data, size_t cnt);
+
+/*
+ * Is called by Tss2_Tcti_Finalize right before the TCTI context is destroyed and
+ * should free user_data and all resources inside like e.g. I2C device handles.
+ */
+typedef void (*TSS2_TCTI_I2C_HELPER_PLATFORM_FINALIZE) (void* user_data);
+
+/*
+ * Contains user implemented platform methods for the I2C TCTI.
+ */
+struct TSS2_TCTI_I2C_HELPER_PLATFORM {
+    void* user_data;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_SLEEP_US_FUNC sleep_us;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_SLEEP_MS_FUNC sleep_ms;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_START_TIMEOUT_FUNC start_timeout;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_TIMEOUT_EXPIRED_FUNC timeout_expired;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_I2C_WRITE_FUNC i2c_write;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_I2C_READ_FUNC i2c_read;
+    TSS2_TCTI_I2C_HELPER_PLATFORM_FINALIZE finalize;
+};
+
+/*
+ * Initializes the I2C TCTI with a context pointer and platform methods.
+ * When the tctiContext pointer is NULL, the needed buffer size is written to *size.
+ * platform_conf contains platform methods implemented by the user for I2C
+ * communication and timeout handling.
+ */
+TSS2_RC Tss2_Tcti_I2c_Helper_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    TSS2_TCTI_I2C_HELPER_PLATFORM *platform_conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_I2C_HELPER_HELPER_H */

--- a/lib/tss2-tcti-i2c-ftdi.def
+++ b/lib/tss2-tcti-i2c-ftdi.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-i2c-ftdi
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_I2c_Ftdi_Init

--- a/lib/tss2-tcti-i2c-ftdi.map
+++ b/lib/tss2-tcti-i2c-ftdi.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_I2c_Ftdi_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-i2c-ftdi.pc.in
+++ b/lib/tss2-tcti-i2c-ftdi.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-i2c-ftdi
+Description: TCTI library for communicating with a TPM over USB-FTDI-I2C converter.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Cflags: -I${includedir} -I${includedir}/tss
+Libs: -ltss2-tcti-i2c-helper -ltss2-tcti-i2c-ftdi -L${libdir} -lftdi

--- a/lib/tss2-tcti-i2c-helper.def
+++ b/lib/tss2-tcti-i2c-helper.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-i2c-helper
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_I2c_Helper_Init

--- a/lib/tss2-tcti-i2c-helper.map
+++ b/lib/tss2-tcti-i2c-helper.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_I2c_Helper_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-i2c-helper.pc.in
+++ b/lib/tss2-tcti-i2c-helper.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-i2c-helper
+Description: TCTI library for communicating with the TPM over I2C.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Cflags: -I${includedir} -I${includedir}/tss
+Libs: -ltss2-tcti-i2c-helper -L${libdir}

--- a/man/tss2-tcti-i2c-ftdi.7.in
+++ b/man/tss2-tcti-i2c-ftdi.7.in
@@ -1,0 +1,14 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-I2C 7 "APRIL 2023" "TPM2 Software Stack"
+.SH NAME
+tcti-i2c-ftdi \- USB to I2C-based TPM TCTI library
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for interaction with
+a I2C-based TPM over the FTDI MPSSE USB to I2C bridge.
+.SH DESCRIPTION
+tcti-i2c-ftdi is a library that abstracts the details of communication
+with a I2C-based TPM over the FTDI MPSSE USB to I2C bridge. The interface
+exposed by this library is defined in the \*(lqTSS System Level API and
+and TPM Command Transmission Interface Specification\*(rq specification.

--- a/man/tss2-tcti-i2c-helper.7.in
+++ b/man/tss2-tcti-i2c-helper.7.in
@@ -1,0 +1,14 @@
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
+.TH TCTI-I2C 7 "APRIL 2023" "TPM2 Software Stack"
+.SH NAME
+tcti-i2c-helper \- device driver TCTI library
+.SH SYNOPSIS
+A TPM Command Transmission Interface (TCTI) module for communication via I2C.
+TPM device driver.
+.SH DESCRIPTION
+tcti-i2c-helper is a library that abstracts the details of communication with a TPM
+via I2C protocol. It uses user supplied methods for I2C and timing operations
+in order to be platform independent. These methods are supplied to `Tss2_Tcti_I2c_Helper_Init`
+via the `TSS2_TCTI_I2C_HELPER_PLATFORM` struct.

--- a/src/tss2-tcti/tcti-i2c-ftdi.c
+++ b/src/tss2-tcti/tcti-i2c-ftdi.c
@@ -1,0 +1,296 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "tss2_tcti.h"
+#include "tcti-i2c-ftdi.h"
+#include "tss2_tcti_i2c_ftdi.h"
+#include "tcti-i2c-helper.h"
+#include "tss2_mu.h"
+#include "util/io.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+TSS2_RC
+platform_sleep_us (void *user_data, int32_t microseconds)
+{
+    (void) user_data;
+    struct timeval tv = {microseconds/1000000, microseconds%1000000};
+    select (0, NULL, NULL, NULL, &tv);
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_sleep_ms (void *user_data, int32_t milliseconds)
+{
+    return platform_sleep_us (user_data, milliseconds*1000);
+}
+
+TSS2_RC
+platform_start_timeout (void *user_data, int32_t milliseconds)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    memset (&platform_data->timeout, 0, sizeof (struct timeval));
+
+    if (gettimeofday (&platform_data->timeout, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    platform_data->timeout.tv_sec += (milliseconds/1000);
+    platform_data->timeout.tv_usec += (milliseconds%1000)*1000;
+    if (platform_data->timeout.tv_usec > 999999) {
+        platform_data->timeout.tv_sec++;
+        platform_data->timeout.tv_usec -= 1000000;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_timeout_expired (void *user_data, bool *is_timeout_expired)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+
+    struct timeval now;
+    if (gettimeofday (&now, NULL)) {
+        LOG_ERROR ("getimeofday failed with errno: %d.", errno);
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    if (now.tv_sec > platform_data->timeout.tv_sec) {
+        *is_timeout_expired = true;
+    } else if ((now.tv_sec == platform_data->timeout.tv_sec)
+               && (now.tv_usec > platform_data->timeout.tv_usec)) {
+        *is_timeout_expired = true;
+    } else {
+        *is_timeout_expired = false;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_i2c_write (void *user_data, uint8_t reg_addr, const void *data, size_t cnt)
+{
+    TSS2_RC rc = TSS2_TCTI_RC_IO_ERROR;
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    struct mpsse_context *mpsse = platform_data->mpsse;
+    uint8_t addr[2] = {I2C_DEV_ADDR_DEFAULT << 1, 0x0};
+
+    if (Start (mpsse) != MPSSE_OK)
+    {
+        return rc;
+    }
+
+    addr[1] = reg_addr;
+    if (Write (mpsse, (char *)addr, sizeof (addr)) != MPSSE_OK)
+    {
+        goto error;
+    }
+
+    if (GetAck (mpsse) != ACK)
+    {
+        goto error;
+    }
+
+    if (Write (mpsse, (char *)data, cnt) != MPSSE_OK)
+    {
+        goto error;
+    }
+
+    rc = TSS2_RC_SUCCESS;
+
+error:
+    if (Stop (mpsse) != MPSSE_OK)
+    {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return rc;
+}
+
+TSS2_RC
+platform_i2c_read (void *user_data, uint8_t reg_addr, void *data, size_t cnt)
+{
+    TSS2_RC rc = TSS2_TCTI_RC_IO_ERROR;
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    struct mpsse_context *mpsse = platform_data->mpsse;
+    uint8_t addr[2] = {I2C_DEV_ADDR_DEFAULT << 1, 0x0};
+    char *data_in = NULL;
+
+    if (Start (mpsse) != MPSSE_OK)
+    {
+        return rc;
+    }
+
+    /* Send the register address */
+    addr[1] = reg_addr;
+    if (Write (mpsse, (char *)addr, sizeof (addr)) != MPSSE_OK)
+    {
+        goto error;
+    }
+
+    if (GetAck (mpsse) != ACK)
+    {
+        goto error;
+    }
+
+    /* Repeat the STOP (S) START (P) sequence */
+    if ((Stop (mpsse) != MPSSE_OK) || (Start (mpsse) != MPSSE_OK))
+    {
+        return rc;
+    }
+
+    /* Send the read command */
+    addr[0] |= 0x01;
+    if (Write (mpsse, (char *)addr, 1) != MPSSE_OK)
+    {
+        goto error;
+    }
+
+    if (GetAck (mpsse) != ACK)
+    {
+        goto error;
+    }
+
+    /* Read in (cnt - 1) bytes with ACK */
+    SendAcks (mpsse);
+    if ((data_in = Read (mpsse, cnt - 1)) == NULL)
+    {
+        goto error;
+    }
+
+    memcpy (data, (unsigned char *)data_in, cnt - 1);
+    free (data_in);
+    data_in = NULL;
+
+    /* Read in the last byte with NACK */
+    SendNacks (mpsse);
+    if ((data_in = Read (mpsse, 1)) == NULL)
+    {
+        goto error;
+    }
+
+    ((unsigned char *)data)[cnt - 1] = *((unsigned char *)data_in);
+    free (data_in);
+
+    rc = TSS2_RC_SUCCESS;
+
+error:
+    if (Stop (mpsse) != MPSSE_OK)
+    {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return rc;
+}
+
+void
+platform_finalize (void *user_data)
+{
+    PLATFORM_USERDATA *platform_data = (PLATFORM_USERDATA *) user_data;
+    struct mpsse_context *mpsse = platform_data->mpsse;
+
+    if (mpsse != NULL) {
+        Close (mpsse);
+    }
+
+    free (platform_data);
+}
+
+TSS2_RC
+create_tcti_i2c_ftdi_platform (TSS2_TCTI_I2C_HELPER_PLATFORM *platform)
+{
+    PLATFORM_USERDATA *platform_data = malloc (sizeof (PLATFORM_USERDATA));
+    struct mpsse_context **mpsse = &platform_data->mpsse;
+
+    if (platform_data == NULL) {
+        return TSS2_BASE_RC_MEMORY;
+    }
+
+    memset (platform_data, 0, sizeof (PLATFORM_USERDATA));
+
+    if ((*mpsse = MPSSE (I2C, ONE_HUNDRED_KHZ, MSB)) == NULL )
+    {
+        goto error;
+    }
+
+    platform->user_data = platform_data;
+    platform->sleep_us = platform_sleep_us;
+    platform->sleep_ms = platform_sleep_ms;
+    platform->start_timeout = platform_start_timeout;
+    platform->timeout_expired = platform_timeout_expired;
+    platform->i2c_write = platform_i2c_write;
+    platform->i2c_read = platform_i2c_read;
+    platform->finalize = platform_finalize;
+
+    return TSS2_RC_SUCCESS;
+
+error:
+    platform_finalize ((void *) platform_data);
+    return TSS2_BASE_RC_IO_ERROR;
+}
+
+TSS2_RC
+Tss2_Tcti_I2c_Ftdi_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const char* config)
+{
+    (void) config;
+    TSS2_RC ret = 0;
+    TSS2_TCTI_I2C_HELPER_PLATFORM tcti_platform = {0};
+
+    if (tcti_context == NULL) {
+        return Tss2_Tcti_I2c_Helper_Init (NULL, size, NULL);
+    }
+
+    if ((ret = create_tcti_i2c_ftdi_platform (&tcti_platform))) {
+        return ret;
+    }
+
+    return Tss2_Tcti_I2c_Helper_Init (tcti_context, size, &tcti_platform);
+}
+
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-i2c-ftdi",
+    .description = "TCTI for communicating with TPM through the USB-FTDI-I2C converter.",
+    .config_help = "Takes no configuration.",
+    .init = Tss2_Tcti_I2c_Ftdi_Init
+};
+
+const TSS2_TCTI_INFO *
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-i2c-ftdi.h
+++ b/src/tss2-tcti/tcti-i2c-ftdi.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TCTI_I2C_FTDI_H
+#define TCTI_I2C_FTDI_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdint.h>
+#include <sys/time.h>
+
+#include "tcti-common.h"
+#include "tss2_tcti_i2c_helper.h"
+#include "mpsse/mpsse.h"
+
+/* The default 7-bit I2C device address defined by TCG */
+#define I2C_DEV_ADDR_DEFAULT 0x2E
+
+typedef struct {
+    struct timeval timeout;
+    struct mpsse_context *mpsse;
+} PLATFORM_USERDATA;
+
+#endif /* TCTI_I2C_FTDI_H */

--- a/src/tss2-tcti/tcti-i2c-helper.c
+++ b/src/tss2-tcti/tcti-i2c-helper.c
@@ -1,0 +1,862 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_i2c_helper.h"
+#include "tss2_mu.h"
+#include "tcti-common.h"
+#include "tcti-i2c-helper.h"
+#include "util/io.h"
+#include "util/tss2_endian.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+/*
+ * CRC-CCITT KERMIT with following parameters:
+ *
+ * Length                           : 16 bit
+ * Poly                             : 0x1021
+ * Init                             : 0x0000
+ * RefIn                            : False
+ * RefOut                           : False
+ * XorOut                           : 0x0000
+ * Output for ASCII "123456789"     : 0x2189
+ */
+static const uint16_t crc16_kermit_lookup[256]= {
+    0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,
+    0x8c48, 0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7,
+    0x1081, 0x0108, 0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e,
+    0x9cc9, 0x8d40, 0xbfdb, 0xae52, 0xdaed, 0xcb64, 0xf9ff, 0xe876,
+    0x2102, 0x308b, 0x0210, 0x1399, 0x6726, 0x76af, 0x4434, 0x55bd,
+    0xad4a, 0xbcc3, 0x8e58, 0x9fd1, 0xeb6e, 0xfae7, 0xc87c, 0xd9f5,
+    0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e, 0x54b5, 0x453c,
+    0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd, 0xc974,
+    0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9, 0x2732, 0x36bb,
+    0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3,
+    0x5285, 0x430c, 0x7197, 0x601e, 0x14a1, 0x0528, 0x37b3, 0x263a,
+    0xdecd, 0xcf44, 0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72,
+    0x6306, 0x728f, 0x4014, 0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9,
+    0xef4e, 0xfec7, 0xcc5c, 0xddd5, 0xa96a, 0xb8e3, 0x8a78, 0x9bf1,
+    0x7387, 0x620e, 0x5095, 0x411c, 0x35a3, 0x242a, 0x16b1, 0x0738,
+    0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862, 0x9af9, 0x8b70,
+    0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e, 0xf0b7,
+    0x0840, 0x19c9, 0x2b52, 0x3adb, 0x4e64, 0x5fed, 0x6d76, 0x7cff,
+    0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036,
+    0x18c1, 0x0948, 0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e,
+    0xa50a, 0xb483, 0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5,
+    0x2942, 0x38cb, 0x0a50, 0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd,
+    0xb58b, 0xa402, 0x9699, 0x8710, 0xf3af, 0xe226, 0xd0bd, 0xc134,
+    0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7, 0x6e6e, 0x5cf5, 0x4d7c,
+    0xc60c, 0xd785, 0xe51e, 0xf497, 0x8028, 0x91a1, 0xa33a, 0xb2b3,
+    0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72, 0x3efb,
+    0xd68d, 0xc704, 0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232,
+    0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a,
+    0xe70e, 0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1,
+    0x6b46, 0x7acf, 0x4854, 0x59dd, 0x2d62, 0x3ceb, 0x0e70, 0x1ff9,
+    0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330,
+    0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
+};
+
+static uint16_t crc_ccitt (const uint8_t *buffer, int size) {
+    int i;
+    uint16_t result = 0;
+
+    for (i = 0; i < size; i++) {
+        uint8_t j = buffer[i] ^ result;
+        result = crc16_kermit_lookup[j] ^ (result >> 8);
+    }
+
+    return result;
+}
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the device TCTI context. The only safe-guard we have to ensure
+ * this operation is possible is the magic number for the device TCTI context.
+ * If passed a NULL context, or the magic number check fails, this function
+ * will return NULL.
+ */
+TSS2_TCTI_I2C_HELPER_CONTEXT* tcti_i2c_helper_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_I2C_HELPER_MAGIC) {
+        return (TSS2_TCTI_I2C_HELPER_CONTEXT*)tcti_ctx;
+    }
+    return NULL;
+}
+
+/*
+ * This function down-casts the device TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+TSS2_TCTI_COMMON_CONTEXT* tcti_i2c_helper_down_cast (TSS2_TCTI_I2C_HELPER_CONTEXT *tcti_i2c_helper)
+{
+    if (tcti_i2c_helper == NULL) {
+        return NULL;
+    }
+    return &tcti_i2c_helper->common;
+}
+
+static inline TSS2_RC i2c_tpm_helper_delay_us (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, int microseconds)
+{
+    /* Sleep a specified amount of microseconds */
+    if (ctx->platform.sleep_us == NULL) {
+        return ctx->platform.sleep_ms (ctx->platform.user_data, (microseconds < 1000) ? 1 : (microseconds / 1000));
+    } else {
+        return ctx->platform.sleep_us (ctx->platform.user_data, microseconds);
+    }
+}
+
+static inline TSS2_RC i2c_tpm_helper_delay_ms (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, int milliseconds)
+{
+    /* Sleep a specified amount of milliseconds */
+    if (ctx->platform.sleep_ms == NULL) {
+        return ctx->platform.sleep_us (ctx->platform.user_data, milliseconds * 1000);
+    } else {
+        return ctx->platform.sleep_ms (ctx->platform.user_data, milliseconds);
+    }
+}
+
+static inline TSS2_RC i2c_tpm_helper_start_timeout (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, int milliseconds)
+{
+    /* Start a timeout timer with the specified amount of milliseconds */
+    return ctx->platform.start_timeout (ctx->platform.user_data, milliseconds);
+}
+
+static inline TSS2_RC i2c_tpm_helper_timeout_expired(TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, bool *result)
+{
+    /* Check if the last started tiemout expired */
+    return ctx->platform.timeout_expired (ctx->platform.user_data, result);
+}
+
+static inline TSS2_RC i2c_tpm_helper_i2c_write (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t reg_addr, const void *data, size_t cnt)
+{
+    TSS2_RC rc;
+    int i = TCTI_I2C_HELPER_RETRY;
+
+    do {
+        /* Perform I2C write with cnt bytes */
+        rc = ctx->platform.i2c_write (ctx->platform.user_data, reg_addr, data, cnt);
+        if (rc == TSS2_RC_SUCCESS) {
+            if (ctx->guard_time_write) {
+                i2c_tpm_helper_delay_us (ctx, ctx->guard_time);
+            }
+            break;
+        }
+
+        i2c_tpm_helper_delay_us (ctx, TCTI_I2C_HELPER_DEFAULT_GUARD_TIME_US);
+    } while (--i);
+
+    return rc;
+}
+
+static inline TSS2_RC i2c_tpm_helper_i2c_read (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t reg_addr, void *data, size_t cnt)
+{
+    TSS2_RC rc;
+    int i = TCTI_I2C_HELPER_RETRY;
+
+    do {
+        /* Perform I2C read with cnt bytes */
+        rc = ctx->platform.i2c_read (ctx->platform.user_data, reg_addr, data, cnt);
+        if (rc == TSS2_RC_SUCCESS) {
+            if (ctx->guard_time_read) {
+                i2c_tpm_helper_delay_us (ctx, ctx->guard_time);
+            }
+            break;
+        }
+
+        i2c_tpm_helper_delay_us (ctx, TCTI_I2C_HELPER_DEFAULT_GUARD_TIME_US);
+    } while (--i);
+
+    return rc;
+}
+
+static inline void i2c_tpm_helper_platform_finalize (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    /* Free user_data and resources inside */
+    if (ctx->platform.finalize)
+        ctx->platform.finalize (ctx->platform.user_data);
+}
+
+static TSS2_RC check_platform_conf(TSS2_TCTI_I2C_HELPER_PLATFORM *platform_conf)
+{
+
+    bool required_set = (platform_conf->sleep_ms || platform_conf->sleep_us) \
+            && platform_conf->i2c_write \
+            && platform_conf->i2c_read && platform_conf->start_timeout \
+            && platform_conf->timeout_expired;
+    if (!required_set) {
+        LOG_ERROR("Expected sleep_us/sleep_ms, i2c_write, i2c_read, start_timeout and timeout_expired to be set.");
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+static void i2c_tpm_helper_log_register_access (enum TCTI_I2C_HELPER_REGISTER_ACCESS_TYPE access, uint8_t reg_addr, const void *buffer, size_t cnt, char* err)
+{
+#if MAXLOGLEVEL == LOGL_NONE
+    (void) access;
+    (void) reg_addr;
+    (void) buffer;
+    (void) cnt;
+    (void) err;
+#else
+    /* Print register access debug information */
+    char* access_str = (access == TCTI_I2C_HELPER_REGISTER_READ) ? "READ" : "WRITE";
+
+    if (err != NULL) {
+        LOG_ERROR ("%s register %#02x (%zu bytes) %s", access_str, reg_addr, cnt, err);
+    } else {
+#if MAXLOGLEVEL < LOGL_TRACE
+        (void) buffer;
+#else
+        LOGBLOB_TRACE (buffer, cnt, "%s register %#02x (%zu bytes)", access_str, reg_addr, cnt);
+#endif
+    }
+#endif
+}
+
+static TSS2_RC i2c_tpm_sanity_check_read (uint8_t reg, uint8_t *buffer, size_t cnt)
+{
+    uint32_t zero_mask;
+    uint32_t value;
+
+    switch (cnt) {
+    case sizeof (uint8_t):
+        value = buffer[0];
+        break;
+    case sizeof (uint16_t):
+        value = le16toh (*((uint16_t *)buffer));
+        break;
+    case sizeof (uint32_t):
+        value = le32toh (*((uint32_t *)buffer));
+        break;
+    default:
+        return TSS2_RC_SUCCESS;
+    }
+
+    switch (reg) {
+    case TCTI_I2C_HELPER_TPM_ACCESS_REG:
+        zero_mask = TCTI_I2C_HELPER_TPM_ACCESS_ZERO;
+        break;
+    case TCTI_I2C_HELPER_TPM_STS_REG:
+        zero_mask = TCTI_I2C_HELPER_TPM_STS_ZERO;
+        break;
+    case TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_REG:
+        zero_mask = TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_ZERO;
+        break;
+    default:
+        return TSS2_RC_SUCCESS;
+    }
+
+    if (value & zero_mask) {
+        LOG_ERROR ("TPM I2C read of register 0x%02x failed sanity check", reg);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+static TSS2_RC i2c_tpm_helper_read_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t reg_addr, void *buffer, size_t cnt)
+{
+    TSS2_RC rc;
+    enum TCTI_I2C_HELPER_REGISTER_ACCESS_TYPE access = TCTI_I2C_HELPER_REGISTER_READ;
+
+    /* Read register */
+    rc = i2c_tpm_helper_i2c_read (ctx, reg_addr, buffer, cnt);
+    if (rc != TSS2_RC_SUCCESS) {
+        i2c_tpm_helper_log_register_access (access, reg_addr, NULL, cnt, "failed in transfer");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Sanity check, check that the 0 bits of the TPM_STS register are indeed 0s*/
+    rc = i2c_tpm_sanity_check_read (reg_addr, buffer, cnt);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    /* Print debug information and return success */
+    i2c_tpm_helper_log_register_access (access, reg_addr, buffer, cnt, NULL);
+    return TSS2_RC_SUCCESS;
+}
+
+static TSS2_RC i2c_tpm_helper_write_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t reg_addr, const void *buffer, size_t cnt)
+{
+    TSS2_RC rc;
+    enum TCTI_I2C_HELPER_REGISTER_ACCESS_TYPE access = TCTI_I2C_HELPER_REGISTER_WRITE;
+
+    /* Write register */
+    rc = i2c_tpm_helper_i2c_write (ctx, reg_addr, buffer, cnt);
+    if (rc != TSS2_RC_SUCCESS) {
+        i2c_tpm_helper_log_register_access (access, reg_addr, buffer, cnt, "failed in transfer");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Print debug information and return success */
+    i2c_tpm_helper_log_register_access (access, reg_addr, buffer, cnt, NULL);
+    return TSS2_RC_SUCCESS;
+}
+
+static uint8_t i2c_tpm_helper_read_access_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    uint8_t access = 0;
+    i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_ACCESS_REG, &access, sizeof(access));
+    return access;
+}
+
+static void i2c_tpm_helper_write_access_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t access_bit)
+{
+    /* Writes to access register can set only 1 bit at a time */
+    if (access_bit & (access_bit - 1)) {
+        LOG_ERROR ("Writes to access register can set only 1 bit at a time.");
+    } else {
+        i2c_tpm_helper_write_reg (ctx, TCTI_I2C_HELPER_TPM_ACCESS_REG, &access_bit, sizeof(access_bit));
+    }
+}
+
+static uint32_t i2c_tpm_helper_read_sts_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    uint32_t status = 0;
+    i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_STS_REG, &status, sizeof(status));
+    return le32toh (status);
+}
+
+static void i2c_tpm_helper_write_sts_reg (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint32_t status)
+{
+    status = htole32 (status);
+    i2c_tpm_helper_write_reg (ctx, TCTI_I2C_HELPER_TPM_STS_REG, &status, sizeof (status));
+}
+
+static uint32_t i2c_tpm_helper_get_burst_count (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    uint32_t status = i2c_tpm_helper_read_sts_reg (ctx);
+    return (status & TCTI_I2C_HELPER_TPM_STS_BURST_COUNT_MASK) >> TCTI_I2C_HELPER_TPM_STS_BURST_COUNT_SHIFT;
+}
+
+static inline size_t i2c_tpm_helper_size_t_min (size_t a, size_t b) {
+    if (a < b) {
+        return a;
+    }
+    return b;
+}
+
+static inline uint32_t i2c_tpm_helper_read_be32 (const void *src)
+{
+    const uint8_t *s = src;
+    return (((uint32_t)s[0]) << 24) | (((uint32_t)s[1]) << 16) | (((uint32_t)s[2]) << 8) | (((uint32_t)s[3]) << 0);
+}
+
+static TSS2_RC i2c_tpm_helper_claim_locality (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    uint8_t access;
+    access = i2c_tpm_helper_read_access_reg (ctx);
+
+    /* Check if locality 0 is active */
+    if (access & TCTI_I2C_HELPER_TPM_ACCESS_ACTIVE_LOCALITY) {
+        LOG_DEBUG ("Locality 0 is already active, status: %#x", access);
+        return TSS2_RC_SUCCESS;
+    }
+
+    /* Request locality 0 */
+    i2c_tpm_helper_write_access_reg (ctx, TCTI_I2C_HELPER_TPM_ACCESS_REQUEST_USE);
+    access = i2c_tpm_helper_read_access_reg (ctx);
+    if (access & (TCTI_I2C_HELPER_TPM_ACCESS_VALID | TCTI_I2C_HELPER_TPM_ACCESS_ACTIVE_LOCALITY)) {
+        LOG_DEBUG ("Claimed locality 0");
+        return TSS2_RC_SUCCESS;
+    }
+
+    LOG_ERROR ("Failed to claim locality 0, status: %#x", access);
+    return TSS2_TCTI_RC_IO_ERROR;
+}
+
+static TSS2_RC i2c_tpm_helper_init_guard_time (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    TSS2_RC rc;
+    uint32_t i2c_caps;
+
+    ctx->guard_time_read = true;
+    ctx->guard_time_write = true;
+    ctx->guard_time = TCTI_I2C_HELPER_DEFAULT_GUARD_TIME_US;
+
+    rc = i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_REG, &i2c_caps, sizeof (i2c_caps));
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed to read TPM_I2C_INTERFACE_CAPABILITY register");
+        return rc;
+    }
+
+    i2c_caps = le32toh (i2c_caps);
+
+    ctx->guard_time_read  = (i2c_caps & TCTI_I2C_HELPER_TPM_GUARD_TIME_RR_MASK) ||
+                            (i2c_caps & TCTI_I2C_HELPER_TPM_GUARD_TIME_RW_MASK);
+    ctx->guard_time_write = (i2c_caps & TCTI_I2C_HELPER_TPM_GUARD_TIME_WR_MASK) ||
+                            (i2c_caps & TCTI_I2C_HELPER_TPM_GUARD_TIME_WW_MASK);
+    ctx->guard_time       = (i2c_caps & TCTI_I2C_HELPER_TPM_GUARD_TIME_MASK) >>
+                            TCTI_I2C_HELPER_TPM_GUARD_TIME_SHIFT;
+
+    return TSS2_RC_SUCCESS;
+}
+
+static TSS2_RC i2c_tpm_helper_enable_crc (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx)
+{
+    TSS2_RC rc;
+    uint8_t crc_enable;
+
+    rc = i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG, &crc_enable, sizeof (crc_enable));
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    if (crc_enable == 1) {
+        return TSS2_RC_SUCCESS;
+    }
+
+    crc_enable = 1;
+    return i2c_tpm_helper_write_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG, &crc_enable, sizeof (crc_enable));
+}
+
+static TSS2_RC i2c_tpm_helper_wait_for_status (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint32_t status_mask, uint32_t status_expected, int32_t timeout)
+{
+    TSS2_RC rc;
+    uint32_t status;
+    bool blocking = (timeout == TSS2_TCTI_TIMEOUT_BLOCK);
+    if (!blocking) {
+        rc = i2c_tpm_helper_start_timeout (ctx, timeout);
+        return_if_error(rc, "i2c_tpm_helper_start_timeout");
+    }
+
+    /* Wait for the expected status with or without timeout */
+    bool is_timeout_expired = false;
+    do {
+        status = i2c_tpm_helper_read_sts_reg (ctx);
+        /* Return success on expected status */
+        if ((status & status_mask) == status_expected) {
+            return TSS2_RC_SUCCESS;
+        }
+        /* Delay next poll by 8ms to avoid spamming the TPM */
+        rc = i2c_tpm_helper_delay_ms (ctx, 8);
+        return_if_error (rc, "i2c_tpm_helper_delay_ms");
+
+        rc = i2c_tpm_helper_timeout_expired (ctx, &is_timeout_expired);
+        return_if_error (rc, "i2c_tpm_helper_timeout_expired");
+    } while (blocking || !is_timeout_expired);
+
+    /* Timed out */
+    return TSS2_TCTI_RC_TRY_AGAIN;
+}
+
+static TSS2_RC i2c_tpm_helper_verify_crc (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, const uint8_t* buffer, size_t size)
+{
+    (void) buffer;
+    (void) size;
+    TSS2_RC rc;
+    uint16_t crc_tpm = 0;
+    uint16_t crc_host = 0;
+
+    rc = i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_CSUM_REG, &crc_tpm, sizeof (crc_tpm));
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    crc_tpm = le16toh (crc_tpm);
+    /* Reflect crc result, regardless of host endianness */
+    crc_tpm = ((crc_tpm >> 8) & 0xFFu) | ((crc_tpm << 8) & 0xFF00u);
+    crc_host = crc_ccitt (buffer, size);
+
+    if (crc_tpm == crc_host) {
+        return TSS2_RC_SUCCESS;
+    }
+
+    return TSS2_TCTI_RC_IO_ERROR;
+}
+
+static void i2c_tpm_helper_fifo_transfer (TSS2_TCTI_I2C_HELPER_CONTEXT* ctx, uint8_t* transfer_buffer, size_t transfer_size, enum TCTI_I2C_HELPER_FIFO_TRANSFER_DIRECTION direction)
+{
+    size_t transaction_size;
+    size_t burst_count;
+    size_t handled_so_far = 0;
+
+    do {
+        do {
+            /* Can be zero when TPM is busy */
+            burst_count = i2c_tpm_helper_get_burst_count (ctx);
+        } while (!burst_count);
+
+        transaction_size = transfer_size - handled_so_far;
+        transaction_size = i2c_tpm_helper_size_t_min (transaction_size, burst_count);
+
+        if (direction == TCTI_I2C_HELPER_FIFO_RECEIVE){
+            i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG, (void*)(transfer_buffer + handled_so_far), transaction_size);
+        } else {
+            i2c_tpm_helper_write_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG, (const void*)(transfer_buffer + handled_so_far), transaction_size);
+        }
+
+        handled_so_far += transaction_size;
+
+    } while (handled_so_far != transfer_size);
+}
+
+TSS2_RC tcti_i2c_helper_transmit (TSS2_TCTI_CONTEXT *tcti_ctx, size_t size, const uint8_t *cmd_buf)
+{
+    TSS2_RC rc;
+    TSS2_TCTI_I2C_HELPER_CONTEXT *tcti_i2c_helper = tcti_i2c_helper_context_cast (tcti_ctx);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_i2c_helper_down_cast (tcti_i2c_helper);
+    tpm_header_t header;
+
+    if (tcti_i2c_helper == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    TSS2_TCTI_I2C_HELPER_CONTEXT* ctx = tcti_i2c_helper;
+
+    rc = tcti_common_transmit_checks (tcti_common, cmd_buf, TCTI_I2C_HELPER_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    rc = header_unmarshal (cmd_buf, &header);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    if (header.size != size) {
+        LOG_ERROR("Buffer size parameter: %zu, and TPM2 command header size "
+                  "field: %" PRIu32 " disagree.", size, header.size);
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    LOGBLOB_DEBUG (cmd_buf, size, "Sending command with TPM_CC %#x and size %" PRIu32,
+               header.code, header.size);
+
+    /* Tell TPM to expect command */
+    i2c_tpm_helper_write_sts_reg(ctx, TCTI_I2C_HELPER_TPM_STS_COMMAND_READY);
+
+    /* Wait until ready bit is set by TPM device */
+    uint32_t expected_status_bits = TCTI_I2C_HELPER_TPM_STS_COMMAND_READY;
+    rc = i2c_tpm_helper_wait_for_status (ctx, expected_status_bits, expected_status_bits, 200);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR("Failed waiting for TPM to become ready");
+        return rc;
+    }
+
+    /* Send command */
+    i2c_tpm_helper_fifo_transfer (ctx, (void*)cmd_buf, size, TCTI_I2C_HELPER_FIFO_TRANSMIT);
+
+    /* Verify CRC */
+    rc = i2c_tpm_helper_verify_crc (ctx, cmd_buf, size);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("CRC mismatch for command");
+        return rc;
+    }
+
+    /* Tell TPM to start processing the command */
+    i2c_tpm_helper_write_sts_reg (ctx, TCTI_I2C_HELPER_TPM_STS_GO);
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC tcti_i2c_helper_receive (TSS2_TCTI_CONTEXT* tcti_context, size_t *response_size, unsigned char *response_buffer, int32_t timeout)
+{
+    TSS2_RC rc;
+    TSS2_TCTI_I2C_HELPER_CONTEXT* tcti_i2c_helper = tcti_i2c_helper_context_cast (tcti_context);
+    TSS2_TCTI_COMMON_CONTEXT* tcti_common = tcti_i2c_helper_down_cast (tcti_i2c_helper);
+
+    if (tcti_i2c_helper == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+
+    rc = tcti_common_receive_checks (tcti_common, response_size, TCTI_I2C_HELPER_MAGIC);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+
+    /* Use ctx as a shorthand for tcti_i2c_helper */
+    TSS2_TCTI_I2C_HELPER_CONTEXT* ctx = tcti_i2c_helper;
+
+    /* Expected status bits for valid status and data availabe */
+    uint32_t expected_status_bits = TCTI_I2C_HELPER_TPM_STS_VALID | TCTI_I2C_HELPER_TPM_STS_DATA_AVAIL;
+
+    /* Check if we already have received the header */
+    if (tcti_common->header.size == 0) {
+        /* Wait for response to be ready */
+        rc = i2c_tpm_helper_wait_for_status (ctx, expected_status_bits, expected_status_bits, timeout);
+        if (rc != TSS2_RC_SUCCESS) {
+            LOG_ERROR ("Failed waiting for status");
+            /* Return rc from wait_for_status(). May be TRY_AGAIN after timeout. */
+            return rc;
+        }
+
+        /* Read only response header into context header buffer */
+        rc = i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG, ctx->header, TCTI_I2C_HELPER_RESP_HEADER_SIZE);
+        if (rc != TSS2_RC_SUCCESS) {
+            LOG_ERROR ("Failed reading response header");
+            return TSS2_TCTI_RC_IO_ERROR;
+        }
+
+        /* Find out the total payload size, skipping the two byte tag and update tcti_common */
+        tcti_common->header.size = i2c_tpm_helper_read_be32 (ctx->header + 2);
+        LOG_TRACE ("Read response size from response header: %" PRIu32 " bytes", tcti_common->header.size);
+    }
+
+    /* Check if response size is requested */
+    if (response_buffer == NULL) {
+        *response_size = tcti_common->header.size;
+        LOG_TRACE ("Caller requested response size. Returning size of %zu bytes", *response_size);
+        return TSS2_RC_SUCCESS;
+    }
+
+    /* Check if response fits in buffer and update response size */
+    if (tcti_common->header.size > *response_size) {
+        LOG_ERROR ("TPM response too long (%" PRIu32 " bytes)", tcti_common->header.size);
+        return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+    }
+    *response_size = tcti_common->header.size;
+
+    /* Receive the TPM response */
+    LOG_TRACE ("Reading response of size %" PRIu32, tcti_common->header.size);
+
+    /* Copy already received header into response buffer */
+    memcpy (response_buffer, ctx->header, TCTI_I2C_HELPER_RESP_HEADER_SIZE);
+
+    /* Read all but the last byte in the FIFO */
+    size_t bytes_to_go = tcti_common->header.size - 1 - TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+    i2c_tpm_helper_fifo_transfer (ctx, response_buffer + TCTI_I2C_HELPER_RESP_HEADER_SIZE, bytes_to_go, TCTI_I2C_HELPER_FIFO_RECEIVE);
+
+    /* Verify that there is still data to read */
+    uint32_t status = i2c_tpm_helper_read_sts_reg (ctx);
+    if ((status & expected_status_bits) != expected_status_bits) {
+        LOG_ERROR ("Unexpected intermediate status %#x",status);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Read the last byte */
+    rc = i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG, response_buffer + tcti_common->header.size - 1, 1);
+    if (rc != TSS2_RC_SUCCESS) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Verify that there is no more data available */
+    status = i2c_tpm_helper_read_sts_reg (ctx);
+    if ((status & expected_status_bits) != TCTI_I2C_HELPER_TPM_STS_VALID) {
+        LOG_ERROR ("Unexpected final status %#x", status);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Verify CRC */
+    rc = i2c_tpm_helper_verify_crc (ctx, response_buffer, *response_size);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("CRC mismatch for response");
+        return rc;
+    }
+
+    LOGBLOB_DEBUG (response_buffer, tcti_common->header.size, "Response buffer received:");
+
+    /* Set the TPM back to idle state */
+    i2c_tpm_helper_write_sts_reg(ctx, TCTI_I2C_HELPER_TPM_STS_COMMAND_READY);
+
+    tcti_common->header.size = 0;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+
+    return TSS2_RC_SUCCESS;
+}
+
+void tcti_i2c_helper_finalize (TSS2_TCTI_CONTEXT* tcti_context)
+{
+    TSS2_TCTI_I2C_HELPER_CONTEXT *tcti_i2c_helper = tcti_i2c_helper_context_cast (tcti_context);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_i2c_helper_down_cast (tcti_i2c_helper);
+
+    if (tcti_i2c_helper == NULL) {
+        return;
+    }
+    tcti_common->state = TCTI_STATE_FINAL;
+
+    /* Free platform struct user data and resources inside */
+    i2c_tpm_helper_platform_finalize (tcti_i2c_helper);
+}
+
+TSS2_RC tcti_i2c_helper_cancel (TSS2_TCTI_CONTEXT* tcti_context)
+{
+    (void)(tcti_context);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC tcti_i2c_helper_get_poll_handles (TSS2_TCTI_CONTEXT* tcti_context, TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles)
+{
+    (void)(tcti_context);
+    (void)(handles);
+    (void)(num_handles);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC tcti_i2c_helper_set_locality (TSS2_TCTI_CONTEXT* tcti_context, uint8_t locality)
+{
+    (void)(tcti_context);
+    (void)(locality);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC Tss2_Tcti_I2c_Helper_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, TSS2_TCTI_I2C_HELPER_PLATFORM *platform_conf)
+{
+    TSS2_RC rc;
+    TSS2_TCTI_I2C_HELPER_CONTEXT* tcti_i2c_helper;
+    TSS2_TCTI_COMMON_CONTEXT* tcti_common;
+
+    if (!size) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    /* Check if context size is requested */
+    if (tcti_context == NULL) {
+        *size = sizeof (TSS2_TCTI_I2C_HELPER_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    if (!platform_conf) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    if (*size < sizeof (TSS2_TCTI_I2C_HELPER_CONTEXT)) {
+        return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+    }
+
+    if (!platform_conf) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    /* Init TCTI context */
+    TSS2_TCTI_MAGIC (tcti_context) = TCTI_I2C_HELPER_MAGIC;
+    TSS2_TCTI_VERSION (tcti_context) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tcti_context) = tcti_i2c_helper_transmit;
+    TSS2_TCTI_RECEIVE (tcti_context) = tcti_i2c_helper_receive;
+    TSS2_TCTI_FINALIZE (tcti_context) = tcti_i2c_helper_finalize;
+    TSS2_TCTI_CANCEL (tcti_context) = tcti_i2c_helper_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tcti_context) = tcti_i2c_helper_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tcti_context) = tcti_i2c_helper_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tcti_context) = tcti_make_sticky_not_implemented;
+
+    /* Init I2C TCTI context */
+    tcti_i2c_helper = tcti_i2c_helper_context_cast (tcti_context);
+    tcti_common = tcti_i2c_helper_down_cast (tcti_i2c_helper);
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    memset (&tcti_common->header, 0, sizeof (tcti_common->header));
+    tcti_common->locality = 0;
+
+    rc = check_platform_conf (platform_conf);
+    return_if_error (rc, "platform_conf invalid");
+
+    /* Copy platform struct into context */
+    tcti_i2c_helper->platform = *platform_conf;
+
+    /* Probe TPM */
+    TSS2_TCTI_I2C_HELPER_CONTEXT* ctx = tcti_i2c_helper;
+    LOG_DEBUG ("Probing TPM...");
+    uint32_t did_vid = 0;
+    for (int retries = 100; retries > 0; retries--) {
+        /* In case of failed read div_vid is set to zero */
+        i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_DID_VID_REG, &did_vid, sizeof(did_vid));
+        if (did_vid != 0) {
+            did_vid = le32toh (did_vid);
+            break;
+        }
+        /* TPM might be resetting, let's retry in a bit */
+        rc = i2c_tpm_helper_delay_ms (ctx, 10);
+        return_if_error (rc, "i2c_tpm_helper_delay_ms");
+    }
+    if (did_vid == 0) {
+        LOG_ERROR ("Probing TPM failed");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+    LOG_DEBUG ("Probing TPM successful");
+
+    /* Init guard time */
+    LOG_DEBUG ("Initializing guard time");
+    rc = i2c_tpm_helper_init_guard_time (ctx);
+    if (rc != TSS2_RC_SUCCESS) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Claim locality */
+    LOG_DEBUG ("Claiming TPM locality");
+    rc = i2c_tpm_helper_claim_locality (ctx);
+    if (rc != TSS2_RC_SUCCESS) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Enable Data Checksum */
+    LOG_DEBUG ("Enable Data Checksum");
+    rc = i2c_tpm_helper_enable_crc (ctx);
+    if (rc != TSS2_RC_SUCCESS) {
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    /* Wait up to 200ms for TPM to become ready */
+    LOG_DEBUG ("Waiting for TPM to become ready...");
+    uint32_t expected_status_bits = TCTI_I2C_HELPER_TPM_STS_COMMAND_READY;
+    rc = i2c_tpm_helper_wait_for_status (ctx, expected_status_bits, expected_status_bits, 200);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed waiting for TPM to become ready");
+        return rc;
+    }
+    LOG_DEBUG ("TPM is ready");
+
+    /* Get rid */
+    uint8_t rid = 0;
+    i2c_tpm_helper_read_reg (ctx, TCTI_I2C_HELPER_TPM_RID_REG, &rid, sizeof(rid));
+
+#if MAXLOGLEVEL >= LOGL_INFO
+    /* Print device details */
+    uint16_t vendor_id, device_id, revision;
+    vendor_id = did_vid & 0xffff;
+    device_id = did_vid >> 16;
+    revision = rid;
+    LOG_INFO ("Connected to TPM with vid:did:rid of %4.4x:%4.4x:%2.2x", vendor_id, device_id, revision);
+#endif
+
+    return TSS2_RC_SUCCESS;
+}
+
+static const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-i2c-helper",
+    .description = "Platform independent TCTI for communication with TPMs over I2C.",
+    .config_help = "TSS2_TCTI_I2C_HELPER_PLATFORM struct containing platform methods. See tss2_tcti_i2c_helper.h for more information.",
+
+    /*
+     * The Tss2_Tcti_I2c_Helper_Init method has a different signature than required by .init due too
+     * our custom platform_conf parameter, so we can't expose it here and it has to be used directly.
+     */
+    .init = NULL,
+};
+
+const TSS2_TCTI_INFO* Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-i2c-helper.h
+++ b/src/tss2-tcti/tcti-i2c-helper.h
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifndef TCTI_I2C_HELPER_H
+#define TCTI_I2C_HELPER_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "tcti-common.h"
+
+#define TCTI_I2C_HELPER_MAGIC 0x392452ED67A5D511ULL
+
+#define TCTI_I2C_HELPER_RESP_HEADER_SIZE 6
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    TSS2_TCTI_I2C_HELPER_PLATFORM platform;
+    bool guard_time_read;
+    bool guard_time_write;
+    int  guard_time;
+    char header[TCTI_I2C_HELPER_RESP_HEADER_SIZE];
+} TSS2_TCTI_I2C_HELPER_CONTEXT;
+
+#define TCTI_I2C_HELPER_RETRY                           50
+#define TCTI_I2C_HELPER_DEFAULT_GUARD_TIME_US           250
+
+#define TCTI_I2C_HELPER_TPM_ACCESS_REG                  0x04
+#define TCTI_I2C_HELPER_TPM_STS_REG                     0x18
+#define TCTI_I2C_HELPER_TPM_DATA_FIFO_REG               0x24
+#define TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_REG    0x30
+#define TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG        0x40
+#define TCTI_I2C_HELPER_TPM_DATA_CSUM_REG               0x44
+#define TCTI_I2C_HELPER_TPM_DID_VID_REG                 0x48
+#define TCTI_I2C_HELPER_TPM_RID_REG                     0x4C
+
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_SR_MASK          0x40000000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_RR_MASK          0x00100000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_RW_MASK          0x00080000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_WR_MASK          0x00040000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_WW_MASK          0x00020000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_MASK             0x0001FE00
+#define TCTI_I2C_HELPER_TPM_BURST_COUNT_STATIC_MASK     0x20000000
+#define TCTI_I2C_HELPER_TPM_GUARD_TIME_SHIFT            9
+
+#define TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_ZERO   0x80000000
+#define TCTI_I2C_HELPER_TPM_STS_ZERO                    0x23
+#define TCTI_I2C_HELPER_TPM_ACCESS_ZERO                 0x48
+
+enum TCTI_I2C_HELPER_TPM_ACCESS {
+    TCTI_I2C_HELPER_TPM_ACCESS_VALID = (1 << 7),
+    TCTI_I2C_HELPER_TPM_ACCESS_ACTIVE_LOCALITY = (1 << 5),
+    TCTI_I2C_HELPER_TPM_ACCESS_REQUEST_USE = (1 << 1)
+};
+
+enum TCTI_I2C_HELPER_TPM_STATUS {
+    TCTI_I2C_HELPER_TPM_STS_BURST_COUNT_SHIFT = 8,
+    TCTI_I2C_HELPER_TPM_STS_BURST_COUNT_MASK = (0xFFFF << TCTI_I2C_HELPER_TPM_STS_BURST_COUNT_SHIFT),
+    TCTI_I2C_HELPER_TPM_STS_VALID = (1 << 7),
+    TCTI_I2C_HELPER_TPM_STS_COMMAND_READY = (1 << 6),
+    TCTI_I2C_HELPER_TPM_STS_GO = (1 << 5),
+    TCTI_I2C_HELPER_TPM_STS_DATA_AVAIL = (1 << 4),
+    TCTI_I2C_HELPER_TPM_STS_DATA_EXPECT = (1 << 3)
+};
+
+enum TCTI_I2C_HELPER_FIFO_TRANSFER_DIRECTION {
+    TCTI_I2C_HELPER_FIFO_TRANSMIT = 0,
+    TCTI_I2C_HELPER_FIFO_RECEIVE = 1
+};
+
+enum TCTI_I2C_HELPER_REGISTER_ACCESS_TYPE {
+    TCTI_I2C_HELPER_REGISTER_WRITE = 0,
+    TCTI_I2C_HELPER_REGISTER_READ = 1
+};
+
+#endif /* TCTI_I2C_HELPER_H */

--- a/test/unit/tcti-i2c-ftdi.c
+++ b/test/unit/tcti-i2c-ftdi.c
@@ -1,0 +1,600 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_i2c_ftdi.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-i2c-ftdi.h"
+#include "tss2-tcti/tcti-i2c-helper.h"
+#include "util/key-value-parse.h"
+
+typedef enum {
+    I2C_IDLE = 0,
+    /* Read sequence */
+    R_I2C_START_0,
+    R_I2C_WRITE_0,
+    R_I2C_GET_ACK_0,
+    R_I2C_STOP_0,
+    R_I2C_START_1,
+    R_I2C_WRITE_1,
+    R_I2C_GET_ACK_1,
+    R_I2C_SEND_ACKS,
+    R_I2C_READ_0,
+    R_I2C_SEND_NACKS,
+    R_I2C_READ_1,
+    R_I2C_STOP_1,
+    R_I2C_LAST,
+    /* Write sequence */
+    W_I2C_START,
+    W_I2C_WRITE_0,
+    W_I2C_GET_ACK,
+    W_I2C_WRITE_1,
+    W_I2C_STOP,
+    W_I2C_LAST
+} i2c_state_t;
+
+typedef enum {
+    /* Tss2_Tcti_I2c_Ftdi_Init () */
+    R_TPM_DID_VID = 0,
+    R_TPM_INTERFACE_CAP,
+    R_TPM_ACCESS,
+    R_TPM_CSUM_ENABLE,
+    W_TPM_CSUM_ENABLE,
+    R_TPM_STS_00,
+    R_TPM_RID,
+    /* TSS2_TCTI_TRANSMIT () */
+    W_TPM_STS_00,
+    R_TPM_STS_01,
+    R_TPM_STS_02,
+    W_TPM_FIFO,
+    R_TPM_CSUM_00,
+    W_TPM_STS_01,
+    /* TSS2_TCTI_RECEIVE () */
+    R_TPM_STS_03,
+    R_TPM_STS_04,
+    R_TPM_FIFO_00,
+    R_TPM_STS_05,
+    R_TPM_FIFO_01,
+    R_TPM_STS_06,
+    R_TPM_FIFO_02,
+    R_TPM_STS_07,
+    R_TPM_CSUM_01,
+    W_TPM_STS_02,
+} tpm_state_t;
+
+static struct m_state_t {
+    tpm_state_t tpm;
+    i2c_state_t i2c;
+} m_state = {R_TPM_DID_VID, I2C_IDLE};
+
+static const uint8_t R_TPM_DID_VID_DATA[] = {0xd1, 0x15, 0x1b, 0x00};
+static const uint8_t R_TPM_INTERFACE_CAP_DATA[] = {0x82, 0x00, 0xe0, 0x1a};
+static const uint8_t R_TPM_ACCESS_DATA[] = {0xa1};
+static const uint8_t R_TPM_CSUM_ENABLE_DATA[] = {0x00};
+static const uint8_t R_TPM_RID_DATA[] = {0x00};
+static const uint8_t R_TPM_STS_00_01_DATA[] = {TCTI_I2C_HELPER_TPM_STS_COMMAND_READY, 0x00, 0x00, 0x00};
+static const uint8_t R_TPM_STS_02_05_DATA[] = {0x00, 0x40, 0x00, 0x00};
+static const uint8_t R_TPM_STS_04_06_DATA[] = {TCTI_I2C_HELPER_TPM_STS_VALID | TCTI_I2C_HELPER_TPM_STS_DATA_AVAIL,
+                                               0x00, 0x00, 0x00};
+static const uint8_t R_TPM_CSUM_DATA[] = {0xf7, 0x4b}; /* CRC-16 (KERMIT) of RW_TPM_FIFO_DATA */
+static const uint8_t R_TPM_STS_03_07_DATA[] = {TCTI_I2C_HELPER_TPM_STS_VALID, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_STS_00_02_DATA[] = {TCTI_I2C_HELPER_TPM_STS_COMMAND_READY, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_STS_01_DATA[] = {TCTI_I2C_HELPER_TPM_STS_GO, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_CSUM_ENABLE_DATA[] = {0x01};
+static const uint8_t RW_TPM_FIFO_DATA[] = {0x80, 0x00, 0x00, 0x00, 0x00, 0x0a, 0xde, 0xad, 0xbe, 0xef};
+
+static struct mpsse_context *_mpsse;
+
+static void state_machine (void)
+{
+    while (true) {
+        switch (m_state.tpm) {
+        case R_TPM_DID_VID:
+        case R_TPM_INTERFACE_CAP:
+        case R_TPM_CSUM_ENABLE:
+        case R_TPM_CSUM_00:
+        case R_TPM_CSUM_01:
+        case R_TPM_ACCESS:
+        case R_TPM_STS_00:
+        case R_TPM_STS_01:
+        case R_TPM_STS_02:
+        case R_TPM_STS_03:
+        case R_TPM_STS_04:
+        case R_TPM_STS_05:
+        case R_TPM_STS_06:
+        case R_TPM_STS_07:
+        case R_TPM_RID:
+        case R_TPM_FIFO_00:
+        case R_TPM_FIFO_01:
+        case R_TPM_FIFO_02:
+            if (m_state.i2c == I2C_IDLE) {
+                /* Start a new read sequence */
+                m_state.i2c = R_I2C_START_0;
+                goto exit;
+            } else if (m_state.i2c == R_I2C_LAST - 1) {
+                /* Read sequence has ended */
+                m_state.i2c = I2C_IDLE;
+                m_state.tpm++;
+            } else {
+                /* Amidst a read sequence */
+                m_state.i2c++;
+                goto exit;
+            }
+            break;
+        case W_TPM_FIFO:
+        case W_TPM_CSUM_ENABLE:
+        case W_TPM_STS_00:
+        case W_TPM_STS_01:
+        case W_TPM_STS_02:
+            if (m_state.i2c == I2C_IDLE) {
+                /* Start a new write sequence */
+                m_state.i2c = W_I2C_START;
+                goto exit;
+            } else if (m_state.i2c == W_I2C_LAST - 1) {
+                /* Write sequence has ended */
+                m_state.i2c = I2C_IDLE;
+                m_state.tpm++;
+            } else {
+                /* Amidst a write sequence */
+                m_state.i2c++;
+                goto exit;
+            }
+            break;
+        default:
+            assert_true (false);
+            return;
+        }
+    }
+
+exit:
+    return;
+}
+
+/*
+ * Mock function select
+ */
+int __wrap_select (int nfds, fd_set *readfds,
+                   fd_set *writefds,
+                   fd_set *exceptfds,
+                   struct timeval *timeout)
+{
+
+    assert_int_equal (nfds, 0);
+    assert_null (readfds);
+    assert_null (writefds);
+    assert_null (exceptfds);
+    assert_non_null (timeout);
+
+    return 0;
+}
+
+/*
+ * Mock function gettimeofday
+ */
+int __wrap_gettimeofday (struct timeval *tv,
+                         struct timezone *tz)
+{
+    assert_null (tz);
+    assert_non_null (tv);
+
+    tv->tv_sec = 0;
+    tv->tv_usec = 0;
+
+    return 0;
+}
+
+/*
+ * Mock function MPSSE
+ */
+struct mpsse_context *__wrap_MPSSE (enum modes mode, int freq, int endianess)
+{
+    assert_int_equal (mode, I2C);
+    assert_int_equal (freq, ONE_HUNDRED_KHZ);
+    assert_int_equal (endianess, MSB);
+
+    _mpsse = malloc (sizeof (struct mpsse_context));
+
+    return _mpsse;
+}
+
+/*
+ * Mock function Start
+ */
+int __wrap_Start (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+    assert_true ((m_state.i2c == R_I2C_START_0) ||
+                 (m_state.i2c == R_I2C_START_1) ||
+                 (m_state.i2c == W_I2C_START));
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function Stop
+ */
+int __wrap_Stop (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+    assert_true ((m_state.i2c == R_I2C_STOP_0) ||
+                 (m_state.i2c == R_I2C_STOP_1) ||
+                 (m_state.i2c == W_I2C_STOP));
+    return MPSSE_OK;
+}
+
+/*
+ * Mock function Close
+ */
+void __wrap_Close (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    free (_mpsse);
+    _mpsse = NULL;
+}
+
+/*
+ * Mock function Read
+ */
+char *__wrap_Read (struct mpsse_context *mpsse, int size)
+{
+    const uint8_t *payload = NULL;
+    int payload_size = 0;
+    char *out = NULL;
+
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+
+    switch (m_state.tpm) {
+    case R_TPM_DID_VID:
+        payload = R_TPM_DID_VID_DATA;
+        payload_size = sizeof (R_TPM_DID_VID_DATA);
+        break;
+    case R_TPM_INTERFACE_CAP:
+        payload = R_TPM_INTERFACE_CAP_DATA;
+        payload_size = sizeof (R_TPM_INTERFACE_CAP_DATA);
+        break;
+    case R_TPM_CSUM_ENABLE:
+        payload = R_TPM_CSUM_ENABLE_DATA;
+        payload_size = sizeof (R_TPM_CSUM_ENABLE_DATA);
+        break;
+    case R_TPM_CSUM_00:
+    case R_TPM_CSUM_01:
+        payload = R_TPM_CSUM_DATA;
+        payload_size = sizeof (R_TPM_CSUM_DATA);
+        break;
+    case R_TPM_ACCESS:
+        payload = R_TPM_ACCESS_DATA;
+        payload_size = sizeof (R_TPM_ACCESS_DATA);
+        break;
+    case R_TPM_STS_00:
+    case R_TPM_STS_01:
+        payload = R_TPM_STS_00_01_DATA;
+        payload_size = sizeof (R_TPM_STS_00_01_DATA);
+        break;
+    case R_TPM_STS_02:
+    case R_TPM_STS_05:
+        payload = R_TPM_STS_02_05_DATA;
+        payload_size = sizeof (R_TPM_STS_02_05_DATA);
+        break;
+    case R_TPM_STS_03:
+    case R_TPM_STS_07:
+        payload = R_TPM_STS_03_07_DATA;
+        payload_size = sizeof (R_TPM_STS_03_07_DATA);
+        break;
+    case R_TPM_STS_04:
+    case R_TPM_STS_06:
+        payload = R_TPM_STS_04_06_DATA;
+        payload_size = sizeof (R_TPM_STS_04_06_DATA);
+        break;
+    case R_TPM_RID:
+        payload = R_TPM_RID_DATA;
+        payload_size = sizeof (R_TPM_RID_DATA);
+        break;
+    case R_TPM_FIFO_00:
+        payload = RW_TPM_FIFO_DATA;
+        payload_size = TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+        break;
+    case R_TPM_FIFO_01:
+        payload = RW_TPM_FIFO_DATA + TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+        payload_size = sizeof (RW_TPM_FIFO_DATA) - 1 - TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+        break;
+    case R_TPM_FIFO_02:
+        payload = RW_TPM_FIFO_DATA + sizeof (RW_TPM_FIFO_DATA) - 1;
+        payload_size = 1;
+        break;
+    default:
+        assert_true (false);
+    }
+
+    switch (m_state.i2c) {
+        case R_I2C_READ_0:
+            assert_int_equal (size, payload_size - 1);
+            out = malloc (size);
+            assert_non_null (out);
+            memcpy (out, payload, payload_size - 1);
+            return out;
+            break;
+        case R_I2C_READ_1:
+            assert_int_equal (size, 1);
+            out = malloc (1);
+            assert_non_null (out);
+            memcpy (out, payload + payload_size - 1, 1);
+            return out;
+            break;
+        default:
+            assert_true (false);
+    }
+
+    return NULL;
+}
+
+/*
+ * Mock function Write
+ */
+int __wrap_Write (struct mpsse_context *mpsse, char *data, int size)
+{
+    const uint8_t *payload = NULL;
+    int payload_size = 0;
+    uint8_t addr[2] = {I2C_DEV_ADDR_DEFAULT << 1, 0x0};
+
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+
+    switch (m_state.tpm) {
+    case R_TPM_DID_VID:
+        addr[1] = TCTI_I2C_HELPER_TPM_DID_VID_REG;
+        break;
+    case R_TPM_INTERFACE_CAP:
+        addr[1] = TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_REG;
+        break;
+    case R_TPM_CSUM_ENABLE:
+        addr[1] = TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG;
+        break;
+    case R_TPM_CSUM_00:
+    case R_TPM_CSUM_01:
+        addr[1] = TCTI_I2C_HELPER_TPM_DATA_CSUM_REG;
+        break;
+    case R_TPM_ACCESS:
+        addr[1] = TCTI_I2C_HELPER_TPM_ACCESS_REG;
+        break;
+    case R_TPM_STS_00:
+    case R_TPM_STS_01:
+    case R_TPM_STS_02:
+    case R_TPM_STS_03:
+    case R_TPM_STS_04:
+    case R_TPM_STS_05:
+    case R_TPM_STS_06:
+    case R_TPM_STS_07:
+        addr[1] = TCTI_I2C_HELPER_TPM_STS_REG;
+        break;
+    case R_TPM_RID:
+        addr[1] = TCTI_I2C_HELPER_TPM_RID_REG;
+        break;
+    case R_TPM_FIFO_00:
+    case R_TPM_FIFO_01:
+    case R_TPM_FIFO_02:
+        addr[1] = TCTI_I2C_HELPER_TPM_DATA_FIFO_REG;
+        break;
+    case W_TPM_STS_00:
+    case W_TPM_STS_02:
+        addr[1] = TCTI_I2C_HELPER_TPM_STS_REG;
+        payload = W_TPM_STS_00_02_DATA;
+        payload_size = sizeof (W_TPM_STS_00_02_DATA);
+        break;
+    case W_TPM_STS_01:
+        addr[1] = TCTI_I2C_HELPER_TPM_STS_REG;
+        payload = W_TPM_STS_01_DATA;
+        payload_size = sizeof (W_TPM_STS_01_DATA);
+        break;
+    case W_TPM_CSUM_ENABLE:
+        addr[1] = TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG;
+        payload = W_TPM_CSUM_ENABLE_DATA;
+        payload_size = sizeof (W_TPM_CSUM_ENABLE_DATA);
+        break;
+    case W_TPM_FIFO:
+        addr[1] = TCTI_I2C_HELPER_TPM_DATA_FIFO_REG;
+        payload = RW_TPM_FIFO_DATA;
+        payload_size = sizeof (RW_TPM_FIFO_DATA);
+        break;
+    default:
+        assert_true (false);
+    }
+
+    switch (m_state.tpm) {
+    case R_TPM_DID_VID:
+    case R_TPM_INTERFACE_CAP:
+    case R_TPM_CSUM_ENABLE:
+    case R_TPM_CSUM_00:
+    case R_TPM_CSUM_01:
+    case R_TPM_ACCESS:
+    case R_TPM_STS_00:
+    case R_TPM_STS_01:
+    case R_TPM_STS_02:
+    case R_TPM_STS_03:
+    case R_TPM_STS_04:
+    case R_TPM_STS_05:
+    case R_TPM_STS_06:
+    case R_TPM_STS_07:
+    case R_TPM_RID:
+    case R_TPM_FIFO_00:
+    case R_TPM_FIFO_01:
+    case R_TPM_FIFO_02:
+        switch (m_state.i2c) {
+            case R_I2C_WRITE_0:
+                assert_int_equal (size, 2);
+                assert_int_equal (strncmp ((const void *)addr, data, 2), 0);
+                break;
+            case R_I2C_WRITE_1:
+                assert_int_equal (size, 1);
+                assert_int_equal ((uint8_t)data[0], addr[0] | 0x01);
+                break;
+            default:
+                assert_true (false);
+        }
+        break;
+    case W_TPM_STS_00:
+    case W_TPM_STS_01:
+    case W_TPM_STS_02:
+    case W_TPM_FIFO:
+    case W_TPM_CSUM_ENABLE:
+        switch (m_state.i2c) {
+            case W_I2C_WRITE_0:
+                assert_int_equal (size, 2);
+                assert_int_equal (strncmp ((const void *)addr, data, 2), 0);
+                break;
+            case W_I2C_WRITE_1:
+                assert_int_equal (size, payload_size);
+                assert_int_equal (strncmp ((const char *)payload, data, payload_size), 0);
+                break;
+            default:
+                assert_true (false);
+        }
+        break;
+    default:
+        assert_true (false);
+    }
+
+    return 0;
+}
+
+/*
+ * Mock function GetAck
+ */
+int __wrap_GetAck (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+    assert_true ((m_state.i2c == R_I2C_GET_ACK_0) ||
+                 (m_state.i2c == R_I2C_GET_ACK_1) ||
+                 (m_state.i2c == W_I2C_GET_ACK));
+    return ACK;
+}
+
+/*
+ * Mock function SendAcks
+ */
+void __wrap_SendAcks (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+    assert_true (m_state.i2c == R_I2C_SEND_ACKS);
+}
+
+/*
+ * Mock function SendNacks
+ */
+void __wrap_SendNacks (struct mpsse_context *mpsse)
+{
+    assert_ptr_equal (mpsse, _mpsse);
+    state_machine ();
+    assert_true (m_state.i2c == R_I2C_SEND_NACKS);
+}
+
+/*
+ * The test will call Tss2_Tcti_I2c_Ftdi_Init(),
+ * which will perform several tasks including reading
+ * the TPM_DID_VID, checking locality, reading TPM_STS,
+ * and reading TPM_RID before exiting the Init function.
+ * The TSS2_TCTI_CONTEXT core functions will be tested as well.
+ * For testing purposes, the TPM responses are hardcoded.
+ */
+static void
+tcti_i2c_generic_test (void **state)
+{
+    TSS2_RC rc;
+    size_t size;
+    uint8_t response[10] = {0};
+    TSS2_TCTI_CONTEXT* tcti_ctx;
+
+    m_state.tpm = 0;
+    m_state.i2c = 0;
+
+    /* Get requested TCTI context size */
+    rc = Tss2_Tcti_I2c_Ftdi_Init (NULL, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Allocate TCTI context size */
+    tcti_ctx = (TSS2_TCTI_CONTEXT*) calloc (1, size);
+    assert_non_null (tcti_ctx);
+
+    /* Initialize TCTI context */
+    rc = Tss2_Tcti_I2c_Ftdi_Init (tcti_ctx, &size, NULL);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Verify the TCTI core functions */
+    assert_int_equal (TSS2_TCTI_MAGIC (tcti_ctx), TCTI_I2C_HELPER_MAGIC);
+    assert_int_equal (TSS2_TCTI_VERSION (tcti_ctx), TCTI_VERSION);
+    assert_int_equal (
+        TSS2_TCTI_TRANSMIT (tcti_ctx) (
+            tcti_ctx, sizeof (RW_TPM_FIFO_DATA), RW_TPM_FIFO_DATA
+        ),
+        TSS2_RC_SUCCESS
+    );
+    size = 0;
+    assert_int_equal (
+        TSS2_TCTI_RECEIVE (tcti_ctx) (
+            tcti_ctx, &size, NULL, 200
+        ),
+        TSS2_RC_SUCCESS
+    );
+    assert_int_equal (size, sizeof (RW_TPM_FIFO_DATA));
+    assert_int_equal (
+        TSS2_TCTI_RECEIVE (tcti_ctx) (
+            tcti_ctx, &size, response, 200
+        ),
+        TSS2_RC_SUCCESS
+    );
+    assert_int_equal (TSS2_TCTI_CANCEL (tcti_ctx) (NULL), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_GET_POLL_HANDLES (tcti_ctx) (NULL, NULL, NULL), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_SET_LOCALITY (tcti_ctx) (NULL, 0), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_MAKE_STICKY (tcti_ctx) (NULL, NULL, 0), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+
+    /* Clean up */
+    TSS2_TCTI_FINALIZE (tcti_ctx) (tcti_ctx);
+    free (tcti_ctx);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (tcti_i2c_generic_test),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}

--- a/test/unit/tcti-i2c-helper.c
+++ b/test/unit/tcti-i2c-helper.c
@@ -1,0 +1,400 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_i2c_helper.h"
+
+#include "tss2-tcti/tcti-common.h"
+#include "tss2-tcti/tcti-i2c-helper.h"
+#include "util/key-value-parse.h"
+
+#define DUMMY_PLATFORM_DATA "my platform data"
+
+typedef enum {
+    /* Tss2_Tcti_I2c_Helper_Init () */
+    R_TPM_DID_VID = 0,
+    R_TPM_INTERFACE_CAP,
+    R_TPM_ACCESS,
+    R_TPM_CSUM_ENABLE,
+    W_TPM_CSUM_ENABLE,
+    R_TPM_STS_00,
+    R_TPM_RID,
+    /* TSS2_TCTI_TRANSMIT () */
+    W_TPM_STS_00,
+    R_TPM_STS_01,
+    R_TPM_STS_02,
+    W_TPM_FIFO,
+    R_TPM_CSUM_00,
+    W_TPM_STS_01,
+    /* TSS2_TCTI_RECEIVE (); is_timeout_blocked == true */
+    R_TPM_STS_03,
+    R_TPM_STS_04,
+    R_TPM_FIFO_00,
+    R_TPM_STS_05,
+    R_TPM_FIFO_01,
+    R_TPM_STS_06,
+    R_TPM_FIFO_02,
+    R_TPM_STS_07,
+    R_TPM_CSUM_01,
+    W_TPM_STS_02,
+    /* TSS2_TCTI_RECEIVE (); is_timeout_blocked == false */
+    R_TPM_STS_08
+} tpm_state_t;
+
+static const uint8_t R_TPM_DID_VID_DATA[] = {0xd1, 0x15, 0x1b, 0x00};
+static const uint8_t R_TPM_INTERFACE_CAP_DATA[] = {0x82, 0x00, 0xe0, 0x1a};
+static const uint8_t R_TPM_ACCESS_DATA[] = {0xa1};
+static const uint8_t R_TPM_CSUM_ENABLE_DATA[] = {0x00};
+static const uint8_t R_TPM_RID_DATA[] = {0x00};
+static const uint8_t R_TPM_STS_00_01_DATA[] = {TCTI_I2C_HELPER_TPM_STS_COMMAND_READY, 0x00, 0x00, 0x00};
+static const uint8_t R_TPM_STS_02_05_DATA[] = {0x00, 0x40, 0x00, 0x00};
+static const uint8_t R_TPM_STS_04_06_DATA[] = {TCTI_I2C_HELPER_TPM_STS_VALID | TCTI_I2C_HELPER_TPM_STS_DATA_AVAIL,
+                                               0x00, 0x00, 0x00};
+static const uint8_t R_TPM_CSUM_DATA[] = {0xf7, 0x4b}; /* CRC-16 (KERMIT) of RW_TPM_FIFO_DATA */
+static const uint8_t R_TPM_STS_03_07_08_DATA[] = {TCTI_I2C_HELPER_TPM_STS_VALID, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_STS_00_02_DATA[] = {TCTI_I2C_HELPER_TPM_STS_COMMAND_READY, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_STS_01_DATA[] = {TCTI_I2C_HELPER_TPM_STS_GO, 0x00, 0x00, 0x00};
+static const uint8_t W_TPM_CSUM_ENABLE_DATA[] = {0x01};
+static const uint8_t RW_TPM_FIFO_DATA[] = {0x80, 0x00, 0x00, 0x00, 0x00, 0x0a, 0xde, 0xad, 0xbe, 0xef};
+
+static tpm_state_t tpm_state;
+static bool is_timeout_blocked;
+
+TSS2_RC
+platform_sleep_us (void* user_data, int32_t microseconds)
+{
+    (void) microseconds;
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_sleep_ms (void* user_data, int32_t milliseconds)
+{
+    (void) milliseconds;
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_start_timeout (void* user_data, int32_t milliseconds)
+{
+    (void) milliseconds;
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_timeout_expired (void* user_data, bool *is_timeout_expired)
+{
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    *is_timeout_expired = (is_timeout_blocked) ? false : true;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_i2c_write (void *user_data, uint8_t reg_addr, const void *data, size_t cnt)
+{
+    size_t data_len = 0;
+
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    assert_non_null (data);
+
+    switch (tpm_state++) {
+    case W_TPM_CSUM_ENABLE:
+        data_len = sizeof (W_TPM_CSUM_ENABLE_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG);
+        assert_int_equal (strncmp ((const void *)W_TPM_CSUM_ENABLE_DATA, data, data_len), 0);
+        break;
+    case W_TPM_STS_00:
+    case W_TPM_STS_02:
+        data_len = sizeof (W_TPM_STS_00_02_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        assert_int_equal (strncmp ((const void *)W_TPM_STS_00_02_DATA, data, data_len), 0);
+        break;
+    case W_TPM_STS_01:
+        data_len = sizeof (W_TPM_STS_01_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        assert_int_equal (strncmp ((const void *)W_TPM_STS_01_DATA, data, data_len), 0);
+        break;
+    case W_TPM_FIFO:
+        data_len = sizeof (RW_TPM_FIFO_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG);
+        assert_int_equal (strncmp ((const void *)RW_TPM_FIFO_DATA, data, data_len), 0);
+        break;
+    default:
+        assert_true (false);
+    }
+
+    assert_int_equal (cnt, data_len);
+
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+platform_i2c_read (void* user_data, uint8_t reg_addr, void *data, size_t cnt)
+{
+    size_t data_len = 0;
+
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    assert_non_null (data);
+
+    switch (tpm_state++) {
+    case R_TPM_DID_VID:
+        data_len = sizeof (R_TPM_DID_VID_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DID_VID_REG);
+        memcpy (data, R_TPM_DID_VID_DATA, data_len);
+        break;
+    case R_TPM_INTERFACE_CAP:
+        data_len = sizeof (R_TPM_INTERFACE_CAP_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_INTERFACE_CAPABILITY_REG);
+        memcpy (data, R_TPM_INTERFACE_CAP_DATA, data_len);
+        break;
+    case R_TPM_ACCESS:
+        data_len = sizeof (R_TPM_ACCESS_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_ACCESS_REG);
+        memcpy (data, R_TPM_ACCESS_DATA, data_len);
+        break;
+    case R_TPM_CSUM_ENABLE:
+        data_len = sizeof (R_TPM_CSUM_ENABLE_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_CSUM_ENABLE_REG);
+        memcpy (data, R_TPM_CSUM_ENABLE_DATA, data_len);
+        break;
+    case R_TPM_RID:
+        data_len = sizeof (R_TPM_RID_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_RID_REG);
+        memcpy (data, R_TPM_RID_DATA, data_len);
+        break;
+    case R_TPM_STS_00:
+    case R_TPM_STS_01:
+        data_len = sizeof (R_TPM_STS_00_01_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        memcpy (data, R_TPM_STS_00_01_DATA, data_len);
+        break;
+    case R_TPM_STS_02:
+    case R_TPM_STS_05:
+        data_len = sizeof (R_TPM_STS_02_05_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        memcpy (data, R_TPM_STS_02_05_DATA, data_len);
+        break;
+    case R_TPM_STS_04:
+    case R_TPM_STS_06:
+        data_len = sizeof (R_TPM_STS_04_06_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        memcpy (data, R_TPM_STS_04_06_DATA, data_len);
+        break;
+    case R_TPM_STS_03:
+    case R_TPM_STS_07:
+    case R_TPM_STS_08:
+        data_len = sizeof (R_TPM_STS_03_07_08_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_STS_REG);
+        memcpy (data, R_TPM_STS_03_07_08_DATA, data_len);
+        break;
+    case R_TPM_FIFO_00:
+        data_len = TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG);
+        memcpy (data, RW_TPM_FIFO_DATA, data_len);
+        break;
+    case R_TPM_FIFO_01:
+        data_len = sizeof (RW_TPM_FIFO_DATA) - 1 - TCTI_I2C_HELPER_RESP_HEADER_SIZE;
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG);
+        memcpy (data, RW_TPM_FIFO_DATA + TCTI_I2C_HELPER_RESP_HEADER_SIZE, data_len);
+        break;
+    case R_TPM_FIFO_02:
+        data_len = 1;
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_FIFO_REG);
+        memcpy (data, RW_TPM_FIFO_DATA + sizeof (RW_TPM_FIFO_DATA) - 1, 1);
+        break;
+    case R_TPM_CSUM_00:
+    case R_TPM_CSUM_01:
+        data_len = sizeof (R_TPM_CSUM_DATA);
+        assert_int_equal (reg_addr, TCTI_I2C_HELPER_TPM_DATA_CSUM_REG);
+        memcpy (data, R_TPM_CSUM_DATA, data_len);
+        break;
+    default:
+        assert_true (false);
+    }
+
+    assert_int_equal (cnt, data_len);
+
+    return TSS2_RC_SUCCESS;
+}
+
+void
+platform_finalize (void* user_data)
+{
+    assert_string_equal ((const char *) user_data, DUMMY_PLATFORM_DATA);
+    free(user_data);
+}
+
+TSS2_TCTI_I2C_HELPER_PLATFORM
+create_tcti_i2c_helper_platform (void)
+{
+    TSS2_TCTI_I2C_HELPER_PLATFORM platform = {};
+
+    // Create dummy platform user data
+    char *platform_data = malloc (sizeof (DUMMY_PLATFORM_DATA));
+    memcpy (platform_data, DUMMY_PLATFORM_DATA, sizeof (DUMMY_PLATFORM_DATA));
+
+    // Create TCTI I2C platform struct with custom platform methods
+    platform.user_data = platform_data;
+    platform.sleep_us = platform_sleep_us;
+    platform.sleep_ms = platform_sleep_ms;
+    platform.start_timeout = platform_start_timeout;
+    platform.timeout_expired = platform_timeout_expired;
+    platform.i2c_write = platform_i2c_write;
+    platform.i2c_read = platform_i2c_read;
+    platform.finalize = platform_finalize;
+
+    return platform;
+}
+
+/*
+ * The test will call Tss2_Tcti_I2c_Helper_Init(),
+ * which will perform several tasks including reading
+ * the TPM_DID_VID, checking locality, reading TPM_STS,
+ * and reading TPM_RID before exiting the Init function.
+ * The TSS2_TCTI_CONTEXT core functions will be tested as well.
+ * For testing purposes, the TPM responses are hardcoded.
+ */
+static void
+tcti_i2c_generic_test (void **state)
+{
+    TSS2_RC rc;
+    size_t size;
+    uint8_t response[10] = {0};
+
+    TSS2_TCTI_I2C_HELPER_PLATFORM tcti_platform = {};
+    TSS2_TCTI_CONTEXT* tcti_ctx;
+
+    tpm_state = R_TPM_DID_VID;
+
+    /* Get requested TCTI context size */
+    rc = Tss2_Tcti_I2c_Helper_Init (NULL, &size, &tcti_platform);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Allocate TCTI context size */
+    tcti_ctx = (TSS2_TCTI_CONTEXT*) calloc (1, size);
+    assert_non_null (tcti_ctx);
+
+    /* Initialize TCTI context */
+    tcti_platform = create_tcti_i2c_helper_platform ();
+    rc = Tss2_Tcti_I2c_Helper_Init (tcti_ctx, &size, &tcti_platform);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Verify the TCTI core functions */
+    assert_int_equal (TSS2_TCTI_MAGIC (tcti_ctx), TCTI_I2C_HELPER_MAGIC);
+    assert_int_equal (TSS2_TCTI_VERSION (tcti_ctx), TCTI_VERSION);
+    assert_int_equal (
+        TSS2_TCTI_TRANSMIT (tcti_ctx) (
+            tcti_ctx, sizeof (RW_TPM_FIFO_DATA), RW_TPM_FIFO_DATA
+        ),
+        TSS2_RC_SUCCESS
+    );
+    size = 0;
+    is_timeout_blocked = true;
+    assert_int_equal (
+        TSS2_TCTI_RECEIVE (tcti_ctx) (
+            tcti_ctx, &size, NULL, 200
+        ),
+        TSS2_RC_SUCCESS
+    );
+    assert_int_equal (size, sizeof (RW_TPM_FIFO_DATA));
+    assert_int_equal (
+        TSS2_TCTI_RECEIVE (tcti_ctx) (
+            tcti_ctx, &size, response, 200
+        ),
+        TSS2_RC_SUCCESS
+    );
+    assert_int_equal (TSS2_TCTI_CANCEL (tcti_ctx) (NULL), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_GET_POLL_HANDLES (tcti_ctx) (NULL, NULL, NULL), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_SET_LOCALITY (tcti_ctx) (NULL, 0), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+    assert_int_equal (TSS2_TCTI_MAKE_STICKY (tcti_ctx) (NULL, NULL, 0), TSS2_TCTI_RC_NOT_IMPLEMENTED);
+
+    /* Test the behavior of TSS2_TCTI_RECEIVE() in a timeout condition */
+    size = 0;
+    is_timeout_blocked = false;
+    ((TSS2_TCTI_I2C_HELPER_CONTEXT*)tcti_ctx)->common.state = TCTI_STATE_RECEIVE;
+    assert_int_equal (
+        TSS2_TCTI_RECEIVE (tcti_ctx) (
+            tcti_ctx, &size, NULL, 200
+        ),
+        TSS2_TCTI_RC_TRY_AGAIN
+    );
+
+    /* Clean up */
+    TSS2_TCTI_FINALIZE (tcti_ctx) (tcti_ctx);
+    free (tcti_ctx);
+}
+
+static void
+tcti_i2c_bad_callbacks_test (void **state)
+{
+    TSS2_RC rc;
+    size_t size;
+    TSS2_TCTI_I2C_HELPER_PLATFORM tcti_platform = {};
+    TSS2_TCTI_CONTEXT* tcti_ctx;
+
+    /* Get requested TCTI context size */
+    rc = Tss2_Tcti_I2c_Helper_Init (NULL, &size, &tcti_platform);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+
+    /* Allocate TCTI context size */
+    tcti_ctx = (TSS2_TCTI_CONTEXT*) calloc (1, size);
+    assert_non_null (tcti_ctx);
+
+    /* Initialize TCTI context */
+    tcti_platform = create_tcti_i2c_helper_platform ();
+    tcti_platform.sleep_us = NULL;
+    tcti_platform.sleep_ms = NULL;
+    rc = Tss2_Tcti_I2c_Helper_Init (tcti_ctx, &size, &tcti_platform);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
+
+    /* Clean up */
+    free (tcti_platform.user_data);
+    free (tcti_ctx);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test (tcti_i2c_generic_test),
+        cmocka_unit_test (tcti_i2c_bad_callbacks_test),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
Implement the tcti modules `tcti-i2c-ftdi` and `tcti-i2c-helper`:
- **`tcti-i2c-ftdi`:** The I2C TCTI FTDI can be used for communication with an I2C-based TPM over the FTDI MPSSE USB to I2C bridge. The FTDI module utilizes the `tcti-i2c-helper` library for handling the PTP I2C protocol and the `libftdi-dev` library for handling the USB to I2C communication.
- **`tcti-i2c-helper`:** The I2C TCTI helper can be used for TPM communication over I2C e.g. in embedded systems. It uses user supplied methods for I2C and timing operations in order to be platform independent. These methods are supplied to `Tss2_Tcti_I2c_Helper_Init` via the `TSS2_TCTI_I2C_HELPER_PLATFORM` struct. `tcti-i2c-ftdi` is an example implementation that utilizes the I2C TCTI helper.
