### PR TITLE
tctildr: turn tctildr into a tcti

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -809,8 +809,6 @@ test_unit_esys_crypto_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
 test_unit_esys_crypto_SOURCES = test/unit/esys-crypto.c \
                                 src/tss2-esys/esys_context.c \
                                 src/tss2-esys/esys_iutil.c \
-                                src/tss2-tcti/tctildr.c \
-                                src/tss2-tcti/tctildr-dl.c \
                                 src/tss2-esys/esys_crypto.c \
                                 $(TSS2_ESYS_SRC_CRYPTO)
 

--- a/doc/tcti.md
+++ b/doc/tcti.md
@@ -107,6 +107,8 @@ Where:
   1. `<child_name>`
   2. `libtss2-tcti-<child_name>.so.0`
   3. `libtss2-tcti-<child_name>.so`
+  4. `libtss2-<child_name>.so.0`
+  5. `libtss2-<child_name>.so`
 
 **`child_conf`**
 

--- a/lib/tss2-tctildr.def
+++ b/lib/tss2-tctildr.def
@@ -1,5 +1,6 @@
 LIBRARY tss2-tctildr
 EXPORTS
+    Tss2_Tcti_Info
     Tss2_TctiLdr_Finalize
     Tss2_TctiLdr_FreeInfo;
     Tss2_TctiLdr_GetInfo;

--- a/lib/tss2-tctildr.map
+++ b/lib/tss2-tctildr.map
@@ -1,5 +1,6 @@
 {
     global:
+        Tss2_Tcti_Info;
         Tss2_TctiLdr_Finalize;
         Tss2_TctiLdr_FreeInfo;
         Tss2_TctiLdr_GetInfo;

--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -78,65 +78,36 @@ TSS2_RC
 handle_from_name(const char *file,
                  void **handle)
 {
-    char *file_xfrm = NULL;
     size_t size;
-    size_t len;
+    char file_xfrm[PATH_MAX];
+    const char *formats[] = {
+        /* <name> */
+        "%s",
+        /* libtss2-tcti-<name>.so.0 */
+        FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX_0,
+        /* libtss2-tcti-<name>.so */
+        FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX,
+    };
 
     if (handle == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
-    *handle = dlopen(file, RTLD_NOW);
-    if (*handle != NULL) {
-        return TSS2_RC_SUCCESS;
-    } else {
-        LOG_DEBUG("Could not load TCTI file: \"%s\": %s", file, dlerror());
+
+    for (size_t i = 0; i < ARRAY_SIZE(formats); i++) {
+        size = snprintf(file_xfrm, sizeof(file_xfrm), formats[i], file);
+        if (size >= sizeof(file_xfrm)) {
+            LOG_ERROR("TCTI name truncated in transform.");
+            return TSS2_TCTI_RC_BAD_VALUE;
+        }
+        *handle = dlopen(file_xfrm, RTLD_NOW);
+        if (*handle != NULL) {
+            return TSS2_RC_SUCCESS;
+        } else {
+            LOG_DEBUG("Could not load TCTI file \"%s\": %s", file, dlerror());
+        }
     }
 
-    len = snprintf(NULL, 0, TCTI_NAME_TEMPLATE_0, file);
-    if (len >= PATH_MAX) {
-        LOG_ERROR("TCTI name truncated in transform.");
-        return TSS2_TCTI_RC_BAD_VALUE;
-    }
-    file_xfrm = calloc(len + 1, sizeof(char));
-    if (file_xfrm == NULL) {
-        return TSS2_TCTI_RC_MEMORY;
-    }
-    /* 'name' alone didn't work, try libtss2-tcti-<name>.so.0 */
-    size = snprintf(file_xfrm,
-                    len + 1,
-                    TCTI_NAME_TEMPLATE_0,
-                    file);
-    if (size >= (len + 1)) {
-        LOG_ERROR("TCTI name truncated in transform.");
-        SAFE_FREE(file_xfrm);
-        return TSS2_TCTI_RC_BAD_VALUE;
-    }
-    *handle = dlopen(file_xfrm, RTLD_NOW);
-    if (*handle != NULL) {
-        SAFE_FREE(file_xfrm);
-        return TSS2_RC_SUCCESS;
-    } else {
-        LOG_DEBUG("Could not load TCTI file \"%s\": %s", file, dlerror());
-    }
-    /* libtss2-tcti-<name>.so.0 didn't work, try libtss2-tcti-<name>.so */
-    size = snprintf(file_xfrm,
-                    len + 1,
-                    TCTI_NAME_TEMPLATE,
-                    file);
-    if (size >= (len + 1)) {
-        LOG_ERROR("TCTI name truncated in transform.");
-        SAFE_FREE(file_xfrm);
-        return TSS2_TCTI_RC_BAD_VALUE;
-    }
-    *handle = dlopen(file_xfrm, RTLD_NOW);
-    if (*handle == NULL) {
-        LOG_DEBUG("Failed to load TCTI for name \"%s\": %s", file, dlerror());
-        SAFE_FREE(file_xfrm);
-        return TSS2_TCTI_RC_NOT_SUPPORTED;
-    }
-
-    SAFE_FREE(file_xfrm);
-    return TSS2_RC_SUCCESS;
+    return TSS2_TCTI_RC_NOT_SUPPORTED;
 }
 TSS2_RC
 tcti_from_file(const char *file,

--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -87,6 +87,10 @@ handle_from_name(const char *file,
         FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX_0,
         /* libtss2-tcti-<name>.so */
         FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX,
+        /* libtss2-<name>.so.0 */
+        FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX_0,
+        /* libtss2-<name>.so */
+        FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX,
     };
 
     if (handle == NULL) {

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -603,7 +603,9 @@ const TSS2_TCTI_INFO tss2_tcti_info = {
         "Where child_name: if not empty, tctildr will try to dynamically load the child tcti library in the following order:\n"
         "   * <child_name>\n"
         "   * libtss2-tcti-<child_name>.so.0\n"
-        "   * libtss2-tcti-<child_name>.so\n",
+        "   * libtss2-tcti-<child_name>.so\n"
+        "   * libtss2-<child_name>.so.0\n"
+        "   * libtss2-<child_name>.so\n",
     .init = Tss2_Tcti_TctiLdr_Init,
 };
 

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -189,6 +189,56 @@ tctildr_conf_parse (const char *name_conf,
 
     return TSS2_RC_SUCCESS;
 }
+/*
+ * calls tctildr_conf_parse.
+ * allocates memory for name and conf if necessary.
+ * does not return empty strings, but NULL instead.
+ */
+TSS2_RC
+tctildr_conf_parse_alloc (const char *name_conf,
+                     char **name,
+                     char **conf)
+{
+    size_t combined_length;
+    TSS2_RC rc;
+
+    if (name_conf == NULL) {
+        *name = NULL;
+        *conf = NULL;
+        return TSS2_RC_SUCCESS;
+    }
+
+    /* Parse name_conf into name and conf */
+    combined_length = strlen (name_conf);
+    if (combined_length > PATH_MAX - 1) {
+        LOG_ERROR ("combined conf length must be between 0 and PATH_MAX");
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    *name = calloc(combined_length + 1, sizeof(char));
+    *conf = calloc(combined_length + 1, sizeof(char));
+    if (*name == NULL || *conf == NULL) {
+        SAFE_FREE(*name);
+        SAFE_FREE(*conf);
+        return TSS2_TCTI_RC_MEMORY;
+    }
+    rc = tctildr_conf_parse (name_conf, *name, *conf);
+    if (rc != TSS2_RC_SUCCESS) {
+        SAFE_FREE(*name);
+        SAFE_FREE(*conf);
+        return rc;
+    }
+
+    /* Set name and conf to NULL if they are empty strings */
+    if (!strcmp(*name, "")) {
+        SAFE_FREE(*name);
+    }
+    if (!strcmp(*conf, "")) {
+        SAFE_FREE(*conf);
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
 TSS2_TCTILDR_CONTEXT*
 tctildr_context_cast (TSS2_TCTI_CONTEXT *ctx)
 {
@@ -407,6 +457,45 @@ Tss2_TctiLdr_FreeInfo (TSS2_TCTI_INFO **info)
     free (info_tmp);
     *info = NULL;
 }
+
+TSS2_RC
+tctildr_init_context_data (TSS2_TCTI_CONTEXT *tctiContext,
+                           const char *name,
+                           const char *conf)
+{
+    TSS2_TCTILDR_CONTEXT *ldr_ctx = NULL;
+    TSS2_TCTI_CONTEXT *child_ctx = NULL;
+    void *dl_handle = NULL;
+    TSS2_RC rc;
+
+    if (tctiContext == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+
+    rc = tctildr_get_tcti(name, conf, &child_ctx, &dl_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERROR ("Failed to instantiate TCTI");
+        return rc;
+    }
+    TSS2_TCTI_MAGIC (tctiContext) = TCTILDR_MAGIC;
+    TSS2_TCTI_VERSION (tctiContext) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tctiContext) = tctildr_transmit;
+    TSS2_TCTI_RECEIVE (tctiContext) = tctildr_receive;
+    TSS2_TCTI_FINALIZE (tctiContext) = tctildr_finalize;
+    TSS2_TCTI_CANCEL (tctiContext) = tctildr_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tctiContext) = tctildr_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tctiContext) = tctildr_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tctiContext) = tctildr_make_sticky;
+    ldr_ctx = tctildr_context_cast(tctiContext);
+    if (ldr_ctx == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    ldr_ctx->library_handle = dl_handle;
+    ldr_ctx->tcti = child_ctx;
+
+    return TSS2_RC_SUCCESS;
+}
+
 TSS2_RC
 Tss2_TctiLdr_Initialize_Ex (const char *name,
                             const char *conf,
@@ -428,29 +517,15 @@ Tss2_TctiLdr_Initialize_Ex (const char *name,
     if (conf != NULL && strcmp (conf, "")) {
         local_conf = conf;
     }
-    rc = tctildr_get_tcti (local_name, local_conf, tctiContext, &dl_handle);
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERROR ("Failed to instantiate TCTI");
-        goto err;
-    }
     ldr_ctx = calloc (1, sizeof (TSS2_TCTILDR_CONTEXT));
     if (ldr_ctx == NULL) {
         rc = TSS2_TCTI_RC_MEMORY;
         goto err;
     }
-    TSS2_TCTI_MAGIC (ldr_ctx) = TCTILDR_MAGIC;
-    TSS2_TCTI_VERSION (ldr_ctx) = TCTI_VERSION;
-    TSS2_TCTI_TRANSMIT (ldr_ctx) = tctildr_transmit;
-    TSS2_TCTI_RECEIVE (ldr_ctx) = tctildr_receive;
-    TSS2_TCTI_FINALIZE (ldr_ctx) = tctildr_finalize;
-    TSS2_TCTI_CANCEL (ldr_ctx) = tctildr_cancel;
-    TSS2_TCTI_GET_POLL_HANDLES (ldr_ctx) = tctildr_get_poll_handles;
-    TSS2_TCTI_SET_LOCALITY (ldr_ctx) = tctildr_set_locality;
-    TSS2_TCTI_MAKE_STICKY (ldr_ctx) = tctildr_make_sticky;
-    ldr_ctx->library_handle = dl_handle;
-    ldr_ctx->tcti = *tctiContext;
-    *tctiContext = (TSS2_TCTI_CONTEXT*)ldr_ctx;
-    return rc;
+
+    *tctiContext = (TSS2_TCTI_CONTEXT *) ldr_ctx;
+    return tctildr_init_context_data(*tctiContext, local_name, local_conf);
+
 err:
     if (*tctiContext != NULL) {
         Tss2_Tcti_Finalize (*tctiContext);
@@ -468,29 +543,73 @@ Tss2_TctiLdr_Initialize (const char *nameConf,
     char *name = NULL;
     char *conf = NULL;
     TSS2_RC rc;
-    size_t combined_length;
 
-    if (nameConf == NULL) {
-        return Tss2_TctiLdr_Initialize_Ex (NULL, NULL, tctiContext);
+    rc = tctildr_conf_parse_alloc (nameConf, &name, &conf);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
     }
-
-    combined_length = strlen (nameConf);
-    if (combined_length > PATH_MAX - 1) {
-        LOG_ERROR ("combined conf length must be between 0 and PATH_MAX");
-        return TSS2_TCTI_RC_BAD_VALUE;
-    }
-    name = calloc(combined_length + 1, sizeof(char));
-    conf = calloc(combined_length + 1, sizeof(char));
-    if (name == NULL || conf == NULL) {
-        rc = TSS2_TCTI_RC_MEMORY;
-        goto out;
-    }
-    rc = tctildr_conf_parse (nameConf, name, conf);
-    if (rc != TSS2_RC_SUCCESS)
-        goto out;
     rc = Tss2_TctiLdr_Initialize_Ex (name, conf, tctiContext);
-out:
+
     SAFE_FREE(name);
     SAFE_FREE(conf);
     return rc;
+}
+
+TSS2_RC Tss2_Tcti_TctiLdr_Init (TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
+                                const char *nameConf)
+{
+    TSS2_RC rc;
+    char *name = NULL;
+    char *conf = NULL;
+
+    LOG_TRACE("tctiContext: 0x%" PRIxPTR ", size: 0x%" PRIxPTR ", conf: %s",
+               (uintptr_t)tctiContext, (uintptr_t)size, nameConf);
+
+    if (tctiContext == NULL && size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    } else if (tctiContext == NULL) {
+        *size = sizeof (TSS2_TCTILDR_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    rc = tctildr_conf_parse_alloc (nameConf, &name, &conf);
+    if (rc != TSS2_RC_SUCCESS) {
+        goto free_name_conf;
+    }
+
+    rc = tctildr_init_context_data(tctiContext, name, conf);
+
+free_name_conf:
+    SAFE_FREE(name);
+    SAFE_FREE(conf);
+    return rc;
+}
+
+__attribute__((weak))
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tctildr",
+    .description = "TCTI module for dynamically loading other TCTI modules",
+    .config_help = "TCTI to load and its configuration. Either"
+        " * <child_name>, e.g. device (child_conf will be NULL) OR\n"
+        " * <child_name>:<child_conf>, e.g., device:/dev/tpmrm0 OR\n"
+        " * NULL, tctildr will attempt to load a child tcti in the following order:\n"
+        "   * libtss2-tcti-default.so\n"
+        "   * libtss2-tcti-tabrmd.so\n"
+        "   * libtss2-tcti-device.so.0:/dev/tpmrm0\n"
+        "   * libtss2-tcti-device.so.0:/dev/tpm0\n"
+        "   * libtss2-tcti-swtpm.so\n"
+        "   * libtss2-tcti-mssim.so\n"
+        "Where child_name: if not empty, tctildr will try to dynamically load the child tcti library in the following order:\n"
+        "   * <child_name>\n"
+        "   * libtss2-tcti-<child_name>.so.0\n"
+        "   * libtss2-tcti-<child_name>.so\n",
+    .init = Tss2_Tcti_TctiLdr_Init,
+};
+
+__attribute__((weak))
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
 }

--- a/src/tss2-tcti/tctildr.h
+++ b/src/tss2-tcti/tctildr.h
@@ -28,6 +28,11 @@ typedef struct {
 } TSS2_TCTILDR_CONTEXT;
 
 TSS2_RC
+Tss2_Tcti_TctiLdr_Init (TSS2_TCTI_CONTEXT *tctiContext,
+                        size_t *size,
+                        const char *conf);
+
+TSS2_RC
 tcti_from_init(TSS2_TCTI_INIT_FUNC init,
                const char* conf,
                TSS2_TCTI_CONTEXT **tcti);

--- a/src/tss2-tcti/tctildr.h
+++ b/src/tss2-tcti/tctildr.h
@@ -9,13 +9,14 @@
 #include "tss2_tpm2_types.h"
 #include "tss2_tcti.h"
 
-#define TCTI_SUFFIX ".so"
-#define TCTI_SUFFIX_0 TCTI_SUFFIX".0"
-#define LIB_PREFIX "lib"
-#define TCTI_PREFIX LIB_PREFIX"tss2-tcti"
-#define TCTI_NAME_TEMPLATE TCTI_PREFIX"-%s"TCTI_SUFFIX
-#define TCTI_NAME_TEMPLATE_0 TCTI_PREFIX"-%s"TCTI_SUFFIX_0
-#define DEFAULT_TCTI_LIBRARY_NAME TCTI_PREFIX"-default"TCTI_SUFFIX
+#define FMT_LIB_PREFIX "lib"
+#define FMT_TSS_PREFIX FMT_LIB_PREFIX"tss2-"
+#define FMT_TCTI_PREFIX FMT_TSS_PREFIX"tcti-"
+
+#define FMT_LIB_SUFFIX_0 FMT_LIB_SUFFIX".0"
+#define FMT_LIB_SUFFIX ".so"
+
+#define DEFAULT_TCTI_LIBRARY_NAME FMT_TCTI_PREFIX"-default"TCTI_SUFFIX
 
 #define TCTILDR_MAGIC 0xbc44a31ca74b4aafULL
 

--- a/test/unit/tctildr-dl.c
+++ b/test/unit/tctildr-dl.c
@@ -152,7 +152,7 @@ test_handle_from_name_first_dlopen_success (void **state)
     assert_int_equal (handle, TEST_HANDLE);
 }
 
-#define TEST_TCTI_NAME_SO_0 TCTI_PREFIX"-"TEST_TCTI_NAME""TCTI_SUFFIX_0
+#define TEST_TCTI_NAME_SO_0 FMT_TCTI_PREFIX TEST_TCTI_NAME""FMT_LIB_SUFFIX_0
 static void
 test_handle_from_name_second_dlopen_success (void **state)
 {
@@ -171,7 +171,7 @@ test_handle_from_name_second_dlopen_success (void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (handle, TEST_HANDLE);
 }
-#define TEST_TCTI_NAME_SO TCTI_PREFIX"-"TEST_TCTI_NAME""TCTI_SUFFIX
+#define TEST_TCTI_NAME_SO FMT_TCTI_PREFIX TEST_TCTI_NAME""FMT_LIB_SUFFIX
 static void
 test_handle_from_name_third_dlopen_success (void **state)
 {

--- a/test/unit/tctildr-dl.c
+++ b/test/unit/tctildr-dl.c
@@ -135,15 +135,21 @@ test_handle_from_name_null_handle (void **state)
     TSS2_RC rc = handle_from_name (NULL, NULL);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
-#define TEST_TCTI_NAME "test-tcti"
-#define TEST_TCTI_CONF "test-conf"
+#define TEST_TCTI_NAME "testname"
+#define TEST_TCTI_CONF "testconf"
+/* see documentation at tcti.md */
+#define TEST_TCTI_TRY_A TEST_TCTI_NAME
+#define TEST_TCTI_TRY_B "libtss2-tcti-" TEST_TCTI_NAME ".so.0"
+#define TEST_TCTI_TRY_C "libtss2-tcti-" TEST_TCTI_NAME ".so"
+#define TEST_TCTI_TRY_D "libtss2-" TEST_TCTI_NAME ".so.0"
+#define TEST_TCTI_TRY_E "libtss2-" TEST_TCTI_NAME ".so"
 static void
 test_handle_from_name_first_dlopen_success (void **state)
 {
     TSS2_RC rc;
     void *handle = NULL;
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_A);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, TEST_HANDLE);
 
@@ -152,18 +158,17 @@ test_handle_from_name_first_dlopen_success (void **state)
     assert_int_equal (handle, TEST_HANDLE);
 }
 
-#define TEST_TCTI_NAME_SO_0 FMT_TCTI_PREFIX TEST_TCTI_NAME""FMT_LIB_SUFFIX_0
 static void
 test_handle_from_name_second_dlopen_success (void **state)
 {
     TSS2_RC rc;
     void *handle = NULL;
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_A);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME_SO_0);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, TEST_HANDLE);
 
@@ -171,22 +176,77 @@ test_handle_from_name_second_dlopen_success (void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (handle, TEST_HANDLE);
 }
-#define TEST_TCTI_NAME_SO FMT_TCTI_PREFIX TEST_TCTI_NAME""FMT_LIB_SUFFIX
 static void
 test_handle_from_name_third_dlopen_success (void **state)
 {
     TSS2_RC rc;
     void *handle = NULL;
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_A);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME_SO_0);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
-    expect_string(__wrap_dlopen, filename, TEST_TCTI_NAME_SO);
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, TEST_HANDLE);
+
+    rc = handle_from_name (TEST_TCTI_NAME, &handle);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (handle, TEST_HANDLE);
+}
+static void
+test_handle_from_name_fourth_dlopen_success (void **state)
+{
+    TSS2_RC rc;
+    void *handle = NULL;
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_A);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_D);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, TEST_HANDLE);
+
+    rc = handle_from_name (TEST_TCTI_NAME, &handle);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_int_equal (handle, TEST_HANDLE);
+}
+static void
+test_handle_from_name_fifth_dlopen_success (void **state)
+{
+    TSS2_RC rc;
+    void *handle = NULL;
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_A);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_D);
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_E);
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, TEST_HANDLE);
 
@@ -229,6 +289,14 @@ test_get_info_default_success (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, HANDLE);
@@ -258,6 +326,14 @@ test_get_info_default_info_fail (void **state)
     will_return(__wrap_dlopen, NULL);
 
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
@@ -413,6 +489,12 @@ test_tcti_fail_all (void **state)
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
 
     /* Skip over libtss2-tcti-tabrmd.so */
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
@@ -422,6 +504,12 @@ test_tcti_fail_all (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-tabrmd.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-tabrmd.so.0.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
@@ -435,6 +523,12 @@ test_tcti_fail_all (void **state)
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
 
     /* Skip over libtss2-tcti-device.so, /dev/tpm0 */
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
@@ -444,6 +538,12 @@ test_tcti_fail_all (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
@@ -457,6 +557,12 @@ test_tcti_fail_all (void **state)
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-swtpm.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-swtpm.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
 
     /* Skip over libtss2-tcti-mssim.so */
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-mssim.so.0");
@@ -466,6 +572,12 @@ test_tcti_fail_all (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-mssim.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-mssim.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-mssim.so.0.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
@@ -494,6 +606,12 @@ test_info_from_name_handle_fail (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-foo.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-foo.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
@@ -612,6 +730,12 @@ test_tctildr_get_info_from_name (void **state)
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-foo.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-foo.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
 
     TSS2_RC rc = tctildr_get_info ("foo", &info, &data);
     assert_int_equal (rc, TSS2_TCTI_RC_NOT_SUPPORTED);
@@ -659,6 +783,8 @@ main(void)
         cmocka_unit_test(test_handle_from_name_first_dlopen_success),
         cmocka_unit_test(test_handle_from_name_second_dlopen_success),
         cmocka_unit_test(test_handle_from_name_third_dlopen_success),
+        cmocka_unit_test(test_handle_from_name_fourth_dlopen_success),
+        cmocka_unit_test(test_handle_from_name_fifth_dlopen_success),
         cmocka_unit_test(test_fail_null),
         cmocka_unit_test(test_tcti_from_file_null_tcti),
 #ifndef ESYS_TCTI_DEFAULT_MODULE


### PR DESCRIPTION
Currently the tctildr is *almost* a tcti. I stumbled upon that when I wanted to create an abstraction for tctis in Rust.

* it misses the `Tss2_Tcti_Info` symbol which enables dynamic loading
* it does not have a caller-allocated init function, only callee-allocated ones

So I added the init function and the symbol. Technically it is a tcti now, so you can load the tctildr by specifying its path now:

```bash
tpm2 startup -c -T "/path/to/libtss2-tctildr.so"
```

Unfortunately, it does not keep to the `libtss2-tcti-<name>.so` convention, so I added a commit which enables loading by just passing `tctildr` and the loading mechanism will try `libtss2-<name>.so` as well.

```bash
tpm2 startup -c -T "tctildr"
```

You might ask yourself: _why would I want tctildr to be loadable_? No idea, but there is no harm in it... Btw, I also refactored the code for loading, so it is less chunky.

