### PR TITLE
INSTALL.md Update autotool-archive version.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ following sections describe them for the supported platforms.
 
 ## GNU/Linux:
 * GNU Autoconf
-* GNU Autoconf Archive, version >= 2017.03.21
+* GNU Autoconf Archive, version >= 2019.01.06
 * GNU Automake
 * GNU Libtool
 * C compiler


### PR DESCRIPTION
Errors with autotools-archive 2018.03.13 did occur (#2624). Therefore the version is updated to 2019.01.06.

 Signed-off-by: Juergen Repp <juergen_repp@web.de>