### PR TITLE
[RFC] vscode support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -240,6 +240,12 @@ AUTHORS :
 	    uniq -c | sort -nr | sed 's/^\s*//' | cut -d" " -f2- > $@
 EXTRA_DIST += AUTHORS
 
+# Use bear to generate compilation database (phony to enable regeneration)
+.PHONY: compile_commands.json
+compile_commands.json:
+	$(AM_V_GEN)bear -- $(MAKE) --always-make all check-programs
+CLEANFILES += compile_commands.json
+
 # pkg-config setup. pc-file declarations happen in the corresponding modules
 pkgconfig_DATA =
 DISTCLEANFILES += $(pkgconfig_DATA)

--- a/_vscode/launch.json
+++ b/_vscode/launch.json
@@ -1,0 +1,53 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug Test",
+            "program": "${workspaceFolder}/${relativeFileDirname}/.libs/${fileBasenameNoExtension}",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "TPM20TEST_TCTI": "${input:tcti}",
+                "TSS2_LOG": "all+trace",
+                "LD_LIBRARY_PATH": "${workspaceFolder}/src/tss2-mu/.libs:${workspaceFolder}/src/tss2-tcti/.libs:${workspaceFolder}/src/tss2-sys/.libs:${workspaceFolder}/src/tss2-esys/.libs:${workspaceFolder}/src/tss2-rc/.libs:${workspaceFolder}/src/tss2-policy/.libs:${workspaceFolder}/src/tss2-fapi/.libs"
+            },
+            "preLaunchTask": "build_test",
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug tpm2 startup",
+            "program": "/bin/env",
+            "args": [
+                "tpm2",
+                "startup",
+                "-c",
+                "-T${input:tcti}",
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "TSS2_LOG": "all+trace",
+                "LD_LIBRARY_PATH": "${workspaceFolder}/src/tss2-mu/.libs:${workspaceFolder}/src/tss2-tcti/.libs:${workspaceFolder}/src/tss2-sys/.libs:${workspaceFolder}/src/tss2-esys/.libs:${workspaceFolder}/src/tss2-rc/.libs:${workspaceFolder}/src/tss2-policy/.libs:${workspaceFolder}/src/tss2-fapi/.libs"
+            },
+            "preLaunchTask": "build_tcti_libtpms",
+        },
+    ],
+    "inputs": [
+        {
+            "id": "tcti",
+            "type": "pickString",
+            "description": "The TCTI for connecting to a TPM",
+            "options": [
+                "libtpms",
+                "swtpm",
+                "mssim"
+            ],
+            "default": "libtpms"
+        }
+    ]
+}

--- a/_vscode/tasks.json
+++ b/_vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "build_test",
+            "command": "make",
+            "args": [
+                "-j",
+                "${relativeFileDirname}/${fileBasenameNoExtension}",
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Build single test executable."
+        },
+        {
+            "type": "shell",
+            "label": "build_tcti_libtpms",
+            "command": "make",
+            "args": [
+                "-j",
+                "src/tss2-tcti/libtss2-tcti-libtpms.la",
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "detail": "Build tcti-libtpms"
+        }
+    ]
+}

--- a/git.mk
+++ b/git.mk
@@ -375,6 +375,9 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk $(top_srcdir)/configure.a
 			$(DEPDIR) \
 			"*.pem" \
 			"*_state[1|2]" \
+			".cache/" \
+			".clangd/" \
+			".vscode/" \
 		; do echo "$$x"; done; \
 	} | \
 	sed "s@^/`echo "$(srcdir)" | sed 's/\(.\)/[\1]/g'`/@/@" | \


### PR DESCRIPTION
This one might be opinionated.

So far there is no clean way to get first-class language support in vscode. Add make target for creating a [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) using [bear](https://github.com/rizsotto/Bear). This enables you to do the following

```
make -j compile_commands.json
```

This file is recognized by many tools including e.g. clang-tidy and the vscode clangd extension. This way, the vscode language server knows *exactly* where symbols come from, which `#ifdefs` are compiled and where to find the right headers.

I also added a `launch.json` which lets you debug single unit and integration tests easily. What do you think of this?

Things I thought of but did not want to do in this first step:
 * Automatic test discovery/running with something like [Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer)
 * A devcontainer
 * IDE-integrated formatting (clang-format) and linting (e.g. clang-tidy, I will probably submit that as a future PR)

Why `_vscode` and not `.vscode`? Because this leaves users who want to use their own, different `.vscode` with a dirty working tree. Once-tracked files cannot be .gitignore-d and there is no clean way to resolve this.