### PR TITLE
FAPI: Add check whether auth values exist for hierarchies.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -512,6 +512,16 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context)
             command->auth_state =  (*capabilityData)->data.tpmProperties.tpmProperty[0].value;
             SAFE_FREE(*capabilityData);
 
+            if (command->auth_state & TPMA_PERMANENT_ENDORSEMENTAUTHSET) {
+                hierarchy_he->misc.hierarchy.with_auth = TPM2_YES;
+            }
+            if (command->auth_state & TPMA_PERMANENT_OWNERAUTHSET) {
+                hierarchy_hs->misc.hierarchy.with_auth = TPM2_YES;
+            }
+            if (command->auth_state & TPMA_PERMANENT_LOCKOUTAUTHSET) {
+                hierarchy_lockout->misc.hierarchy.with_auth = TPM2_YES;
+            }
+
             /* Check the TPM capabilities for the persistent handle. */
             if (command->public_templ.persistent_handle) {
                 r = Esys_GetCapability_Async(context->esys,


### PR DESCRIPTION
Currently FAPI provisioning tries to create the EK and SRK with the NULL auth value for the hierarchies.
Now first the corresponding flag in  TPM2_CAP_TPM_PROPERTIES with the property TPM2_PT_PERMANENT is checked. If an auth value is used for the hierarchy the auth value callback will be called. The "retry" code in the BAD_AUTH case is removed.