### PR TITLE
aux_util: fix missing format specifier

### DIFF
--- a/src/util/aux_util.h
+++ b/src/util/aux_util.h
@@ -10,6 +10,7 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <inttypes.h>
 #include "tss2_tpm2_types.h"
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes: ./src/util/aux_util.h:22:40: error: expected ')' before 'PRIx32'