### PR TITLE
esys: close TR handle for input persistent handle in EvictControl_Finish 3.2.x

### DIFF
--- a/src/tss2-esys/api/Esys_EvictControl.c
+++ b/src/tss2-esys/api/Esys_EvictControl.c
@@ -361,6 +361,9 @@ Esys_EvictControl_Finish(
     /* The object was already persistent */
     if (iesys_get_handle_type(objectHandleNode->rsrc.handle) == TPM2_HT_PERSISTENT) {
         *newObjectHandle = ESYS_TR_NONE;
+        r = Esys_TR_Close(esysContext, &objectHandle);
+        if (r != TSS2_RC_SUCCESS)
+            return r;
     } else {
         /* A new resource is created and updated with date from the not persistent object */
         RSRC_NODE_T *newObjectHandleNode = NULL;


### PR DESCRIPTION
The TSS ESAPI spec (1.00 rev 14) says:

> If the ESYS_TR object on input was a persistent object, [the ESYS_TR
> output] parameter will not return a ESYS_TR object but instead will
> return ESYS_TR_NULL. Also the metadata in the ESYS_CONTEXT regarding
> the ESYS_TR object will be removed and the ESYS_TR object will be
> marked as invalid.

However, currently although the output parameter is set to ESYS_TR_NONE, the input ESYS_TR object isn't closed. Other than the obvious leak, this can cause an error when Esys_TR_FromTPMPublic is called twice, with the object having been recreated with different public data and persisted with Esys_EvictControl in between, since Esys_TR_FromTPMPublic now verifies that the public data hasn't changed for the ESYS_TR object (which it now has).

Address this by closing the input ESYS_TR handle in the case that it referred to a persistent object.