### PR TITLE
FAPI: Fix unneeded encryption 3.2.x

### DIFF
--- a/src/tss2-fapi/api/Fapi_Delete.c
+++ b/src/tss2-fapi/api/Fapi_Delete.c
@@ -614,7 +614,7 @@ Fapi_Delete_Finish(
                                             command->auth_index,
                                             object->handle,
                                             auth_session,
-                                            ENC_SESSION_IF_POLICY(auth_session),
+                                            ESYS_TR_NONE,
                                             ESYS_TR_NONE);
             goto_if_error_reset_state(r, " Fapi_NV_UndefineSpace_Async", error_cleanup);
 

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -297,7 +297,7 @@ Fapi_NvIncrement_Finish(
         r = Esys_NV_Increment_Async(context->esys,  command->auth_index,
                                     nvIndex,
                                     auth_session,
-                                    ENC_SESSION_IF_POLICY(auth_session),
+                                    ESYS_TR_NONE,
                                     ESYS_TR_NONE);
         goto_if_error_reset_state(r, " Fapi_NvIncrement_Async", error_cleanup);
 

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -927,7 +927,7 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             /* Prepare the setting of the dictionary attack parameters. */
             r = Esys_DictionaryAttackParameters_Async(context->esys, ESYS_TR_RH_LOCKOUT,
                        auth_session,
-                       ENC_SESSION_IF_POLICY(auth_session),
+                       ESYS_TR_NONE,
                        ESYS_TR_NONE,
                        defaultProfile->newMaxTries, defaultProfile->newRecoveryTime,
                        defaultProfile->lockoutRecovery);

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -3594,7 +3594,7 @@ ifapi_key_create(
             r = Esys_EvictControl_Async(context->esys, hierarchy->handle,
                                         context->loadKey.handle,
                                         auth_session,
-                                        ENC_SESSION_IF_POLICY(auth_session),
+                                        ESYS_TR_NONE,
                                         ESYS_TR_NONE,
                                         object->misc.key.persistent_handle);
             goto_if_error(r, "Error Esys EvictControl", error_cleanup);


### PR DESCRIPTION
A second session for encryption can only be used if the command has TPM2B parameters which can be encrypted. If no such parameter exists the TPM produces an error.
The call of the macro ENC_SESSION_IF_POLICY is replaces with ESYS_TR_NONE in these cases.

Signed-off-by: Juergen Repp <juergen_repp@web.de>