### PR TITLE
FAPI: Add new profiles P_RSA3072SHA384 P_ECCP384SHA384

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -707,7 +707,9 @@ tpm2-tss-fapi.conf: dist/tmpfiles.d/tpm2-tss-fapi.conf.in
 
 fapiprofilesdir = @sysconfdir@/tpm2-tss/fapi-profiles
 fapiprofiles_DATA = dist/fapi-profiles/P_RSA2048SHA256.json \
-                    dist/fapi-profiles/P_ECCP256SHA256.json
+                    dist/fapi-profiles/P_ECCP256SHA256.json \
+                    dist/fapi-profiles/P_RSA3072SHA384.json \
+                    dist/fapi-profiles/P_ECCP384SHA384.json
 
 libtss2_fapi = src/tss2-fapi/libtss2-fapi.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_fapi.h
@@ -717,6 +719,8 @@ EXTRA_DIST +=  \
     dist/fapi-config.json.in \
     dist/fapi-profiles/P_RSA2048SHA256.json \
     dist/fapi-profiles/P_ECCP256SHA256.json \
+    dist/fapi-profiles/P_RSA3072SHA384.json \
+    dist/fapi-profiles/P_ECCP384SHA384.json \
     dist/sysusers.d/tpm2-tss.conf \
     dist/tmpfiles.d/tpm2-tss-fapi.conf.in \
     doc/fapi-config.md \

--- a/dist/fapi-profiles/P_ECCP256SHA256.json
+++ b/dist/fapi-profiles/P_ECCP256SHA256.json
@@ -10,7 +10,7 @@
         "scheme":"TPM2_ALG_ECDSA",
         "details":{
             "hashAlg":"TPM2_ALG_SHA256"
-        },
+        }
     },
     "sym_mode":"TPM2_ALG_CFB",
     "sym_parameters": {
@@ -21,7 +21,7 @@
     "sym_block_size": 16,
     "pcr_selection": [
        { "hash": "TPM2_ALG_SHA1",
-         "pcrSelect": [ ],
+         "pcrSelect": [ ]
        },
        { "hash": "TPM2_ALG_SHA256",
          "pcrSelect": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]

--- a/dist/fapi-profiles/P_ECCP384SHA384.json
+++ b/dist/fapi-profiles/P_ECCP384SHA384.json
@@ -1,0 +1,99 @@
+{
+    "type": "TPM2_ALG_ECC",
+    "nameAlg":"TPM2_ALG_SHA384",
+    "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
+    "srk_persistent": 0,
+    "ek_template":  "system,restricted,decrypt,user",
+    "ek_description": "Endorsement key EK",
+    "ecc_signing_scheme": {
+        "scheme":"TPM2_ALG_ECDSA",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        }
+    },
+    "sym_mode":"TPM2_ALG_CFB",
+    "sym_parameters": {
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "sym_block_size": 16,
+    "pcr_selection": [
+       { "hash": "TPM2_ALG_SHA1",
+         "pcrSelect": [ ]
+       },
+       { "hash": "TPM2_ALG_SHA256",
+         "pcrSelect": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+       }
+    ],
+    "curveID": "TPM2_ECC_NIST_P384",
+    "session_symmetric":{
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "ek_policy": {
+        "description": "Endorsement hierarchy used for policy secret.",
+        "policy":[
+            {
+                "type": "PolicyOR",
+                "branches": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"POLICYSECRET",
+                                "objectName": "4000000b"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "B",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"AUTHORIZENV",
+                                "nvPublic": {
+				    "size": 60,
+				    "nvPublic": {
+                                        "nvIndex": 29392642,
+                                        "nameAlg":"SHA384",
+                                        "attributes":{
+                                          "PPWRITE":0,
+                                          "OWNERWRITE":0,
+                                          "AUTHWRITE":0,
+                                          "POLICYWRITE":1,
+                                          "POLICY_DELETE":0,
+                                          "WRITELOCKED":0,
+                                          "WRITEALL":1,
+                                          "WRITEDEFINE":0,
+                                          "WRITE_STCLEAR":0,
+                                          "GLOBALLOCK":0,
+                                          "PPREAD":1,
+                                          "OWNERREAD":1,
+                                          "AUTHREAD":1,
+                                          "POLICYREAD":1,
+                                          "NO_DA":1,
+                                          "ORDERLY":0,
+                                          "CLEAR_STCLEAR":0,
+                                          "READLOCKED":0,
+                                          "WRITTEN":1,
+                                          "PLATFORMCREATE":0,
+                                          "READ_STCLEAR":0,
+                                          "TPM2_NT":"ORDINARY"
+                                        },
+                                        "authPolicy":"8bbf2266537c171cb56e403c4dc1d4b64f432611dc386e6f532050c3278c930e143e8bb1133824ccb431053871c6db53",
+                                        "dataSize":50
+				    }
+	                        }
+
+                           }
+		        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/dist/fapi-profiles/P_RSA2048SHA256.json
+++ b/dist/fapi-profiles/P_RSA2048SHA256.json
@@ -35,7 +35,6 @@
     ],
     "exponent": 0,
     "keyBits": 2048,
-    "session_hash_alg": "TPM2_ALG_SHA256",
     "session_symmetric":{
         "algorithm":"TPM2_ALG_AES",
         "keyBits":"128",

--- a/dist/fapi-profiles/P_RSA3072SHA384.json
+++ b/dist/fapi-profiles/P_RSA3072SHA384.json
@@ -1,0 +1,107 @@
+{
+    "type": "TPM2_ALG_RSA",
+    "nameAlg":"TPM2_ALG_SHA384",
+    "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
+    "srk_persistent": 1,
+    "ek_template":  "system,restricted,decrypt,user",
+    "ek_description": "Endorsement key EK",
+    "rsa_signing_scheme": {
+        "scheme":"TPM2_ALG_RSAPSS",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        }
+    },
+    "rsa_decrypt_scheme": {
+        "scheme":"TPM2_ALG_OAEP",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        }
+    },
+    "sym_mode":"TPM2_ALG_CFB",
+    "sym_parameters": {
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "sym_block_size": 16,
+    "pcr_selection": [
+        { "hash": "TPM2_ALG_SHA1",
+          "pcrSelect": [ ]
+        },
+        { "hash": "TPM2_ALG_SHA256",
+          "pcrSelect": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+        }
+    ],
+    "exponent": 0,
+    "keyBits": 3072,
+    "session_symmetric":{
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "ek_policy": {
+        "description": "Endorsement hierarchy used for policy secret.",
+        "policy":[
+            {
+                "type": "PolicyOR",
+                "branches": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"POLICYSECRET",
+                                "objectName": "4000000b"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "B",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"AUTHORIZENV",
+                                "nvPublic": {
+				    "size": 60,
+				    "nvPublic": {
+                                        "nvIndex": 29392642,
+                                        "nameAlg":"SHA384",
+                                        "attributes":{
+                                          "PPWRITE":0,
+                                          "OWNERWRITE":0,
+                                          "AUTHWRITE":0,
+                                          "POLICYWRITE":1,
+                                          "POLICY_DELETE":0,
+                                          "WRITELOCKED":0,
+                                          "WRITEALL":1,
+                                          "WRITEDEFINE":0,
+                                          "WRITE_STCLEAR":0,
+                                          "GLOBALLOCK":0,
+                                          "PPREAD":1,
+                                          "OWNERREAD":1,
+                                          "AUTHREAD":1,
+                                          "POLICYREAD":1,
+                                          "NO_DA":1,
+                                          "ORDERLY":0,
+                                          "CLEAR_STCLEAR":0,
+                                          "READLOCKED":0,
+                                          "WRITTEN":1,
+                                          "PLATFORMCREATE":0,
+                                          "READ_STCLEAR":0,
+                                          "TPM2_NT":"ORDINARY"
+                                        },
+                                        "authPolicy":"8bbf2266537c171cb56e403c4dc1d4b64f432611dc386e6f532050c3278c930e143e8bb1133824ccb431053871c6db53",
+                                        "dataSize":50
+				    }
+	                        }
+
+                           }
+		        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+}

--- a/src/tss2-fapi/api/Fapi_Encrypt.c
+++ b/src/tss2-fapi/api/Fapi_Encrypt.c
@@ -435,7 +435,8 @@ Fapi_Encrypt_Finish(
 
 error_cleanup:
     /* Cleanup any intermediate results and state stored in the context. */
-    if (command->key_handle != ESYS_TR_NONE)
+    if (command->key_handle != ESYS_TR_NONE &&
+        command->key_object && !command->key_object->misc.key.persistent_handle)
         Esys_FlushContext(context->esys,  command->key_handle);
     if (r)
         SAFE_FREE(command->cipherText);

--- a/src/tss2-fapi/api/Fapi_ExportKey.c
+++ b/src/tss2-fapi/api/Fapi_ExportKey.c
@@ -430,6 +430,8 @@ Fapi_ExportKey_Finish(
             return_try_again(r);
             goto_if_error(r, "Flush key", cleanup);
 
+            command->key_object->public.handle = ESYS_TR_NONE;
+
             fallthrough;
 
         statecase(context->state, EXPORT_KEY_WAIT_FOR_FLUSH2);
@@ -437,6 +439,8 @@ Fapi_ExportKey_Finish(
             r = ifapi_flush_object(context, command->handle_ext_key);
             return_try_again(r);
             goto_if_error(r, "Flush key", cleanup);
+
+            command->handle_ext_key = ESYS_TR_NONE;
 
             fallthrough;
 

--- a/src/tss2-fapi/api/Fapi_GetEsysBlob.c
+++ b/src/tss2-fapi/api/Fapi_GetEsysBlob.c
@@ -337,10 +337,6 @@ Fapi_GetEsysBlob_Finish(
             SAFE_FREE(key_context);
             goto_if_error(r, "Marshaling context", error_cleanup);
 
-            /* Cleanup policy session if an error did occur. */
-            ifapi_flush_policy_session(context, context->policy.session, r);
-            goto_if_error(r, "Cleanup policy session", error_cleanup);
-
             /* Flush current object used for blob computation. */
             if (!key_object->misc.key.persistent_handle) {
                 r = Esys_FlushContext_Async(context->esys, key_object->public.handle);

--- a/src/tss2-fapi/api/Fapi_Import.c
+++ b/src/tss2-fapi/api/Fapi_Import.c
@@ -652,6 +652,8 @@ Fapi_Import_Finish(
             if (!command->parent_object->misc.key.persistent_handle) {
                 r = ifapi_flush_object(context, command->parent_object->public.handle);
                 return_try_again(r);
+
+                command->parent_object->public.handle = ESYS_TR_NONE;
                 ifapi_cleanup_ifapi_object(command->parent_object);
                 goto_if_error(r, "Flush key", error_cleanup);
             } else {

--- a/src/tss2-fapi/api/Fapi_NvExtend.c
+++ b/src/tss2-fapi/api/Fapi_NvExtend.c
@@ -410,7 +410,9 @@ Fapi_NvExtend_Finish(
             /* libjson-c does not deliver an array if array has only one element */
             if (jsoType != json_type_array) {
                 json_object *jsonArray = json_object_new_array();
-                json_object_array_add(jsonArray, command->jso_event_log);
+                if (json_object_array_add(jsonArray, command->jso_event_log)) {
+                    return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+                }
                 command->jso_event_log = jsonArray;
             }
         } else {
@@ -423,7 +425,9 @@ Fapi_NvExtend_Finish(
         r = ifapi_json_IFAPI_EVENT_serialize(&command->pcr_event, &jso);
         goto_if_error(r, "Error serialize event", error_cleanup);
 
-        json_object_array_add(command->jso_event_log, jso);
+        if (json_object_array_add(command->jso_event_log, jso)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
         SAFE_FREE(object->misc.nv.event_log);
         strdup_check(object->misc.nv.event_log,
             json_object_to_json_string_ext(command->jso_event_log,

--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -240,6 +240,7 @@ typedef struct {
     TPM2B_AUTH auth;            /**< The Password */
     IFAPI_NV nv_obj;            /**< The NV Object */
     ESYS_TR auth_index;         /**< The ESAPI handle of the authorization object */
+    ESYS_TR auth_session;       /**< The autorization session for a nv object */
     uint64_t bitmap;            /**< The bitmask for the SetBits command */
     IFAPI_NV_TEMPLATE public_templ; /**< The template for nv creation, adjusted
                                          appropriate by the passed flags */

--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -1156,7 +1156,6 @@ ifapi_session_init(FAPI_CONTEXT *context)
 
     context->session1 = ESYS_TR_NONE;
     context->session2 = ESYS_TR_NONE;
-    context->policy.session = ESYS_TR_NONE;
     context->srk_handle = ESYS_TR_NONE;
     return TSS2_RC_SUCCESS;
 }
@@ -1185,7 +1184,6 @@ ifapi_non_tpm_mode_init(FAPI_CONTEXT *context)
 
     context->session1 = ESYS_TR_NONE;
     context->session2 = ESYS_TR_NONE;
-    context->policy.session = ESYS_TR_NONE;
     context->srk_handle = ESYS_TR_NONE;
     return TSS2_RC_SUCCESS;
 }
@@ -1200,9 +1198,6 @@ ifapi_non_tpm_mode_init(FAPI_CONTEXT *context)
 void
 ifapi_session_clean(FAPI_CONTEXT *context)
 {
-    if (context->policy_session && context->policy_session != ESYS_TR_NONE) {
-        Esys_FlushContext(context->esys, context->policy_session);
-    }
     if (context->session1 != ESYS_TR_NONE && context->session1 != ESYS_TR_PASSWORD) {
         if (context->session1 == context->session2) {
             context->session2 = ESYS_TR_NONE;
@@ -1246,7 +1241,6 @@ ifapi_cleanup_session(FAPI_CONTEXT *context)
     TSS2_RC r;
 
     /* Policy sessions were closed after successful execution. */
-    context->policy_session = ESYS_TR_NONE;
 
     switch (context->cleanup_state) {
         statecase(context->cleanup_state, CLEANUP_INIT);
@@ -2096,27 +2090,6 @@ get_name_alg(FAPI_CONTEXT *context, IFAPI_OBJECT *object)
     }
 }
 
-/** Check whether policy session has to be flushed.
- *
- * Policy sessions with cleared continue session flag are not flushed in error
- * cases. Therefore the return code will be checked and if a policy session was
- * used the session will be flushed if the command was not executed successfully.
- *
- * @param[in,out] context for storing all state information.
- * @param[in] session the session to be checked whether flush is needed.
- * @param[in] r The return code of the command using the session.
- */
-void
-ifapi_flush_policy_session(FAPI_CONTEXT *context, ESYS_TR session, TSS2_RC r)
-{
-    if (session != context->session1) {
-        /* A policy session was used instead auf the default session. */
-        if (r != TSS2_RC_SUCCESS) {
-            Esys_FlushContext(context->esys, session);
-        }
-    }
-}
-
 /** State machine to authorize a key, a NV object of a hierarchy.
  *
  * @param[in,out] context for storing all state information.
@@ -2229,6 +2202,7 @@ ifapi_authorize_object(FAPI_CONTEXT *context, IFAPI_OBJECT *object, ESYS_TR *ses
 error:
     /* No policy call was executed session can be flushed */
     Esys_FlushContext(context->esys, *session);
+    *session = ESYS_TR_NONE;
     return r;
 }
 
@@ -2370,6 +2344,8 @@ ifapi_nv_write(
         r = ifapi_authorize_object(context, auth_object, &auth_session);
         FAPI_SYNC(r, "Authorize NV object.", error_cleanup);
 
+        context->nv_cmd.auth_session = auth_session;
+
         /* Prepare the writing to NV ram. */
         r = Esys_NV_Write_Async(context->esys,
                                 context->nv_cmd.auth_index,
@@ -2409,11 +2385,8 @@ ifapi_nv_write(
                 r = Esys_NV_Write_Async(context->esys,
                                         context->nv_cmd.auth_index,
                                         nv_index,
-                                        (!context->policy.session
-                                         || context->policy.session == ESYS_TR_NONE) ? context->session1 :
-                                        context->policy.session,
-                                        (context->policy.session && context->policy.session != ESYS_TR_NONE) ?
-                                        context->session2 : ESYS_TR_NONE,
+                                        context->nv_cmd.auth_session,
+                                        ENC_SESSION_IF_POLICY(context->nv_cmd.auth_session),
                                         ESYS_TR_NONE,
                                         aux_data,
                                         context->nv_cmd.data_idx);
@@ -2975,9 +2948,7 @@ ifapi_key_sign(
         context->Key_Sign.handle = sig_key_object->public.handle;
 
         r = ifapi_authorize_object(context, sig_key_object, &session);
-        FAPI_SYNC(r, "Authorize signature key.", cleanup);
-
-        context->policy.session = session;
+        return_try_again(r);
 
         r = ifapi_get_sig_scheme(context, sig_key_object, padding, digest, &sig_scheme);
         goto_if_error(r, "Get signature scheme", cleanup);
@@ -3000,7 +2971,6 @@ ifapi_key_sign(
                              &context->Key_Sign.signature);
         return_try_again(r);
         context->session2 = ESYS_TR_NONE;
-        ifapi_flush_policy_session(context, context->policy.session, r);
         goto_if_error(r, "Error: Sign", cleanup);
 
         /* Prepare the flushing of the signing key. */
@@ -3717,6 +3687,8 @@ ifapi_key_create(
             r = ifapi_flush_object(context, context->loadKey.handle);
             return_try_again(r);
             goto_if_error(r, "Flush key", error_cleanup);
+
+            context->loadKey.handle = ESYS_TR_NONE;
         }
 
         fallthrough;
@@ -4891,6 +4863,8 @@ ifapi_create_primary(
         r = ifapi_flush_object(context, context->cmd.Key_Create.handle);
         return_try_again(r);
         goto_if_error(r, "Flush key", error_cleanup);
+
+        context->cmd.Key_Create.handle = ESYS_TR_NONE;
 
         fallthrough;
 

--- a/src/tss2-fapi/fapi_util.h
+++ b/src/tss2-fapi/fapi_util.h
@@ -125,12 +125,6 @@ ifapi_nv_read(
     uint8_t     **data,
     size_t       *size);
 
-void
-ifapi_flush_policy_session(
-    FAPI_CONTEXT *context,
-    ESYS_TR session,
-    TSS2_RC r);
-
 TSS2_RC
 ifapi_nv_write(
     FAPI_CONTEXT *context,

--- a/src/tss2-fapi/ifapi_eventlog.c
+++ b/src/tss2-fapi/ifapi_eventlog.c
@@ -123,7 +123,9 @@ ifapi_eventlog_get_async(
             r = ifapi_json_IFAPI_EVENT_serialize(&cel_event, &jso);
             goto_if_error(r, "Error serialize event", error);
 
-            json_object_array_add(eventlog->log, jso);
+            if (json_object_array_add(eventlog->log, jso)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         }
     }
 
@@ -155,7 +157,9 @@ ifapi_eventlog_get_async(
             r = ifapi_json_IFAPI_EVENT_serialize(&cel_event, &jso);
             goto_if_error(r, "Error serialize event", error);
 
-            json_object_array_add(eventlog->log, jso);
+            if (json_object_array_add(eventlog->log, jso)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         }
     }
     if (eventlog->ima_log_file) {
@@ -286,7 +290,9 @@ loop:
         json_type jso_type = json_object_get_type(logpart);
         if (jso_type != json_type_array) {
             /* libjson-c does not deliver an array if array has only one element */
-            json_object_array_add(eventlog->log, logpart);
+            if (json_object_array_add(eventlog->log, logpart)) {
+                return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+            }
         } else {
             /* Iterate through the array of logpart and add each item to the eventlog */
             /* The return type of json_object_array_length() was changed, thus the case */
@@ -294,7 +300,9 @@ loop:
                 jso_event = json_object_array_get_idx(logpart, i);
                 /* Increment the refcount of event so it does not get freed on put(logpart) below */
                 json_object_get(jso_event);
-                json_object_array_add(eventlog->log, jso_event);
+                if (json_object_array_add(eventlog->log, jso_event)) {
+                    return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+                }
             }
             json_object_put(logpart);
         }
@@ -365,7 +373,9 @@ ifapi_eventlog_append_check(
             json_type jso_type = json_object_get_type(eventlog->log);
             if (jso_type != json_type_array) {
                 json_object *json_array = json_object_new_array();
-                json_object_array_add(json_array, eventlog->log);
+                if (json_object_array_add(json_array, eventlog->log)) {
+                    return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+                }
                 eventlog->log = json_array;
             }
         } else {
@@ -444,7 +454,9 @@ ifapi_eventlog_append_finish(
             goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Error serializing event data", error_cleanup);
         }
 
-        json_object_array_add(eventlog->log, event);
+        if (json_object_array_add(eventlog->log, event)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
         logstr2 = json_object_to_json_string_ext(eventlog->log, JSON_C_TO_STRING_PRETTY);
 
         /* Construct the filename for the eventlog file */

--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -574,8 +574,10 @@ cleanup:
     SAFE_FREE(current_policy->buffer);
     SAFE_FREE(current_policy->pem_key);
     /* In error cases object might not have been flushed. */
-    if (current_policy->object_handle != ESYS_TR_NONE)
+    if (current_policy->object_handle != ESYS_TR_NONE)  {
         Esys_FlushContext(esys_ctx, current_policy->object_handle);
+        current_policy->object_handle = ESYS_TR_NONE;
+    }
     return r;
 }
 
@@ -745,9 +747,10 @@ execute_policy_authorize(
     }
 cleanup:
     /* In error cases object might not have been flushed. */
-    if (current_policy->object_handle != ESYS_TR_NONE)
+    if (current_policy->object_handle != ESYS_TR_NONE) {
         Esys_FlushContext(esys_ctx, current_policy->object_handle);
-
+        current_policy->object_handle = ESYS_TR_NONE;
+    }
     return r;
 }
 
@@ -955,6 +958,7 @@ execute_policy_secret(
     statecase(current_policy->state, POLICY_FLUSH_KEY);
         r = Esys_FlushContext_Finish(esys_ctx);
         try_again_or_error(r, "Flush key finish.");
+        current_policy->auth_handle = ESYS_TR_NONE;
         current_policy->state = POLICY_EXECUTE_INIT;
         break;
 
@@ -964,8 +968,9 @@ execute_policy_secret(
     return r;
 
  cleanup:
-    if (current_policy->flush_handle) {
+    if (current_policy->flush_handle && current_policy->auth_handle != ESYS_TR_NONE) {
          Esys_FlushContext(esys_ctx, current_policy->auth_handle);
+         current_policy->auth_handle = ESYS_TR_NONE;
     }
     SAFE_FREE(current_policy->nonceTPM);
     return r;
@@ -1907,7 +1912,6 @@ ifapi_policyeval_execute(
         if (r != TSS2_RC_SUCCESS) {
             if (do_flush) {
                 Esys_FlushContext(esys_ctx, current_policy->session);
-                current_policy->session = ESYS_TR_NONE;
             }
             ifapi_free_node_list(current_policy->policy_elements);
 

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -3578,7 +3578,7 @@ ifapi_json_TPMI_RSA_KEY_BITS_deserialize(json_object *jso,
         TPMI_RSA_KEY_BITS *out)
 {
     SUBTYPE_FILTER(TPMI_RSA_KEY_BITS, UINT16,
-        1024, 2048);
+        1024, 2048, 3072, 4096);
 }
 
 /** Deserialize a TPM2B_ECC_PARAMETER json object.

--- a/src/tss2-fapi/tpm_json_serialize.c
+++ b/src/tss2-fapi/tpm_json_serialize.c
@@ -3452,7 +3452,7 @@ ifapi_json_TPM2B_PUBLIC_KEY_RSA_serialize(const TPM2B_PUBLIC_KEY_RSA *in, json_o
 TSS2_RC
 ifapi_json_TPMI_RSA_KEY_BITS_serialize(const TPMI_RSA_KEY_BITS in, json_object **jso)
 {
-    CHECK_IN_LIST(TPMI_RSA_KEY_BITS, in, 1024, 2048);
+    CHECK_IN_LIST(TPMI_RSA_KEY_BITS, in, 1024, 2048, 3072, 4096);
     return ifapi_json_UINT16_serialize(in, jso);
 }
 

--- a/test/data/fapi/P_RSA3072.json
+++ b/test/data/fapi/P_RSA3072.json
@@ -1,0 +1,107 @@
+{
+    "type": "TPM2_ALG_RSA",
+    "nameAlg":"TPM2_ALG_SHA384",
+    "srk_template": "system,restricted,decrypt,0x81000001",
+    "srk_description": "Storage root key SRK",
+    "srk_persistent": 1,
+    "ek_template":  "system,restricted,decrypt,user",
+    "ek_description": "Endorsement key EK",
+    "rsa_signing_scheme": {
+        "scheme":"TPM2_ALG_RSAPSS",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        }
+    },
+    "rsa_decrypt_scheme": {
+        "scheme":"TPM2_ALG_OAEP",
+        "details":{
+            "hashAlg":"TPM2_ALG_SHA384"
+        }
+    },
+    "sym_mode":"TPM2_ALG_CFB",
+    "sym_parameters": {
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "sym_block_size": 16,
+    "pcr_selection": [
+        { "hash": "TPM2_ALG_SHA1",
+          "pcrSelect": [ ]
+        },
+        { "hash": "TPM2_ALG_SHA256",
+          "pcrSelect": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+        }
+    ],
+    "exponent": 0,
+    "keyBits": 3072,
+    "session_symmetric":{
+        "algorithm":"TPM2_ALG_AES",
+        "keyBits":"256",
+        "mode":"TPM2_ALG_CFB"
+    },
+    "ek_policy": {
+        "description": "Endorsement hierarchy used for policy secret.",
+        "policy":[
+            {
+                "type": "PolicyOR",
+                "branches": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"POLICYSECRET",
+                                "objectName": "4000000b"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "B",
+                        "description": "",
+                        "policy": [
+                            {
+                                "type":"AUTHORIZENV",
+                                "nvPublic": {
+				    "size": 60,
+				    "nvPublic": {
+                                        "nvIndex": 29392642,
+                                        "nameAlg":"SHA384",
+                                        "attributes":{
+                                          "PPWRITE":0,
+                                          "OWNERWRITE":0,
+                                          "AUTHWRITE":0,
+                                          "POLICYWRITE":1,
+                                          "POLICY_DELETE":0,
+                                          "WRITELOCKED":0,
+                                          "WRITEALL":1,
+                                          "WRITEDEFINE":0,
+                                          "WRITE_STCLEAR":0,
+                                          "GLOBALLOCK":0,
+                                          "PPREAD":1,
+                                          "OWNERREAD":1,
+                                          "AUTHREAD":1,
+                                          "POLICYREAD":1,
+                                          "NO_DA":1,
+                                          "ORDERLY":0,
+                                          "CLEAR_STCLEAR":0,
+                                          "READLOCKED":0,
+                                          "WRITTEN":1,
+                                          "PLATFORMCREATE":0,
+                                          "READ_STCLEAR":0,
+                                          "TPM2_NT":"ORDINARY"
+                                        },
+                                        "authPolicy":"8bbf2266537c171cb56e403c4dc1d4b64f432611dc386e6f532050c3278c930e143e8bb1133824ccb431053871c6db53",
+                                        "dataSize":50
+				    }
+	                        }
+
+                           }
+		        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+}

--- a/test/integration/fapi-data-crypt.int.c
+++ b/test/integration/fapi-data-crypt.int.c
@@ -96,9 +96,11 @@ signatureCallback(
     UNUSED(publicKey);
     UNUSED(publicKeyHint);
     uint8_t *aux_signature = NULL;
+    size_t profile_len = strlen(FAPI_PROFILE);
 
-    if (strcmp(objectPath, "P_RSA/HS/SRK/myRsaCryptKey") != 0) {
-        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path");
+    if (strcmp(objectPath + profile_len, "/HS/SRK/myRsaCryptKey") ||
+        strncmp(objectPath, "P_RSA", 5))
+        return_error(TSS2_FAPI_RC_BAD_VALUE, "Unexpected path") {
     }
 
     if (userData != userDataTest) {

--- a/test/integration/fapi-get-esys-blobs.int.c
+++ b/test/integration/fapi-get-esys-blobs.int.c
@@ -72,6 +72,7 @@ auth_callback(
  * @param[in,out] context The FAPI_CONTEXT.
  * @retval EXIT_FAILURE
  * @retval EXIT_SUCCESS
+ * @retval EXIT_SKIP
  */
 int
 test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
@@ -89,6 +90,11 @@ test_fapi_get_esys_blobs(FAPI_CONTEXT *context)
     size_t         offset = 0;
     ESYS_TR        esys_handle;
     uint8_t        type;
+
+    if (strncmp(FAPI_PROFILE,"P_ECC", 5)) {
+        LOG_WARNING("Profile %s is no ECC profile.", FAPI_PROFILE);
+        return EXIT_SKIP;
+    }
 
     /* We need to reset the passwords again, in order to not brick physical TPMs */
     r = Fapi_Provision(context, NULL, NULL, NULL);

--- a/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-nv-sign.int.c
@@ -141,7 +141,7 @@ test_fapi_key_create_policy_authorize_nv(FAPI_CONTEXT *context)
         return EXIT_SKIP;
     }
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         if (snprintf(&extended_name[0], 1023, "%s_sha384", POLICY_AUTHORIZE_NV) < 0) {
             LOG_ERROR("snprint failed");
             return EXIT_FAILURE;
@@ -158,7 +158,7 @@ test_fapi_key_create_policy_authorize_nv(FAPI_CONTEXT *context)
 
      if (strcmp(FAPI_PROFILE, "P_ECC") == 0) {
         policy_nv_auth_size = 34;
-    } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         policy_nv_auth_size = 50;
     } else {
         LOG_ERROR("No appropriate policy file exists!");

--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -53,8 +53,8 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
     char *policy_pcr = "/policy/pol_pcr";
-    char *policy_file_pcr;
-    char *policy_file_authorize;
+    char *policy_file_pcr = NULL;
+    char *policy_file_authorize = NULL;
     char *policy_name_authorize = "/policy/pol_authorize";
     // uint8_t policyRef[] = { 1, 2, 3, 4, 5 };
     FILE *stream = NULL;
@@ -72,6 +72,9 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
     } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
         policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json";
         policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json";
+    } else {
+        LOG_ERROR("Invalid profile for ECC test: %s", FAPI_PROFILE);
+        return EXIT_FAILURE;
     }
 #else
     policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json";

--- a/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-pem-sign.int.c
@@ -69,12 +69,12 @@ test_fapi_key_create_policy_authorize_pem_sign(FAPI_CONTEXT *context)
     if (strcmp(FAPI_PROFILE, "P_ECC") == 0) {
         policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem.json";
         policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized.json";
-    } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    } else if (strcmp(FAPI_PROFILE, "P_ECC384" ) == 0) {
         policy_file_authorize = TOP_SOURCEDIR "/test/data/fapi/policy/pol_authorize_ecc_pem_sha384.json";
         policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_ecc_authorized_sha384.json";
     } else {
-        LOG_ERROR("Invalid profile for ECC test: %s", FAPI_PROFILE);
-        return EXIT_FAILURE;
+        LOG_ERROR("Profule can't be used for test: %s", FAPI_PROFILE);
+        return EXIT_SKIP;
     }
 #else
     policy_file_pcr = TOP_SOURCEDIR "/test/data/fapi/policy/pol_pcr16_0_rsa_authorized.json";

--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -281,7 +281,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     ASSERT(policy != NULL);
     LOG_INFO("\nTEST_JSON\nPolicy_sha256:\n%s\nEND_JSON", policy);
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         CHECK_JSON(policy, policy_sha384_check, error);
     } else {
         CHECK_JSON(policy, policy_sha256_check, error);
@@ -296,7 +296,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_ExportPolicy", error);
     ASSERT(policy != NULL);
     LOG_INFO("\nTEST_JSON\nPolicy export1:\n%s\nEND_JSON", policy);
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         CHECK_JSON(policy, policy_sha384_export_check, error)
     } else {
         CHECK_JSON(policy, policy_sha256_export_check, error)
@@ -427,7 +427,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_ExportPolicy", error);
     ASSERT(policy != NULL);
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0){
         CHECK_JSON(policy, policy_sha384_check, error);
     } else {
         CHECK_JSON(policy, policy_sha256_check, error);

--- a/test/integration/fapi-key-create-policy-signed-keyedhash.int.c
+++ b/test/integration/fapi-key-create-policy-signed-keyedhash.int.c
@@ -206,7 +206,7 @@ test_fapi_key_create_policy_signed(FAPI_CONTEXT *context)
     char    *publicKey = NULL;
     char    *certificate = NULL;
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
 	policy_name = "/policy/pol_signed_keyedhash_sha384";
         policy_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_signed_keyedhash_sha384.json";
     } else {

--- a/test/integration/fapi-nv-authorizenv-cphash.int.c
+++ b/test/integration/fapi-nv-authorizenv-cphash.int.c
@@ -96,7 +96,7 @@ test_fapi_nv_authorizenv_cphash(FAPI_CONTEXT *context)
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         policy2_name = "/policy/pol_cphash_sha384";
         policy2_file = TOP_SOURCEDIR "/test/data/fapi/policy/pol_cphash_sha384.json";
         policy_nv_auth_size = 50;

--- a/test/integration/fapi-nv-extend.int.c
+++ b/test/integration/fapi-nv-extend.int.c
@@ -91,7 +91,7 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
     LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
     char *fields_log1[] =  { "0", "digests", "0", "digest" };
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         CHECK_JSON_FIELDS(log, fields_log1,
                           "c8ffec7d7d70c61b16adaab88925a1759b94cf6b50669b04aef1a8427fabb131eafbf9a21e3b8bddd9c5d5e7",
                           error);
@@ -120,7 +120,7 @@ test_fapi_nv_extend(FAPI_CONTEXT *context)
     LOG_INFO("\nTEST_JSON\nLog:\n%s\nEND_JSON", log);
     char *fields_log2[] =  { "1", "digests", "0", "digest" };
 
-    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         CHECK_JSON_FIELDS(log, fields_log2,
                           "c8ffec7d7d70c61b16adaab88925a1759b94cf6b50669b04aef1a8427fabb131eafbf9a21e3b8bddd9c5d5e7",
                           error);

--- a/test/integration/fapi-quote-destructive-eventlog.int.c
+++ b/test/integration/fapi-quote-destructive-eventlog.int.c
@@ -1091,7 +1091,9 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
         jso_duplicate = json_object_get(jso_event);
         goto_if_null(jso_duplicate, "Out of memory.", TSS2_FAPI_RC_MEMORY, error);
 
-        json_object_array_add(jso_log2, jso_duplicate);
+        if (json_object_array_add(jso_log2, jso_duplicate)) {
+            return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
+        }
     }
 
     pcrEventLog2 = strdup(json_object_to_json_string_ext(jso_log2, JSON_C_TO_STRING_PRETTY));

--- a/test/integration/fapi-quote-destructive-eventlog.int.c
+++ b/test/integration/fapi-quote-destructive-eventlog.int.c
@@ -1001,6 +1001,7 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
     size_t i;
     json_object *jso_log = NULL;
     json_object *jso_log2 = NULL;
+    bool sha1_bank_exists;
 
     uint8_t data[EVENT_SIZE] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     size_t signatureSize = 0;
@@ -1009,6 +1010,13 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context)
     #ifdef WORDS_BIGENDIAN
     return EXIT_SKIP;
     #endif
+
+    r = pcr_bank_sha1_exists(context, &sha1_bank_exists);
+    goto_if_error(r, "Test sha1 bank", error);
+
+    if (!sha1_bank_exists) {
+        return EXIT_SKIP;
+    }
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
 

--- a/test/integration/fapi-second-provisioning.int.c
+++ b/test/integration/fapi-second-provisioning.int.c
@@ -63,6 +63,11 @@ test_fapi_test_second_provisioning(FAPI_CONTEXT *context)
 {
     TSS2_RC r;
 
+    if (strncmp(FAPI_PROFILE, "P_RSA", 5) == 0) {
+        LOG_WARNING("Default ECC profile needed for this test %s is used", FAPI_PROFILE);
+        return EXIT_SKIP;
+    }
+
     /* We need to reset the passwords again, in order to not brick physical TPMs */
     r = Fapi_Provision(context, PASSWORD, PASSWORD, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
@@ -148,6 +153,8 @@ test_fapi_test_second_provisioning(FAPI_CONTEXT *context)
     if (strcmp(FAPI_PROFILE, "P_ECC") == 0) {
         rc = init_fapi("P_ECC", &context);
     } else if (strcmp(FAPI_PROFILE, "P_ECC384") == 0) {
+        rc = init_fapi("P_ECC384", &context);
+    } else if (strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
         rc = init_fapi("P_ECC384", &context);
     } else {
         LOG_ERROR("Profile %s not supported for this test!", FAPI_PROFILE);

--- a/test/integration/test-fapi.h
+++ b/test/integration/test-fapi.h
@@ -140,6 +140,9 @@ TSS2_RC
 pcr_extend(FAPI_CONTEXT *context, UINT32 pcr, TPML_DIGEST_VALUES *digest_values);
 
 TSS2_RC
+pcr_bank_sha1_exists(FAPI_CONTEXT *context, bool *exists);
+
+TSS2_RC
 pcr_reset(FAPI_CONTEXT *context, UINT32 pcr);
 
 bool cmp_strtokens(char* string1, char *string2, char *delimiter);


### PR DESCRIPTION
* The new profiles are added to the dist directory.
* The key size 3072 and 4092 is added to the json serialization and deserialization.
* The integration tests are adapted to enable usage of P_RSA3072 as default profile.
* The state handling in the state machines of the policy utilities is fixed.
* The policy error handling has been cleaned up
