### PR TITLE
test fapi-get-esys-blobs: missing FlushContext

### DIFF
--- a/test/integration/fapi-get-esys-blobs.int.c
+++ b/test/integration/fapi-get-esys-blobs.int.c
@@ -178,7 +178,12 @@ test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
         &inScheme,
         &hash_validation,
         &signature);
-    goto_if_error(r, "Error: Sign", error);
+
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_ERROR("%s " TPM2_ERROR_FORMAT, "Error: Sign", TPM2_ERROR_TEXT(r));
+        Esys_FlushContext(context->esys, esys_handle);
+        goto error;
+    }
 
     SAFE_FREE(signature);
 


### PR DESCRIPTION
In case of error in Esys_Sign, esys_handle needs to be flushed before jumping to 'error' part