### PR TITLE
configure.ac: Make sysusers and tmpfiles optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -609,10 +609,14 @@ fapi-config.json: dist/fapi-config.json.in
 		-e 's|[@]sysmeasurements@|$(sysmeasurements)|g' \
 		< "$<" > "$@"
 
+if SYSD_SYSUSERS
 sysusers_DATA = dist/sysusers.d/tpm2-tss.conf
-tmpfiles_DATA = tpm2-tss-fapi.conf
+endif
 
+if SYSD_TMPFILES
+tmpfiles_DATA = tpm2-tss-fapi.conf
 CLEANFILES += tpm2-tss-fapi.conf
+endif
 
 # We have to do this ourselves, in order to get absolute paths
 tpm2-tss-fapi.conf: dist/tmpfiles.d/tpm2-tss-fapi.conf.in

--- a/configure.ac
+++ b/configure.ac
@@ -602,9 +602,9 @@ AS_IF([test "x$enable_integration" = "xyes" && test "x$enable_self_generated_cer
 
 # Check for systemd helper tools used by make install
 AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
-AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
+AM_CONDITIONAL([SYSD_SYSUSERS], [test "x$systemd_sysusers" = "xyes" && test "x$sysusersdir" != "xno"])
 AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
-AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+AM_CONDITIONAL([SYSD_TMPFILES], [test "x$systemd_tmpfiles" = "xyes" && test "x$tmpfilesdir" != "xno"])
 
 # Check all tools used by make install
 AS_IF([test "$HOSTOS" = "Linux" && test "x$systemd_sysusers" != "xyes"],


### PR DESCRIPTION
--without-sysusersdir and --without-tmpfilesdir does not work as expected. Since there's already machinery to exclude them, this patch adds onto it so they may be excluded through the normal autoconf mechanisms. 