### PR TITLE
FAPI: fix problems detected by scanner.

### DIFF
--- a/src/tss2-fapi/fapi_int.h
+++ b/src/tss2-fapi/fapi_int.h
@@ -226,6 +226,7 @@ typedef struct {
     UINT16 offset;              /**< Offset in TPM memory TPM */
     size_t data_idx;            /**< Offset in the read buffer */
     const uint8_t *data;        /**< Buffer for data to be written */
+    uint8_t *nv_buffer;         /**< Buffer for data to be written */
     uint8_t *rdata;             /**< Buffer for data to be read */
     size_t size;                /**< size of rdata */
     IFAPI_OBJECT auth_object;   /**< Object used for authentication */

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -85,8 +85,8 @@ ifapi_set_key_flags(const char *type, bool policy, IFAPI_KEY_TEMPLATE *template)
         } else if (strcasecmp(flag, "noda") == 0) {
             attributes |= TPMA_OBJECT_NODA;
         } else if (strncmp(flag, "0x", 2) == 0) {
-            sscanf(&flag[2], "%"SCNx32 "%n", &handle, &pos);
-            if ((size_t)pos != strlen(flag) - 2) {
+            if (sscanf(&flag[2], "%"SCNx32 "%n", &handle, &pos) < 1 ||
+                (size_t)pos != strlen(flag) - 2) {
                 goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Invalid flag: %s",
                            error, flag);
             }
@@ -182,8 +182,8 @@ ifapi_set_nv_flags(const char *type, IFAPI_NV_TEMPLATE *template,
         } else if (strcasecmp(flag, "noda") == 0) {
             attributes |= TPMA_NV_NO_DA;
         } else if (strncmp(flag, "0x", 2) == 0) {
-            sscanf(&flag[2], "%"SCNx32 "%n", &handle, &pos);
-            if ((size_t)pos != strlen(flag) - 2) {
+            if (sscanf(&flag[2], "%"SCNx32 "%n", &handle, &pos) < 1 ||
+                (size_t)pos != strlen(flag) - 2) {
                 goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Invalid flag: %s",
                            error, flag);
             }

--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -147,7 +147,7 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
 \
     if (dest != NULL) { \
         dest->size = size; \
-        memcpy(((TPM2B *)dest)->buffer, &buffer[local_offset], size); \
+        memcpy(&dest->buf_name, &buffer[local_offset], size);    \
     } \
     local_offset += size; \
     if (offset != NULL) { \


### PR DESCRIPTION
* Fix missing check of scanf result.
* Fix storing of local variable stored in non-local memory.
* MU: Remove unneeded cast in TPM2B_UNMARSHAL.
