### PR TITLE
FAPI: Fix compiler warnings

### DIFF
--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -2090,7 +2090,7 @@ ifapi_base64encode(uint8_t *buffer, size_t buffer_size, char** b64_data) {
                    cleanup);
     }
 
-    BIO_flush(bio);
+    (void) BIO_flush(bio);
     BIO_get_mem_ptr(bio, &b64_mem);
     goto_if_null2(b64_mem, "Out of memory.", r, TSS2_FAPI_RC_MEMORY, cleanup);
 

--- a/src/tss2-fapi/ifapi_profiles.c
+++ b/src/tss2-fapi/ifapi_profiles.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "tss2_common.h"
 


### PR DESCRIPTION
On some platforms, compiler warnings are generated due to not include <strings.h> (note plural) when using index(3) as well as not utilizing the return value to BIO_flush().