### PR TITLE
cirrus-ci update image-family to freebsd-13-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,9 @@ task:
     libusb_version: v1.0.26
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-1
+      image_family: freebsd-13-2
   install_script:
+    - IGNORE_OSVERSION=yes
     - pkg update -f
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive


### PR DESCRIPTION
13-1 caused errors during package installation.

Signed-off-by: Juergen Repp <juergen_repp@web.de>