### PR TITLE
fix tcm patch git check failed.

### DIFF
--- a/doc/tcti.md
+++ b/doc/tcti.md
@@ -96,8 +96,9 @@ flowchart TD
   2. `libtss2-tcti-tabrmd.so`
   3. `libtss2-tcti-device.so.0:/dev/tpmrm0`
   4. `libtss2-tcti-device.so.0:/dev/tpm0`
-  5. `libtss2-tcti-swtpm.so`
-  6. `libtss2-tcti-mssim.so`
+  5. `libtss2-tcti-device.so.0:/dev/tcm0`
+  6. `libtss2-tcti-swtpm.so`
+  7. `libtss2-tcti-mssim.so`
 
 Where:
 
@@ -118,7 +119,7 @@ Where:
 ## tcti-device
 
 To put it simply, tcti-device writes to and reads from a file, typically
-`/dev/tpm0` or `/dev/tpmrm0`. The character devices are provided by the Linux
+`/dev/tpm0` or `/dev/tpmrm0` or `/dev/tcm0`. The character devices are provided by the Linux
 kernel module `tpm_tis`. If no files like these are present, verify that the
 kernel module is loaded (`lsmod`) and load it if necessary (`modprobe tpm_tis`).
 
@@ -136,7 +137,7 @@ flowchart TD
 
 **`conf`**
 
-* path to the character device, typically `/dev/tpm0` or `/dev/tpmrm0`
+* path to the character device, typically `/dev/tpm0` or `/dev/tpmrm0` or `/dev/tcm0`
 
 ## tcti-tbs
 

--- a/src/tss2-esys/esys_context.c
+++ b/src/tss2-esys/esys_context.c
@@ -28,6 +28,7 @@
  *       Library libtss2-tcti-tabrmd.so (tabrmd)
  *       Device /dev/tpmrm0 (kernel resident resource manager)
  *       Device /dev/tpm0 (hardware TPM)
+ *       Device /dev/tcm0 (hardware TCM)
  *       TCP socket localhost:2321 (TPM simulator)
  * @param esys_context [out] The ESYS_CONTEXT.
  * @param tcti [in] The TCTI context used to connect to the TPM (may be NULL).

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -63,6 +63,7 @@ static char *default_conf[] = {
 #else
     "/dev/tpmrm0",
     "/dev/tpm0",
+    "/dev/tcm0",
 #endif /* __VX_WORKS__ */
 };
 

--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -48,6 +48,11 @@ struct {
         .description = "Access libtss2-tcti-device.so.0 with /dev/tpm0",
     },
     {
+        .file = "libtss2-tcti-device.so.0",
+        .conf = "/dev/tcm0",
+        .description = "Access libtss2-tcti-device.so.0 with /dev/tcm0",
+    },
+    {
         .file = "libtss2-tcti-swtpm.so.0",
         .description = "Access to libtss2-tcti-swtpm.so",
     },

--- a/src/tss2-tcti/tctildr-nodl.c
+++ b/src/tss2-tcti/tctildr-nodl.c
@@ -100,6 +100,16 @@ struct {
         .conf = "/dev/tpm0",
         .description = "Access to /dev/tpm0",
     },
+    {
+        .names = {
+            "libtss2-tcti-device.so.0",
+            "libtss2-tcti-device.so",
+            "device",
+        },
+        .init = Tss2_Tcti_Device_Init,
+        .conf = "/dev/tcm0",
+        .description = "Access to /dev/tcm0",
+    },
 #endif /* TCTI_DEVICE */
 #endif /* _WIN32 */
 #ifdef TCTI_SWTPM

--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -598,6 +598,7 @@ const TSS2_TCTI_INFO tss2_tcti_info = {
         "   * libtss2-tcti-tabrmd.so\n"
         "   * libtss2-tcti-device.so.0:/dev/tpmrm0\n"
         "   * libtss2-tcti-device.so.0:/dev/tpm0\n"
+        "   * libtss2-tcti-device.so.0:/dev/tcm0\n"
         "   * libtss2-tcti-swtpm.so\n"
         "   * libtss2-tcti-mssim.so\n"
         "Where child_name: if not empty, tctildr will try to dynamically load the child tcti library in the following order:\n"

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -114,6 +114,7 @@ tcti_device_init_conf_default_fail (void **state)
     errno = EACCES; /* Permission denied */
     will_return (__wrap_open, -1);
     will_return (__wrap_open, -1);
+    will_return (__wrap_open, -1);
     ret = Tss2_Tcti_Device_Init (ctx, &tcti_size, NULL);
     assert_true (ret == TSS2_TCTI_RC_IO_ERROR);
 

--- a/test/unit/tctildr-dl.c
+++ b/test/unit/tctildr-dl.c
@@ -547,6 +547,23 @@ test_tcti_fail_all (void **state)
     expect_value(__wrap_dlopen, flags, RTLD_NOW);
     will_return(__wrap_dlopen, NULL);
 
+    /* Skip over libtss2-tcti-device.so, /dev/tcm0 */
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+    expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
+    will_return(__wrap_dlopen, NULL);
+
     /* Skip over libtss2-tcti-swtpm.so */
     expect_string(__wrap_dlopen, filename, "libtss2-tcti-swtpm.so.0");
     expect_value(__wrap_dlopen, flags, RTLD_NOW);

--- a/test/unit/tctildr-nodl.c
+++ b/test/unit/tctildr-nodl.c
@@ -62,6 +62,9 @@ test_tctildr_get_default_all_fail (void **state)
     TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
 
 #define TEST_RC 0x65203563
+    /* device:/dev/tcm0 */
+    will_return(__wrap_tcti_from_init, tcti_ctx);
+    will_return(__wrap_tcti_from_init, TEST_RC);
     /* device:/dev/tpm0 */
     will_return (__wrap_tcti_from_init, tcti_ctx);
     will_return (__wrap_tcti_from_init, TEST_RC);


### PR DESCRIPTION
2023-10-19T13:17:25.4519676Z [ ERROR ] --- No entries for symbol __wrap_open.
2023-10-19T13:17:25.4520617Z ../test/unit/tcti-device.c:51: error: Could not get value to mock function __wrap_open
2023-10-19T13:17:25.4521802Z ../test/unit/tcti-device.c:116: note: Previously returned mock value was declared here
2023-10-19T13:17:25.4522459Z
2023-10-19T13:17:25.4522650Z [ FAILED ] tcti_device_init_conf_default_fail

try fix this error.