### PR TITLE
test: skip tcti-spidev on 32bit architectures with 64bit time_t

### DIFF
--- a/test/unit/tcti-spidev.c
+++ b/test/unit/tcti-spidev.c
@@ -29,6 +29,11 @@
 struct timeval;
 struct timezone;
 
+#define LOGMODULE tests
+#include "util/log.h"
+
+#define EXIT_SKIP 77
+
 typedef enum {
     TPM_DID_VID_HEAD = 0,
     TPM_DID_VID_DATA,
@@ -206,6 +211,12 @@ int
 main (int   argc,
       char *argv[])
 {
+#if __SIZEOF_POINTER__ == 4 && _TIME_BITS == 64
+    // Would produce cmocka error
+    LOG_WARNING("_TIME_BITS == 64 would produce cmocka errors on this platform.");
+    return EXIT_SKIP;
+#endif
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_spi_init_test),
     };


### PR DESCRIPTION
The tests fail, similarly to how they failed due to _FILE_OFFSET_BITS == 64 as fixed in 932b1e78047ed0ddc09fcb06bff2e7cf96406976

```
FAIL: test/unit/tcti-spidev
===========================

[==========] tests: Running 1 test(s).
[ RUN      ] tcti_spi_init_test
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:48:platform_spi_acquire() SPI acquire failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spi-helper.c:164:spi_tpm_helper_log_register_access() READ register 0xd40f00 (4 bytes) failed in transaction start
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:68:platform_spi_release() SPI release failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:48:platform_spi_acquire() SPI acquire failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spi-helper.c:164:spi_tpm_helper_log_register_access() READ register 0xd40f00 (4 bytes) failed in transaction start
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:68:platform_spi_release() SPI release failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:48:platform_spi_acquire() SPI acquire failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spi-helper.c:164:spi_tpm_helper_log_register_access() READ register 0xd40f00 (4 bytes) failed in transaction start
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:68:platform_spi_release() SPI release failed: Bad file descriptor
...
ERROR:tcti:src/tss2-tcti/tcti-spi-helper.c:164:spi_tpm_helper_log_register_access() READ register 0xd40f00 (4 bytes) failed in transaction start
ERROR:tcti:src/tss2-tcti/tcti-spidev.c:68:platform_spi_release() SPI release failed: Bad file descriptor
ERROR:tcti:src/tss2-tcti/tcti-spi-helper.c:728:Tss2_Tcti_Spi_Helper_Init() Probing TPM failed
[  ERROR   ] --- 0xa000a != 0
[   LINE   ] --- test/unit/tcti-spidev.c:200: error: Failure!
[  FAILED  ] tcti_spi_init_test
```