### PR TITLE
readthedocs: add requirement file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,6 @@ build:
 sphinx:
   builder: html
   configuration: sphinx/conf.py
+python:
+  install:
+    - requirements: sphinx/requirements.txt

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -1,0 +1,2 @@
+.. toctree::
+   :maxdepth: 2

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,0 +1,4 @@
+# needed for readthedocs builds:
+GitPython
+myst_parser
+sphinx_rtd_theme


### PR DESCRIPTION
* Not all needed python packages to generate the index.html file were installed. Addresses: #2917
* index.rst is added.