### PR TITLE
ESYS TEST: Update physical presence error test esys-pp-commands

### DIFF
--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -58,8 +58,9 @@ test_esys_pp_commands(ESYS_CONTEXT * esys_context)
     }
 
     if (r == (TPM2_RC_WARN  | TPM2_RC_PP)) {
-        LOG_INFO("Command TPM2_PP_Commands requires physical presence.");
-        return EXIT_SUCCESS;
+        LOG_WARNING("Command TPM2_PP_Commands requires physical presence.");
+        failure_return = EXIT_SKIP;
+        goto error;
     }
 
     if (number_rc(r) == TPM2_RC_BAD_AUTH) {


### PR DESCRIPTION
Test esys-pp-commands: Update management of physical presence error (command is skipped). A 'goto error' is added to skip the end of the test (it is not needed to check the Platform Authorization in case of Physical Presence not available).

Signed-off-by: Laurent Charpentier laurent.charpentier@st.com