### PR TITLE
ESYS TEST: Platform authorization management in PCR_Allocate test

### DIFF
--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -142,6 +142,7 @@ test_esys_pcr_basic(ESYS_CONTEXT * esys_context)
         /* Platform authorization not possible test will be skipped */
         LOG_WARNING("Platform authorization not possible.");
         failure_return =  EXIT_SKIP;
+        goto error;
     }
 
     goto_if_error(r, "Error: PCR_Allocate", error);


### PR DESCRIPTION
In Integration Test esys-pcr-basic, when it is not possible to use Platform authorization, a 'goto error' is missing to skip the test.

Signed-off-by: Laurent Charpentier laurent.charpentier@st.com