### PR TITLE
readthedocs: Add configuration key build to the readthedocs yaml file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,10 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 sphinx:
   builder: html
   configuration: sphinx/conf.py


### PR DESCRIPTION
To fix the error "Config validation error in build.os. Value build not found".