### PR TITLE
FAPI: Fix usage of endorsement handle 3.2.x

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -925,9 +925,12 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
         /* Check whether a persistent key was loaded.
            In this case the handle has already been set. */
         if (pkey_object->handle != ESYS_TR_NONE) {
-            if (pkey->creationTicket.hierarchy == TPM2_RH_EK) {
+            if (pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT &&
+                strcmp("/EK",
+                       &pkey_object->rel_path[strlen(pkey_object->rel_path)-3]) == 0) {
                 context->ek_persistent = true;
-            } else {
+            } else if (strcmp("/SRK",
+                              &pkey_object->rel_path[strlen(pkey_object->rel_path)-4]) == 0) {
                 context->srk_persistent = true;
             }
             /* It has to be checked whether the persistent handle exists. */
@@ -935,7 +938,7 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
             return TSS2_FAPI_RC_TRY_AGAIN;
         }
         else {
-            if (pkey->creationTicket.hierarchy == TPM2_RH_EK) {
+            if (pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT) {
                 context->ek_persistent = false;
             } else {
                 context->srk_persistent = false;
@@ -945,8 +948,7 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
 
     statecase(context->primary_state, PRIMARY_READ_HIERARCHY);
         /* The hierarchy object used for auth_session will be loaded from key store. */
-        if (pkey->creationTicket.hierarchy == TPM2_RH_EK ||
-            (pkey->ek_profile && pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT)) {
+    if (pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT) {
             r = ifapi_keystore_load_async(&context->keystore, &context->io, "/HE");
             return_if_error2(r, "Could not open hierarchy /HE");
         } else if (pkey->creationTicket.hierarchy == TPM2_RH_NULL) {
@@ -966,10 +968,7 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
         r = ifapi_initialize_object(context->esys, hierarchy);
         goto_if_error_reset_state(r, "Initialize hierarchy object", error_cleanup);
 
-        if (pkey->creationTicket.hierarchy == TPM2_RH_EK) {
-            hierarchy->handle = ESYS_TR_RH_ENDORSEMENT;
-        } else if (pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT &&
-                   pkey->ek_profile) {
+        if (pkey->creationTicket.hierarchy == TPM2_RH_ENDORSEMENT) {
             hierarchy->handle = ESYS_TR_RH_ENDORSEMENT;
         } else if (pkey->creationTicket.hierarchy == TPM2_RH_NULL) {
             hierarchy->handle = ESYS_TR_RH_NULL;
@@ -1045,6 +1044,14 @@ ifapi_load_primary_finish(FAPI_CONTEXT *context, ESYS_TR *handle)
         }
         *handle = pkey_object->handle;
         context->primary_state = PRIMARY_INIT;
+
+        /* Check whether the public key corresponds to key in key store. */
+        if (!ifapi_cmp_public_key(outPublic, &pkey_object->misc.key.public)) {
+            goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
+                       "Public key for %s was not created correctly.",
+                       error_cleanup, pkey_object->rel_path);
+        }
+
         break;
 
     statecase(context->primary_state, PRIMARY_VERIFY_PERSISTENT);


### PR DESCRIPTION
In several cases the wrong handle TPM2_RH_EK was used instead of TPM2_RH_ENDORSEMENT.
This caused a wrong recreation of keys (except the EK) under the endorsement hierarchy.
Now the correct hierarchy handle is used and a check whether the recreated public key of the recreated primary corresponds to the keystore.

Signed-off-by: Juergen Repp <juergen_repp@web.de>
