### PR TITLE
FAPI: Fix Fapi_Quote errors.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Quote.c
+++ b/src/tss2-fapi/api/Fapi_Quote.c
@@ -427,7 +427,7 @@ Fapi_Quote_Finish(
 
             /* Return the key's certificate if requested. */
             if (certificate) {
-                strdup_check(*certificate, sig_key_object->misc.key.certificate, r, error_cleanup);
+                strdup_check(command->certificate, sig_key_object->misc.key.certificate, r, error_cleanup);
             }
 
             /* If the pcrLog was not requested, the operation is done. */
@@ -460,6 +460,8 @@ Fapi_Quote_Finish(
 
             if (pcrLog)
                 *pcrLog = command->pcrLog;
+            if (certificate)
+                *certificate = command->certificate;
             *signature = command->signature;
             *signatureSize = command->signatureSize;
             break;
@@ -474,6 +476,8 @@ error_cleanup:
     SAFE_FREE(command->keyPath);
     SAFE_FREE(command->pcrList);
     if (r) {
+        SAFE_FREE(command->certificate);
+        SAFE_FREE(command->quoteInfo);
         SAFE_FREE(command->pcrLog);
         SAFE_FREE(command->signature);
     }

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -292,7 +292,8 @@ typedef struct {
     uint32_t const *hashAlgs;
     uint32_t *hashAlgs2;
     size_t numHashAlgs;
-    char    const *quoteInfo;
+    char const *quoteInfo;
+    char *certificate;
     TPM2B_ATTEST *tpm_quoted;
     TPMT_SIGNATURE *tpm_signature;
     uint8_t *signature;

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -2233,7 +2233,7 @@ ifapi_calculate_pcrs(
                 }
             }
         }
-        if (i_evt == n_events && quote_digest) {
+        if (n_events > 0 && i_evt == n_events && quote_digest) {
             /* Quote digest was not found. */
             r = TSS2_FAPI_RC_SIGNATURE_VERIFICATION_FAILED;
         }
@@ -2242,7 +2242,9 @@ ifapi_calculate_pcrs(
 error_cleanup:
     if (cryptoContext)
         ifapi_crypto_hash_abort(&cryptoContext);
-    ifapi_cleanup_event(&event);
+    if (n_events > 0) {
+        ifapi_cleanup_event(&event);
+    }
     return r;
 }
 


### PR DESCRIPTION
* Invalid free was executed when the event list is empty.
* QuoteInfo was not freed in error cases.
* Initialization of certificate was moved to last state of state machine.