### PR TITLE
esys tests: Fix layer check for TPM2_RC_COMMAND_CODE.

### DIFF
--- a/test/integration/esys-act-set-timeout.int.c
+++ b/test/integration/esys-act-set-timeout.int.c
@@ -75,7 +75,9 @@ test_esys_act_set_timeout(ESYS_CONTEXT * esys_context)
         }
     }
     /* If the TPM doesn't support it return skip */
-    if (r == TPM2_RC_COMMAND_CODE)
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER)))
         return EXIT_SKIP;
     else
         return EXIT_FAILURE;

--- a/test/integration/esys-certifyX509.int.c
+++ b/test/integration/esys-certifyX509.int.c
@@ -223,7 +223,9 @@ test_esys_certifyx509(ESYS_CONTEXT * esys_context)
         Esys_Free(tbsDigest);
 
     /* If the TPM doesn't support it return skip */
-    if (r == TPM2_RC_COMMAND_CODE)
+    if ((r == TPM2_RC_COMMAND_CODE) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
+        (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER)))
         return EXIT_SKIP;
     else
         return EXIT_FAILURE;


### PR DESCRIPTION
Two integration tests failed for tests with /dev/tpmrm0 because the layer of the return code was not checked.

Signed-off-by: Juergen Repp <juergen_repp@web.de>