### PR TITLE
Update maintainer list and fix CI problems....

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -33,6 +35,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -52,6 +56,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -74,6 +80,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -93,6 +101,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -112,6 +122,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main
@@ -151,6 +163,8 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Coverity Action
         uses:
           tpm2-software/ci/coverityScan@main

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,0 @@
-Andreas Fuchs <andreas.fuchs@infineon.com>
-Bill Roberts <william.c.roberts@intel.com>
-Juergen Repp <juergen_repp@web.de>

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,5 @@
+|email|PGP Fingerprint|
+| ------------- | ------------- |
+| Andreas Fuchs <andreas.fuchs@infineon.com>| [D533275B0123D0A679F51FF48F4F9A45D7FFEE74](htps://keys.openpgp.org/vks/v1/by-fingerprint/D533275B0123D0A679F51FF48F4F9A45D7FFEE74)|
+| Bill Roberts <william.c.roberts@intel.com>| [5b482b8e3e19da7c978e1d016de2e9078e1f50c1](https://keys.openpgp.org/vks/v1/by-fingerprint/5B482B8E3E19DA7C978E1D016DE2E9078E1F50C1)|
+| Juergen Repp <juergen_repp@web.de>| [7A8F470DA9C8B2CACED1DBAAF1B152D9441A2563](https://keys.openpgp.org/vks/v1/by-fingerprint/7A8F470DA9C8B2CACED1DBAAF1B152D9441A2563)|

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 |email|PGP Fingerprint|
 | ------------- | ------------- |
-| Andreas Fuchs <andreas.fuchs@infineon.com>| [D533275B0123D0A679F51FF48F4F9A45D7FFEE74](htps://keys.openpgp.org/vks/v1/by-fingerprint/D533275B0123D0A679F51FF48F4F9A45D7FFEE74)|
+| Andreas Fuchs <andreas.fuchs@infineon.com>| [D533275B0123D0A679F51FF48F4F9A45D7FFEE74](https://keys.openpgp.org/vks/v1/by-fingerprint/D533275B0123D0A679F51FF48F4F9A45D7FFEE74)|
 | Bill Roberts <william.c.roberts@intel.com>| [5b482b8e3e19da7c978e1d016de2e9078e1f50c1](https://keys.openpgp.org/vks/v1/by-fingerprint/5B482B8E3E19DA7C978E1D016DE2E9078E1F50C1)|
 | Juergen Repp <juergen_repp@web.de>| [7A8F470DA9C8B2CACED1DBAAF1B152D9441A2563](https://keys.openpgp.org/vks/v1/by-fingerprint/7A8F470DA9C8B2CACED1DBAAF1B152D9441A2563)|

--- a/Makefile.am
+++ b/Makefile.am
@@ -212,7 +212,7 @@ EXTRA_DIST += \
     CONTRIBUTING.md \
     INSTALL.md \
     LICENSE \
-    MAINTAINERS \
+    MAINTAINERS.md \
     README.md \
     RELEASE.md \
     VERSION

--- a/src/tss2-fapi/ifapi_policy_json_serialize.c
+++ b/src/tss2-fapi/ifapi_policy_json_serialize.c
@@ -793,6 +793,13 @@ ifapi_json_TPMS_POLICYAUTHORIZE_serialize(const TPMS_POLICYAUTHORIZE *in,
         return_error(TSS2_FAPI_RC_GENERAL_FAILURE, "Could not add json object.");
     }
 
+    /* Check whether only one condition field found in policy. */
+    if (cond_cnt > 1) {
+        return_error(TSS2_FAPI_RC_BAD_VALUE,
+                     "Exactly one conditional is allowed for policy "
+                     "duplication select.");
+    }
+
     return TSS2_RC_SUCCESS;
 }
 

--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -34,9 +34,11 @@ json_object*
 ifapi_parse_json(const char *jstring) {
     json_object *jso = NULL;
     enum json_tokener_error jerr;
+#if MAXLOGLEVEL > 0
     int line = 1;
     int line_offset = 0;
     int char_pos;
+#endif
     struct json_tokener* tok = json_tokener_new();
     if (!tok) {
         LOG_ERROR("Could not allocate json tokener");
@@ -45,6 +47,7 @@ ifapi_parse_json(const char *jstring) {
     jso = json_tokener_parse_ex(tok, jstring, -1);
     jerr = json_tokener_get_error(tok);
     if (jerr != json_tokener_success) {
+#if MAXLOGLEVEL > 0
         for (char_pos = 0; char_pos <= tok->char_offset; char_pos++) {
             if (jstring[char_pos] == '\n') {
                 line++;
@@ -55,6 +58,7 @@ ifapi_parse_json(const char *jstring) {
         }
         LOG_ERROR("Invalid JSON at line %i column %i: %s.", line, line_offset,
                   json_tokener_error_desc(jerr));
+#endif
         json_tokener_free(tok);
         return NULL;
     }

--- a/test/integration/esys-pcr-auth-value.int.c
+++ b/test/integration/esys-pcr-auth-value.int.c
@@ -39,7 +39,7 @@ test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
     int failure_return = EXIT_FAILURE;
 
     /*
-     * PCR register 20 belongs to the policy group and the auth value group.
+     * PCR register 21 belongs to the policy group and the auth value group.
      * PCRs of these groups can be used for SetAuthValue and SetAuthPolicy.
      */
     ESYS_TR  pcrHandle_handle = 20;
@@ -60,7 +60,8 @@ test_esys_pcr_auth_value(ESYS_CONTEXT * esys_context)
         );
 
 
-    if ((r == TPM2_RC_COMMAND_CODE) ||
+    if ((r == TPM2_RC_VALUE) ||
+        (r == TPM2_RC_COMMAND_CODE) ||
         (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
         (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
         LOG_WARNING("Command TPM2_PCR_SetAuthValue not supported by TPM.");

--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -28,6 +28,7 @@
 #define LOGMODULE tests
 #include "util/log.h"
 
+#define EXIT_SKIP 77
 /*
  * The unit tests will simulate error codes which can be returned by the
  * system calls for file system IO.
@@ -364,6 +365,12 @@ check_io_write_finish(void **state) {
 int
 main(int argc, char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(check_io_read_async),
         cmocka_unit_test(check_io_read_finish),

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -25,6 +25,11 @@
 #include "tss2-tcti/tcti-common.h"
 #include "tss2-tcti/tcti-device.h"
 
+#define LOGMODULE tests
+#include "util/log.h"
+
+#define EXIT_SKIP 77
+
 /*
  * Size of the TPM2 buffer used in these tests. In some cases this will be
  * the command sent (transmit tests) and in others it's used as the response
@@ -444,6 +449,12 @@ tcti_device_poll_io_error (void **state)
 int
 main(int argc, char* argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_device_init_all_null_test),
         cmocka_unit_test(tcti_device_init_size_test),

--- a/test/unit/tcti-libtpms.c
+++ b/test/unit/tcti-libtpms.c
@@ -28,6 +28,8 @@
 #define LOGMODULE test
 #include "util/log.h"
 
+#define EXIT_SKIP 77
+
 #define LIBTPMS_DL_HANDLE  0x12345678
 #define STATEFILE_PATH     "statefile.bin"
 #define STATEFILE_FD       0xAABB
@@ -1786,6 +1788,12 @@ int
 main(int   argc,
      char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(tcti_libtpms_init_all_null_test),
         cmocka_unit_test(tcti_libtpms_init_dlopen_fail_test),

--- a/test/unit/tcti-pcap.c
+++ b/test/unit/tcti-pcap.c
@@ -27,6 +27,11 @@
 #include "tss2-tcti/tcti-common.h"
 #include "tss2-tcti/tcti-pcap.h"
 
+#define LOGMODULE tests
+#include "util/log.h"
+
+#define EXIT_SKIP 77
+
 #if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define _LE32TOH(a,b,c,d) d,c,b,a
 #define _LE16TOH(a,b) b,a
@@ -726,6 +731,12 @@ int
 main (int   argc,
       char *argv[])
 {
+#if _FILE_OFFSET_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_FILE_OFFSET == 64 would produce cmocka errors.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_pcap_init_context_and_size_null_test),
         cmocka_unit_test (tcti_pcap_init_size_test),


### PR DESCRIPTION
* fapi: fix warning variable not used.
* ci: fix stuck in a AddressSanitizer:DEADLYSIGNAL loop in the CI.
* esys test: fix test esys-pcr-auth-value
* maintainers: add pgp keys to maintainer list.
* unit tests:  skip tests which fail on 32-bit with _FILE_BITS=64

 