### PR TITLE
readthedocs: downgrade sphinx

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -11,6 +11,7 @@ cryptography>=3.0
 packaging
 pyyaml
 # needed for readthedocs builds:
+sphinx==6.2.1
 GitPython
 myst_parser
 sphinx_rtd_theme


### PR DESCRIPTION
Embedding of README.mv did not work in newer sphinx versions.