### PR TITLE
Fix unstable test/unit/tcti-spi-ftdi

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -557,7 +557,9 @@ test_unit_tcti_spi_lt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
                                    -Wl,--wrap=libusb_open_device_with_vid_pid \
                                    -Wl,--wrap=libusb_release_interface \
                                    -Wl,--wrap=libusb_set_auto_detach_kernel_driver \
-                                   -Wl,--wrap=libusb_strerror
+                                   -Wl,--wrap=libusb_strerror \
+                                   -Wl,--wrap=select \
+                                   -Wl,--wrap=gettimeofday
 test_unit_tcti_spi_lt2go_SOURCES = test/unit/tcti-spi-lt2go.c \
                                    src/tss2-tcti/tcti-spi-lt2go.c
 endif
@@ -571,7 +573,9 @@ test_unit_tcti_spi_ftdi_LDFLAGS = -Wl,--wrap=Close \
                                   -Wl,--wrap=PinLow \
                                   -Wl,--wrap=Start \
                                   -Wl,--wrap=Stop \
-                                  -Wl,--wrap=Transfer
+                                  -Wl,--wrap=Transfer \
+                                  -Wl,--wrap=select \
+                                  -Wl,--wrap=gettimeofday
 test_unit_tcti_spi_ftdi_SOURCES = test/unit/tcti-spi-ftdi.c \
                                   src/tss2-tcti/tcti-spi-ftdi.c
 endif

--- a/test/unit/tcti-spi-ftdi.c
+++ b/test/unit/tcti-spi-ftdi.c
@@ -43,6 +43,39 @@ static const unsigned char TPM_RID_0[] = {0x80, 0xd4, 0x0f, 0x04, 0x00};
 static struct mpsse_context *_mpsse;
 
 /*
+ * Mock function select
+ */
+int __wrap_select (int nfds, fd_set *readfds,
+                   fd_set *writefds,
+                   fd_set *exceptfds,
+                   struct timeval *timeout)
+{
+
+    assert_int_equal (nfds, 0);
+    assert_null (readfds);
+    assert_null (writefds);
+    assert_null (exceptfds);
+    assert_non_null (timeout);
+
+    return 0;
+}
+
+/*
+ * Mock function gettimeofday
+ */
+int __wrap_gettimeofday (struct timeval *tv,
+                         struct timezone *tz)
+{
+    assert_null (tz);
+    assert_non_null (tv);
+
+    tv->tv_sec = 0;
+    tv->tv_usec = 0;
+
+    return 0;
+}
+
+/*
  * Mock function MPSSE
  */
 struct mpsse_context *__wrap_MPSSE (enum modes mode, int freq, int endianess)

--- a/test/unit/tcti-spi-lt2go.c
+++ b/test/unit/tcti-spi-lt2go.c
@@ -60,6 +60,39 @@ static size_t device_mem_alloc_length;
 static uint16_t transfer_length;
 
 /*
+ * Mock function select
+ */
+int __wrap_select (int nfds, fd_set *readfds,
+                   fd_set *writefds,
+                   fd_set *exceptfds,
+                   struct timeval *timeout)
+{
+
+    assert_int_equal (nfds, 0);
+    assert_null (readfds);
+    assert_null (writefds);
+    assert_null (exceptfds);
+    assert_non_null (timeout);
+
+    return 0;
+}
+
+/*
+ * Mock function gettimeofday
+ */
+int __wrap_gettimeofday (struct timeval *tv,
+                         struct timezone *tz)
+{
+    assert_null (tz);
+    assert_non_null (tv);
+
+    tv->tv_sec = 0;
+    tv->tv_usec = 0;
+
+    return 0;
+}
+
+/*
  * Mock function libusb_get_device.
  */
 libusb_device * __wrap_libusb_get_device (libusb_device_handle *dev_handle)


### PR DESCRIPTION
To nullify the effect of the timeout in the unit test, as the runtime environment of the unit test is unpredictable. This is to address the reported issue https://github.com/tpm2-software/tpm2-tss/issues/2610