### PR TITLE
FAPI: Fix length check in auth callback. 3.2.x

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -441,6 +441,10 @@ ifapi_set_auth(
         return_if_error(r, "policyAuthCallback");
         if (auth != NULL) {
             authValue.size = strlen(auth);
+            if (authValue.size > sizeof(TPMU_HA)) {
+                return_error2(TSS2_FAPI_RC_BAD_VALUE, "Auth value %u > %lu",
+                              authValue.size, sizeof(TPMU_HA));
+            }
             memcpy(&authValue.buffer[0], auth, authValue.size);
         }
 


### PR DESCRIPTION
The max size of the value returned by the auth value callback sizeof(TPMU_HA) is now checked.