### PR TITLE
cirrus-ci update image-family to freebsd-13-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     ibmtpm_name: ibmtpm1637
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-1
+      image_family: freebsd-13-2
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
13-1 caused errors during package installation.