### PR TITLE
CI: Fix cirrus ci after update of FreeBSD to 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,6 @@ task:
   env:
     CFLAGS: "-I/usr/local/include -I/usr/local/openssl/include"
     LDFLAGS: -L/usr/local/lib
-    ibmtpm_name: ibmtpm1637
     libusb_version: v1.0.26
   freebsd_instance:
     matrix:
@@ -23,5 +22,5 @@ task:
     # Due to a race condition that only occurs in the cirrus ci, "make distcheck" has been replaced by "make check".
     #
     ./bootstrap &&
-    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --disable-dependency-tracking &&
+    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --enable-nodl --disable-dependency-tracking &&
     gmake -j check || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
     libusb_version: v1.0.26
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-0
+      image_family: freebsd-14-1
   install_script:
     - IGNORE_OSVERSION=yes
     - pkg update -f

--- a/Makefile.am
+++ b/Makefile.am
@@ -609,7 +609,7 @@ src_tss2_esys_libtss2_esys_la_SOURCES = $(TSS2_ESYS_SRC) $(TSS2_ESYS_SRC_CRYPTO)
     src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h \
     src/tss2-tcti/tctildr-interface.h
 if NO_DL
-src_tss2_esys_libtss2_esys_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim) $(libtss2_tcti_cmd)
+src_tss2_esys_libtss2_esys_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim) $(libtss2_tcti_cmd)  $(libtss2_tcti_swtpm)
 src_tss2_esys_libtss2_esys_la_SOURCES += src/tss2-tcti/tctildr-nodl.c src/tss2-tcti/tctildr-nodl.h
 else
 src_tss2_esys_libtss2_esys_la_LIBADD += $(LIBADD_DL)


### PR DESCRIPTION
* dlopen for swtpm failed after the upgrade from FreeBsd 14.0 to 14.1 As a workaround the configure option `--enable-nodl` is used for FreeBSD.
  Addresses: #2907
* Initialisation of src_tss2_esys_libtss2_esys_la_LIBADD in Makefile.am is fixed.

