### PR TITLE
FAPI: Fix wrong format directive in ifap_set_auth

### DIFF
--- a/src/tss2-fapi/fapi_util.c
+++ b/src/tss2-fapi/fapi_util.c
@@ -435,7 +435,7 @@ ifapi_set_auth(
         if (auth != NULL) {
             authValue.size = strlen(auth);
             if (authValue.size > sizeof(TPMU_HA)) {
-                return_error2(TSS2_FAPI_RC_BAD_VALUE, "Size of auth value %u > %lu",
+                return_error2(TSS2_FAPI_RC_BAD_VALUE, "Size of auth value %"PRIu16" > %zu",
                               authValue.size, sizeof(TPMU_HA));
             }
             memcpy(&authValue.buffer[0], auth, authValue.size);


### PR DESCRIPTION
%u was used for a 16 bit unsigned integer and %lu for sizeof. Fixes: #2856