### PR TITLE
Fix coverity errors

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -2948,6 +2948,7 @@ ifapi_key_sign(
 
         r = ifapi_authorize_object(context, sig_key_object, &session);
         return_try_again(r);
+        goto_if_error(r, "Authorize signing key", cleanup);
 
         r = ifapi_get_sig_scheme(context, sig_key_object, padding, digest, &sig_scheme);
         goto_if_error(r, "Get signature scheme", cleanup);

--- a/src/tss2-fapi/ifapi_ima_eventlog.c
+++ b/src/tss2-fapi/ifapi_ima_eventlog.c
@@ -679,6 +679,11 @@ size_t read_ima_header(IFAPI_IMA_TEMPLATE *template, FILE *fp, TSS2_RC *rc)
         }
         memcpy(&template->ima_type[0], "ima", 3);
         /* Get the description of the IMA event. */
+        if (template->ima_type_size < 3) {
+            LOG_ERROR("Invalid ima data");
+            *rc = TSS2_FAPI_RC_BAD_VALUE;
+            return 0;
+        }
         size = template->ima_type_size - 3;
         if (size > 0) {
             if (size > TCG_EVENT_NAME_LEN_MAX) {
@@ -692,8 +697,10 @@ size_t read_ima_header(IFAPI_IMA_TEMPLATE *template, FILE *fp, TSS2_RC *rc)
                 *rc = TSS2_FAPI_RC_BAD_VALUE;
                 return 0;
             }
+            template->ima_type[template->ima_type_size] = '\0';
+        } else {
+            template->ima_type[3] = '\0';
         }
-        template->ima_type[template->ima_type_size] = '\0';
         template->hash_alg =  TPM2_ALG_SHA1;
         template->hash_size = TPM2_SHA1_DIGEST_SIZE;
         return header_size;

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -199,6 +199,9 @@ tcti_device_receive (
                            tcti_dev->fd, errno, strerror (errno));
                     return TSS2_TCTI_RC_IO_ERROR;
                 }
+            } else {
+                LOG_ERROR ("Header could not be received");
+                return TSS2_TCTI_RC_GENERAL_FAILURE;
             }
             LOG_DEBUG("Partial read - received header");
             rc = Tss2_MU_UINT32_Unmarshal(header, TPM_HEADER_SIZE,


### PR DESCRIPTION
* Coverity errors are fixed for TCTI (device), and FAPI.
* The missing error check for the authorization of FAPI signing keys is added.