### PR TITLE
FAPI: Fix unnecessary writes to keystore.

### DIFF
--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -419,10 +419,19 @@ Fapi_ChangeAuth_Finish(
                empty authorization or an actual password. */
             object = command->key_object;
 
-            if (strlen(command->authValue) > 0)
+            if (strlen(command->authValue) > 0) {
+                if (object->misc.key.with_auth == TPM2_YES) {
+                     context->state = ENTITY_CHANGE_AUTH_CLEANUP;
+                     return TSS2_FAPI_RC_TRY_AGAIN;
+                }
                 object->misc.key.with_auth = TPM2_YES;
-            else
+            } else {
+                if (object->misc.key.with_auth == TPM2_NO) {
+                     context->state = ENTITY_CHANGE_AUTH_CLEANUP;
+                     return TSS2_FAPI_RC_TRY_AGAIN;
+                }
                 object->misc.key.with_auth = TPM2_NO;
+            }
             fallthrough;
 
         statecase(context->state, ENTITY_CHANGE_AUTH_WRITE_PREPARE)
@@ -502,10 +511,19 @@ Fapi_ChangeAuth_Finish(
 
             /* Update the information about whether the new Auth is an empty
                authorization or an actual password. */
-            if (strlen(command->authValue) > 0)
+            if (strlen(command->authValue) > 0) {
+                if (object->misc.key.with_auth == TPM2_YES) {
+                     context->state = ENTITY_CHANGE_AUTH_CLEANUP;
+                     return TSS2_FAPI_RC_TRY_AGAIN;
+                }
                 object->misc.nv.with_auth = TPM2_YES;
-            else
+            } else {
+                if (object->misc.key.with_auth == TPM2_NO) {
+                     context->state = ENTITY_CHANGE_AUTH_CLEANUP;
+                     return TSS2_FAPI_RC_TRY_AGAIN;
+                }
                 object->misc.nv.with_auth = TPM2_NO;
+            }
 
             /* Jump over to the AUTH_WRITE_PREPARE state for storing the
                new metadata to the keystore. */


### PR DESCRIPTION
* A duplicate write operation to the keystore was executed by Fapi_NvWrite.
* A write operation to the keystore was only needed after the first call of Fapi_NvWrite because the NV_WRITTEN bit was set.
* A write operation to the keystore by Fapi_ChangeAuth was only needed if the value of the attribute with_auth was changed.

Addresses: #2881