### PR TITLE
unit tests: fix pointer casts on 32 bit systems.

### DIFF
--- a/test/unit/esys-vendor.c
+++ b/test/unit/esys-vendor.c
@@ -128,7 +128,8 @@ static TSS2_RC tcti_fake_recv(
     UNUSED(tctiContext);
     UNUSED(timeout);
 
-    const char *id = (const char*)mock();
+    /* Use size_t to cast 64 bit number to pointer (needed for 32 bit systems) */
+    const char *id = (const char*)(size_t)mock();
 
     get_response(id, response, size);
     return TSS2_RC_SUCCESS;

--- a/test/unit/tcti-spidev.c
+++ b/test/unit/tcti-spidev.c
@@ -108,8 +108,10 @@ int __wrap_ioctl(int fd, unsigned long request, struct spi_ioc_transfer *tr)
     assert_int_equal(tr->bits_per_word, 8);
 
     size_t len = tr->len;
-    uint8_t *tx_buf = (uint8_t *) tr->tx_buf;
-    uint8_t *rx_buf = (uint8_t *) tr->rx_buf;
+
+    /* Use size_t to cast 64 bit number to pointer (needed for 32 bit systems) */
+    uint8_t *tx_buf = (uint8_t *)(size_t) tr->tx_buf;
+    uint8_t *rx_buf = (uint8_t *)(size_t) tr->rx_buf;
 
     static tpm_state_t tpm_state = TPM_DID_VID_HEAD;
 


### PR DESCRIPTION
Conversions of max uint64 numbers to pointers did produce compile errors on 32bit systems. A cast to size_t is now added before the casting to a pointer.