### PR TITLE
ESYS: Remove dead code from change auth functions.

### DIFF
--- a/src/tss2-esys/api/Esys_NV_ChangeAuth.c
+++ b/src/tss2-esys/api/Esys_NV_ChangeAuth.c
@@ -194,8 +194,7 @@ Esys_NV_ChangeAuth_Async(
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_NV_ChangeAuth_Prepare(esysContext->sys,
-                                       (nvIndexNode == NULL) ? TPM2_RH_NULL
-                                        : nvIndexNode->rsrc.handle, newAuth);
+                                       nvIndexNode->rsrc.handle, newAuth);
     return_state_if_error(r, _ESYS_STATE_INIT, "SAPI Prepare returned error.");
 
     /* Calculate the cpHash Values */

--- a/src/tss2-esys/api/Esys_ObjectChangeAuth.c
+++ b/src/tss2-esys/api/Esys_ObjectChangeAuth.c
@@ -194,9 +194,7 @@ Esys_ObjectChangeAuth_Async(
 
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_ObjectChangeAuth_Prepare(esysContext->sys,
-                                          (objectHandleNode == NULL)
-                                           ? TPM2_RH_NULL
-                                           : objectHandleNode->rsrc.handle,
+                                          objectHandleNode->rsrc.handle,
                                           (parentHandleNode == NULL)
                                            ? TPM2_RH_NULL
                                            : parentHandleNode->rsrc.handle,


### PR DESCRIPTION
The check whether the esys object exists was not needed in the sys prepare call.