### PR TITLE
fapi: remove deprecated index function.

### DIFF
--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -256,12 +256,12 @@ ifapi_profiles_get(
     }
 
     /* Search for path delimiter */
-    split = index(name, IFAPI_FILE_DELIM_CHAR);
+    split = strchr(name, IFAPI_FILE_DELIM_CHAR);
 
     /* If the path beging with delimiters, skip over those */
     if (name == split) {
         name += 1;
-        split = index(name, IFAPI_FILE_DELIM_CHAR);
+        split = strchr(name, IFAPI_FILE_DELIM_CHAR);
     }
     if (split == NULL)
         len = strlen(name);


### PR DESCRIPTION
The deprecated index function is replaced by strchr. Fixes: #2656

Signed-off-by: Juergen Repp <juergen_repp@web.de>