### PR TITLE
Remote trailing slash from bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -56,16 +56,16 @@ echo "Generating file lists: ${VARS_FILE}"
   src_listvar "src/util-io" "*.h" "UTIL_IO_H"
   printf "UTIL_IO_SRC = \$(UTIL_IO_C) \$(UTIL_IO_H)\n"
 
-  src_listvar "src/tss2-sys/" "*.c" "TSS2_SYS_C"
-  src_listvar "src/tss2-sys/" "*.h" "TSS2_SYS_H"
+  src_listvar "src/tss2-sys" "*.c" "TSS2_SYS_C"
+  src_listvar "src/tss2-sys" "*.h" "TSS2_SYS_H"
   printf "TSS2_SYS_SRC = \$(TSS2_SYS_H) \$(TSS2_SYS_C)\n"
 
-  src_esys_listvar "src/tss2-esys/" "*.h" "TSS2_ESYS_H"  src/tss2-esys/esys_crypto_ossl.h src/tss2-esys/esys_crypto_mbed.h
-  src_esys_listvar "src/tss2-esys/" "*.c" "TSS2_ESYS_C" src/tss2-esys/esys_crypto_ossl.c src/tss2-esys/esys_crypto_mbed.c
+  src_esys_listvar "src/tss2-esys" "*.h" "TSS2_ESYS_H"  src/tss2-esys/esys_crypto_ossl.h src/tss2-esys/esys_crypto_mbed.h
+  src_esys_listvar "src/tss2-esys" "*.c" "TSS2_ESYS_C" src/tss2-esys/esys_crypto_ossl.c src/tss2-esys/esys_crypto_mbed.c
   printf "TSS2_ESYS_SRC = \$(TSS2_ESYS_H) \$(TSS2_ESYS_C)\n"
 
-  src_listvar "src/tss2-fapi/" "*.h" "TSS2_FAPI_H"
-  src_listvar "src/tss2-fapi/" "*.c" "TSS2_FAPI_C"
+  src_listvar "src/tss2-fapi" "*.h" "TSS2_FAPI_H"
+  src_listvar "src/tss2-fapi" "*.c" "TSS2_FAPI_C"
   printf "TSS2_FAPI_SRC = \$(TSS2_FAPI_H) \$(TSS2_FAPI_C)\n"
 
   src_listvar "src/tss2-mu" "*.c" "TSS2_MU_C"


### PR DESCRIPTION
With autoconf 2.72, the trailing / in bootstrap causes cryptic build failures to occur on MacOS. Removing these / allows autoconf to proceed.

And example of the error is:

```
# ./bootstrap
Generating file lists: src_vars.mk
aminclude_static.am:63: warning: GITIGNOREFILES was already defined in condition TRUE, which includes condition AUTOCONF_CODE_COVERAGE_2019_01_06 and CODE_COVERAGE_ENABLED ...
Makefile.am:56:   'aminclude_static.am' included from here
Makefile.am:52: ... 'GITIGNOREFILES' previously defined here
Makefile.am: error: object 'src/tss2-esys/libtss2_esys_la-esys_crypto_mbed.lo' created by 'src/tss2-esys/esys_crypto_mbed.c' and 'src/tss2-esys//esys_crypto_mbed.c'
Makefile.am: error: object 'src/tss2-esys/libtss2_esys_la-esys_crypto_ossl.lo' created by 'src/tss2-esys/esys_crypto_ossl.c' and 'src/tss2-esys//esys_crypto_ossl.c'
autoreconf: error: automake failed with exit status: 1
```

Note the double `//` in `src/tss2-esys//esys_crypto_mbed.c` 