### PR TITLE
FAPI: Fix authorization session handling. 3.2.x

### DIFF
--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -129,7 +129,8 @@ typedef struct {
 
 #define ENC_SESSION_IF_POLICY(auth_session)             \
     (auth_session == ESYS_TR_PASSWORD || auth_session == ESYS_TR_NONE || \
-     auth_session == context->session2) ? ESYS_TR_NONE : context->session2
+     auth_session == context->session2 || \
+     !context->session2) ? ESYS_TR_NONE : context->session2
 
 /** The states for the FAPI's object authorization state*/
 enum IFAPI_GET_CERT_STATE {

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -2150,6 +2150,7 @@ ifapi_authorize_object(FAPI_CONTEXT *context, IFAPI_OBJECT *object, ESYS_TR *ses
                 else
                     /* Use password session if session1 had not been created */
                     *session = ESYS_TR_PASSWORD;
+                context->session2 = ESYS_TR_NONE;
                 break;
             }
 


### PR DESCRIPTION
If no policy is used the sessíon2 in FAPI context must be initialized with ESYS_TR_NONE in the authorization function.
The macro ENC_SESSION_IF_POLIY did produce an invalid ESYS handle if session2 was not initialized.

Signed-off-by: Juergen Repp <juergen_repp@web.de>