### PR TITLE
test esys-pp-commands: update pp management

### DIFF
--- a/test/integration/esys-pp-commands.int.c
+++ b/test/integration/esys-pp-commands.int.c
@@ -58,8 +58,9 @@ test_esys_pp_commands(ESYS_CONTEXT * esys_context)
     }
 
     if (r == (TPM2_RC_WARN  | TPM2_RC_PP)) {
-        LOG_INFO("Command TPM2_PP_Commands requires physical presence.");
-        return EXIT_SUCCESS;
+        LOG_WARNING("Command TPM2_PP_Commands requires physical presence.");
+        failure_return = EXIT_SKIP;
+        goto error;
     }
 
     if (number_rc(r) == TPM2_RC_BAD_AUTH) {


### PR DESCRIPTION
Update the management of error on physical presence (command is skipped). A 'goto error' is added to skip the end of the test (it is not needed to check the Platform Authorization in case of Physical Presence not available).