### PR TITLE
readthedocs: fix requirements

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -14,6 +14,7 @@
 # serve to show the default.
 
 import subprocess
+import os
 
 # Create (unused) root file
 with open("index.rst", "w") as index_rst:
@@ -306,3 +307,25 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+# -- Extension configuration -------------------------------------------------
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+def builder_finished_handler(app, exception):
+    if exception is None:
+        os.environ["SPHINX_OUTDIR"] = str(app.outdir)
+        script = os.path.join(app.confdir, "sphinx-finished.sh")
+        subprocess.check_call(script, shell=True)
+
+
+#
+# Hook the setup of readthedocs so we can hook into events as defined in:
+# - https://www.sphinx-doc.org/en/master/extdev/appapi.html
+#
+def setup(app):
+    app.connect("build-finished", builder_finished_handler)

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,3 +1,15 @@
+setuptools_scm[toml]>=3.4.3
+cffi>=1.0.0
+pkgconfig
+cryptography>=3.0
+asn1crypto
+packaging
+pycparser
+cffi>=1.0.0
+asn1crypto
+cryptography>=3.0
+packaging
+pyyaml
 # needed for readthedocs builds:
 GitPython
 myst_parser


### PR DESCRIPTION
* The list of required packages is extended.
* A handler to fix wrong html generation of index.html is added.