### PR TITLE
FAPI: Add missing error check for json object add functions

### DIFF
--- a/src/tss2-fapi/ifapi_ima_eventlog.c
+++ b/src/tss2-fapi/ifapi_ima_eventlog.c
@@ -80,7 +80,9 @@ get_json_content(json_object *jso, json_object **jso_sub) {
     if (!ifapi_get_sub_object(jso, CONTENT, jso_sub)) {
         *jso_sub = json_object_new_object();
         return_if_null(*jso_sub, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-        json_object_object_add(jso, CONTENT, *jso_sub);
+        if (json_object_object_add(jso, CONTENT, *jso_sub)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -105,7 +107,9 @@ add_uint8_ary_to_json(UINT8 *buffer, UINT32 size, json_object *jso, const char *
     SAFE_FREE(hex_string)
     return_if_null(jso_byte_string, "Out of memory", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(jso, jso_tag, jso_byte_string);
+    if (json_object_object_add(jso, jso_tag, jso_byte_string)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -120,7 +124,9 @@ add_string_to_json(const char *string, json_object *jso, const char *jso_tag)
     jso_string = json_object_new_string(string);
     return_if_null(jso_string, "Out of memory", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(jso, jso_tag, jso_string);
+    if (json_object_object_add(jso, jso_tag, jso_string)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -134,7 +140,9 @@ add_number_to_json(UINT32 number, json_object *jso, const char *jso_tag)
     jso_number = json_object_new_int64(number);
     return_if_null(jso_number, "Out of memory", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(jso, jso_tag, jso_number);
+    if (json_object_object_add(jso, jso_tag, jso_number)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -178,14 +186,20 @@ set_ff_digest(json_object *jso) {
     jso_digest_type = json_object_new_string ("sha1");
     goto_if_null(jso_digest_type, "Out of memory.", TSS2_FAPI_RC_MEMORY, error);
 
-    json_object_object_add(jso_digest, "hashAlg", jso_digest_type);
+    if (json_object_object_add(jso_digest, "hashAlg", jso_digest_type)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_ary = json_object_new_array();
     goto_if_null(jso_ary, "Out of memory.", TSS2_FAPI_RC_MEMORY, error);
 
-    json_object_array_add(jso_ary, jso_digest);
+    if (json_object_array_add(jso_ary, jso_digest)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     json_object_object_del(jso, "digests");
-    json_object_object_add(jso, "digests", jso_ary);
+    if (json_object_object_add(jso, "digests", jso_ary)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 
  error:
@@ -397,13 +411,19 @@ event_header_json_cb(
     jso_digest_type = json_object_new_string (hash_name);
     return_if_null(jso_digest_type, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(jso_digest, "hashAlg", jso_digest_type);
+    if (json_object_object_add(jso_digest, "hashAlg", jso_digest_type)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_ary = json_object_new_array();
     return_if_null(jso_ary, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_array_add(jso_ary, jso_digest);
-    json_object_object_add(*jso, "digests", jso_ary);
+    if (json_object_array_add(jso_ary, jso_digest)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(*jso, "digests", jso_ary)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     r = add_uint8_ary_to_json(digest, digest_size, jso_digest, "digest");
     return_if_error(r, "Add digest to json");
@@ -417,7 +437,9 @@ event_header_json_cb(
     r = add_string_to_json(ima_type, jso_content, "template_name");
     return_if_error(r, "Add number to json object.");
 
-    json_object_array_add(jso_list, *jso);
+    if (json_object_array_add(jso_list, *jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 

--- a/src/tss2-fapi/ifapi_json_eventlog_serialize.c
+++ b/src/tss2-fapi/ifapi_json_eventlog_serialize.c
@@ -56,7 +56,9 @@ add_string_to_json(const char *string, json_object *jso, const char *jso_tag)
     jso_string = json_object_new_string(string);
     return_if_null(jso_string, "Out of memory", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(jso, jso_tag, jso_string);
+    if (json_object_object_add(jso, jso_tag, jso_string)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -194,14 +196,18 @@ TSS2_RC ifapi_json_TCG_DIGEST2_serialize(const TCG_DIGEST2 *in, json_object **js
     r = ifapi_json_TPM2_ALG_ID_serialize(in->AlgorithmId, &jso2);
     return_if_jso_error(r, "Serialize hash algorithm", jso2);
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
 
     size = ifapi_hash_get_digest_size(in->AlgorithmId);
     r = ifapi_json_BYTE_ARY_serialize(&in->Digest[0], size, &jso2);
     return_if_jso_error(r, "Serialize UINT8", jso2);
 
-    json_object_object_add(*jso, "digest", jso2);
+    if (json_object_object_add(*jso, "digest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -237,7 +243,9 @@ bool ifapi_json_TCG_DIGEST2_cb(const TCG_DIGEST2 *in, size_t size, void *data)
         return false;
     }
 
-    json_object_array_add(jso_digests, jso_digest);
+    if (json_object_array_add(jso_digests, jso_digest)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return true;
 }
 
@@ -422,7 +430,9 @@ TSS2_RC ifapi_json_TCG_EVENT2_serialize(const TCG_EVENT2 *in, UINT32 event_type,
         r = ifapi_json_BYTE_ARY_serialize(&in->Event[0], in->EventSize, &jso2);
         return_if_jso_error(r, "Serialize UINT8", jso2);
 
-        json_object_object_add(*jso, "event_data", jso2);
+        if (json_object_object_add(*jso, "event_data", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
         return TSS2_RC_SUCCESS;
 }
@@ -487,7 +497,9 @@ TSS2_RC ifapi_json_TCG_EVENT_HEADER2_serialize(
     }
     jso_sub = json_object_new_object();
     return_if_null(jso_sub, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-    json_object_object_add(*jso, CONTENT, jso_sub);
+    if (json_object_object_add(*jso, CONTENT, jso_sub)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     r = add_string_to_json("pcclient_std", *jso, CONTENT_TYPE);
     return_if_error(r, "Add event type");
@@ -495,20 +507,28 @@ TSS2_RC ifapi_json_TCG_EVENT_HEADER2_serialize(
     r = ifapi_json_UINT32_serialize(in->PCRIndex, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "pcr", jso2);
+    if (json_object_object_add(*jso, "pcr", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
 
     jso2 = json_object_new_int64(recnum);
     return_if_null(jso2, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-    json_object_object_add(*jso, "recnum", jso2);
+    if (json_object_object_add(*jso, "recnum", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = json_object_new_string(eventtype_to_string(in->EventType));
 
-    json_object_object_add(jso_sub, "event_type", jso2);
+    if (json_object_object_add(jso_sub, "event_type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_ary = json_object_new_array();
     return_if_null(jso_ary, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-    json_object_object_add(*jso, "digests", jso_ary);
+    if (json_object_object_add(*jso, "digests", jso_ary)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -542,7 +562,9 @@ bool ifapi_json_TCG_EVENT_HEADER2_cb(
 
     cb_data->recnum_tab[in->PCRIndex]++;
 
-    json_object_array_add(jso_event_list, jso);
+    if (json_object_array_add(jso_event_list, jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return true;
 }
 
@@ -591,19 +613,27 @@ TSS2_RC ifapi_json_TCG_EVENT_serialize(const TCG_EVENT *in, size_t recnum, json_
     r = ifapi_json_UINT32_serialize(in->pcrIndex, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "pcr", jso2);
+    if (json_object_object_add(*jso, "pcr", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = json_object_new_int64(recnum);
     return_if_null(jso2, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(*jso, "recnum", jso2);
+    if (json_object_object_add(*jso, "recnum", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = json_object_new_string(eventtype_to_string(in->eventType));
     return_if_null(jso2, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
     jso_sub = json_object_new_object();
     return_if_null(jso_sub, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-    json_object_object_add(*jso, CONTENT, jso_sub);
+    if (json_object_object_add(*jso, CONTENT, jso_sub)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
-    json_object_object_add(jso_sub, "event_type", jso2);
+    if (json_object_object_add(jso_sub, "event_type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_digest = json_object_new_object();
     return_if_null(*jso, "Out of memory.", TSS2_FAPI_RC_MEMORY);
@@ -612,25 +642,35 @@ TSS2_RC ifapi_json_TCG_EVENT_serialize(const TCG_EVENT *in, size_t recnum, json_
     r = ifapi_json_TPM2_ALG_ID_serialize(TPM2_ALG_SHA1, &jso2);
     return_if_error(r, "Serialize hash algorithm");
 
-    json_object_object_add(jso_digest, "hashAlg", jso2);
+    if (json_object_object_add(jso_digest, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_BYTE_ARY_serialize(&in->digest[0], 20, &jso2);
     return_if_error(r, "Serialize BYTE");
 
-    json_object_object_add(jso_digest, "digest", jso2);
+    if (json_object_object_add(jso_digest, "digest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_ary = json_object_new_array();
     return_if_null(jso_ary, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_array_add(jso_ary, jso_digest);
+    if (json_object_array_add(jso_ary, jso_digest)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
-    json_object_object_add(*jso, "digests", jso_ary);
+    if (json_object_object_add(*jso, "digests", jso_ary)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_BYTE_ARY_serialize(&in->event[0], in->eventDataSize, &jso2);
     return_if_error(r, "Serialize BYTE");
 
-    json_object_object_add(jso_sub, "event_data", jso2);
+    if (json_object_object_add(jso_sub, "event_data", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -660,7 +700,9 @@ bool ifapi_json_TCG_EVENT_cb(const TCG_EVENT *in, size_t size, void *data)
 
      cb_data->recnum_tab[in->pcrIndex]++;
 
-    json_object_array_add(jso_event_list, jso);
+    if (json_object_array_add(jso_event_list, jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return true;
 }
 
@@ -690,12 +732,16 @@ TSS2_RC ifapi_json_TCG_SPECID_ALG_serialize(
     r = ifapi_json_TPM2_ALG_ID_serialize(in->algorithmId, &jso2);
     return_if_error(r, "Serialize UINT16");
 
-    json_object_object_add(*jso, "algorithmId", jso2);
+    if (json_object_object_add(*jso, "algorithmId", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT16_serialize(in->digestSize, &jso2);
     return_if_error(r, "Serialize UINT16");
 
-    json_object_object_add(*jso, "digestSize", jso2);
+    if (json_object_object_add(*jso, "digestSize", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -726,7 +772,9 @@ TSS2_RC ifapi_json_TCG_VENDOR_INFO_serialize(const TCG_VENDOR_INFO *in, json_obj
     r = ifapi_json_BYTE_ARY_serialize(&in->vendorInfo[0], in->vendorInfoSize, &jso2);
     return_if_error(r, "Serialize BYTE");
 
-    json_object_object_add(*jso, "vendorInfo", jso2);
+    if (json_object_object_add(*jso, "vendorInfo", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -819,7 +867,9 @@ bool ifapi_json_TCG_SPECID_EVENT_cb(
         return false;
     }
 
-    json_object_array_add(jso_event_list, jso);
+    if (json_object_array_add(jso_event_list, jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return true;
 }
 

--- a/src/tss2-fapi/ifapi_json_serialize.c
+++ b/src/tss2-fapi/ifapi_json_serialize.c
@@ -105,41 +105,55 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
     r = ifapi_json_TPMI_YES_NO_serialize(in->with_auth, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "with_auth", jso2);
+    if (json_object_object_add(*jso, "with_auth", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->persistent_handle, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "persistent_handle", jso2);
+    if (json_object_object_add(*jso, "persistent_handle", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_PUBLIC_serialize(&in->public, &jso2);
     return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-    json_object_object_add(*jso, "public", jso2);
+    if (json_object_object_add(*jso, "public", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT8_ARY_serialize(&in->serialization, &jso2);
     return_if_error(r, "Serialize UINT8_ARY");
 
-    json_object_object_add(*jso, "serialization", jso2);
+    if (json_object_object_add(*jso, "serialization", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->private.buffer != NULL) {
         jso2 = NULL;
         r = ifapi_json_UINT8_ARY_serialize(&in->private, &jso2);
         return_if_error(r, "Serialize UINT8_ARY");
 
-        json_object_object_add(*jso, "private", jso2);
+        if (json_object_object_add(*jso, "private", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->appData.buffer != NULL) {
         jso2 = NULL;
         r = ifapi_json_UINT8_ARY_serialize(&in->appData, &jso2);
         return_if_error(r, "Serialize UINT8_ARY");
 
-        json_object_object_add(*jso, "appData", jso2);
+        if (json_object_object_add(*jso, "appData", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->policyInstance, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "policyInstance", jso2);
+    if (json_object_object_add(*jso, "policyInstance", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     /* Creation Data is not available for imported keys */
     if (in->creationData.size) {
@@ -147,7 +161,9 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
         r = ifapi_json_TPM2B_CREATION_DATA_serialize(&in->creationData, &jso2);
         return_if_error(r, "Serialize TPM2B_CREATION_DATA");
 
-        json_object_object_add(*jso, "creationData", jso2);
+        if (json_object_object_add(*jso, "creationData", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Creation Hash is not available for imported keys */
     if (in->creationHash.size) {
@@ -155,7 +171,9 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
         r = ifapi_json_TPM2B_DIGEST_serialize(&in->creationHash, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "creationHash", jso2);
+        if (json_object_object_add(*jso, "creationHash", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Creation Ticket is not available for imported keys */
     if (in->creationTicket.tag) {
@@ -163,18 +181,24 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
         r = ifapi_json_TPMT_TK_CREATION_serialize(&in->creationTicket, &jso2);
         return_if_error(r, "Serialize TPMT_TK_CREATION");
 
-        json_object_object_add(*jso, "creationTicket", jso2);
+        if (json_object_object_add(*jso, "creationTicket", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->certificate, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "certificate", jso2);
+    if (json_object_object_add(*jso, "certificate", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->public.publicArea.type != TPM2_ALG_KEYEDHASH) {
         /* Keyed hash objects to not need a signing scheme. */
@@ -182,38 +206,50 @@ ifapi_json_IFAPI_KEY_serialize(const IFAPI_KEY *in, json_object **jso)
         r = ifapi_json_TPMT_SIG_SCHEME_serialize(&in->signing_scheme, &jso2);
         return_if_error(r, "Serialize TPMT_SIG_SCHEME");
 
-        json_object_object_add(*jso, "signing_scheme", jso2);
+        if (json_object_object_add(*jso, "signing_scheme", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->name, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "name", jso2);
+    if (json_object_object_add(*jso, "name", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     if (in->reset_count) {
         r = ifapi_json_UINT32_serialize(in->reset_count, &jso2);
         return_if_error(r, "Serialize UINT32");
 
-        json_object_object_add(*jso, "reset_count", jso2);
+        if (json_object_object_add(*jso, "reset_count", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPMI_YES_NO_serialize(in->delete_prohibited, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "delete_prohibited", jso2);
+    if (json_object_object_add(*jso, "delete_prohibited", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPMI_YES_NO_serialize(in->ek_profile, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "ek_profile", jso2);
+    if (json_object_object_add(*jso, "ek_profile", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->nonce.size) {
         jso2 = NULL;
         r = ifapi_json_TPM2B_DIGEST_serialize(&in->nonce, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "nonce", jso2);
+        if (json_object_object_add(*jso, "nonce", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
 
@@ -245,13 +281,17 @@ ifapi_json_IFAPI_EXT_PUB_KEY_serialize(const IFAPI_EXT_PUB_KEY *in,
     r = ifapi_json_char_serialize(in->pem_ext_public, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "pem_ext_public", jso2);
+    if (json_object_object_add(*jso, "pem_ext_public", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     if (in->certificate) {
         r = ifapi_json_char_serialize(in->certificate, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "certificate", jso2);
+        if (json_object_object_add(*jso, "certificate", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->public.publicArea.type) {
         /* Public area was initialized */
@@ -259,7 +299,9 @@ ifapi_json_IFAPI_EXT_PUB_KEY_serialize(const IFAPI_EXT_PUB_KEY *in,
         r = ifapi_json_TPM2B_PUBLIC_serialize(&in->public, &jso2);
         return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-        json_object_object_add(*jso, "public", jso2);
+        if (json_object_object_add(*jso, "public", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -287,51 +329,69 @@ ifapi_json_IFAPI_NV_serialize(const IFAPI_NV *in, json_object **jso)
     r = ifapi_json_TPMI_YES_NO_serialize(in->with_auth, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "with_auth", jso2);
+    if (json_object_object_add(*jso, "with_auth", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     /* Add tag to classify json NV objects without deserialization */
     jso2 = json_object_new_boolean(true);
-    json_object_object_add(*jso, "nv_object", jso2);
+    if (json_object_object_add(*jso, "nv_object", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&in->public, &jso2);
     return_if_error(r, "Serialize TPM2B_NV_PUBLIC");
 
-    json_object_object_add(*jso, "public", jso2);
+    if (json_object_object_add(*jso, "public", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT8_ARY_serialize(&in->serialization, &jso2);
     return_if_error(r, "Serialize UINT8_ARY");
 
-    json_object_object_add(*jso, "serialization", jso2);
+    if (json_object_object_add(*jso, "serialization", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->hierarchy, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "hierarchy", jso2);
+    if (json_object_object_add(*jso, "hierarchy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->policyInstance, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "policyInstance", jso2);
+    if (json_object_object_add(*jso, "policyInstance", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->appData.buffer != NULL) {
         jso2 = NULL;
         r = ifapi_json_UINT8_ARY_serialize(&in->appData, &jso2);
         return_if_error(r, "Serialize UINT8_ARY");
 
-        json_object_object_add(*jso, "appData", jso2);
+        if (json_object_object_add(*jso, "appData", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     if (in->event_log) {
         r = ifapi_json_char_serialize(in->event_log, &jso2);
         return_if_error(r, "Serialize event log");
 
-        json_object_object_add(*jso, "event_log", jso2);
+        if (json_object_object_add(*jso, "event_log", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -359,25 +419,33 @@ ifapi_json_IFAPI_HIERARCHY_serialize(const IFAPI_HIERARCHY *in, json_object **js
     r = ifapi_json_TPMI_YES_NO_serialize(in->with_auth, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "with_auth", jso2);
+    if (json_object_object_add(*jso, "with_auth", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->authPolicy, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "authPolicy", jso2);
+    if (json_object_object_add(*jso, "authPolicy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->esysHandle, &jso2);
     return_if_error(r, "Serialize esys handle");
 
-    json_object_object_add(*jso, "esysHandle", jso2);
+    if (json_object_object_add(*jso, "esysHandle", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -406,12 +474,16 @@ ifapi_json_FAPI_QUOTE_INFO_serialize(const FAPI_QUOTE_INFO *in,
     r = ifapi_json_TPMT_SIG_SCHEME_serialize(&in->sig_scheme, &jso2);
     return_if_error(r, "Serialize TPMT_SIG_SCHEME");
 
-    json_object_object_add(*jso, "sig_scheme", jso2);
+    if (json_object_object_add(*jso, "sig_scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMS_ATTEST_serialize(&in->attest, &jso2);
     return_if_error(r, "Serialize TPMS_ATTEST");
 
-    json_object_object_add(*jso, "attest", jso2);
+    if (json_object_object_add(*jso, "attest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -440,36 +512,48 @@ ifapi_json_IFAPI_DUPLICATE_serialize(const IFAPI_DUPLICATE *in,
     r = ifapi_json_TPM2B_PRIVATE_serialize(&in->duplicate, &jso2);
     return_if_error(r, "Serialize TPM2B_PRIVATE");
 
-    json_object_object_add(*jso, "duplicate", jso2);
+    if (json_object_object_add(*jso, "duplicate", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_ENCRYPTED_SECRET_serialize(&in->encrypted_seed, &jso2);
     return_if_error(r, "Serialize TPM2B_ENCRYPTED_SECRET");
 
-    json_object_object_add(*jso, "encrypted_seed", jso2);
+    if (json_object_object_add(*jso, "encrypted_seed", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     if (in->certificate) {
         r = ifapi_json_char_serialize(in->certificate, &jso2);
         return_if_error(r, "Serialize certificate");
 
-        json_object_object_add(*jso, "certificate", jso2);
+        if (json_object_object_add(*jso, "certificate", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPM2B_PUBLIC_serialize(&in->public, &jso2);
     return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-    json_object_object_add(*jso, "public", jso2);
+    if (json_object_object_add(*jso, "public", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPM2B_PUBLIC_serialize(&in->public_parent, &jso2);
     return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-    json_object_object_add(*jso, "public_parent", jso2);
+    if (json_object_object_add(*jso, "public_parent", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->policy) {
         jso2 = NULL;
         r = ifapi_json_TPMS_POLICY_serialize(in->policy, &jso2);
         return_if_error(r, "Serialize policy");
 
-        json_object_object_add(*jso, "policy", jso2);
+        if (json_object_object_add(*jso, "policy", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     return TSS2_RC_SUCCESS;
@@ -520,12 +604,16 @@ ifapi_json_IFAPI_OBJECT_serialize(const IFAPI_OBJECT *in,
     r = ifapi_json_IFAPI_OBJECT_TYPE_CONSTANT_serialize(in->objectType, &jso2);
     return_if_error(r, "Serialize IFAPI_OBJECT");
 
-    json_object_object_add(*jso, "objectType", jso2);
+    if (json_object_object_add(*jso, "objectType", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_YES_NO_serialize(in->system, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "system", jso2);
+    if (json_object_object_add(*jso, "system", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     switch (in->objectType) {
     case IFAPI_HIERARCHY_OBJ:
@@ -565,7 +653,9 @@ ifapi_json_IFAPI_OBJECT_serialize(const IFAPI_OBJECT *in,
         r = ifapi_json_TPMS_POLICY_serialize(in->policy, &jso2);
         return_if_error(r, "Serialize policy");
 
-        json_object_object_add(*jso, "policy", jso2);
+        if (json_object_object_add(*jso, "policy", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     if (in->policy) {
@@ -573,7 +663,9 @@ ifapi_json_IFAPI_OBJECT_serialize(const IFAPI_OBJECT *in,
         r = ifapi_json_TPMS_POLICY_serialize(in->policy, &jso2);
         return_if_error(r, "Serialize policy");
 
-        json_object_object_add(*jso, "policy", jso2);
+        if (json_object_object_add(*jso, "policy", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -601,13 +693,17 @@ ifapi_json_IFAPI_CAP_INFO_serialize(const IFAPI_CAP_INFO *in, json_object **jso)
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPMS_CAPABILITY_DATA_serialize(in->capability, &jso2);
     return_if_error(r, "Serialize TPMS_CAPABILITY_DATA");
 
-    json_object_object_add(*jso, "info", jso2);
+    if (json_object_object_add(*jso, "info", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -637,12 +733,16 @@ ifapi_json_IFAPI_INFO_serialize(const IFAPI_INFO *in, json_object **jso)
     r = ifapi_json_char_serialize(in->fapi_version, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "version", jso2);
+    if (json_object_object_add(*jso, "version", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_IFAPI_CONFIG_serialize(&in->fapi_config, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "fapi_config", jso2);
+    if (json_object_object_add(*jso, "fapi_config", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso_cap_list = json_object_new_array();
 
     for (i = 0; i < IFAPI_MAX_CAP_INFO; i++) {
@@ -650,10 +750,14 @@ ifapi_json_IFAPI_INFO_serialize(const IFAPI_INFO *in, json_object **jso)
         r = ifapi_json_IFAPI_CAP_INFO_serialize(&in->cap[i], &jso2);
         return_if_error(r, "Serialize TPMS_CAPABILITY_DATA");
 
-        json_object_array_add(jso_cap_list, jso2);
+        if (json_object_array_add(jso_cap_list, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
 
     }
-    json_object_object_add(*jso, "capabilities", jso_cap_list);
+    if (json_object_object_add(*jso, "capabilities", jso_cap_list)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -736,7 +840,9 @@ ifapi_json_IFAPI_TSS_EVENT_serialize(const IFAPI_TSS_EVENT *in,
     r = ifapi_json_TPM2B_EVENT_serialize(&in->data, &jso2);
     return_if_error(r, "Serialize TPM2B_EVENT");
 
-    json_object_object_add(*jso, "data", jso2);
+    if (json_object_object_add(*jso, "data", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->event) {
         /* The in->event field is somewhat special. Its an arbitrary json
@@ -746,7 +852,9 @@ ifapi_json_IFAPI_TSS_EVENT_serialize(const IFAPI_TSS_EVENT *in,
         jso2 = ifapi_parse_json(in->event);
         return_if_null(jso2, "Event is not valid JSON.", TSS2_FAPI_RC_BAD_VALUE);
 
-        json_object_object_add(*jso, "event", jso2);
+        if (json_object_object_add(*jso, "event", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -775,7 +883,9 @@ ifapi_json_IFAPI_IMA_EVENT_serialize(const IFAPI_IMA_EVENT *in,
     r = ifapi_json_UINT8_ARY_serialize(&in->template_value, &jso2);
     return_if_error(r, "Serialize UINT8_ARY");
 
-    json_object_object_add(*jso, "template_data", jso2);
+    if (json_object_object_add(*jso, "template_data", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -855,11 +965,21 @@ ifapi_json_IFAPI_EVENT_serialize(const IFAPI_EVENT *in, json_object **jso)
         }
     }
 
-    json_object_object_add(*jso, "recnum", recnum);
-    json_object_object_add(*jso, "pcr", pcr);
-    json_object_object_add(*jso, "digests", digests);
-    json_object_object_add(*jso, CONTENT_TYPE, type);
-    json_object_object_add(*jso, CONTENT, content);
+    if (json_object_object_add(*jso, "recnum", recnum)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(*jso, "pcr", pcr)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(*jso, "digests", digests)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(*jso, CONTENT_TYPE, type)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(*jso, CONTENT, content)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 
@@ -901,76 +1021,100 @@ ifapi_json_IFAPI_CONFIG_serialize(const IFAPI_CONFIG *in, json_object **jso)
      r = ifapi_json_char_serialize(in->profile_dir, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "profile_dir", jso2);
+     if (json_object_object_add(*jso, "profile_dir", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->user_dir, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "user_dir", jso2);
+     if (json_object_object_add(*jso, "user_dir", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->keystore_dir, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "system_dir", jso2);
+     if (json_object_object_add(*jso, "system_dir", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->log_dir, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "log_dir", jso2);
+     if (json_object_object_add(*jso, "log_dir", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->profile_name, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "profile_name", jso2);
+     if (json_object_object_add(*jso, "profile_name", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->tcti, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "tcti", jso2);
+     if (json_object_object_add(*jso, "tcti", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_TPML_PCR_SELECTION_serialize(&in->system_pcrs, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "system_pcrs", jso2);
+     if (json_object_object_add(*jso, "system_pcrs", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->ek_cert_file, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "ek_cert_file", jso2);
+     if (json_object_object_add(*jso, "ek_cert_file", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      jso2 = NULL;
      r = ifapi_json_TPMI_YES_NO_serialize(in->ek_cert_less, &jso2);
      return_if_error(r, "Serialize yes no");
 
-     json_object_object_add(*jso, "ek_cert_less", jso2);
+     if (json_object_object_add(*jso, "ek_cert_less", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      if (in->ek_fingerprint.hashAlg) {
          jso2 = NULL;
          ifapi_json_TPMT_HA_serialize(&in->ek_fingerprint, &jso2);
          return_if_error(r, "Serialize char");
 
-         json_object_object_add(*jso, "ek_fingerprint", jso2);
+         if (json_object_object_add(*jso, "ek_fingerprint", jso2)) {
+             return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+         }
      }
 
      jso2 = NULL;
      r = ifapi_json_char_serialize(in->web_cert_service, &jso2);
      return_if_error(r, "Serialize char");
 
-     json_object_object_add(*jso, "web_cert_service", jso2);
+     if (json_object_object_add(*jso, "web_cert_service", jso2)) {
+         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+     }
 
      if (in->firmware_log_file) {
          jso2 = NULL;
          r = ifapi_json_char_serialize(in->firmware_log_file, &jso2);
          return_if_error(r, "Serialize char");
 
-         json_object_object_add(*jso, "firmware_log_file", jso2);
+         if (json_object_object_add(*jso, "firmware_log_file", jso2)) {
+             return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+         }
      }
 
      if (in->ima_log_file) {
@@ -978,7 +1122,9 @@ ifapi_json_IFAPI_CONFIG_serialize(const IFAPI_CONFIG *in, json_object **jso)
          r = ifapi_json_char_serialize(in->ima_log_file, &jso2);
          return_if_error(r, "Serialize char");
 
-         json_object_object_add(*jso, "ima_log_file", jso2);
+         if (json_object_object_add(*jso, "ima_log_file", jso2)) {
+             return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+         }
      }
 
      return TSS2_RC_SUCCESS;
@@ -1006,12 +1152,16 @@ ifapi_json_TPMS_CEL_VERSION_serialize(
     r = ifapi_json_UINT16_serialize(in->major, &jso2);
     return_if_error(r, "Serialize major version");
 
-    json_object_object_add(*jso, "major", jso2);
+    if (json_object_object_add(*jso, "major", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT16_serialize(in->minor, &jso2);
     return_if_error(r, "Serialize minor version");
 
-    json_object_object_add(*jso, "minor", jso2);
+    if (json_object_object_add(*jso, "minor", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -1040,7 +1190,9 @@ ifapi_json_TPMU_CELMGT_serialize(const TPMU_CELMGT *in, UINT32 selector, json_ob
             jso2 = NULL;
             if (ifapi_json_UINT64_serialize(in->cel_timestamp, &jso2))
                  return TSS2_FAPI_RC_BAD_VALUE;
-            json_object_object_add(*jso, "cel_timestamp", jso2);
+            if (json_object_object_add(*jso, "cel_timestamp", jso2)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
             break;
         default:
             LOG_ERROR("\nSelector %"PRIx32 " did not match", selector);
@@ -1098,13 +1250,17 @@ ifapi_json_TPMS_EVENT_CELMGT_serialize(const TPMS_EVENT_CELMGT *in, json_object 
     r = ifapi_json_TPMI_CELMGTTYPE_serialize(in->type, &jso2);
     return_if_jso_error(r, "Serialize TPMI_CELMGTTYPE", jso2);
 
-    json_object_object_add(*jso, "type", jso2);
+    if (json_object_object_add(*jso, "type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_CELMGT_serialize(&in->data, in->type, &jso2);
     return_if_jso_error(r,"Serialize TPMU_CELMGT", jso2);
 
     if (jso2) {
-        json_object_object_add(*jso, "data", jso2);
+        if (json_object_object_add(*jso, "data", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -135,14 +135,18 @@ ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
         r = ifapi_json_TPM2B_DIGEST_serialize(&in->cpHashA, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "cpHashA", jso2);
+        if (json_object_object_add(*jso, "cpHashA", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->policyRef.size != 0) {
         jso2 = NULL;
         r = ifapi_json_TPM2B_NONCE_serialize(&in->policyRef, &jso2);
         return_if_error(r, "Serialize TPM2B_NONCE");
 
-        json_object_object_add(*jso, "policyRef", jso2);
+        if (json_object_object_add(*jso, "policyRef", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->keyPath && strlen(in->keyPath) > 0) {
         jso2 = NULL;
@@ -150,7 +154,9 @@ ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
         r = ifapi_json_char_serialize(in->keyPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "keyPath", jso2);
+        if (json_object_object_add(*jso, "keyPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->keyPublic.type != 0) {
         jso2 = NULL;
@@ -158,7 +164,9 @@ ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
         r = ifapi_json_TPMT_PUBLIC_serialize(&in->keyPublic, &jso2);
         return_if_error(r, "Serialize TPMT_PUBLIC");
 
-        json_object_object_add(*jso, "keyPublic", jso2);
+        if (json_object_object_add(*jso, "keyPublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if ((in->keyPEM) && strcmp(in->keyPEM, "") != 0) {
         jso2 = NULL;
@@ -166,28 +174,36 @@ ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
         r = ifapi_json_char_serialize(in->keyPEM, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "keyPEM", jso2);
+        if (json_object_object_add(*jso, "keyPEM", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if ((in->publicKeyHint) && strcmp(in->publicKeyHint, "") != 0) {
         jso2 = NULL;
         r = ifapi_json_char_serialize(in->publicKeyHint, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "publicKeyHint", jso2);
+        if (json_object_object_add(*jso, "publicKeyHint", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->publicKey.size) {
         jso2 = NULL;
         r = ifapi_json_TPM2B_NAME_serialize(&in->publicKey, &jso2);
         return_if_error(r, "Serialize key name");
 
-        json_object_object_add(*jso, "publicKey", jso2);
+        if (json_object_object_add(*jso, "publicKey", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->keyPEMhashAlg != 0) {
         jso2 = NULL;
         r = ifapi_json_TPMI_ALG_HASH_serialize(in->keyPEMhashAlg, &jso2);
         return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-        json_object_object_add(*jso, "keyPEMhashAlg", jso2);
+        if (json_object_object_add(*jso, "keyPEMhashAlg", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Check whether only one conditional is used. */
     if (cond_cnt != 1) {
@@ -198,7 +214,9 @@ ifapi_json_TPMS_POLICYSIGNED_serialize(const TPMS_POLICYSIGNED *in,
     r = ifapi_json_TPMT_RSA_SCHEME_serialize(&in->rsaScheme, &jso2);
     return_if_error(r, "Serialize RSA scheme");
 
-    json_object_object_add(*jso, "rsaScheme", jso2);
+    if (json_object_object_add(*jso, "rsaScheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -228,31 +246,41 @@ ifapi_json_TPMS_POLICYSECRET_serialize(const TPMS_POLICYSECRET *in,
     r = ifapi_json_TPM2B_NONCE_serialize(&in->nonceTPM, &jso2);
     return_if_error(r, "Serialize TPM2B_NONCE");
 
-    json_object_object_add(*jso, "nonceTPM", jso2);
+    if (json_object_object_add(*jso, "nonceTPM", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->cpHashA, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "cpHashA", jso2);
+    if (json_object_object_add(*jso, "cpHashA", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->policyRef.size != 0) {
         jso2 = NULL;
         r = ifapi_json_TPM2B_NONCE_serialize(&in->policyRef, &jso2);
         return_if_error(r, "Serialize TPM2B_NONCE");
 
-        json_object_object_add(*jso, "policyRef", jso2);
+        if (json_object_object_add(*jso, "policyRef", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_INT32_serialize(in->expiration, &jso2);
     return_if_error(r, "Serialize INT32");
 
-    json_object_object_add(*jso, "expiration", jso2);
+    if (json_object_object_add(*jso, "expiration", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if ((in->objectPath) && strcmp(in->objectPath, "") != 0) {
         jso2 = NULL;
         cond_cnt++;
         r = ifapi_json_char_serialize(in->objectPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "objectPath", jso2);
+        if (json_object_object_add(*jso, "objectPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->objectName.size != 0) {
         jso2 = NULL;
@@ -260,7 +288,9 @@ ifapi_json_TPMS_POLICYSECRET_serialize(const TPMS_POLICYSECRET *in,
         r = ifapi_json_TPM2B_NAME_serialize(&in->objectName, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "objectName", jso2);
+        if (json_object_object_add(*jso, "objectName", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (cond_cnt != 1) {
         return_error(TSS2_FAPI_RC_BAD_VALUE,
@@ -293,7 +323,9 @@ ifapi_json_TPMS_POLICYLOCALITY_serialize(const TPMS_POLICYLOCALITY *in,
     r = ifapi_json_TPMA_LOCALITY_serialize(in->locality, &jso2);
     return_if_error(r, "Serialize TPMA_LOCALITY");
 
-    json_object_object_add(*jso, "locality", jso2);
+    if (json_object_object_add(*jso, "locality", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -323,7 +355,9 @@ ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
         r = ifapi_json_char_serialize(in->nvPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "nvPath", jso2);
+        if (json_object_object_add(*jso, "nvPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->nvIndex != 0) {
         jso2 = NULL;
@@ -331,7 +365,9 @@ ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
         r = ifapi_json_TPMI_RH_NV_INDEX_serialize(in->nvIndex, &jso2);
         return_if_error(r, "Serialize TPMI_RH_NV_INDEX");
 
-        json_object_object_add(*jso, "nvIndex", jso2);
+        if (json_object_object_add(*jso, "nvIndex", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     if (in->nvPublic.nvIndex) {
@@ -341,27 +377,35 @@ ifapi_json_TPMS_POLICYNV_serialize(const TPMS_POLICYNV *in, json_object **jso)
         r = ifapi_json_TPM2B_NV_PUBLIC_serialize(&tmp, &jso2);
         return_if_error(r, "Serialize TPM2B_NV_PUBLIC");
 
-        json_object_object_add(*jso, "nvPublic", jso2);
+        if (json_object_object_add(*jso, "nvPublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     jso2 = NULL;
     r = ifapi_json_TPM2B_OPERAND_serialize(&in->operandB, &jso2);
     return_if_error(r, "Serialize TPM2B_OPERAND");
 
-    json_object_object_add(*jso, "operandB", jso2);
+    if (json_object_object_add(*jso, "operandB", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->offset != 0) {
         jso2 = NULL;
         r = ifapi_json_UINT16_serialize(in->offset, &jso2);
         return_if_error(r, "Serialize UINT16");
 
-        json_object_object_add(*jso, "offset", jso2);
+        if (json_object_object_add(*jso, "offset", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->operation != 0) {
         jso2 = NULL;
         r = ifapi_json_TPM2_EO_serialize(in->operation, &jso2);
         return_if_error(r, "Serialize TPM2_EO");
 
-        json_object_object_add(*jso, "operation", jso2);
+        if (json_object_object_add(*jso, "operation", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Check whether only one conditional is used. */
     if (cond_cnt != 1) {
@@ -396,19 +440,25 @@ ifapi_json_TPMS_POLICYCOUNTERTIMER_serialize(const TPMS_POLICYCOUNTERTIMER *in,
     r = ifapi_json_TPM2B_OPERAND_serialize(&in->operandB, &jso2);
     return_if_error(r, "Serialize TPM2B_OPERAND");
 
-    json_object_object_add(*jso, "operandB", jso2);
+    if (json_object_object_add(*jso, "operandB", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->offset != 0) {
         jso2 = NULL;
         r = ifapi_json_UINT16_serialize(in->offset, &jso2);
         return_if_error(r, "Serialize UINT16");
 
-        json_object_object_add(*jso, "offset", jso2);
+        if (json_object_object_add(*jso, "offset", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPM2_EO_serialize(in->operation, &jso2);
     return_if_error(r, "Serialize TPM2_EO");
 
-    json_object_object_add(*jso, "operation", jso2);
+    if (json_object_object_add(*jso, "operation", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -436,7 +486,9 @@ ifapi_json_TPMS_POLICYCOMMANDCODE_serialize(const TPMS_POLICYCOMMANDCODE *in,
     r = ifapi_json_TPM2_CC_serialize(in->code, &jso2);
     return_if_error(r, "Serialize TPM2_CC");
 
-    json_object_object_add(*jso, "code", jso2);
+    if (json_object_object_add(*jso, "code", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -484,7 +536,9 @@ ifapi_json_TPMS_POLICYCPHASH_serialize(const TPMS_POLICYCPHASH *in,
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->cpHash, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "cpHash", jso2);
+    if (json_object_object_add(*jso, "cpHash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -519,7 +573,9 @@ ifapi_json_TPMS_POLICYNAMEHASH_serialize(const TPMS_POLICYNAMEHASH *in,
         r = ifapi_json_TPM2B_DIGEST_serialize(&in->nameHash, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "nameHash", jso2);
+        if (json_object_object_add(*jso, "nameHash", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
 
         /* No need to serialize namePaths or objectNames from which would be
            needed to compute nameHash. */
@@ -537,18 +593,26 @@ ifapi_json_TPMS_POLICYNAMEHASH_serialize(const TPMS_POLICYNAMEHASH *in,
             r = ifapi_json_char_serialize(in->namePaths[i], &jso2);
             return_if_error(r, "Serialize char");
 
-            json_object_array_add(jso_ary, jso2);
+            if (json_object_array_add(jso_ary, jso2)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         }
-        json_object_object_add(*jso, "namePaths", jso_ary);
+        if (json_object_object_add(*jso, "namePaths", jso_ary)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     } else {
         /* TPM object names are used */
         for (i = 0; i < in->count; i++) {
             jso2 = NULL;
             r = ifapi_json_TPM2B_NAME_serialize(&in->objectNames[i], &jso2);
             return_if_error(r, "Serialize TPM2B_NAME");
-            json_object_array_add(jso_ary, jso2);
+            if (json_object_array_add(jso_ary, jso2)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         }
-        json_object_object_add(*jso, "objectNames", jso_ary);
+        if (json_object_object_add(*jso, "objectNames", jso_ary)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Check whether only one condition field found in policy. */
     if (cond_cnt != 1) {
@@ -584,7 +648,9 @@ ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
     r = ifapi_json_TPM2B_NAME_serialize(&in->objectName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "objectName", jso2);
+    if (json_object_object_add(*jso, "objectName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->newParentName.size) {
         cond_cnt++;
@@ -592,13 +658,17 @@ ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
         r = ifapi_json_TPM2B_NAME_serialize(&in->newParentName, &jso2);
         return_if_error(r, "Serialize TPM2B_NAME");
 
-        json_object_object_add(*jso, "newParentName", jso2);
+        if (json_object_object_add(*jso, "newParentName", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPMI_YES_NO_serialize(in->includeObject, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "includeObject", jso2);
+    if (json_object_object_add(*jso, "includeObject", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->newParentPath) {
         jso2 = NULL;
@@ -606,7 +676,9 @@ ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
         r = ifapi_json_char_serialize(in->newParentPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "newParentPath", jso2);
+        if (json_object_object_add(*jso, "newParentPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     if (in->newParentPublic.type) {
@@ -615,7 +687,9 @@ ifapi_json_TPMS_POLICYDUPLICATIONSELECT_serialize(const
         r = ifapi_json_TPMT_PUBLIC_serialize(&in->newParentPublic, &jso2);
         return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-        json_object_object_add(*jso, "newParentPublic", jso2);
+        if (json_object_object_add(*jso, "newParentPublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     /* Check whether only one condition field found in policy. */
@@ -652,19 +726,25 @@ ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->approvedPolicy, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "approvedPolicy", jso2);
+    if (json_object_object_add(*jso, "approvedPolicy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->policyRef.size != 0) {
         jso2 = NULL;
         r = ifapi_json_TPM2B_NONCE_serialize(&in->policyRef, &jso2);
         return_if_error(r, "Serialize TPM2B_NONCE");
 
-        json_object_object_add(*jso, "policyRef", jso2);
+        if (json_object_object_add(*jso, "policyRef", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->keyName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "keyName", jso2);
+    if (json_object_object_add(*jso, "keyName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
 
     if (in->keyPath) {
@@ -672,7 +752,9 @@ ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
         r = ifapi_json_char_serialize(in->keyPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "keyPath", jso2);
+        if (json_object_object_add(*jso, "keyPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->keyPublic.type != 0) {
         jso2 = NULL;
@@ -680,28 +762,36 @@ ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
         r = ifapi_json_TPMT_PUBLIC_serialize(&in->keyPublic, &jso2);
         return_if_error(r, "Serialize TPMT_PUBLIC");
 
-        json_object_object_add(*jso, "keyPublic", jso2);
+        if (json_object_object_add(*jso, "keyPublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if ((in->keyPEM) && strcmp(in->keyPEM, "") != 0) {
         jso2 = NULL;
         r = ifapi_json_char_serialize(in->keyPEM, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "keyPEM", jso2);
+        if (json_object_object_add(*jso, "keyPEM", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->keyPEMhashAlg != 0) {
         jso2 = NULL;
         r = ifapi_json_TPMI_ALG_HASH_serialize(in->keyPEMhashAlg, &jso2);
         return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-        json_object_object_add(*jso, "keyPEMhashAlg", jso2);
+        if (json_object_object_add(*jso, "keyPEMhashAlg", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     jso2 = NULL;
     r = ifapi_json_TPMT_RSA_SCHEME_serialize(&in->rsaScheme, &jso2);
     return_if_error(r, "Serialize RSA scheme");
 
-    json_object_object_add(*jso, "rsaScheme", jso2);
+    if (json_object_object_add(*jso, "rsaScheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -770,7 +860,9 @@ ifapi_json_TPMS_POLICYNVWRITTEN_serialize(const TPMS_POLICYNVWRITTEN *in,
     r = ifapi_json_TPMI_YES_NO_serialize(in->writtenSet, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "writtenSet", jso2);
+    if (json_object_object_add(*jso, "writtenSet", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -801,7 +893,9 @@ ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
         r = ifapi_json_TPM2B_DIGEST_serialize(&in->templateHash, &jso2);
         return_if_error(r, "Serialize TPM2B_DIGEST");
 
-        json_object_object_add(*jso, "templateHash", jso2);
+        if (json_object_object_add(*jso, "templateHash", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->templatePublic.publicArea.type) {
         jso2 = NULL;
@@ -809,7 +903,9 @@ ifapi_json_TPMS_POLICYTEMPLATE_serialize(const TPMS_POLICYTEMPLATE *in,
         r = ifapi_json_TPMT_PUBLIC_serialize(&in->templatePublic.publicArea, &jso2);
         return_if_error(r, "Serialize TPM2B_PUBLIC");
 
-        json_object_object_add(*jso, "templatePublic", jso2);
+        if (json_object_object_add(*jso, "templatePublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     /* Check whether only one condition field found in policy. */
@@ -847,7 +943,9 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_serialize(const TPMS_POLICYAUTHORIZENV *in,
         r = ifapi_json_char_serialize(in->nvPath, &jso2);
         return_if_error(r, "Serialize char");
 
-        json_object_object_add(*jso, "nvPath", jso2);
+        if (json_object_object_add(*jso, "nvPath", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     if (in->nvPublic.nvIndex > 0) {
@@ -856,7 +954,9 @@ ifapi_json_TPMS_POLICYAUTHORIZENV_serialize(const TPMS_POLICYAUTHORIZENV *in,
         r = ifapi_json_TPMS_NV_PUBLIC_serialize(&in->nvPublic, &jso2);
         return_if_error(r, "Serialize TPM2B_NV_PUBLIC");
 
-        json_object_object_add(*jso, "nvPublic", jso2);
+        if (json_object_object_add(*jso, "nvPublic", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (cond_cnt != 1) {
         return_error(TSS2_FAPI_RC_BAD_VALUE,
@@ -889,7 +989,9 @@ ifapi_json_TPMS_POLICYACTION_serialize(const TPMS_POLICYACTION *in,
     r = ifapi_json_char_serialize(in->action, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "action", jso2);
+    if (json_object_object_add(*jso, "action", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -916,17 +1018,23 @@ ifapi_json_TPMS_PCRVALUE_serialize(const TPMS_PCRVALUE *in, json_object **jso)
     r = ifapi_json_UINT32_serialize(in->pcr, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "pcr", jso2);
+    if (json_object_object_add(*jso, "pcr", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2_ALG_ID_serialize(in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPM2_ALG_ID");
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_HA_serialize(&in->digest, in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPMU_HA");
 
-    json_object_object_add(*jso, "digest", jso2);
+    if (json_object_object_add(*jso, "digest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -955,7 +1063,9 @@ ifapi_json_TPML_PCRVALUES_serialize(const TPML_PCRVALUES *in, json_object **jso)
         r = ifapi_json_TPMS_PCRVALUE_serialize(&in->pcrs[i], &jso2);
         return_if_error(r, "Serialize TPMS_PCRVALUE");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -986,7 +1096,9 @@ ifapi_json_TPMS_POLICYPCR_serialize(const TPMS_POLICYPCR *in, json_object **jso)
         r = ifapi_json_TPML_PCRVALUES_serialize(in->pcrs, &jso2);
         return_if_error(r, "Serialize TPML_PCRVALUES");
 
-        json_object_object_add(*jso, "pcrs", jso2);
+        if (json_object_object_add(*jso, "pcrs", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     if (in->currentPCRandBanks.count) {
@@ -995,7 +1107,9 @@ ifapi_json_TPMS_POLICYPCR_serialize(const TPMS_POLICYPCR *in, json_object **jso)
         r = ifapi_json_TPML_PCR_SELECTION_serialize(&in->currentPCRandBanks, &jso2);
         return_if_error(r, "Serialize TPML_PCR_SELECTION");
 
-        json_object_object_add(*jso, "currentPCRandBanks", jso2);
+        if (json_object_object_add(*jso, "currentPCRandBanks", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     if (in->currentPCRs.sizeofSelect) {
@@ -1004,7 +1118,9 @@ ifapi_json_TPMS_POLICYPCR_serialize(const TPMS_POLICYPCR *in, json_object **jso)
         r = ifapi_json_TPMS_PCR_SELECT_serialize(&in->currentPCRs, &jso2);
         return_if_error(r, "Serialize TPMS_PCR_SELECT");
 
-        json_object_object_add(*jso, "currentPCRs", jso2);
+        if (json_object_object_add(*jso, "currentPCRs", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     /* Check whether only one conditional is used. */
     if (cond_cnt != 1) {
@@ -1039,52 +1155,68 @@ ifapi_json_TPMS_POLICYAUTHORIZATION_serialize(
     r = ifapi_json_char_serialize(in->type, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "type", jso2);
+    if (json_object_object_add(*jso, "type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     r = ifapi_json_TPM2B_NONCE_serialize(&in->policyRef, &jso2);
     return_if_error(r, "Serialize TPM2B_NONCE");
 
-    json_object_object_add(*jso, "policyRef", jso2);
+    if (json_object_object_add(*jso, "policyRef", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (strcmp(in->type, "tpm") == 0) {
         jso2 = NULL;
         r = ifapi_json_TPMT_PUBLIC_serialize(&in->key, &jso2);
         return_if_error(r, "Serialize TPMT_PUBLIC");
 
-        json_object_object_add(*jso, "key", jso2);
+        if (json_object_object_add(*jso, "key", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
         jso2 = NULL;
 
         jso2 = NULL;
         r = ifapi_json_TPMT_SIGNATURE_serialize(&in->signature, &jso2);
         return_if_error(r, "Serialize TPMT_SIGNATURE");
 
-        json_object_object_add(*jso, "signature", jso2);
+        if (json_object_object_add(*jso, "signature", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     } else if (strcmp(in->type, "pem") == 0) {
         jso2 = NULL;
         r = ifapi_json_char_serialize(in->keyPEM, &jso2);
         return_if_error(r, "Serialize TPMT_PUBLIC");
 
-        json_object_object_add(*jso, "key", jso2);
+        if (json_object_object_add(*jso, "key", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
         jso2 = NULL;
 
         jso2 = NULL;
         r = ifapi_json_UINT8_ARY_serialize(&in->pemSignature, &jso2);
         return_if_error(r, "Serialize Signature");
 
-        json_object_object_add(*jso, "signature", jso2);
+        if (json_object_object_add(*jso, "signature", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
 
         jso2 = NULL;
         r = ifapi_json_TPMT_RSA_SCHEME_serialize(&in->rsaScheme, &jso2);
         return_if_error(r, "Serialize RSA scheme");
 
-        json_object_object_add(*jso, "rsaScheme", jso2);
+        if (json_object_object_add(*jso, "rsaScheme", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
 
         jso2 = NULL;
         r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
         return_if_error(r, "Serialize hash alg.");
 
-        json_object_object_add(*jso, "hashAlg", jso2);
+        if (json_object_object_add(*jso, "hashAlg", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     } else {
         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid key type.");
     }
@@ -1121,7 +1253,9 @@ ifapi_json_TPML_POLICYAUTHORIZATIONS_serialize(const TPML_POLICYAUTHORIZATIONS
                 &jso2);
         return_if_error(r, "Serialize TPMS_POLICYAUTHORIZATION");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1150,23 +1284,31 @@ ifapi_json_TPMS_POLICYBRANCH_serialize(const TPMS_POLICYBRANCH *in,
     r = ifapi_json_char_serialize(in->name, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "name", jso2);
+    if (json_object_object_add(*jso, "name", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPML_POLICYELEMENTS_serialize(in->policy, &jso2);
     return_if_error(r, "Serialize TPML_POLICYELEMENTS");
 
-    json_object_object_add(*jso, "policy", jso2);
+    if (json_object_object_add(*jso, "policy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->policyDigests.count > 0) {
         jso2 = NULL;
         r = ifapi_json_TPML_DIGEST_VALUES_serialize(&in->policyDigests, &jso2);
         return_if_error(r, "Serialize TPML_DIGEST_VALUES");
 
-        json_object_object_add(*jso, "policyDigests", jso2);
+        if (json_object_object_add(*jso, "policyDigests", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1199,7 +1341,9 @@ ifapi_json_TPML_POLICYBRANCHES_serialize(const TPML_POLICYBRANCHES *in,
         r = ifapi_json_TPMS_POLICYBRANCH_serialize(&in->authorizations[i], &jso2);
         return_if_error(r, "Serialize TPMS_POLICYBRANCH");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1227,7 +1371,9 @@ ifapi_json_TPMS_POLICYOR_serialize(const TPMS_POLICYOR *in, json_object **jso)
     r = ifapi_json_TPML_POLICYBRANCHES_serialize(in->branches, &jso2);
     return_if_error(r, "Serialize TPML_POLICYBRANCHES");
 
-    json_object_object_add(*jso, "branches", jso2);
+    if (json_object_object_add(*jso, "branches", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -1323,14 +1469,18 @@ ifapi_json_TPMT_POLICYELEMENT_serialize(const TPMT_POLICYELEMENT *in,
     r = ifapi_json_TPMI_POLICYTYPE_serialize(in->type, &jso2);
     return_if_error(r, "Serialize TPMI_POLICYTYPE");
 
-    json_object_object_add(*jso, "type", jso2);
+    if (json_object_object_add(*jso, "type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     if (in->policyDigests.count > 0) {
         jso2 = NULL;
         r = ifapi_json_TPML_DIGEST_VALUES_serialize(&in->policyDigests, &jso2);
         return_if_error(r, "Serialize TPML_DIGEST_VALUES");
 
-        json_object_object_add(*jso, "policyDigests", jso2);
+        if (json_object_object_add(*jso, "policyDigests", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     r = ifapi_json_TPMU_POLICYELEMENT_serialize(&in->element, in->type, jso);
     return_if_error(r, "Serialize TPMU_POLICYELEMENT");
@@ -1366,7 +1516,9 @@ ifapi_json_TPML_POLICYELEMENTS_serialize(const TPML_POLICYELEMENTS *in,
         r = ifapi_json_TPMT_POLICYELEMENT_serialize(&in->elements[i], &jso2);
         return_if_error(r, "Serialize TPMT_POLICYELEMENT");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1395,24 +1547,32 @@ ifapi_json_TPMS_POLICY_serialize(const TPMS_POLICY *in,
     r = ifapi_json_char_serialize(in->description, &jso2);
     return_if_error(r, "Serialize char");
 
-    json_object_object_add(*jso, "description", jso2);
+    if (json_object_object_add(*jso, "description", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPML_DIGEST_VALUES_serialize(&in->policyDigests, &jso2);
     return_if_error(r, "Serialize TPML_DIGEST_VALUES");
 
-    json_object_object_add(*jso, "policyDigests", jso2);
+    if (json_object_object_add(*jso, "policyDigests", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->policyAuthorizations) {
         jso2 = NULL;
         r = ifapi_json_TPML_POLICYAUTHORIZATIONS_serialize(in->policyAuthorizations,
                 &jso2);
         return_if_error(r, "Serialize TPML_POLICYAUTHORIZATIONS");
 
-        json_object_object_add(*jso, "policyAuthorizations", jso2);
+        if (json_object_object_add(*jso, "policyAuthorizations", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso2 = NULL;
     r = ifapi_json_TPML_POLICYELEMENTS_serialize(in->policy, &jso2);
     return_if_error(r, "Serialize TPML_POLICYELEMENTS");
 
-    json_object_object_add(*jso, "policy", jso2);
+    if (json_object_object_add(*jso, "policy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-fapi/tpm_json_serialize.c
+++ b/src/tss2-fapi/tpm_json_serialize.c
@@ -71,7 +71,9 @@ ifapi_json_pcr_select_serialize(
         if (pcrSelect[i2 / 8] & (BYTE)(1 << (i2 % 8))) {
             jso2 = json_object_new_int(i2);
             return_if_null(jso2, "Out of memory.", TSS2_FAPI_RC_MEMORY);
-            json_object_array_add(*jso, jso2);
+            if (json_object_array_add(*jso, jso2)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         }
     }
     return TSS2_RC_SUCCESS;
@@ -119,12 +121,16 @@ ifapi_json_TPMS_PCR_SELECTION_serialize(const TPMS_PCR_SELECTION *in,
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hash, &jso2);
     return_if_error(r, "Serialize pcr selection");
 
-    json_object_object_add(*jso, "hash", jso2);
+    if (json_object_object_add(*jso, "hash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_pcr_select_serialize(in->sizeofSelect, &in->pcrSelect[0], &jso2);
     return_if_error(r, "Serialize pcr selection");
 
-    json_object_object_add(*jso, "pcrSelect", jso2);
+    if (json_object_object_add(*jso, "pcrSelect", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -147,12 +153,16 @@ ifapi_json_TPMS_TAGGED_PCR_SELECT_serialize(const TPMS_TAGGED_PCR_SELECT *in,
     r = ifapi_json_TPM2_PT_PCR_serialize(in->tag, &jso2);
     return_if_error(r, "Serialize pcr selection");
 
-    json_object_object_add(*jso, "tag", jso2);
+    if (json_object_object_add(*jso, "tag", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_pcr_select_serialize(in->sizeofSelect, &in->pcrSelect[0], &jso2);
     return_if_error(r, "Serialize pcr selection");
 
-    json_object_object_add(*jso, "pcrSelect", jso2);
+    if (json_object_object_add(*jso, "pcrSelect", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -174,12 +184,16 @@ ifapi_json_TPMS_TAGGED_POLICY_serialize(const TPMS_TAGGED_POLICY *in, json_objec
     r = ifapi_json_TPM2_HANDLE_serialize(in->handle, &jso2);
     return_if_error(r, "Serialize tagged policy");
 
-    json_object_object_add(*jso, "handle", jso2);
+    if (json_object_object_add(*jso, "handle", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMT_HA_serialize(&in->policyHash, &jso2);
     return_if_error(r, "Serialize tagged policy");
 
-    json_object_object_add(*jso, "policyHash", jso2);
+    if (json_object_object_add(*jso, "policyHash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -201,17 +215,23 @@ ifapi_json_TPMS_ACT_DATA_serialize(const TPMS_ACT_DATA *in, json_object **jso)
     r = ifapi_json_TPM2_HANDLE_serialize(in->handle, &jso2);
     return_if_error(r, "Serialize act data");
 
-    json_object_object_add(*jso, "handle", jso2);
+    if (json_object_object_add(*jso, "handle", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->timeout, &jso2);
     return_if_error(r, "Serialize act data");
 
-    json_object_object_add(*jso, "timeout", jso2);
+    if (json_object_object_add(*jso, "timeout", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMA_ACT_serialize(in->attributes, &jso2);
     return_if_error(r, "Serialize act data");
 
-    json_object_object_add(*jso, "attributes", jso2);
+    if (json_object_object_add(*jso, "attributes", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -307,8 +327,12 @@ ifapi_json_UINT64_serialize(UINT64 in, json_object **jso)
     if (!*jso) json_object_put(jso2);
     return_if_null(*jso, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_array_add(*jso, jso1);
-    json_object_array_add(*jso, jso2);
+    if (json_object_array_add(*jso, jso1)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_array_add(*jso, jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -877,7 +901,9 @@ ifapi_json_TPMA_ALGORITHM_serialize(const TPMA_ALGORITHM in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -922,7 +948,9 @@ ifapi_json_TPMA_OBJECT_serialize(const TPMA_OBJECT in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -963,13 +991,17 @@ ifapi_json_TPMA_LOCALITY_serialize(const TPMA_LOCALITY in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso_bit_idx = json_object_new_int64((TPMA_LOCALITY_EXTENDED_MASK & input) >>
                                          5);
     return_if_null(jso_bit_idx, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(*jso, "Extended", jso_bit_idx);
+    if (json_object_object_add(*jso, "Extended", jso_bit_idx)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -1009,22 +1041,30 @@ ifapi_json_TPMA_CC_serialize(const TPMA_CC in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     jso_bit_idx = json_object_new_int64((TPMA_CC_COMMANDINDEX_MASK & input) >> 0);
     return_if_null(jso_bit_idx, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(*jso, "commandIndex", jso_bit_idx);
+    if (json_object_object_add(*jso, "commandIndex", jso_bit_idx)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_bit_idx = json_object_new_int64((TPMA_CC_CHANDLES_MASK & input) >> 25);
     return_if_null(jso_bit_idx, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(*jso, "cHandles", jso_bit_idx);
+    if (json_object_object_add(*jso, "cHandles", jso_bit_idx)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso_bit_idx = json_object_new_int64((TPMA_CC_RES_MASK & input) >> 30);
     return_if_null(jso_bit_idx, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-    json_object_object_add(*jso, "Res", jso_bit_idx);
+    if (json_object_object_add(*jso, "Res", jso_bit_idx)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -1062,7 +1102,9 @@ ifapi_json_TPMA_ACT_serialize(const TPMA_ACT in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1315,13 +1357,17 @@ ifapi_json_TPMT_HA_serialize(const TPMT_HA *in, json_object **jso)
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->hashAlg != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_HA_serialize(&in->digest, in->hashAlg, &jso2);
         return_if_error(r, "Serialize TPMU_HA");
 
-        json_object_object_add(*jso, "digest", jso2);
+        if (json_object_object_add(*jso, "digest", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1532,17 +1578,23 @@ ifapi_json_TPMT_TK_CREATION_serialize(const TPMT_TK_CREATION *in, json_object **
     r = ifapi_json_TPM2_ST_serialize(in->tag, &jso2);
     return_if_error(r, "Serialize TPM2_ST");
 
-    json_object_object_add(*jso, "tag", jso2);
+    if (json_object_object_add(*jso, "tag", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_RH_HIERARCHY_serialize(in->hierarchy, &jso2);
     return_if_error(r, "Serialize TPMI_RH_HIERARCHY");
 
-    json_object_object_add(*jso, "hierarchy", jso2);
+    if (json_object_object_add(*jso, "hierarchy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->digest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "digest", jso2);
+    if (json_object_object_add(*jso, "digest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -1576,12 +1628,16 @@ ifapi_json_TPMS_ALG_PROPERTY_serialize(const TPMS_ALG_PROPERTY *in, json_object 
     r = ifapi_json_TPM2_ALG_ID_serialize(in->alg, &jso2);
     return_if_error(r, "Serialize TPM2_ALG_ID");
 
-    json_object_object_add(*jso, "alg", jso2);
+    if (json_object_object_add(*jso, "alg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMA_ALGORITHM_serialize(in->algProperties, &jso2);
     return_if_error(r, "Serialize TPMA_ALGORITHM");
 
-    json_object_object_add(*jso, "algProperties", jso2);
+    if (json_object_object_add(*jso, "algProperties", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -1607,12 +1663,16 @@ ifapi_json_TPMS_TAGGED_PROPERTY_serialize(const TPMS_TAGGED_PROPERTY *in, json_o
     r = ifapi_json_TPM2_PT_serialize(in->property, &jso2);
     return_if_error(r, "Serialize TPM2_PT");
 
-    json_object_object_add(*jso, "property", jso2);
+    if (json_object_object_add(*jso, "property", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->value, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "value", jso2);
+    if (json_object_object_add(*jso, "value", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -1644,7 +1704,9 @@ ifapi_json_TPML_CC_serialize(const TPML_CC *in, json_object **jso)
         r = ifapi_json_TPM2_CC_serialize (in->commandCodes[i], &jso2);
         return_if_error(r, "Serialize TPM2_CC");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1677,7 +1739,9 @@ ifapi_json_TPML_CCA_serialize(const TPML_CCA *in, json_object **jso)
         r = ifapi_json_TPMA_CC_serialize (in->commandAttributes[i], &jso2);
         return_if_error(r, "Serialize TPMA_CC");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1710,7 +1774,9 @@ ifapi_json_TPML_HANDLE_serialize(const TPML_HANDLE *in, json_object **jso)
         r = ifapi_json_TPM2_HANDLE_serialize (in->handle[i], &jso2);
         return_if_error(r, "Serialize TPM2_HANDLE");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1743,7 +1809,9 @@ ifapi_json_TPML_DIGEST_VALUES_serialize(const TPML_DIGEST_VALUES *in, json_objec
         r = ifapi_json_TPMT_HA_serialize (&in->digests[i], &jso2);
         return_if_error(r, "Serialize TPMT_HA");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1776,7 +1844,9 @@ ifapi_json_TPML_PCR_SELECTION_serialize(const TPML_PCR_SELECTION *in, json_objec
         r = ifapi_json_TPMS_PCR_SELECTION_serialize (&in->pcrSelections[i], &jso2);
         return_if_error(r, "Serialize TPMS_PCR_SELECTION");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1809,7 +1879,9 @@ ifapi_json_TPML_ALG_PROPERTY_serialize(const TPML_ALG_PROPERTY *in, json_object 
         r = ifapi_json_TPMS_ALG_PROPERTY_serialize (&in->algProperties[i], &jso2);
         return_if_error(r, "Serialize TPMS_ALG_PROPERTY");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1842,7 +1914,9 @@ ifapi_json_TPML_TAGGED_TPM_PROPERTY_serialize(const TPML_TAGGED_TPM_PROPERTY *in
         r = ifapi_json_TPMS_TAGGED_PROPERTY_serialize (&in->tpmProperty[i], &jso2);
         return_if_error(r, "Serialize TPMS_TAGGED_PROPERTY");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1875,7 +1949,9 @@ ifapi_json_TPML_TAGGED_PCR_PROPERTY_serialize(const TPML_TAGGED_PCR_PROPERTY *in
         r = ifapi_json_TPMS_TAGGED_PCR_SELECT_serialize (&in->pcrProperty[i], &jso2);
         return_if_error(r, "Serialize TPMS_TAGGED_PCR_SELECT");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1908,7 +1984,9 @@ ifapi_json_TPML_ECC_CURVE_serialize(const TPML_ECC_CURVE *in, json_object **jso)
         r = ifapi_json_TPM2_ECC_CURVE_serialize (in->eccCurves[i], &jso2);
         return_if_error(r, "Serialize TPM2_ECC_CURVE");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1941,7 +2019,9 @@ ifapi_json_TPML_TAGGED_POLICY_serialize(const TPML_TAGGED_POLICY *in, json_objec
         r = ifapi_json_TPMS_TAGGED_POLICY_serialize (&in->policies[i], &jso2);
         return_if_error(r, "Serialize TPMS_TAGGED_POLICY");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -1974,7 +2054,9 @@ ifapi_json_TPML_ACT_DATA_serialize(const TPML_ACT_DATA *in, json_object **jso)
         r = ifapi_json_TPMS_ACT_DATA_serialize(&in->actData[i], &jso2);
         return_if_error(r, "Serialize TPMS_ACT_DATA");
 
-        json_object_array_add(*jso, jso2);
+        if (json_object_array_add(*jso, jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -2045,12 +2127,16 @@ ifapi_json_TPMS_CAPABILITY_DATA_serialize(const TPMS_CAPABILITY_DATA *in, json_o
     r = ifapi_json_TPM2_CAP_serialize(in->capability, &jso2);
     return_if_error(r, "Serialize TPM2_CAP");
 
-    json_object_object_add(*jso, "capability", jso2);
+    if (json_object_object_add(*jso, "capability", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_CAPABILITIES_serialize(&in->data, in->capability, &jso2);
     return_if_error(r,"Serialize TPMU_CAPABILITIES");
 
-    json_object_object_add(*jso, "data", jso2);
+    if (json_object_object_add(*jso, "data", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2076,22 +2162,30 @@ ifapi_json_TPMS_CLOCK_INFO_serialize(const TPMS_CLOCK_INFO *in, json_object **js
     r = ifapi_json_UINT64_serialize(in->clock, &jso2);
     return_if_error(r, "Serialize UINT64");
 
-    json_object_object_add(*jso, "clock", jso2);
+    if (json_object_object_add(*jso, "clock", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->resetCount, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "resetCount", jso2);
+    if (json_object_object_add(*jso, "resetCount", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->restartCount, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "restartCount", jso2);
+    if (json_object_object_add(*jso, "restartCount", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_YES_NO_serialize(in->safe, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "safe", jso2);
+    if (json_object_object_add(*jso, "safe", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2117,12 +2211,16 @@ ifapi_json_TPMS_TIME_INFO_serialize(const TPMS_TIME_INFO *in, json_object **jso)
     r = ifapi_json_UINT64_serialize(in->time, &jso2);
     return_if_error(r, "Serialize UINT64");
 
-    json_object_object_add(*jso, "time", jso2);
+    if (json_object_object_add(*jso, "time", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMS_CLOCK_INFO_serialize(&in->clockInfo, &jso2);
     return_if_error(r, "Serialize TPMS_CLOCK_INFO");
 
-    json_object_object_add(*jso, "clockInfo", jso2);
+    if (json_object_object_add(*jso, "clockInfo", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2148,12 +2246,16 @@ ifapi_json_TPMS_TIME_ATTEST_INFO_serialize(const TPMS_TIME_ATTEST_INFO *in, json
     r = ifapi_json_TPMS_TIME_INFO_serialize(&in->time, &jso2);
     return_if_error(r, "Serialize TPMS_TIME_INFO");
 
-    json_object_object_add(*jso, "time", jso2);
+    if (json_object_object_add(*jso, "time", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT64_serialize(in->firmwareVersion, &jso2);
     return_if_error(r, "Serialize UINT64");
 
-    json_object_object_add(*jso, "firmwareVersion", jso2);
+    if (json_object_object_add(*jso, "firmwareVersion", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2179,12 +2281,16 @@ ifapi_json_TPMS_CERTIFY_INFO_serialize(const TPMS_CERTIFY_INFO *in, json_object 
     r = ifapi_json_TPM2B_NAME_serialize(&in->name, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "name", jso2);
+    if (json_object_object_add(*jso, "name", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->qualifiedName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "qualifiedName", jso2);
+    if (json_object_object_add(*jso, "qualifiedName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2210,12 +2316,16 @@ ifapi_json_TPMS_QUOTE_INFO_serialize(const TPMS_QUOTE_INFO *in, json_object **js
     r = ifapi_json_TPML_PCR_SELECTION_serialize(&in->pcrSelect, &jso2);
     return_if_error(r, "Serialize TPML_PCR_SELECTION");
 
-    json_object_object_add(*jso, "pcrSelect", jso2);
+    if (json_object_object_add(*jso, "pcrSelect", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->pcrDigest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "pcrDigest", jso2);
+    if (json_object_object_add(*jso, "pcrDigest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2241,22 +2351,30 @@ ifapi_json_TPMS_COMMAND_AUDIT_INFO_serialize(const TPMS_COMMAND_AUDIT_INFO *in, 
     r = ifapi_json_UINT64_serialize(in->auditCounter, &jso2);
     return_if_error(r, "Serialize UINT64");
 
-    json_object_object_add(*jso, "auditCounter", jso2);
+    if (json_object_object_add(*jso, "auditCounter", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2_ALG_ID_serialize(in->digestAlg, &jso2);
     return_if_error(r, "Serialize TPM2_ALG_ID");
 
-    json_object_object_add(*jso, "digestAlg", jso2);
+    if (json_object_object_add(*jso, "digestAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->auditDigest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "auditDigest", jso2);
+    if (json_object_object_add(*jso, "auditDigest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->commandDigest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "commandDigest", jso2);
+    if (json_object_object_add(*jso, "commandDigest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2282,12 +2400,16 @@ ifapi_json_TPMS_SESSION_AUDIT_INFO_serialize(const TPMS_SESSION_AUDIT_INFO *in, 
     r = ifapi_json_TPMI_YES_NO_serialize(in->exclusiveSession, &jso2);
     return_if_error(r, "Serialize TPMI_YES_NO");
 
-    json_object_object_add(*jso, "exclusiveSession", jso2);
+    if (json_object_object_add(*jso, "exclusiveSession", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->sessionDigest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "sessionDigest", jso2);
+    if (json_object_object_add(*jso, "sessionDigest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2313,12 +2435,16 @@ ifapi_json_TPMS_CREATION_INFO_serialize(const TPMS_CREATION_INFO *in, json_objec
     r = ifapi_json_TPM2B_NAME_serialize(&in->objectName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "objectName", jso2);
+    if (json_object_object_add(*jso, "objectName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->creationHash, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "creationHash", jso2);
+    if (json_object_object_add(*jso, "creationHash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2344,17 +2470,23 @@ ifapi_json_TPMS_NV_CERTIFY_INFO_serialize(const TPMS_NV_CERTIFY_INFO *in, json_o
     r = ifapi_json_TPM2B_NAME_serialize(&in->indexName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "indexName", jso2);
+    if (json_object_object_add(*jso, "indexName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT16_serialize(in->offset, &jso2);
     return_if_error(r, "Serialize UINT16");
 
-    json_object_object_add(*jso, "offset", jso2);
+    if (json_object_object_add(*jso, "offset", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_MAX_NV_BUFFER_serialize(&in->nvContents, &jso2);
     return_if_error(r, "Serialize TPM2B_MAX_NV_BUFFER");
 
-    json_object_object_add(*jso, "nvContents", jso2);
+    if (json_object_object_add(*jso, "nvContents", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2433,37 +2565,51 @@ ifapi_json_TPMS_ATTEST_serialize(const TPMS_ATTEST *in, json_object **jso)
     r = ifapi_json_TPM2_GENERATED_serialize(in->magic, &jso2);
     return_if_error(r, "Serialize TPM2_GENERATED");
 
-    json_object_object_add(*jso, "magic", jso2);
+    if (json_object_object_add(*jso, "magic", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_ST_ATTEST_serialize(in->type, &jso2);
     return_if_error(r, "Serialize TPMI_ST_ATTEST");
 
-    json_object_object_add(*jso, "type", jso2);
+    if (json_object_object_add(*jso, "type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->qualifiedSigner, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "qualifiedSigner", jso2);
+    if (json_object_object_add(*jso, "qualifiedSigner", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DATA_serialize(&in->extraData, &jso2);
     return_if_error(r, "Serialize TPM2B_DATA");
 
-    json_object_object_add(*jso, "extraData", jso2);
+    if (json_object_object_add(*jso, "extraData", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMS_CLOCK_INFO_serialize(&in->clockInfo, &jso2);
     return_if_error(r, "Serialize TPMS_CLOCK_INFO");
 
-    json_object_object_add(*jso, "clockInfo", jso2);
+    if (json_object_object_add(*jso, "clockInfo", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT64_serialize(in->firmwareVersion, &jso2);
     return_if_error(r, "Serialize UINT64");
 
-    json_object_object_add(*jso, "firmwareVersion", jso2);
+    if (json_object_object_add(*jso, "firmwareVersion", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_ATTEST_serialize(&in->attested, in->type, &jso2);
     return_if_error(r,"Serialize TPMU_ATTEST");
 
-    json_object_object_add(*jso, "attested", jso2);
+    if (json_object_object_add(*jso, "attested", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2594,20 +2740,26 @@ ifapi_json_TPMT_SYM_DEF_OBJECT_serialize(const TPMT_SYM_DEF_OBJECT *in, json_obj
     r = ifapi_json_TPMI_ALG_SYM_OBJECT_serialize(in->algorithm, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_SYM_OBJECT");
 
-    json_object_object_add(*jso, "algorithm", jso2);
+    if (json_object_object_add(*jso, "algorithm", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->algorithm != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_SYM_KEY_BITS_serialize(&in->keyBits, in->algorithm, &jso2);
         return_if_error(r,"Serialize TPMU_SYM_KEY_BITS");
 
-        json_object_object_add(*jso, "keyBits", jso2);
+        if (json_object_object_add(*jso, "keyBits", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     if (in->algorithm != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_SYM_MODE_serialize(&in->mode, in->algorithm, &jso2);
         return_if_error(r,"Serialize TPMU_SYM_MODE");
 
-        json_object_object_add(*jso, "mode", jso2);
+        if (json_object_object_add(*jso, "mode", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -2634,7 +2786,9 @@ ifapi_json_TPMS_SYMCIPHER_PARMS_serialize(const TPMS_SYMCIPHER_PARMS *in, json_o
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_serialize(&in->sym, &jso2);
     return_if_error(r, "Serialize TPMT_SYM_DEF_OBJECT");
 
-    json_object_object_add(*jso, "sym", jso2);
+    if (json_object_object_add(*jso, "sym", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2660,7 +2814,9 @@ ifapi_json_TPMS_SCHEME_HASH_serialize(const TPMS_SCHEME_HASH *in, json_object **
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2686,12 +2842,16 @@ ifapi_json_TPMS_SCHEME_ECDAA_serialize(const TPMS_SCHEME_ECDAA *in, json_object 
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT16_serialize(in->count, &jso2);
     return_if_error(r, "Serialize UINT16");
 
-    json_object_object_add(*jso, "count", jso2);
+    if (json_object_object_add(*jso, "count", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2747,12 +2907,16 @@ ifapi_json_TPMS_SCHEME_XOR_serialize(const TPMS_SCHEME_XOR *in, json_object **js
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hashAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hashAlg", jso2);
+    if (json_object_object_add(*jso, "hashAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_ALG_KDF_serialize(in->kdf, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_KDF");
 
-    json_object_object_add(*jso, "kdf", jso2);
+    if (json_object_object_add(*jso, "kdf", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -2804,13 +2968,17 @@ ifapi_json_TPMT_KEYEDHASH_SCHEME_serialize(const TPMT_KEYEDHASH_SCHEME *in, json
     r = ifapi_json_TPMI_ALG_KEYEDHASH_SCHEME_serialize(in->scheme, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_KEYEDHASH_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->scheme != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_SCHEME_KEYEDHASH_serialize(&in->details, in->scheme, &jso2);
         return_if_error(r,"Serialize TPMU_SCHEME_KEYEDHASH");
 
-        json_object_object_add(*jso, "details", jso2);
+        if (json_object_object_add(*jso, "details", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -2963,13 +3131,17 @@ ifapi_json_TPMT_SIG_SCHEME_serialize(const TPMT_SIG_SCHEME *in, json_object **js
     r = ifapi_json_TPMI_ALG_SIG_SCHEME_serialize(in->scheme, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_SIG_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->scheme != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_SIG_SCHEME_serialize(&in->details, in->scheme, &jso2);
         return_if_error(r,"Serialize TPMU_SIG_SCHEME");
 
-        json_object_object_add(*jso, "details", jso2);
+        if (json_object_object_add(*jso, "details", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -3113,13 +3285,17 @@ ifapi_json_TPMT_KDF_SCHEME_serialize(const TPMT_KDF_SCHEME *in, json_object **js
     r = ifapi_json_TPMI_ALG_KDF_serialize(in->scheme, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_KDF");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->scheme != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_KDF_SCHEME_serialize(&in->details, in->scheme, &jso2);
         return_if_error(r,"Serialize TPMU_KDF_SCHEME");
 
-        json_object_object_add(*jso, "details", jso2);
+        if (json_object_object_add(*jso, "details", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -3219,13 +3395,17 @@ ifapi_json_TPMT_RSA_SCHEME_serialize(const TPMT_RSA_SCHEME *in, json_object **js
     r = ifapi_json_TPMI_ALG_RSA_SCHEME_serialize(in->scheme, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_RSA_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->scheme != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_ASYM_SCHEME_serialize(&in->details, in->scheme, &jso2);
         return_if_error(r,"Serialize TPMU_ASYM_SCHEME");
 
-        json_object_object_add(*jso, "details", jso2);
+        if (json_object_object_add(*jso, "details", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -3328,12 +3508,16 @@ ifapi_json_TPMS_ECC_POINT_serialize(const TPMS_ECC_POINT *in, json_object **jso)
     r = ifapi_json_TPM2B_ECC_PARAMETER_serialize(&in->x, &jso2);
     return_if_error(r, "Serialize TPM2B_ECC_PARAMETER");
 
-    json_object_object_add(*jso, "x", jso2);
+    if (json_object_object_add(*jso, "x", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_ECC_PARAMETER_serialize(&in->y, &jso2);
     return_if_error(r, "Serialize TPM2B_ECC_PARAMETER");
 
-    json_object_object_add(*jso, "y", jso2);
+    if (json_object_object_add(*jso, "y", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3390,13 +3574,17 @@ ifapi_json_TPMT_ECC_SCHEME_serialize(const TPMT_ECC_SCHEME *in, json_object **js
     r = ifapi_json_TPMI_ALG_ECC_SCHEME_serialize(in->scheme, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_ECC_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->scheme != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_ASYM_SCHEME_serialize(&in->details, in->scheme, &jso2);
         return_if_error(r,"Serialize TPMU_ASYM_SCHEME");
 
-        json_object_object_add(*jso, "details", jso2);
+        if (json_object_object_add(*jso, "details", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -3423,12 +3611,16 @@ ifapi_json_TPMS_SIGNATURE_RSA_serialize(const TPMS_SIGNATURE_RSA *in, json_objec
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hash, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hash", jso2);
+    if (json_object_object_add(*jso, "hash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_PUBLIC_KEY_RSA_serialize(&in->sig, &jso2);
     return_if_error(r, "Serialize TPM2B_PUBLIC_KEY_RSA");
 
-    json_object_object_add(*jso, "sig", jso2);
+    if (json_object_object_add(*jso, "sig", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3484,17 +3676,23 @@ ifapi_json_TPMS_SIGNATURE_ECC_serialize(const TPMS_SIGNATURE_ECC *in, json_objec
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->hash, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "hash", jso2);
+    if (json_object_object_add(*jso, "hash", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_ECC_PARAMETER_serialize(&in->signatureR, &jso2);
     return_if_error(r, "Serialize TPM2B_ECC_PARAMETER");
 
-    json_object_object_add(*jso, "signatureR", jso2);
+    if (json_object_object_add(*jso, "signatureR", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_ECC_PARAMETER_serialize(&in->signatureS, &jso2);
     return_if_error(r, "Serialize TPM2B_ECC_PARAMETER");
 
-    json_object_object_add(*jso, "signatureS", jso2);
+    if (json_object_object_add(*jso, "signatureS", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3616,13 +3814,17 @@ ifapi_json_TPMT_SIGNATURE_serialize(const TPMT_SIGNATURE *in, json_object **jso)
     r = ifapi_json_TPMI_ALG_SIG_SCHEME_serialize(in->sigAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_SIG_SCHEME");
 
-    json_object_object_add(*jso, "sigAlg", jso2);
+    if (json_object_object_add(*jso, "sigAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     if (in->sigAlg != TPM2_ALG_NULL) {
         json_object *jso2 = NULL;
         r = ifapi_json_TPMU_SIGNATURE_serialize(&in->signature, in->sigAlg, &jso2);
         return_if_error(r,"Serialize TPMU_SIGNATURE");
 
-        json_object_object_add(*jso, "signature", jso2);
+        if (json_object_object_add(*jso, "signature", jso2)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     return TSS2_RC_SUCCESS;
 }
@@ -3725,7 +3927,9 @@ ifapi_json_TPMS_KEYEDHASH_PARMS_serialize(const TPMS_KEYEDHASH_PARMS *in, json_o
     r = ifapi_json_TPMT_KEYEDHASH_SCHEME_serialize(&in->scheme, &jso2);
     return_if_error(r, "Serialize TPMT_KEYEDHASH_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3751,22 +3955,30 @@ ifapi_json_TPMS_RSA_PARMS_serialize(const TPMS_RSA_PARMS *in, json_object **jso)
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_serialize(&in->symmetric, &jso2);
     return_if_error(r, "Serialize TPMT_SYM_DEF_OBJECT");
 
-    json_object_object_add(*jso, "symmetric", jso2);
+    if (json_object_object_add(*jso, "symmetric", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMT_RSA_SCHEME_serialize(&in->scheme, &jso2);
     return_if_error(r, "Serialize TPMT_RSA_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_RSA_KEY_BITS_serialize(in->keyBits, &jso2);
     return_if_error(r, "Serialize TPMI_RSA_KEY_BITS");
 
-    json_object_object_add(*jso, "keyBits", jso2);
+    if (json_object_object_add(*jso, "keyBits", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT32_serialize(in->exponent, &jso2);
     return_if_error(r, "Serialize UINT32");
 
-    json_object_object_add(*jso, "exponent", jso2);
+    if (json_object_object_add(*jso, "exponent", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3792,22 +4004,30 @@ ifapi_json_TPMS_ECC_PARMS_serialize(const TPMS_ECC_PARMS *in, json_object **jso)
     r = ifapi_json_TPMT_SYM_DEF_OBJECT_serialize(&in->symmetric, &jso2);
     return_if_error(r, "Serialize TPMT_SYM_DEF_OBJECT");
 
-    json_object_object_add(*jso, "symmetric", jso2);
+    if (json_object_object_add(*jso, "symmetric", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMT_ECC_SCHEME_serialize(&in->scheme, &jso2);
     return_if_error(r, "Serialize TPMT_ECC_SCHEME");
 
-    json_object_object_add(*jso, "scheme", jso2);
+    if (json_object_object_add(*jso, "scheme", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_ECC_CURVE_serialize(in->curveID, &jso2);
     return_if_error(r, "Serialize TPMI_ECC_CURVE");
 
-    json_object_object_add(*jso, "curveID", jso2);
+    if (json_object_object_add(*jso, "curveID", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMT_KDF_SCHEME_serialize(&in->kdf, &jso2);
     return_if_error(r, "Serialize TPMT_KDF_SCHEME");
 
-    json_object_object_add(*jso, "kdf", jso2);
+    if (json_object_object_add(*jso, "kdf", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3863,32 +4083,44 @@ ifapi_json_TPMT_PUBLIC_serialize(const TPMT_PUBLIC *in, json_object **jso)
     r = ifapi_json_TPMI_ALG_PUBLIC_serialize(in->type, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_PUBLIC");
 
-    json_object_object_add(*jso, "type", jso2);
+    if (json_object_object_add(*jso, "type", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->nameAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "nameAlg", jso2);
+    if (json_object_object_add(*jso, "nameAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMA_OBJECT_serialize(in->objectAttributes, &jso2);
     return_if_error(r, "Serialize TPMA_OBJECT");
 
-    json_object_object_add(*jso, "objectAttributes", jso2);
+    if (json_object_object_add(*jso, "objectAttributes", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->authPolicy, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "authPolicy", jso2);
+    if (json_object_object_add(*jso, "authPolicy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_PUBLIC_PARMS_serialize(&in->parameters, in->type, &jso2);
     return_if_error(r,"Serialize TPMU_PUBLIC_PARMS");
 
-    json_object_object_add(*jso, "parameters", jso2);
+    if (json_object_object_add(*jso, "parameters", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMU_PUBLIC_ID_serialize(&in->unique, in->type, &jso2);
     return_if_error(r,"Serialize TPMU_PUBLIC_ID");
 
-    json_object_object_add(*jso, "unique", jso2);
+    if (json_object_object_add(*jso, "unique", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -3914,13 +4146,17 @@ ifapi_json_TPM2B_PUBLIC_serialize(const TPM2B_PUBLIC *in, json_object **jso)
     if (ifapi_json_UINT16_serialize(in->size, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "size", jso2);
+    if (json_object_object_add(*jso, "size", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     if (ifapi_json_TPMT_PUBLIC_serialize(&in->publicArea, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "publicArea", jso2);
+    if (json_object_object_add(*jso, "publicArea", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -4038,14 +4274,18 @@ ifapi_json_TPMA_NV_serialize(const TPMA_NV in, json_object **jso)
             jso_bit = json_object_new_int(0);
         return_if_null(jso_bit, "Out of memory.", TSS2_FAPI_RC_MEMORY);
 
-        json_object_object_add(*jso, tab[i].name, jso_bit);
+        if (json_object_object_add(*jso, tab[i].name, jso_bit)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
     TPM2_NT input2 = (TPMA_NV_TPM2_NT_MASK & input)>>4;
     json_object *jso2 = NULL;
     TSS2_RC r = ifapi_json_TPM2_NT_serialize(input2, &jso2);
     return_if_error(r, "Bad value");
 
-    json_object_object_add(*jso, "TPM2_NT", jso2);
+    if (json_object_object_add(*jso, "TPM2_NT", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -4072,27 +4312,37 @@ ifapi_json_TPMS_NV_PUBLIC_serialize(const TPMS_NV_PUBLIC *in, json_object **jso)
     r = ifapi_json_TPMI_RH_NV_INDEX_serialize(in->nvIndex, &jso2);
     return_if_error(r, "Serialize TPMI_RH_NV_INDEX");
 
-    json_object_object_add(*jso, "nvIndex", jso2);
+    if (json_object_object_add(*jso, "nvIndex", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMI_ALG_HASH_serialize(in->nameAlg, &jso2);
     return_if_error(r, "Serialize TPMI_ALG_HASH");
 
-    json_object_object_add(*jso, "nameAlg", jso2);
+    if (json_object_object_add(*jso, "nameAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMA_NV_serialize(in->attributes, &jso2);
     return_if_error(r, "Serialize TPMA_NV");
 
-    json_object_object_add(*jso, "attributes", jso2);
+    if (json_object_object_add(*jso, "attributes", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->authPolicy, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "authPolicy", jso2);
+    if (json_object_object_add(*jso, "authPolicy", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_UINT16_serialize(in->dataSize, &jso2);
     return_if_error(r, "Serialize UINT16");
 
-    json_object_object_add(*jso, "dataSize", jso2);
+    if (json_object_object_add(*jso, "dataSize", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -4118,13 +4368,17 @@ ifapi_json_TPM2B_NV_PUBLIC_serialize(const TPM2B_NV_PUBLIC *in, json_object **js
     if (ifapi_json_UINT16_serialize(in->size, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "size", jso2);
+    if (json_object_object_add(*jso, "size", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     if (ifapi_json_TPMS_NV_PUBLIC_serialize(&in->nvPublic, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "nvPublic", jso2);
+    if (json_object_object_add(*jso, "nvPublic", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }
@@ -4151,37 +4405,51 @@ ifapi_json_TPMS_CREATION_DATA_serialize(const TPMS_CREATION_DATA *in, json_objec
     r = ifapi_json_TPML_PCR_SELECTION_serialize(&in->pcrSelect, &jso2);
     return_if_error(r, "Serialize TPML_PCR_SELECTION");
 
-    json_object_object_add(*jso, "pcrSelect", jso2);
+    if (json_object_object_add(*jso, "pcrSelect", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DIGEST_serialize(&in->pcrDigest, &jso2);
     return_if_error(r, "Serialize TPM2B_DIGEST");
 
-    json_object_object_add(*jso, "pcrDigest", jso2);
+    if (json_object_object_add(*jso, "pcrDigest", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPMA_LOCALITY_serialize(in->locality, &jso2);
     return_if_error(r, "Serialize TPMA_LOCALITY");
 
-    json_object_object_add(*jso, "locality", jso2);
+    if (json_object_object_add(*jso, "locality", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2_ALG_ID_serialize(in->parentNameAlg, &jso2);
     return_if_error(r, "Serialize TPM2_ALG_ID");
 
-    json_object_object_add(*jso, "parentNameAlg", jso2);
+    if (json_object_object_add(*jso, "parentNameAlg", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->parentName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "parentName", jso2);
+    if (json_object_object_add(*jso, "parentName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_NAME_serialize(&in->parentQualifiedName, &jso2);
     return_if_error(r, "Serialize TPM2B_NAME");
 
-    json_object_object_add(*jso, "parentQualifiedName", jso2);
+    if (json_object_object_add(*jso, "parentQualifiedName", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     jso2 = NULL;
     r = ifapi_json_TPM2B_DATA_serialize(&in->outsideInfo, &jso2);
     return_if_error(r, "Serialize TPM2B_DATA");
 
-    json_object_object_add(*jso, "outsideInfo", jso2);
+    if (json_object_object_add(*jso, "outsideInfo", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
     return TSS2_RC_SUCCESS;
 }
 
@@ -4207,13 +4475,17 @@ ifapi_json_TPM2B_CREATION_DATA_serialize(const TPM2B_CREATION_DATA *in, json_obj
     if (ifapi_json_UINT16_serialize(in->size, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "size", jso2);
+    if (json_object_object_add(*jso, "size", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     jso2 = NULL;
     if (ifapi_json_TPMS_CREATION_DATA_serialize(&in->creationData, &jso2))
         return TSS2_FAPI_RC_BAD_VALUE;
 
-    json_object_object_add(*jso, "creationData", jso2);
+    if (json_object_object_add(*jso, "creationData", jso2)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     return TSS2_RC_SUCCESS;
 }

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -184,8 +184,12 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
     jso = json_object_new_object();
     goto_if_null2(jso, "Out of memory", r, TSS2_FAPI_RC_MEMORY, error);
 
-    json_object_object_add(jso, "public", publicblobHex_jso);
-    json_object_object_add(jso, "private", privateblobHex_jso);
+    if (json_object_object_add(jso, "public", publicblobHex_jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(jso, "private", privateblobHex_jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     const char * jso_string = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PRETTY);
 

--- a/test/integration/fapi-key-create2-sign.int.c
+++ b/test/integration/fapi-key-create2-sign.int.c
@@ -322,8 +322,12 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context)
     jso = json_object_new_object();
     goto_if_null2(jso, "Out of memory", r, TSS2_FAPI_RC_MEMORY, error);
 
-    json_object_object_add(jso, "public", publicblobHex_jso);
-    json_object_object_add(jso, "private", privateblobHex_jso);
+    if (json_object_object_add(jso, "public", publicblobHex_jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
+    if (json_object_object_add(jso, "private", privateblobHex_jso)) {
+        return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+    }
 
     const char * jso_string = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PRETTY);
 


### PR DESCRIPTION
It was not checked whether the return code is equal 0 for the functions json_object_array_add and json_object_object_add.