### PR TITLE
FAPI: Fix misleading error message.

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -1164,7 +1164,7 @@ keystore_search_obj(
     statecase(keystore->key_search.state, KSEARCH_SEARCH_OBJECT)
         /* Use the next object in the path list */
         if (keystore->key_search.path_idx == 0) {
-            goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND, "Key not found.", cleanup);
+            goto_error(r, TSS2_FAPI_RC_PATH_NOT_FOUND, "Key or NV object not found.", cleanup);
         }
         keystore->key_search.path_idx -= 1;
         path_idx = keystore->key_search.path_idx;


### PR DESCRIPTION
The error message "key not found" was misleading for the case when a NV object was not found.