### PR TITLE
TCTI: Fix leak produced in Tss2_TctiLdr_Initialize_Ex

### DIFF
--- a/src/tss2-tcti/tctildr.c
+++ b/src/tss2-tcti/tctildr.c
@@ -525,7 +525,10 @@ Tss2_TctiLdr_Initialize_Ex (const char *name,
     }
 
     *tctiContext = (TSS2_TCTI_CONTEXT *) ldr_ctx;
-    return tctildr_init_context_data(*tctiContext, local_name, local_conf);
+    rc = tctildr_init_context_data(*tctiContext, local_name, local_conf);
+    if (rc == TSS2_RC_SUCCESS) {
+        return rc;
+    }
 
 err:
     if (*tctiContext != NULL) {


### PR DESCRIPTION
The return code of tctildr_init_context_data was not checked in Tss2_TctiLdr_Initialize_Ex. The cleanup part of this function was not executed and so a leak was produced.
Fixes #2842