### PR TITLE
FAPI Test: Fix check with self signed certificate.

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -404,7 +404,6 @@ FAPI_TESTS_INTEGRATION = \
     test/integration/fapi-policy-or-nv-read-write.fint \
     test/integration/fapi-second-provisioning.fint \
     test/integration/fapi-provisioning-error.fint \
-    test/integration/fapi-provisioning-cert-error.fint \
     test/integration/fapi-info.fint \
     test/integration/fapi-unseal.fint \
     test/integration/fapi-unseal-persistent.fint
@@ -434,7 +433,8 @@ FAPI_TESTS_INTEGRATION += \
     test/integration/fapi-quote-destructive-eventlog.fint \
     test/integration/fapi-quote-destructive-eventlog-pc-client.fint \
 	test/integration/fapi-provisioning-with-template.fint \
-	test/integration/fapi-provisioning-with-template-rsa.fint
+	test/integration/fapi-provisioning-with-template-rsa.fint \
+    test/integration/fapi-provisioning-cert-error.fint
 
 endif #!TESTDEVICE
 

--- a/test/integration/fapi-provisioning-cert-error.int.c
+++ b/test/integration/fapi-provisioning-cert-error.int.c
@@ -40,10 +40,9 @@ test_fapi_test_provisioning_cert_error(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
 
-#ifndef SELF_SIGNED_CERTIFICATE
+#if !defined(SELF_SIGNED_CERTIFICATE) || defined(FAPI_TEST_EK_CERT_LESS)
     return EXIT_SKIP;
 #endif
-
 
     setenv("FAPI_TEST_ROOT_CERT", "self", 1);
     setenv("FAPI_TEST_INT_CERT",  "./ca/root-ca/root-ca.cert.pem", 1);


### PR DESCRIPTION
* The test is now skipped if no ek_cert_less is set.
* The test is moved to the tests without device.