### PR TITLE
m4: fix test ld version script.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,5 +22,5 @@ task:
     # Due to a race condition that only occurs in the cirrus ci, "make distcheck" has been replaced by "make check".
     #
     ./bootstrap &&
-    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --enable-nodl --disable-dependency-tracking &&
+    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --disable-dependency-tracking &&
     gmake -j check || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -26,20 +26,14 @@ AC_DEFUN([gl_LD_VERSION_SCRIPT],
        [gl_cv_sys_ld_version_script=no
         save_LDFLAGS=$LDFLAGS
         LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
-        echo foo >conftest.map
+        echo "{ global: *; };" > conftest.map
         AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
-          [],
-          [cat > conftest.map <<EOF
-VERS_1 {
-        global: sym;
-};
-
-VERS_2 {
-        global: sym;
-} VERS_1;
-EOF
-           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
-             [gl_cv_sys_ld_version_script=yes])])
+          [gl_cv_sys_ld_version_script=yes],
+          [gl_cv_sys_ld_version_script=no])
+        echo foo > conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [gl_cv_sys_ld_version_script=no],
+          [])
         rm -f conftest.map
         LDFLAGS=$save_LDFLAGS])
      have_ld_version_script=$gl_cv_sys_ld_version_script])


### PR DESCRIPTION
* The test macro gl_LD_VERSION_SCRIPT which not work on FreeBSD 14.1 is simplified and works now also on FreeBSD 14.1
* The option --enable-nodl, which was used as a workaround for this problem in the cirrus CI, is removed.