### PR TITLE
unit tests:  skip tests which fail on 32-bit with _FILE_BITS=64

### DIFF
--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -28,6 +28,7 @@
 #define LOGMODULE tests
 #include "util/log.h"
 
+#define EXIT_SKIP 77
 /*
  * The unit tests will simulate error codes which can be returned by the
  * system calls for file system IO.
@@ -364,6 +365,12 @@ check_io_write_finish(void **state) {
 int
 main(int argc, char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(check_io_read_async),
         cmocka_unit_test(check_io_read_finish),

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -25,6 +25,11 @@
 #include "tss2-tcti/tcti-common.h"
 #include "tss2-tcti/tcti-device.h"
 
+#define LOGMODULE tests
+#include "util/log.h"
+
+#define EXIT_SKIP 77
+
 /*
  * Size of the TPM2 buffer used in these tests. In some cases this will be
  * the command sent (transmit tests) and in others it's used as the response
@@ -444,6 +449,12 @@ tcti_device_poll_io_error (void **state)
 int
 main(int argc, char* argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_device_init_all_null_test),
         cmocka_unit_test(tcti_device_init_size_test),

--- a/test/unit/tcti-libtpms.c
+++ b/test/unit/tcti-libtpms.c
@@ -28,6 +28,8 @@
 #define LOGMODULE test
 #include "util/log.h"
 
+#define EXIT_SKIP 77
+
 #define LIBTPMS_DL_HANDLE  0x12345678
 #define STATEFILE_PATH     "statefile.bin"
 #define STATEFILE_FD       0xAABB
@@ -1786,6 +1788,12 @@ int
 main(int   argc,
      char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(tcti_libtpms_init_all_null_test),
         cmocka_unit_test(tcti_libtpms_init_dlopen_fail_test),

--- a/test/unit/tcti-pcap.c
+++ b/test/unit/tcti-pcap.c
@@ -27,6 +27,11 @@
 #include "tss2-tcti/tcti-common.h"
 #include "tss2-tcti/tcti-pcap.h"
 
+#define LOGMODULE tests
+#include "util/log.h"
+
+#define EXIT_SKIP 77
+
 #if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define _LE32TOH(a,b,c,d) d,c,b,a
 #define _LE16TOH(a,b) b,a
@@ -726,6 +731,12 @@ int
 main (int   argc,
       char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_pcap_init_context_and_size_null_test),
         cmocka_unit_test (tcti_pcap_init_size_test),


### PR DESCRIPTION
Tests file the unit tests are compiled with _FILE_BITS is set to 64. The tests work without problems if _FILE_BITS is not set. Addresses: #2786