### PR TITLE
MU: Display error message for errors with wrong selectors.

### DIFF
--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -328,7 +328,7 @@ TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint32_t selector, uint8_t buf
     ret = TSS2_RC_SUCCESS; \
     break; \
     default: \
-    LOG_DEBUG("wrong selector 0x%"PRIx32" return error", selector); \
+    LOG_ERROR("wrong selector 0x%"PRIx32" return error", selector); \
     break; \
     } \
     return ret; \
@@ -425,7 +425,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     ret = TSS2_RC_SUCCESS; \
     break; \
     default: \
-    LOG_DEBUG("wrong selector 0x%"PRIx32" return error", selector); \
+    LOG_ERROR("wrong selector 0x%"PRIx32" return error", selector); \
     break; \
     } \
     return ret; \


### PR DESCRIPTION
If a wrong selector was used for a TPMU objects to be marshalled only the error bad value was returned.
Now an error log message is displayed.