### PR TITLE
FAPI: Use a second session for parameter encryption.

### DIFF
--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -352,7 +352,8 @@ Fapi_ChangeAuth_Finish(
                     command->handle,
                     context->loadKey.parent_handle,
                     auth_session,
-                    ESYS_TR_NONE, ESYS_TR_NONE,
+                    ENC_SESSION_IF_POLICY(auth_session),
+                    ESYS_TR_NONE,
                     &command->newAuthValue);
             goto_if_error(r, "Error: Sign", error_cleanup);
 
@@ -481,7 +482,7 @@ Fapi_ChangeAuth_Finish(
             r = Esys_NV_ChangeAuth_Async(context->esys,
                     command->object.public.handle,
                     auth_session,
-                    ESYS_TR_NONE,
+                    ENC_SESSION_IF_POLICY(auth_session),
                     ESYS_TR_NONE,
                     &command->newAuthValue);
             goto_if_error(r, "Error: NV_ChangeAuth", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -421,7 +421,7 @@ Fapi_CreateNv_Finish(
             r = Esys_NV_DefineSpace_Async(context->esys,
                                           hierarchy->public.handle,
                                           auth_session,
-                                          ESYS_TR_NONE,
+                                          ENC_SESSION_IF_POLICY(auth_session),
                                           ESYS_TR_NONE,
                                           auth,
                                           publicInfo);

--- a/src/tss2-fapi/api/Fapi_Decrypt.c
+++ b/src/tss2-fapi/api/Fapi_Decrypt.c
@@ -315,7 +315,9 @@ Fapi_Decrypt_Finish(
             /* Decrypt the actual data. */
             r = Esys_RSA_Decrypt_Async(context->esys,
                                        context->cmd.Data_EncryptDecrypt.key_handle,
-                                       command->auth_session, ESYS_TR_NONE, ESYS_TR_NONE,
+                                       command->auth_session,
+                                       ENC_SESSION_IF_POLICY(command->auth_session),
+                                       ESYS_TR_NONE,
                                        aux_data,
                                        &command->profile->rsa_decrypt_scheme,
                                        &null_data);

--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -614,7 +614,7 @@ Fapi_Delete_Finish(
                                             command->auth_index,
                                             object->public.handle,
                                             auth_session,
-                                            ESYS_TR_NONE,
+                                            ENC_SESSION_IF_POLICY(auth_session),
                                             ESYS_TR_NONE);
             goto_if_error_reset_state(r, " Fapi_NV_UndefineSpace_Async", error_cleanup);
 
@@ -658,8 +658,9 @@ Fapi_Delete_Finish(
                     r = Esys_EvictControl_Async(context->esys, ESYS_TR_RH_OWNER,
                                                 object->public.handle,
                                                 auth_session,
-                                                ESYS_TR_NONE, ESYS_TR_NONE,
-                                            object->misc.key.persistent_handle);
+                                                ESYS_TR_NONE,
+                                                ESYS_TR_NONE,
+                                                object->misc.key.persistent_handle);
                     goto_if_error(r, "Evict Control", error_cleanup);
                     context->state = ENTITY_DELETE_NULL_AUTH_SENT_FOR_KEY;
                 }

--- a/src/tss2-fapi/api/Fapi_ExportKey.c
+++ b/src/tss2-fapi/api/Fapi_ExportKey.c
@@ -391,7 +391,8 @@ Fapi_ExportKey_Finish(
                                      command->key_object->public.handle,
                                      command->handle_ext_key,
                                      auth_session,
-                                     ESYS_TR_NONE, ESYS_TR_NONE,
+                                     ENC_SESSION_IF_POLICY(auth_session),
+                                     ESYS_TR_NONE,
                                      &encryptionKey, &symmetric);
             goto_if_error(r, "Duplicate", cleanup);
 

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -427,7 +427,8 @@ Fapi_Import_Finish(
 
             r = Esys_Load_Async(context->esys, context->loadKey.handle,
                                 auth_session,
-                                ESYS_TR_NONE, ESYS_TR_NONE,
+                                ENC_SESSION_IF_POLICY(auth_session),
+                                ESYS_TR_NONE,
                                 &private, &object->misc.key.public);
             goto_if_error(r, "Load async", error_cleanup);
             fallthrough;
@@ -534,7 +535,8 @@ Fapi_Import_Finish(
             r = Esys_Import_Async(context->esys,
                   command->parent_object->public.handle,
                   session,
-                  ESYS_TR_NONE, ESYS_TR_NONE,
+                  ENC_SESSION_IF_POLICY(session),
+                  ESYS_TR_NONE,
                   NULL, &keyTree->public,
                   &keyTree->duplicate,
                   &keyTree->encrypted_seed,

--- a/src/tss2-fapi/api/Fapi_NvExtend.c
+++ b/src/tss2-fapi/api/Fapi_NvExtend.c
@@ -349,7 +349,7 @@ Fapi_NvExtend_Finish(
                                  command->auth_index,
                                  nvIndex,
                                  auth_session,
-                                 ESYS_TR_NONE,
+                                 ENC_SESSION_IF_POLICY(auth_session),
                                  ESYS_TR_NONE,
                                  auxData);
         goto_if_error_reset_state(r, " Fapi_NvExtend_Async", error_cleanup);

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -297,7 +297,8 @@ Fapi_NvIncrement_Finish(
         r = Esys_NV_Increment_Async(context->esys,  command->auth_index,
                                     nvIndex,
                                     auth_session,
-                                    ESYS_TR_NONE, ESYS_TR_NONE);
+                                    ENC_SESSION_IF_POLICY(auth_session),
+                                    ESYS_TR_NONE);
         goto_if_error_reset_state(r, " Fapi_NvIncrement_Async", error_cleanup);
 
         fallthrough;

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -1022,7 +1022,9 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
 
             /* Prepare the setting of the dictionary attack parameters. */
             r = Esys_DictionaryAttackParameters_Async(context->esys, ESYS_TR_RH_LOCKOUT,
-                       auth_session, ESYS_TR_NONE, ESYS_TR_NONE,
+                       auth_session,
+                       ENC_SESSION_IF_POLICY(auth_session),
+                       ESYS_TR_NONE,
                        defaultProfile->newMaxTries, defaultProfile->newRecoveryTime,
                        defaultProfile->lockoutRecovery);
             goto_if_error(r, "Error Esys_DictionaryAttackParameters",

--- a/src/tss2-fapi/api/Fapi_Quote.c
+++ b/src/tss2-fapi/api/Fapi_Quote.c
@@ -371,7 +371,9 @@ Fapi_Quote_Finish(
 
             /* Perform the Quote operation. */
             r = Esys_Quote_Async(context->esys, command->handle,
-                                 auth_session, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 auth_session,
+                                 ENC_SESSION_IF_POLICY(auth_session),
+                                 ESYS_TR_NONE,
                                  &command->qualifyingData,
                                  &command->key_object->misc.key.signing_scheme,
                                  &command->pcr_selection);

--- a/src/tss2-fapi/api/Fapi_Unseal.c
+++ b/src/tss2-fapi/api/Fapi_Unseal.c
@@ -244,7 +244,8 @@ Fapi_Unseal_Finish(
             /* Perform the unseal operation with the TPM. */
             r = Esys_Unseal_Async(context->esys, command->object->public.handle,
                     auth_session,
-                    ESYS_TR_NONE, ESYS_TR_NONE);
+                    ENC_SESSION_IF_POLICY(auth_session),
+                    ESYS_TR_NONE);
             goto_if_error(r, "Error esys Unseal ", error_cleanup);
 
             fallthrough;

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -127,6 +127,10 @@ typedef struct {
         goto label;  \
     }
 
+#define ENC_SESSION_IF_POLICY(auth_session)             \
+    (auth_session == ESYS_TR_PASSWORD || auth_session == ESYS_TR_NONE || \
+     auth_session == context->session2) ? ESYS_TR_NONE : context->session2
+
 /** The states for the FAPI's object authorization state*/
 enum IFAPI_GET_CERT_STATE {
     GET_CERT_INIT = 0,

--- a/src/tss2-fapi/ifapi_policy_callbacks.h
+++ b/src/tss2-fapi/ifapi_policy_callbacks.h
@@ -32,6 +32,7 @@ typedef struct {
     ESYS_TR auth_index;             /**< Index of authorization object */
     ESYS_TR flush_handle;           /**< Handle which has to be flushed after policy execution */
     IFAPI_OBJECT auth_object;       /**< FAPI auth object needed for authorization */
+    ESYS_TR *enc_session;           /**< FAPI session used for encryption if policy is used */
     IFAPI_LoadKey load_ctx_sav;
     IFAPI_LoadKey load_ctx;
     IFAPI_CreatePrimary create_primary_ctx_sav;

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -1303,8 +1303,9 @@ execute_policy_cp_hash(
 
         /* Disable encryption to enable check of cp hash defined in
            policy cp. */
-        r = Esys_TRSess_SetAttributes(esys_ctx, current_policy->session,
-                                      0, 0xff);
+        if (current_policy->enc_session) {
+            *current_policy->enc_session = ESYS_TR_NONE;
+        }
 
         current_policy->state = POLICY_EXECUTE_INIT;
         return r;

--- a/src/tss2-fapi/ifapi_policy_execute.h
+++ b/src/tss2-fapi/ifapi_policy_execute.h
@@ -74,6 +74,8 @@ struct IFAPI_POLICY_EXEC_CTX {
     ESYS_TR session;                /**< The current policy session */
     TPMS_POLICY *policy;
     ESYS_TR policySessionSav;       /**< Backup policy session */
+    ESYS_TR *enc_session;           /**< ession used for encryption if policy is used */
+
     ESYS_TR object_handle;
     ESYS_TR nv_index;
     ESYS_TR auth_handle;

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -53,6 +53,9 @@ new_policy(
         return_error(TSS2_FAPI_RC_MEMORY, "Out of memory");
     }
     (*current_policy)->pol_exec_ctx = pol_exec_ctx;
+    /* Save address of encryption session to disable encryption if
+       policy cp hash is executed. */
+    pol_exec_ctx->enc_session = &context->session2;
     pol_exec_ctx->callbacks.cbauth = ifapi_policyeval_cbauth;
     pol_exec_ctx->callbacks.cbauth_userdata = context;
     pol_exec_ctx->callbacks.cbload = ifapi_policyeval_cbload_key;
@@ -122,9 +125,6 @@ create_session(
         if (r != TSS2_RC_SUCCESS)
             return r;
 
-        r = Esys_TRSess_SetAttributes(context->esys, *session,
-                                      TPMA_SESSION_ENCRYPT | TPMA_SESSION_DECRYPT,
-                                      0xff);
         context->policy.create_session_state = CREATE_SESSION_INIT;
         break;
 

--- a/test/integration/fapi-nv-authorizenv-cphash.int.c
+++ b/test/integration/fapi-nv-authorizenv-cphash.int.c
@@ -148,7 +148,6 @@ test_fapi_nv_authorizenv_cphash(FAPI_CONTEXT *context)
     r = Fapi_WriteAuthorizeNv(context, "/nv/Owner/myNV", policy2_name);
     goto_if_error(r, "Error Fapi_WriteAuthorizeNv", error);
 
-    LOG_ERROR("XXXX Write");
     r = Fapi_NvWrite(context, "/nv/Owner/myNV2", &data[0], sizeof(data));
     goto_if_error(r, "Error Fapi_NvWrite", error);
 


### PR DESCRIPTION
For policy sessions the auth value is needed to generate the key for parameter encryption if the encryption is activated. To avoid the usage of the auth value for policy sessions a second session will be used to activate parameter encryption.

Signed-off-by: Juergen Repp <juergen_repp@web.de>