### PR TITLE
Fix coverity errors

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -66,10 +66,16 @@ ifapi_crypto_context_free(IFAPI_CRYPTO_CONTEXT *ctx)
     if (!ctx)
         return;
 
-    EVP_MD_CTX_destroy(ctx->osslContext);
+    if (ctx->osslContext) {
+        EVP_MD_CTX_destroy(ctx->osslContext);
+    }
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    EVP_MD_free(ctx->osslHashAlgorithm);
-    OSSL_LIB_CTX_free(ctx->libctx);
+    if (ctx->osslHashAlgorithm) {
+        EVP_MD_free(ctx->osslHashAlgorithm);
+    }
+    if (ctx->libctx) {
+        OSSL_LIB_CTX_free(ctx->libctx);
+    }
 #endif
     SAFE_FREE(ctx);
 }
@@ -1659,11 +1665,11 @@ ifapi_crypto_hash_start(IFAPI_CRYPTO_CONTEXT_BLOB **context,
     }
 
     *context = (IFAPI_CRYPTO_CONTEXT_BLOB *) mycontext;
-
     return TSS2_RC_SUCCESS;
 
 cleanup:
     ifapi_crypto_context_free(mycontext);
+    *context = NULL;
     return r;
 }
 
@@ -1766,9 +1772,8 @@ ifapi_crypto_hash_abort(IFAPI_CRYPTO_CONTEXT_BLOB **context)
         LOG_DEBUG("Null-Pointer passed");
         return;
     }
-    IFAPI_CRYPTO_CONTEXT *mycontext = (IFAPI_CRYPTO_CONTEXT *) * context;
 
-    ifapi_crypto_context_free(mycontext);
+    ifapi_crypto_context_free(*context);
     *context = NULL;
 }
 

--- a/src/tss2-fapi/ifapi_ima_eventlog.c
+++ b/src/tss2-fapi/ifapi_ima_eventlog.c
@@ -679,18 +679,14 @@ size_t read_ima_header(IFAPI_IMA_TEMPLATE *template, FILE *fp, TSS2_RC *rc)
         }
         memcpy(&template->ima_type[0], "ima", 3);
         /* Get the description of the IMA event. */
-        if (template->ima_type_size < 3) {
+        if (template->ima_type_size < 3 ||
+            template->ima_type_size >= TCG_EVENT_NAME_LEN_MAX) {
             LOG_ERROR("Invalid ima data");
             *rc = TSS2_FAPI_RC_BAD_VALUE;
             return 0;
         }
         size = template->ima_type_size - 3;
         if (size > 0) {
-            if (size > TCG_EVENT_NAME_LEN_MAX) {
-                LOG_ERROR("Invalid ima data");
-                *rc = TSS2_FAPI_RC_BAD_VALUE;
-                return 0;
-            }
             rsize = fread(&template->ima_type[3], size, 1, fp);
             if (rsize != 1) {
                 LOG_ERROR("Invalid ima data");


### PR DESCRIPTION
* Possible out of bound array access in ima parser was fixed.
* Possible null pointer access in error cases in fapi crypto is fixed.