### PR TITLE
tcti-msim: Fix call of socket_xmit_buf in send_sim_session_end.

### DIFF
--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -136,7 +136,7 @@ send_sim_session_end (
     TSS2_RC rc;
 
     rc = Tss2_MU_UINT32_Marshal (TPM_SESSION_END, buf, sizeof (buf), NULL);
-    if (rc == TSS2_RC_SUCCESS) {
+    if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
     return socket_xmit_buf (sock, buf, sizeof (buf));

--- a/test/unit/tcti-mssim.c
+++ b/test/unit/tcti-mssim.c
@@ -336,6 +336,9 @@ tcti_socket_teardown (void **state)
 {
     TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
 
+    will_return (__wrap_write, 4);
+    will_return (__wrap_write, 4);
+
     Tss2_Tcti_Finalize (ctx);
     free (ctx);
     return 0;


### PR DESCRIPTION
* socket_xmit_buf was not called after successful marshalling.
* The result of the write function was not set in the wrapper function for write in the teardown function.

Fixes: #2915