### PR TITLE
ESYS: Add reference counting for Esys_TR_FromTPMPublic 3.2.x

### DIFF
--- a/src/tss2-esys/api/Esys_FlushContext.c
+++ b/src/tss2-esys/api/Esys_FlushContext.c
@@ -184,6 +184,7 @@ Esys_FlushContext_Finish(
     ESYS_CONTEXT *esysContext)
 {
     TSS2_RC r;
+    RSRC_NODE_T *flushHandleNode;
     LOG_TRACE("context=%p",
               esysContext);
 
@@ -244,6 +245,12 @@ Esys_FlushContext_Finish(
                           "Received error from SAPI unmarshaling" );
 
     /* The ESYS_TR object has to be invalidated */
+
+    r = esys_GetResourceObject(esysContext, esysContext->in.FlushContext.flushHandle,
+                               &flushHandleNode);
+    return_state_if_error(r, _ESYS_STATE_INIT, "flushHandle unknown.");
+
+    flushHandleNode->reference_count = 0;
     r = Esys_TR_Close(esysContext, &esysContext->in.FlushContext.flushHandle);
     return_if_error(r, "invalidate object");
 

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -23,6 +23,7 @@ typedef struct RSRC_NODE_T {
                                      to reference this entry. */
     TPM2B_AUTH auth;            /**< The authValue for this resource object. */
     IESYS_RESOURCE rsrc;        /**< The meta data for this resource object. */
+    size_t reference_count;     /**< Reference Count for Esys_TR_FromTPMPublic */
     struct RSRC_NODE_T * next;  /**< The next object in the linked list. */
 } RSRC_NODE_T;
 

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -313,6 +313,7 @@ Esys_TR_FromTPMPublic_Finish(ESYS_CONTEXT * esys_context, ESYS_TR * object)
         return_if_error(r, "Error TR FromTPMPublic");
         return TSS2_ESYS_RC_TRY_AGAIN;
     } else {
+        objectHandleNode->reference_count++;
         *object = objectHandle;
         return TSS2_RC_SUCCESS;
     }
@@ -425,6 +426,10 @@ Esys_TR_Close(ESYS_CONTEXT * esys_context, ESYS_TR * object)
          node != NULL;
          update_ptr = &node->next, node = node->next) {
         if (node->esys_handle == *object) {
+            if (node->reference_count > 1) {
+                node->reference_count--;
+                return TSS2_RC_SUCCESS;
+            }
             *update_ptr = node->next;
             SAFE_FREE(node);
             *object = ESYS_TR_NONE;


### PR DESCRIPTION
For every call of Esys_TR_FromTPMPublic the reference counter is incremented to ensure that the created esys object is only freed by Esys_Close if the reference count will be zero or decreased to zero.

Signed-off-by: Juergen Repp <juergen_repp@web.de>