### PR TITLE
FAPI: Fix intermediate self signed certificate.

### DIFF
--- a/src/tss2-fapi/fapi_certificates.h
+++ b/src/tss2-fapi/fapi_certificates.h
@@ -435,6 +435,22 @@ static char * root_cert_list[] = {
     "2N/xZkcohRZIAiBDufnmhZWCbX4pibbzAOgcxjsc5+qmpAovxW9ipWJEsA==\n"
     "-----END CERTIFICATE-----\n",
 
+     /* Nuvoton TPM Root CA 1210 */
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICHTCCAaOgAwIBAgIBATAKBggqhkjOPQQDAzBVMR0wGwYDVQQDExROdXZvdG9u\n"
+    "VFBNUm9vdENBMTIxMDEnMCUGA1UEChMeTnV2b3RvbiBUZWNobm9sb2d5IENvcnBv\n"
+    "cmF0aW9uMQswCQYDVQQGEwJUVzAgFw0yMTA4MDIwMjUyMTVaGA8yMDUxMDcyNzAy\n"
+    "NTIxNVowVTEdMBsGA1UEAxMUTnV2b3RvblRQTVJvb3RDQTEyMTAxJzAlBgNVBAoT\n"
+    "Hk51dm90b24gVGVjaG5vbG9neSBDb3Jwb3JhdGlvbjELMAkGA1UEBhMCVFcwdjAQ\n"
+    "BgcqhkjOPQIBBgUrgQQAIgNiAARvsPpMWmh0EW5n+tBoGvcLWeRUiTCZIwyAFimh\n"
+    "wFrQ8SgvxX5A7QaUGQuyel/6Lio8GEzA15tDJPKn34fcWXvM2r2wPFQbE/a5N9Pl\n"
+    "R//ygpvgM1nTocas6xLd4BRIhcajRTBDMA4GA1UdDwEB/wQEAwICBDASBgNVHRMB\n"
+    "Af8ECDAGAQH/AgEEMB0GA1UdDgQWBBThUbCrBr/3WwdOW2qoNOLaL7qDgzAKBggq\n"
+    "hkjOPQQDAwNoADBlAjBKFPxjYwwwhFZ+w0wl0XrwRiPVzRkT2/HW3X7C8lC00sj7\n"
+    "z4fZilzZetOJPuTY0DACMQD3yABKMvC/Lu6/QclxX/2Tqk9Le3J8LyW5vIUFPesY\n"
+    "azaJJ7CuWqE9XgXOlfZR0vU=\n"
+    "-----END CERTIFICATE-----\n",
+
     /* Nuvoton TPM Root CA 2010 */
     "-----BEGIN CERTIFICATE-----\n"
     "MIIDkjCCAnqgAwIBAgIIWAnP9p2CIZcwDQYJKoZIhvcNAQEFBQAwVTFTMB8GA1UE\n"
@@ -512,6 +528,21 @@ static char * root_cert_list[] = {
     "rtdSVy4wCgYIKoZIzj0EAwIDSAAwRQIgXgXs2eVt2U4sCoRf1GLoUTf2ZzYTSsyg\n"
     "6I5w6hPTLigCIQDLLFlXK1xw1a1D1/idVhdd3a8gkE0FnTJO890WwiQbpg==\n"
     "-----END CERTIFICATE-----",
+
+     /* Nuvoton TPM Root CA 2112 */
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICBjCCAa2gAwIBAgIJAOmPfeHxqsTXMAoGCCqGSM49BAMCMFUxUzAfBgNVBAMT\n"
+    "GE51dm90b24gVFBNIFJvb3QgQ0EgMjExMjAlBgNVBAoTHk51dm90b24gVGVjaG5v\n"
+    "bG9neSBDb3Jwb3JhdGlvbjAJBgNVBAYTAlRXMB4XDTIxMDMyMzA3NTgwNloXDTQx\n"
+    "MDMxOTA3NTgwNlowVTFTMB8GA1UEAxMYTnV2b3RvbiBUUE0gUm9vdCBDQSAyMTEy\n"
+    "MCUGA1UEChMeTnV2b3RvbiBUZWNobm9sb2d5IENvcnBvcmF0aW9uMAkGA1UEBhMC\n"
+    "VFcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASWuAVsyaGySEs+Z2NfR+0ZVq8d\n"
+    "rwXGuvaplMoiQFLr0Qphw/OaTrIcuBJ3Qdf3n1GH4Qi2/JyV9Vzg9s+OqOgio2Yw\n"
+    "ZDAOBgNVHQ8BAf8EBAMCAgQwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU\n"
+    "5Khmb49MbZw5MqlIhHeApoEMQhMwHwYDVR0jBBgwFoAU5Khmb49MbZw5MqlIhHeA\n"
+    "poEMQhMwCgYIKoZIzj0EAwIDRwAwRAIgAeBBSSNr4BvEDi0v5vJVOCV9W9Hy+nGB\n"
+    "TR4/YoYg3t8CIHC7KC8PS56v9xhPQQjJmN+DxH51RQ2s8ONrb1D8z/2m\n"
+    "-----END CERTIFICATE-----\n",
 
     /* AMD root certificate ECC */
     "-----BEGIN CERTIFICATE-----\n"

--- a/src/tss2-fapi/ifapi_curl.c
+++ b/src/tss2-fapi/ifapi_curl.c
@@ -120,6 +120,19 @@ cleanup:
     return r;
 }
 
+static bool
+is_self_signed(X509 *cert) {
+    X509_NAME *issuer = X509_get_issuer_name(cert);
+    X509_NAME *subject = X509_get_subject_name(cert);
+
+    /* Compare the issuer and subject names */
+    if (X509_NAME_cmp(issuer, subject) == 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 /**
  * Verify EK certificate read from TPM.
  *
@@ -258,25 +271,28 @@ ifapi_curl_verify_ek_cert(
     }
 
     /* Verify intermediate certificate */
-    ctx = X509_STORE_CTX_new();
-    goto_if_null2(ctx, "Failed to create X509 store context.",
-                  r, TSS2_FAPI_RC_GENERAL_FAILURE, cleanup);
-    if (1 != X509_STORE_CTX_init(ctx, store, intermed_cert, NULL)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
-                   "Failed to initialize X509 context.", cleanup);
-    }
-    if (1 != X509_verify_cert(ctx)) {
-        LOG_ERROR("%s", X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
-                   "Failed to verify intermediate certificate", cleanup);
-    }
-    if (1 != X509_STORE_add_cert(store, intermed_cert)) {
-        goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
-                   "Failed to add intermediate certificate", cleanup);
-    }
+    if (!is_self_signed(intermed_cert)) {
+        ctx = X509_STORE_CTX_new();
+        goto_if_null2(ctx, "Failed to create X509 store context.",
+                      r, TSS2_FAPI_RC_GENERAL_FAILURE, cleanup);
 
-    X509_STORE_CTX_cleanup(ctx);
-    X509_STORE_CTX_free(ctx);
+        if (1 != X509_STORE_CTX_init(ctx, store, intermed_cert, NULL)) {
+            goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
+                       "Failed to initialize X509 context.", cleanup);
+        }
+        if (1 != X509_verify_cert(ctx)) {
+            LOG_ERROR("%s", X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
+            goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
+                       "Failed to verify intermediate certificate", cleanup);
+        }
+        if (1 != X509_STORE_add_cert(store, intermed_cert)) {
+            goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE,
+                       "Failed to add intermediate certificate", cleanup);
+        }
+
+        X509_STORE_CTX_cleanup(ctx);
+        X509_STORE_CTX_free(ctx);
+    }
     ctx = NULL;
     ctx = X509_STORE_CTX_new();
     goto_if_null2(ctx, "Failed to create X509 store context.",


### PR DESCRIPTION
If a certificate which is downloaded from the uri defined in the EK certificate is self signed it can't be verified. It will not be stored in the certificate store. Self signed certificates have to be defined in the list of root certificates of FAPI.
Further Nuvoton root certificates TPM Root CA 1210 and 2112 are added.
Fixes #2738