### PR TITLE
ci: remove ubuntu 18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-22.04, alpine-3.15]
+        docker_image: [ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-22.04, alpine-3.15]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
@@ -117,7 +117,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-18.04
+          DOCKER_IMAGE: ubuntu-20.04
           ENABLE_COVERAGE: true
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure
@@ -159,7 +159,7 @@ jobs:
           REPO_BRANCH: ${{ github.ref }}
           REPO_NAME: ${{ github.repository }}
           ENABLE_COVERITY: true
-          DOCKER_IMAGE: ubuntu-18.04
+          DOCKER_IMAGE: ubuntu-20.04
           CC: gcc
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SUBMISSION_EMAIL: tadeusz.struk@intel.com

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -178,6 +178,12 @@ $ sudo udevadm control --reload-rules && sudo udevadm trigger
 If this doesn't work on your distro please consult your distro's
 documentation for UDEVADM(8).
 
+Users who should have access to the TPM and the FAPI keystore should be
+included in the tss group.
+​```
+ sudo usermod -aG tss <username>
+ ```
+
 ## ldconfig
 
 It may be necessary to run ldconfig (as root) to update the run-time
@@ -249,3 +255,12 @@ for cortex-m4:
         LDFLAGS='--specs=nosys.specs'
 make
 ```
+
+## Test operating systems in the CI
+
+* ubuntu-20.04
+* fedora-32
+* opensuse-leap
+* ubuntu-22.04
+* alpine-3.15
+* FreeBSD

--- a/Makefile.am
+++ b/Makefile.am
@@ -999,12 +999,11 @@ uninstall-local:
 clean-hook:
 	-rm -r -f $(top_builddir)/ca
 
-check-hook:
-	-rm -r -f $(top_builddir)/ca
-
 prepare-check:
 if INIT_CA
 	$(top_srcdir)/script/ekca/init_ca.sh $(top_builddir)
+	@echo "Build CI in:" 1>&2
+	@echo $(top_builddir) 1>&2
 endif
 
 check: prepare-check

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -946,7 +946,10 @@ load_intermed_cert_and_key(const char *ca_key_path, EVP_PKEY **ca_key,
     /* Load the intermediate certificate */
     bio = BIO_new(BIO_s_file());
     if (!bio || !BIO_read_filename(bio, ca_cert_path)) {
-        LOG_ERROR("Failure in BIO_read_filename %s", ca_cert_path);
+        unsigned long err = ERR_get_error();
+        char err_buffer[256];
+        ERR_error_string_n(err, err_buffer, sizeof(err_buffer));
+        LOG_ERROR("Failure in BIO_read_filename %s", err_buffer);
         goto error_cleanup;
     }
     *ca_crt = PEM_read_bio_X509(bio, NULL, NULL, NULL);
@@ -959,7 +962,10 @@ load_intermed_cert_and_key(const char *ca_key_path, EVP_PKEY **ca_key,
     /* Load the intermediate key. */
     bio = BIO_new(BIO_s_file());
     if (!bio  || !BIO_read_filename(bio, ca_key_path)) {
-        LOG_ERROR("Failure in BIO_read_filename %s", ca_key_path);
+        unsigned long err = ERR_get_error();
+        char err_buffer[256];
+        ERR_error_string_n(err, err_buffer, sizeof(err_buffer));
+        LOG_ERROR("Failure in BIO_read_filename %s", err_buffer);
         goto error_cleanup;
     }
     *ca_key = PEM_read_bio_PrivateKey(bio, NULL, pass_cb, NULL);


### PR DESCRIPTION
* Error messages for the FAPI tests are improved.
* Ubuntu 18.04 will no longer be supported.
* INSTALL.md includes a list of operating systemes in the CI.