### PR TITLE
FAPI: Fix cleanup of policy sessions.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_execute.c
+++ b/src/tss2-fapi/ifapi_policy_execute.c
@@ -1910,7 +1910,8 @@ ifapi_policyeval_execute(
         return_try_again(r);
 
         if (r != TSS2_RC_SUCCESS) {
-            if (do_flush) {
+            if (do_flush && current_policy->session &&
+                current_policy->session != ESYS_TR_NONE) {
                 Esys_FlushContext(esys_ctx, current_policy->session);
             }
             ifapi_free_node_list(current_policy->policy_elements);


### PR DESCRIPTION
Policy sessions were not flushed if the policy session was successfully executed but the command where the policy was used for authorization was executed with an error.
Fixes: #2784