### PR TITLE
TCTI-SPI-LTT2GO: Correct naming from ltl2go to ltt2go

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -155,8 +155,8 @@ endif
 if ENABLE_TCTI_SPI_HELPER
 TESTS_UNIT += test/unit/tcti-spi-helper
 endif
-if ENABLE_TCTI_SPI_LT2GO
-TESTS_UNIT += test/unit/tcti-spi-lt2go
+if ENABLE_TCTI_SPI_LTT2GO
+TESTS_UNIT += test/unit/tcti-spi-ltt2go
 endif
 if ENABLE_TCTI_SPI_FTDI
 TESTS_UNIT += test/unit/tcti-spi-ftdi
@@ -546,10 +546,10 @@ test_unit_tcti_spi_helper_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
 test_unit_tcti_spi_helper_SOURCES = test/unit/tcti-spi-helper.c
 endif
 
-if ENABLE_TCTI_SPI_LT2GO
-test_unit_tcti_spi_lt2go_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
-test_unit_tcti_spi_lt2go_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
-test_unit_tcti_spi_lt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
+if ENABLE_TCTI_SPI_LTT2GO
+test_unit_tcti_spi_ltt2go_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
+test_unit_tcti_spi_ltt2go_LDADD   = $(CMOCKA_LIBS) $(libtss2_tcti_spi_helper)
+test_unit_tcti_spi_ltt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
                                    -Wl,--wrap=libusb_claim_interface \
                                    -Wl,--wrap=libusb_close \
                                    -Wl,--wrap=libusb_control_transfer \
@@ -566,8 +566,8 @@ test_unit_tcti_spi_lt2go_LDFLAGS = -Wl,--wrap=libusb_bulk_transfer \
                                    -Wl,--wrap=libusb_strerror \
                                    -Wl,--wrap=select \
                                    -Wl,--wrap=gettimeofday
-test_unit_tcti_spi_lt2go_SOURCES = test/unit/tcti-spi-lt2go.c \
-                                   src/tss2-tcti/tcti-spi-lt2go.c
+test_unit_tcti_spi_ltt2go_SOURCES = test/unit/tcti-spi-ltt2go.c \
+                                   src/tss2-tcti/tcti-spi-ltt2go.c
 endif
 
 if ENABLE_TCTI_SPI_FTDI

--- a/Makefile.am
+++ b/Makefile.am
@@ -424,25 +424,25 @@ src_tss2_tcti_libtss2_tcti_spi_helper_la_SOURCES  = \
 endif # ENABLE_TCTI_SPI_HELPER
 
 # tcti library for letstrust-tpm2go usb tpm
-if ENABLE_TCTI_SPI_LT2GO
-libtss2_tcti_spi_lt2go = src/tss2-tcti/libtss2-tcti-spi-lt2go.la
-tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_spi_lt2go.h
-lib_LTLIBRARIES += $(libtss2_tcti_spi_lt2go)
-pkgconfig_DATA += lib/tss2-tcti-spi-lt2go.pc
+if ENABLE_TCTI_SPI_LTT2GO
+libtss2_tcti_spi_ltt2go = src/tss2-tcti/libtss2-tcti-spi-ltt2go.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_spi_ltt2go.h
+lib_LTLIBRARIES += $(libtss2_tcti_spi_ltt2go)
+pkgconfig_DATA += lib/tss2-tcti-spi-ltt2go.pc
 
-src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LDFLAGS  = -lusb-1.0
+src_tss2_tcti_libtss2_tcti_spi_ltt2go_la_LDFLAGS  = -lusb-1.0
 
 if HAVE_LD_VERSION_SCRIPT
-src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LDFLAGS  += -Wl,--version-script=$(srcdir)/lib/tss2-tcti-spi-lt2go.map
+src_tss2_tcti_libtss2_tcti_spi_ltt2go_la_LDFLAGS  += -Wl,--version-script=$(srcdir)/lib/tss2-tcti-spi-ltt2go.map
 endif # HAVE_LD_VERSION_SCRIPT
-src_tss2_tcti_libtss2_tcti_spi_lt2go_la_LIBADD   = $(libutil) $(libtss2_mu) $(libtss2_tcti_spi_helper)
-src_tss2_tcti_libtss2_tcti_spi_lt2go_la_SOURCES  = \
+src_tss2_tcti_libtss2_tcti_spi_ltt2go_la_LIBADD   = $(libutil) $(libtss2_mu) $(libtss2_tcti_spi_helper)
+src_tss2_tcti_libtss2_tcti_spi_ltt2go_la_SOURCES  = \
     src/tss2-tcti/tcti-common.c \
-    src/tss2-tcti/tcti-spi-lt2go.c \
-    src/tss2-tcti/tcti-spi-lt2go.h
-endif # ENABLE_TCTI_SPI_LT2GO
-EXTRA_DIST += lib/tss2-tcti-spi-lt2go.map \
-              lib/tss2-tcti-spi-lt2go.def
+    src/tss2-tcti/tcti-spi-ltt2go.c \
+    src/tss2-tcti/tcti-spi-ltt2go.h
+endif # ENABLE_TCTI_SPI_LTT2GO
+EXTRA_DIST += lib/tss2-tcti-spi-ltt2go.map \
+              lib/tss2-tcti-spi-ltt2go.def
 
 # tcti library for ftdi connected tpm
 if ENABLE_TCTI_SPI_FTDI
@@ -902,7 +902,7 @@ man7_MANS = \
     man/man7/tss2-tcti-mssim.7 \
     man/man7/tss2-tcti-cmd.7 \
     man/man7/tss2-tcti-spi-helper.7 \
-    man/man7/tss2-tcti-spi-lt2go.7 \
+    man/man7/tss2-tcti-spi-ltt2go.7 \
     man/man7/tss2-tcti-spi-ftdi.7 \
     man/man7/tss2-tcti-i2c-helper.7 \
     man/man7/tss2-tcti-i2c-ftdi.7 \
@@ -985,7 +985,7 @@ EXTRA_DIST += \
     man/tss2-tcti-mssim.7.in \
     man/tss2-tcti-cmd.7.in \
     man/tss2-tcti-spi-helper.7.in \
-    man/tss2-tcti-spi-lt2go.7.in \
+    man/tss2-tcti-spi-ltt2go.7.in \
     man/tss2-tcti-spi-ftdi.7.in \
     man/tss2-tcti-i2c-helper.7.in \
     man/tss2-tcti-i2c-ftdi.7.in \

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-lt2go.pc lib/tss2-tcti-spi-ftdi.pc lib/tss2-tcti-i2c-helper.pc lib/tss2-tcti-i2c-ftdi.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-ltt2go.pc lib/tss2-tcti-spi-ftdi.pc lib/tss2-tcti-i2c-helper.pc lib/tss2-tcti-i2c-ftdi.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -298,28 +298,28 @@ AM_CONDITIONAL([ENABLE_TCTI_SPI_HELPER], [test "x$enable_tcti_spi_helper" != xno
 AS_IF([test "x$enable_tcti_spi_helper" = "xyes"],
 	[AC_DEFINE([TCTI_SPI_HELPER],[1], [TCTI HELPER FOR SPI BASED ACCESS TO TPM2 DEVICE])])
 
-AC_ARG_ENABLE([tcti-spi-lt2go],
-            [AS_HELP_STRING([--disable-tcti-spi-lt2go],
-                            [don't build the tcti-spi-lt2go module])],
-            [AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
+AC_ARG_ENABLE([tcti-spi-ltt2go],
+            [AS_HELP_STRING([--disable-tcti-spi-ltt2go],
+                            [don't build the tcti-spi-ltt2go module])],
+            [AS_IF([test "x$enable_tcti_spi_ltt2go" = "xyes"],
                    [PKG_CHECK_MODULES([LIBUSB], [libusb-1.0],
                         [AC_CHECK_HEADER(libusb-1.0/libusb.h,
-                                [enable_tcti_spi_lt2go=yes],
-                                [enable_tcti_spi_lt2go=no] [AC_MSG_ERROR([libusb-1.0 library header is missing.])])],
-                        [enable_tcti_spi_lt2go=no] [AC_MSG_ERROR([libusb-1.0 library is missing.])])],
-                   [AS_IF([test "x$enable_tcti_spi_lt2go" = "xno"],
-                          [enable_tcti_spi_lt2go=no])])],
+                                [enable_tcti_spi_ltt2go=yes],
+                                [enable_tcti_spi_ltt2go=no] [AC_MSG_ERROR([libusb-1.0 library header is missing.])])],
+                        [enable_tcti_spi_ltt2go=no] [AC_MSG_ERROR([libusb-1.0 library is missing.])])],
+                   [AS_IF([test "x$enable_tcti_spi_ltt2go" = "xno"],
+                          [enable_tcti_spi_ltt2go=no])])],
             [PKG_CHECK_MODULES([LIBUSB], [libusb-1.0],
                    [AC_CHECK_HEADER(libusb-1.0/libusb.h,
-                         [enable_tcti_spi_lt2go=yes],
-                         [enable_tcti_spi_lt2go=no])],
-                   [enable_tcti_spi_lt2go=no])])
+                         [enable_tcti_spi_ltt2go=yes],
+                         [enable_tcti_spi_ltt2go=no])],
+                   [enable_tcti_spi_ltt2go=no])])
 
 
-AM_CONDITIONAL([ENABLE_TCTI_SPI_LT2GO], [test "x$enable_tcti_spi_lt2go" != xno])
+AM_CONDITIONAL([ENABLE_TCTI_SPI_LTT2GO], [test "x$enable_tcti_spi_ltt2go" != xno])
 
-AS_IF([test "x$enable_tcti_spi_lt2go" = "xyes"],
-    AC_DEFINE([TCTI_SPI_LT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
+AS_IF([test "x$enable_tcti_spi_ltt2go" = "xyes"],
+    AC_DEFINE([TCTI_SPI_LTT2GO],[1], [TCTI FOR USB BASED ACCESS TO LETSTRUST-TPM2GO]))
 
 PKG_CHECK_MODULES([LIBFTDI],
                   [libftdi],
@@ -716,7 +716,7 @@ AC_MSG_RESULT([
     userstatedir:       [\$HOME/]$with_userstatedir
     sysmeasurements:    $sysmeasurements
     imameasurements:    $imameasurements
-    tcti_spi_lt2go      $enable_tcti_spi_lt2go
+    tcti_spi_ltt2go      $enable_tcti_spi_ltt2go
     tcti_spi_ftdi       $enable_tcti_spi_ftdi
     tcti_i2c_ftdi       $enable_tcti_i2c_ftdi
 ])

--- a/doc/tcti-spi-ltt2go.md
+++ b/doc/tcti-spi-ltt2go.md
@@ -1,6 +1,6 @@
-# SPI TCTI LT2GO
-The SPI TCTI LT2GO can be used for communication with LetsTrust-TPM2Go USB TPM.
-The LT2GO module utilizes the `tcti-spi-helper` library for PTP SPI protocol handling
+# SPI TCTI LTT2GO
+The SPI TCTI LTT2GO can be used for communication with LetsTrust-TPM2Go USB TPM.
+The LTT2GO module utilizes the `tcti-spi-helper` library for PTP SPI protocol handling
 and the `libusb-1.0-0-dev` library for USB communication.
 
 # EXAMPLES
@@ -31,16 +31,16 @@ sudo udevadm info -e | grep LetsTrust
  E: ID_SERIAL=www.pi3g.com_LetsTrust-TPM2Go_000010
 ```
 
-Use tcti-spi-lt2go to communicate with LetsTrust-TPM2Go:
+Use tcti-spi-ltt2go to communicate with LetsTrust-TPM2Go:
 ```console
-tpm2_startup -Tspi-lt2go -c
-tpm2_getrandom -Tspi-lt2go 8 --hex
+tpm2_startup -Tspi-ltt2go -c
+tpm2_getrandom -Tspi-ltt2go 8 --hex
 ```
 
 Enable abrmd:
 ```console
 export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork`
-tpm2-abrmd --allow-root --session --tcti=spi-lt2go &
+tpm2-abrmd --allow-root --session --tcti=spi-ltt2go &
 
 export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
 tpm2_startup -c

--- a/include/tss2/tss2_tcti_spi_ltt2go.h
+++ b/include/tss2/tss2_tcti_spi_ltt2go.h
@@ -2,8 +2,8 @@
 /*
  * Copyright 2020 Peter Huewe
  */
-#ifndef TSS2_TCTI_SPI_LT2GO_H
-#define TSS2_TCTI_SPI_LT2GO_H
+#ifndef TSS2_TCTI_SPI_LTT2GO_H
+#define TSS2_TCTI_SPI_LTT2GO_H
 
 #include <stdbool.h>
 #include "tss2_tcti.h"
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-TSS2_RC Tss2_Tcti_Spi_Lt2go_Init (
+TSS2_RC Tss2_Tcti_Spi_Ltt2go_Init (
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t *size,
     const char *config);
@@ -22,4 +22,4 @@ TSS2_RC Tss2_Tcti_Spi_Lt2go_Init (
 }
 #endif
 
-#endif /* TSS2_TCTI_SPI_LT2GO_H */
+#endif /* TSS2_TCTI_SPI_LTT2GO_H */

--- a/lib/tss2-tcti-spi-lt2go.def
+++ b/lib/tss2-tcti-spi-lt2go.def
@@ -1,4 +1,0 @@
-LIBRARY tss2-tcti-spi-lt2go
-EXPORTS
-    Tss2_Tcti_Info
-    Tss2_Tcti_Spi_Lt2go_Init

--- a/lib/tss2-tcti-spi-ltt2go.def
+++ b/lib/tss2-tcti-spi-ltt2go.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-spi-ltt2go
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Spi_Ltt2go_Init

--- a/lib/tss2-tcti-spi-ltt2go.map
+++ b/lib/tss2-tcti-spi-ltt2go.map
@@ -1,7 +1,7 @@
 {
     global:
         Tss2_Tcti_Info;
-        Tss2_Tcti_Spi_Lt2go_Init;
+        Tss2_Tcti_Spi_Ltt2go_Init;
     local:
         *;
 };

--- a/lib/tss2-tcti-spi-ltt2go.pc.in
+++ b/lib/tss2-tcti-spi-ltt2go.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: tss2-tcti-spi-lt2go
+Name: tss2-tcti-spi-ltt2go
 Description: TCTI library for communicating with the LetsTrust-TPM2Go over USB.
 URL: https://github.com/tpm2-software/tpm2-tss
 Version: @VERSION@
 Cflags: -I${includedir} -I${includedir}/tss
-Libs: -ltss2-tcti-spi-helper -ltss2-tcti-spi-lt2go -L${libdir} -lusb-1.0
+Libs: -ltss2-tcti-spi-helper -ltss2-tcti-spi-ltt2go -L${libdir} -lusb-1.0

--- a/man/tss2-tcti-spi-ltt2go.7.in
+++ b/man/tss2-tcti-spi-ltt2go.7.in
@@ -3,12 +3,12 @@
 .\"
 .TH TCTI-SPI 7 "NOVEMBER 2022" "TPM2 Software Stack"
 .SH NAME
-tcti-spi-lt2go \- LetsTrust-TPM2Go USB TPM TCTI library
+tcti-spi-ltt2go \- LetsTrust-TPM2Go USB TPM TCTI library
 .SH SYNOPSIS
 A TPM Command Transmission Interface (TCTI) module for interaction with
 the LetsTrust-TPM2Go USB TPM.
 .SH DESCRIPTION
-tcti-spi-lt2go is a library that abstracts the details of communication
+tcti-spi-ltt2go is a library that abstracts the details of communication
 with the LetsTrust-TPM2Go USB TPM. The interface exposed by this library
 is defined in the \*(lqTSS System Level API and TPM Command Transmission
 Interface Specification\*(rq specification.

--- a/src/tss2-tcti/tcti-spi-ltt2go.c
+++ b/src/tss2-tcti/tcti-spi-ltt2go.c
@@ -14,8 +14,8 @@
 #include <assert.h>
 
 #include "tss2_tcti.h"
-#include "tcti-spi-lt2go.h"
-#include "tss2_tcti_spi_lt2go.h"
+#include "tcti-spi-ltt2go.h"
+#include "tss2_tcti_spi_ltt2go.h"
 #include "tcti-spi-helper.h"
 #include "tss2_mu.h"
 #include "util/io.h"
@@ -196,7 +196,7 @@ platform_finalize(void *user_data)
 }
 
 TSS2_RC
-create_tcti_spi_lt2go_platform (TSS2_TCTI_SPI_HELPER_PLATFORM *platform)
+create_tcti_spi_ltt2go_platform (TSS2_TCTI_SPI_HELPER_PLATFORM *platform)
 {
     int ret = 0;
     int nb_ifaces = 0;
@@ -296,7 +296,7 @@ out:
 }
 
 TSS2_RC
-Tss2_Tcti_Spi_Lt2go_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const char* config)
+Tss2_Tcti_Spi_Ltt2go_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const char* config)
 {
     (void) config;
     TSS2_RC ret = 0;
@@ -307,7 +307,7 @@ Tss2_Tcti_Spi_Lt2go_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const c
         return Tss2_Tcti_Spi_Helper_Init (NULL, size, NULL);
     }
 
-    if ((ret = create_tcti_spi_lt2go_platform (&tcti_platform))) {
+    if ((ret = create_tcti_spi_ltt2go_platform (&tcti_platform))) {
         return ret;
     }
 
@@ -317,10 +317,10 @@ Tss2_Tcti_Spi_Lt2go_Init (TSS2_TCTI_CONTEXT* tcti_context, size_t* size, const c
 
 const TSS2_TCTI_INFO tss2_tcti_info = {
     .version = TCTI_VERSION,
-    .name = "tcti-spi-lt2go",
+    .name = "tcti-spi-ltt2go",
     .description = "TCTI for communicating with LetsTrust-TPM2Go.",
     .config_help = "Takes no configuration.",
-    .init = Tss2_Tcti_Spi_Lt2go_Init
+    .init = Tss2_Tcti_Spi_Ltt2go_Init
 };
 
 const TSS2_TCTI_INFO *

--- a/src/tss2-tcti/tcti-spi-ltt2go.h
+++ b/src/tss2-tcti/tcti-spi-ltt2go.h
@@ -2,8 +2,8 @@
 /*
  * Copyright 2020 Peter Huewe
  */
-#ifndef TCTI_SPI_LT2GO_H
-#define TCTI_SPI_LT2GO_H
+#ifndef TCTI_SPI_LTT2GO_H
+#define TCTI_SPI_LTT2GO_H
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -21,4 +21,4 @@ typedef struct {
     uint8_t *spi_dma_buffer;
 } PLATFORM_USERDATA;
 
-#endif /* TCTI_SPI_LT2GO_H */
+#endif /* TCTI_SPI_LTT2GO_H */

--- a/test/unit/tcti-spi-ltt2go.c
+++ b/test/unit/tcti-spi-ltt2go.c
@@ -19,10 +19,10 @@
 #include <cmocka.h>
 
 #include "tss2_tcti.h"
-#include "tss2_tcti_spi_lt2go.h"
+#include "tss2_tcti_spi_ltt2go.h"
 
 #include "tss2-tcti/tcti-common.h"
-#include "tss2-tcti/tcti-spi-lt2go.h"
+#include "tss2-tcti/tcti-spi-ltt2go.h"
 #include "tss2-tcti/tcti-spi-helper.h"
 #include "util/key-value-parse.h"
 
@@ -336,7 +336,7 @@ int __wrap_libusb_dev_mem_free (libusb_device_handle *dev_handle,
 }
 
 /*
- * The test will invoke Tss2_Tcti_Spi_Lt2go_Init() and subsequently
+ * The test will invoke Tss2_Tcti_Spi_Ltt2go_Init() and subsequently
  * it will start reading TPM_DID_VID, claim locality, read TPM_STS,
  * and finally read TPM_RID before exiting the Init function.
  * For testing purpose, the TPM responses are hardcoded.
@@ -350,7 +350,7 @@ tcti_spi_no_wait_state_success_test (void **state)
     TSS2_TCTI_CONTEXT* tcti_ctx;
 
     /* Get requested TCTI context size */
-    rc = Tss2_Tcti_Spi_Lt2go_Init (NULL, &size, NULL);
+    rc = Tss2_Tcti_Spi_Ltt2go_Init (NULL, &size, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
     /* Allocate TCTI context size */
@@ -358,7 +358,7 @@ tcti_spi_no_wait_state_success_test (void **state)
     assert_non_null (tcti_ctx);
 
     /* Initialize TCTI context */
-    rc = Tss2_Tcti_Spi_Lt2go_Init (tcti_ctx, &size, NULL);
+    rc = Tss2_Tcti_Spi_Ltt2go_Init (tcti_ctx, &size, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 
     TSS2_TCTI_SPI_HELPER_PLATFORM platform = ((TSS2_TCTI_SPI_HELPER_CONTEXT *) tcti_ctx)->platform;


### PR DESCRIPTION
The product is called LetsTrust-TPM2Go.
This should be reflected in all references as well as the file names.  

Signed-off-by: Paul Kissinger <paul.kissinger@letstrust.de>