### PR TITLE
Update deprecated actions/upload-artifact@v1

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,7 +17,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
cifuzz failed due to deprecated version of `actions/upload-artifact: v1`. 

https://github.com/actions/upload-artifact:
- v1/v2 were deprecated on June 30, 2024.
- v3 will be deprecated on November 30, 2024.