### PR TITLE
fapi: remove includes from ifdef HAVE_CONFIG_H

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -6,10 +6,10 @@
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
-#include <dirent.h>
-#include <ctype.h>
 #endif
 
+#include <dirent.h>
+#include <ctype.h>
 #include "ifapi_io.h"
 #include "ifapi_helpers.h"
 #include "ifapi_keystore.h"


### PR DESCRIPTION
The standard-library includes should be inside the ifdef? Fixes: #2660

Signed-off-by: Juergen Repp <juergen_repp@web.de>