### PR TITLE
Makefile.am Delete invalid character.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -818,7 +818,7 @@ define make_fapi_dirs
 endef
 
 define set_fapi_permissions
-    if test -z "${DESTDIR}"; then \ e
+    if test -z "${DESTDIR}"; then \
         ($(call set_tss_permissions,$(DESTDIR)$(runstatedir)/tpm2-tss)) && \
         ($(call set_tss_permissions,$(DESTDIR)$(localstatedir)/lib/tpm2-tss)) \
     fi


### PR DESCRIPTION
The invalid character e in the function fapi_set_permissions was deleted.

Signed-off-by: Juergen Repp <juergen_repp@web.de>