### PR TITLE
FAPI: Fix segfault if json field is null.

### DIFF
--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -253,13 +253,25 @@ ifapi_get_sub_object(json_object *jso, char *name, json_object **sub_jso)
 {
     int i;
     if (json_object_object_get_ex(jso, name, sub_jso)) {
-        return true;
+        if (*sub_jso) {
+            return true;
+        } else {
+            return false;
+        }
     } else {
         char name2[strlen(name) + 1];
         for (i = 0; name[i]; i++)
             name2[i] = (char) tolower(name[i]);
         name2[strlen(name)] = '\0';
-        return json_object_object_get_ex(jso, name2, sub_jso);
+        if (json_object_object_get_ex(jso, name2, sub_jso)) {
+            if (*sub_jso) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
The function json_object_object_get_ex does not create a json object for the parameter value in the case "key":null. This caused a segfault in json deserialization.
Fixes: #2878