### PR TITLE
fapi tests: Fix layer check for TPM2_RC_COMMAND_CODE.

### DIFF
--- a/test/integration/fapi-key-create-policies-sign.int.c
+++ b/test/integration/fapi-key-create-policies-sign.int.c
@@ -165,7 +165,7 @@ test_fapi_key_create_policies_sign(FAPI_CONTEXT *context)
     if (number_rc(r) == TPM2_RC_PP) {
         LOG_WARNING("Test requires physical presence.");
         goto skip;
-    } else if (r == TPM2_RC_COMMAND_CODE) {
+    } else if (base_rc(r) == TPM2_RC_COMMAND_CODE) {
         LOG_WARNING("Command not supported, probably PolicyPhysicalPresence");
         goto skip;
     }


### PR DESCRIPTION
A bit mask for the layer of the return code was not used in one case of the  integration test fapi-key-create-policies-sign.int.c

Signed-off-by: Juergen Repp <juergen_repp@web.de>
