### PR TITLE
Do not consider failures to write files in /sys hard errors

### DIFF
--- a/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+++ b/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
@@ -3,5 +3,5 @@ d       @localstatedir@/lib/tpm2-tss/system/keystore   2775 tss  tss   -        
 a+      @localstatedir@/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx
 d       @runstatedir@/tpm2-tss/eventlog                2775 tss  tss   -           -
 a+      @runstatedir@/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx
-z	/sys/kernel/security/tpm[0-9]/binary_bios_measurements	0440  root tss	-	    -
-z	/sys/kernel/security/ima/binary_runtime_measurements	0440  root tss	-	    -
+z-	/sys/kernel/security/tpm[0-9]/binary_bios_measurements	0440  root tss	-	    -
+z-	/sys/kernel/security/ima/binary_runtime_measurements	0440  root tss	-	    -


### PR DESCRIPTION
systemd-tmpfiles can run in containers, chroots, ... where writing to /sys will fail, so let's suffix these lines with "-" to avoid considering these cases hard errors.