### PR TITLE
ESYS: Support of Cp and RpHashes from Esys Layer

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -238,6 +238,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-clockset.int \
     test/integration/esys-clockset-audit.int \
     test/integration/esys-commit.int \
+    test/integration/esys-cp-hash.int \
     test/integration/esys-create-fail.int \
     test/integration/esys-create-password-auth.int \
     test/integration/esys-create-policy-auth.int \
@@ -1136,7 +1137,7 @@ if POLICY
 TESTS_UNIT += test/unit/tss2_policy
 
 test_unit_tss2_policy_CFLAGS  = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
-test_unit_tss2_policy_LDADD   = $(CMOCKA_LIBS) $(libtss2_policy) $(libtss2_esys)
+test_unit_tss2_policy_LDADD   = $(CMOCKA_LIBS) $(libtss2_policy) $(libtss2_esys) $(libtss2_sys)
 test_unit_tss2_policy_SOURCES = test/unit/tss2_policy.c src/util/log.c \
     test/data/test-fapi-policies.h test/helper/cmocka_all.h
 endif # POLICY
@@ -1591,6 +1592,13 @@ test_integration_esys_get_random_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_get_random_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_get_random_int_SOURCES = \
     test/integration/esys-get-random.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_cp_hash_int_CFLAGS  = $(TESTS_CFLAGS)
+test_integration_esys_cp_hash_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_cp_hash_int_LDFLAGS = $(TESTS_LDFLAGS)
+test_integration_esys_cp_hash_int_SOURCES = \
+    test/integration/esys-cp-hash.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
 
 test_integration_esys_get_time_int_CFLAGS  = $(TESTS_CFLAGS) $(TSS2_ESYS_CFLAGS_CRYPTO)

--- a/Makefile.am
+++ b/Makefile.am
@@ -383,6 +383,25 @@ src_tss2_tcti_libtss2_tcti_pcap_la_SOURCES  = \
 endif # ENABLE_TCTI_PCAP
 EXTRA_DIST += lib/tss2-tcti-pcap.map
 
+# tcti null library
+if ENABLE_TCTI_NULL
+libtss2_tcti_null = src/tss2-tcti/libtss2-tcti-null.la
+tss2_HEADERS += $(srcdir)/include/tss2/tss2_tcti_null.h
+lib_LTLIBRARIES += $(libtss2_tcti_null)
+pkgconfig_DATA += lib/tss2-tcti-null.pc
+
+if HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_null_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/lib/tss2-tcti-null.map
+endif # HAVE_LD_VERSION_SCRIPT
+src_tss2_tcti_libtss2_tcti_null_la_LIBADD   = $(libtss2_tctildr) $(libtss2_mu) $(libutil) $(libutilio)
+src_tss2_tcti_libtss2_tcti_null_la_SOURCES  = \
+    src/tss2-tcti/tcti-common.c \
+    src/tss2-tcti/tcti-null.c \
+    src/tss2-tcti/tcti-null.h
+endif # ENABLE_TCTI_NULL
+EXTRA_DIST += lib/tss2-tcti-null.map
+
+
 # tcti libtpms library
 if ENABLE_TCTI_LIBTPMS
 libtss2_tcti_libtpms = src/tss2-tcti/libtss2-tcti-libtpms.la

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setti
 
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-ltt2go.pc lib/tss2-tcti-spidev.pc lib/tss2-tcti-spi-ftdi.pc lib/tss2-tcti-i2c-helper.pc lib/tss2-tcti-i2c-ftdi.pc])
+AC_CONFIG_FILES([Makefile Doxyfile lib/tss2-sys.pc lib/tss2-esys.pc lib/tss2-mu.pc lib/tss2-tcti-device.pc lib/tss2-tcti-mssim.pc lib/tss2-tcti-swtpm.pc lib/tss2-tcti-pcap.pc lib/tss2-tcti-null.pc lib/tss2-tcti-libtpms.pc lib/tss2-rc.pc lib/tss2-tctildr.pc lib/tss2-fapi.pc lib/tss2-tcti-cmd.pc lib/tss2-policy.pc lib/tss2-tcti-spi-helper.pc lib/tss2-tcti-spi-ltt2go.pc lib/tss2-tcti-spidev.pc lib/tss2-tcti-spi-ftdi.pc lib/tss2-tcti-i2c-helper.pc lib/tss2-tcti-i2c-ftdi.pc])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
@@ -277,6 +277,12 @@ AC_ARG_ENABLE([tcti-pcap],
                             [don't build the tcti-pcap module])],,
             [enable_tcti_pcap=yes])
 AM_CONDITIONAL([ENABLE_TCTI_PCAP], [test "x$enable_tcti_pcap" != xno])
+
+AC_ARG_ENABLE([tcti-null],
+            [AS_HELP_STRING([--disable-tcti-null],
+                            [don't build the tcti-null module])],,
+            [enable_tcti_null=yes])
+AM_CONDITIONAL([ENABLE_TCTI_NULL], [test "x$enable_tcti_null" != xno])
 
 AC_ARG_ENABLE([tcti-libtpms],
             [AS_HELP_STRING([--disable-tcti-libtpms],

--- a/include/tss2/tss2_esys.h
+++ b/include/tss2/tss2_esys.h
@@ -3808,6 +3808,24 @@ Esys_SetCryptoCallbacks(
     ESYS_CONTEXT *esysContext,
     ESYS_CRYPTO_CALLBACKS *callbacks);
 
+TSS2_RC
+Esys_GetCpHash(
+    ESYS_CONTEXT* esysContext,
+    TPMI_ALG_HASH hashAlg,
+    uint8_t **cpHash,
+    size_t *cpHash_size);
+
+TSS2_RC
+Esys_GetRpHash(
+    ESYS_CONTEXT* esysContext,
+    TPMI_ALG_HASH hashAlg,
+    uint8_t **cpHash,
+    size_t *cpHash_size);
+
+TSS2_RC
+Esys_Abort(
+    ESYS_CONTEXT* esysContext);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/tss2/tss2_sys.h
+++ b/include/tss2/tss2_sys.h
@@ -2319,6 +2319,9 @@ TSS2_RC Tss2_Sys_PolicyAuthorizeNV(
     TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray);
 
+TSS2_RC Tss2_Sys_Abort(
+     TSS2_SYS_CONTEXT *sysContext);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/tss2/tss2_tcti_null.h
+++ b/include/tss2/tss2_tcti_null.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020 Infineon Technologies AG
+ * All rights reserved.
+ */
+#ifndef TSS2_TCTI_NULL_H
+#define TSS2_TCTI_NULL_H
+
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Null_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_NULL_H */

--- a/lib/tss2-esys.def
+++ b/lib/tss2-esys.def
@@ -1,5 +1,6 @@
 LIBRARY tss2-esys
 EXPORTS
+    Esys_Abort
     Esys_AC_GetCapability
     Esys_AC_GetCapability_Async
     Esys_AC_GetCapability_Finish
@@ -110,10 +111,12 @@ EXPORTS
     Esys_GetCommandAuditDigest
     Esys_GetCommandAuditDigest_Async
     Esys_GetCommandAuditDigest_Finish
+    Esys_GetCpHash
     Esys_GetPollHandles
     Esys_GetRandom
     Esys_GetRandom_Async
     Esys_GetRandom_Finish
+    Esys_GetRpHash
     Esys_GetSessionAuditDigest
     Esys_GetSessionAuditDigest_Async
     Esys_GetSessionAuditDigest_Finish

--- a/lib/tss2-esys.map
+++ b/lib/tss2-esys.map
@@ -1,5 +1,6 @@
 {
     global:
+        Esys_Abort;
         Esys_AC_GetCapability;
         Esys_AC_GetCapability_Async;
         Esys_AC_GetCapability_Finish;
@@ -109,9 +110,11 @@
         Esys_GetCommandAuditDigest;
         Esys_GetCommandAuditDigest_Async;
         Esys_GetCommandAuditDigest_Finish;
+        Esys_GetCpHash;
         Esys_GetRandom;
         Esys_GetRandom_Async;
         Esys_GetRandom_Finish;
+        Esys_GetRpHash;
         Esys_GetSessionAuditDigest;
         Esys_GetSessionAuditDigest_Async;
         Esys_GetSessionAuditDigest_Finish;

--- a/lib/tss2-sys.def
+++ b/lib/tss2-sys.def
@@ -1,5 +1,6 @@
 LIBRARY tss2-sys
 EXPORTS
+    Tss2_Sys_Abort
     Tss2_Sys_ActivateCredential_Prepare
     Tss2_Sys_ActivateCredential_Complete
     Tss2_Sys_ActivateCredential

--- a/lib/tss2-sys.map
+++ b/lib/tss2-sys.map
@@ -1,5 +1,6 @@
 {
     global:
+        Tss2_Sys_Abort;
         Tss2_Sys_AC_GetCapability_Prepare;
         Tss2_Sys_AC_GetCapability_Complete;
         Tss2_Sys_AC_GetCapability;

--- a/lib/tss2-tcti-null.def
+++ b/lib/tss2-tcti-null.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-null
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Null_Init

--- a/lib/tss2-tcti-null.map
+++ b/lib/tss2-tcti-null.map
@@ -1,0 +1,7 @@
+{
+    global:
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Null_Init;
+    local:
+        *;
+};

--- a/lib/tss2-tcti-null.pc.in
+++ b/lib/tss2-tcti-null.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: tss2-tcti-null
+Description: TCTI library which only provides TCTI initialization.
+URL: https://github.com/tpm2-software/tpm2-tss
+Version: @VERSION@
+Requires.private: tss2-tctildr
+Cflags: -I${includedir}
+Libs: -ltss2-tcti-null -L${libdir}

--- a/src/tss2-esys/esys_cp_rp_hash.c
+++ b/src/tss2-esys/esys_cp_rp_hash.c
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2025, Juergen Repp
+ * All rights reserved.
+ ******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include <inttypes.h>         // for PRIx32, uint8_t, SIZE_MAX, int32_t
+#include <stdbool.h>          // for bool, false, true
+#include <stdlib.h>           // for NULL, malloc, size_t, calloc
+#include <string.h>           // for memcmp
+
+#include "esys_int.h"         // for RSRC_NODE_T, ESYS_CONTEXT, _ESYS_ASSERT...
+#include "esys_mu.h"          // for iesys_MU_IESYS_RESOURCE_Marshal, iesys_...
+#include "esys_types.h"       // for IESYS_RESOURCE, IESYS_RSRC_UNION, IESYS...
+#include "esys_iutil.h"       // for iesys_compute_cp_hash ...
+#include "tss2_common.h"      // for TSS2_RC, TSS2_RC_SUCCESS, TSS2_ESYS_RC_...
+#include "tss2_esys.h"        // for ESYS_CONTEXT, ESYS_TR, ESYS_TR_NONE
+#include "tss2_tpm2_types.h"  // for TPM2B_NAME, TPM2_HANDLE, TPM2_HR_SHIFT
+
+#define LOGMODULE esys
+#include "util/log.h"         // for return_if_error, SAFE_FREE, goto_if_error
+
+/** Get the cpHash buffer computed by an ESYS async call.
+ *
+ * The buffer will be returned if the buffer is found for the passed hashAlg.
+ * @param esys_ctxt [in,out] The ESYS_CONTEXT.
+ * @param hashAlg [in] The hash alg used to compute the cp hash.
+ * @param cpHash [out] The buffer containing the cp hash.
+ *        (caller-callocated)
+ * @param cpHash_size [out] The size of the cpHash buffer.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_SYS_RC_BAD_SEQUENCE: if the SAPI is not in appropriate state.
+ * @retval TSS2_ESYS_RC_BAD_VALUE if hashAlg is not found.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE if esys_ctx is NULL.
+ * @retval TSS2_ESYS_RC_MEMORY if the buffer for the cpHash can't
+ *         be allocated.
+ */
+TSS2_RC Esys_GetCpHash(ESYS_CONTEXT* esys_ctx,
+                       TPMI_ALG_HASH hashAlg, uint8_t **cpHash, size_t *cpHash_size) {
+
+    uint8_t cp_hash[sizeof(TPMU_HA)];
+    TSS2_RC r;
+
+    return_if_null(esys_ctx, "ESYS context is NULL",
+                   TSS2_ESYS_RC_BAD_REFERENCE);
+    r = iesys_compute_cp_hash(esys_ctx, hashAlg, &cp_hash[0], cpHash_size);
+    return_if_error(r, "Compute cp hash");
+    *cpHash = malloc(*cpHash_size);
+    return_if_null(*cpHash, "Buffer could not be allocated",
+                   TSS2_ESYS_RC_MEMORY);
+    memcpy(*cpHash, &cp_hash[0], *cpHash_size);
+    return TSS2_RC_SUCCESS;}
+
+/** Get the rpHash buffer computed by an ESYS finalize call.
+ *
+ * The buffer will be returned if the buffer is found for the passed hashAlg.
+ * @param esys_ctx [in,out] The ESYS_CONTEXT.
+ * @param hashAlg [in] The hash alg used to compute the rp hash.
+ * @param rpHash [out] The buffer containing the rp hash.
+ *        (caller-callocated)
+ * @param rpHash_size [out] The size of the rpHash buffer.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_SYS_RC_BAD_SEQUENCE: if the SAPI is not in appropriate state.
+ * @retval TSS2_ESYS_RC_BAD_VALUE if hashAlg is not found.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE if esys_ctx is NULL.
+ * @retval TSS2_ESYS_RC_MEMORY if the buffer for the rpHash can't
+ *         be allocated.
+ */
+TSS2_RC Esys_GetRpHash(ESYS_CONTEXT* esys_ctx,
+                       TPMI_ALG_HASH hashAlg, uint8_t **rpHash, size_t *rpHash_size) {
+    uint8_t rp_hash[sizeof(TPMU_HA)];
+    TSS2_RC r;
+
+    return_if_null(esys_ctx, "ESYS context is NULL",
+                   TSS2_ESYS_RC_BAD_REFERENCE);
+
+    r = iesys_compute_rp_hash(esys_ctx, hashAlg, &rp_hash[0], rpHash_size);
+    return_if_error(r, "Compute rp hash");
+    *rpHash = malloc(*rpHash_size);
+
+    return_if_null(*rpHash, "Buffer could not be allocated",
+                   TSS2_ESYS_RC_MEMORY);
+    memcpy(*rpHash, &rp_hash[0], *rpHash_size);
+    return TSS2_RC_SUCCESS;
+}
+
+/** Reset the ESYS state.
+ *
+ * If only the cp hash will be computed and there will no finish call
+ * after the async call the ESYS sate and also the SAPI state has to be
+ * reset to allow further ESYS and SAPI calls.
+ * @param esys_ctx [in,out] The ESYS_CONTEXT.
+ * @param cpHash_size [out] The size of the cpHash buffer.
+ * @retval TSS2_RC_SUCCESS on Success.
+ * @retval TSS2_ESYS_RC_BAD_REFERENCE if esys_ctx is NULL.
+ */
+TSS2_RC Esys_Abort(ESYS_CONTEXT* esys_ctx) {
+    TSS2_SYS_CONTEXT *sys_ctx;
+    TSS2_RC r;
+
+    return_if_null(esys_ctx, "ESYS context is NULL",
+                   TSS2_ESYS_RC_BAD_REFERENCE);
+    esys_ctx->state = ESYS_STATE_INIT;
+
+    r = Esys_GetSysContext(esys_ctx, &sys_ctx);
+    return_if_error(r, "Could not get Sys context");
+
+    return Tss2_Sys_Abort(sys_ctx);
+}

--- a/src/tss2-esys/esys_cp_rp_hash.c
+++ b/src/tss2-esys/esys_cp_rp_hash.c
@@ -104,10 +104,14 @@ TSS2_RC Esys_Abort(ESYS_CONTEXT* esys_ctx) {
 
     return_if_null(esys_ctx, "ESYS context is NULL",
                    TSS2_ESYS_RC_BAD_REFERENCE);
-    esys_ctx->state = ESYS_STATE_INIT;
 
     r = Esys_GetSysContext(esys_ctx, &sys_ctx);
     return_if_error(r, "Could not get Sys context");
 
-    return Tss2_Sys_Abort(sys_ctx);
+    r =  Tss2_Sys_Abort(sys_ctx);
+    return_if_error(r, "Call of Tss2_Sys_Abort failed.");
+
+    esys_ctx->state = ESYS_STATE_INIT;
+
+    return TSS2_RC_SUCCESS;
 }

--- a/src/tss2-esys/esys_int.h
+++ b/src/tss2-esys/esys_int.h
@@ -177,6 +177,7 @@ struct ESYS_CONTEXT {
                                       current command execution. */
     RSRC_NODE_T *session_tab[3]; /**< The list of TPM session meta data in the
                                       current command execution. */
+    RSRC_NODE_T *auth_objects[3];/**< The list of objects to be authenticated */
     int encryptNonceIdx;         /**< The index of the encrypt session. */
     TPM2B_NONCE *encryptNonce;   /**< The nonce of the encrypt session, or NULL
                                       if no encrypt session exists. */

--- a/src/tss2-esys/esys_iutil.h
+++ b/src/tss2-esys/esys_iutil.h
@@ -33,13 +33,6 @@ extern "C" {
  */
 #define ESYS_TR_MIN_OBJECT (TPM2_RH_LAST + 1 + 0x1000)
 
-/** An entry in a cpHash or rpHash table. */
-typedef struct {
-    TPM2_ALG_ID alg;                 /**< The hash algorithm. */
-    size_t size;                     /**< The digest size. */
-    uint8_t digest[sizeof(TPMU_HA)]; /**< The digest. */
-} HASH_TAB_ITEM;
-
 TSS2_RC init_session_tab(
     ESYS_CONTEXT *esysContext,
     ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3);
@@ -51,21 +44,6 @@ TSS2_RC iesys_compute_encrypt_nonce(
     ESYS_CONTEXT *esysContext,
     int *encryptNonceIdx,
     TPM2B_NONCE **encryptNonce);
-
-TSS2_RC iesys_compute_cp_hashtab(
-    ESYS_CONTEXT *esysContext,
-    const TPM2B_NAME *name1,
-    const TPM2B_NAME *name2,
-    const TPM2B_NAME *name3,
-    HASH_TAB_ITEM cp_hash_tab[3],
-    uint8_t *cpHashNum);
-
-TSS2_RC iesys_compute_rp_hashtab(
-    ESYS_CONTEXT *esysContext,
-    const uint8_t *rpBuffer,
-    size_t rpBuffer_size,
-    HASH_TAB_ITEM rp_hash_tab[3],
-    uint8_t *rpHashNum);
 
 TSS2_RC esys_CreateResourceObject(
     ESYS_CONTEXT *esys_context,
@@ -113,9 +91,7 @@ TSS2_RC iesys_decrypt_param(
 
 TSS2_RC iesys_check_rp_hmacs(
     ESYS_CONTEXT *esysContext,
-    TSS2L_SYS_AUTH_RESPONSE *rspAuths,
-    HASH_TAB_ITEM rp_hash_tab[3],
-    uint8_t rpHashNum);
+    TSS2L_SYS_AUTH_RESPONSE *rspAuths);
 
 void iesys_compute_bound_entity(
     const TPM2B_NAME *name,
@@ -144,8 +120,6 @@ void iesys_compute_session_value(
 TSS2_RC iesys_compute_hmac(
     ESYS_CONTEXT *esys_context,
     RSRC_NODE_T *session,
-    HASH_TAB_ITEM cp_hash_tab[3],
-    uint8_t cpHashNum,
     TPM2B_NONCE *decryptNonce,
     TPM2B_NONCE *encryptNonce,
     TPMS_AUTH_COMMAND *auth);
@@ -180,6 +154,18 @@ TSS2_RC iesys_adapt_auth_value(
 
 void iesys_strip_trailing_zeros(
     TPM2B_AUTH *auth_value);
+
+TSS2_RC iesys_compute_cp_hash(
+    ESYS_CONTEXT *esys_context,
+    TPMI_ALG_HASH hash_alg,
+    uint8_t *cp_hash,
+    size_t *cp_hash_size);
+
+ TSS2_RC iesys_compute_rp_hash(
+    ESYS_CONTEXT *esys_context,
+    TPMI_ALG_HASH hash_alg,
+    uint8_t *rp_hash,
+    size_t *rp_hash_size);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -243,6 +243,7 @@
     <ClCompile Include="api\Esys_VerifySignature.c" />
     <ClCompile Include="api\Esys_ZGen_2Phase.c" />
     <ClCompile Include="esys_context.c" />
+    <ClCompile Include="esys_cp_rp_hash.c" />
     <ClCompile Include="esys_crypto.c" />
     <ClCompile Include="esys_crypto_ossl.c" />
     <ClCompile Include="esys_free.c" />

--- a/src/tss2-sys/api/Tss2_Sys_Abort.c
+++ b/src/tss2-sys/api/Tss2_Sys_Abort.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/***********************************************************************;
+ * Copyright (c) 2025, Juergen Repp
+ * All rights reserved.
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include "sysapi_util.h"      // for _TSS2_SYS_CONTEXT_BLOB, syscontext_cast
+#include "tss2_common.h"      // for TSS2_RC, TSS2_SYS_RC_BAD_REFERENCE, UINT16
+#include "tss2_sys.h"         // for TSS2_SYS_CONTEXT, TSS2L_SYS_AUTH_COMMAND
+
+TSS2_RC Tss2_Sys_Abort(
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    ctx->previousStage = CMD_STAGE_INITIALIZE;
+    return TSS2_RC_SUCCESS;
+}

--- a/src/tss2-sys/api/Tss2_Sys_GetCpBuffer.c
+++ b/src/tss2-sys/api/Tss2_Sys_GetCpBuffer.c
@@ -25,7 +25,7 @@ TSS2_RC Tss2_Sys_GetCpBuffer(
     if (!ctx || !cpBufferUsedSize || !cpBuffer)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (ctx->previousStage != CMD_STAGE_PREPARE)
+    if (ctx->previousStage != CMD_STAGE_PREPARE && ctx->previousStage != CMD_STAGE_SEND_COMMAND)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
     *cpBuffer = ctx->cpBuffer;

--- a/src/tss2-sys/tss2-sys.vcxproj
+++ b/src/tss2-sys/tss2-sys.vcxproj
@@ -32,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\util\log.c" />
+    <ClCompile Include="api\Tss2_Sys_Abort.c" />
     <ClCompile Include="api\Tss2_Sys_CreateLoaded.c" />
     <ClCompile Include="api\Tss2_Sys_GetRspAuths.c" />
     <ClCompile Include="api\Tss2_Sys_PolicyAuthorizeNV.c" />

--- a/src/tss2-tcti/tcti-null.c
+++ b/src/tss2-tcti/tcti-null.c
@@ -1,0 +1,178 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025 Juergen Repp
+ * All rights reserved.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include <inttypes.h>           // for PRIxPTR, uintptr_t, uint8_t, int32_t
+#include <string.h>             // for NULL, size_t, memset
+
+#include "tcti-common.h"        // for TSS2_TCTI_COMMON_CONTEXT, TCTI_STATE_...
+#include "tss2_common.h"        // for TSS2_RC_SUCCESS, TSS2_RC, TSS2_TCTI_R...
+#include "tss2_tcti.h"          // for TSS2_TCTI_CONTEXT, TSS2_TCTI_INFO
+#include "tss2_tpm2_types.h"    // for TPM2_RC_SUCCESS
+#include "util/aux_util.h"      // for UNUSED
+
+#define LOGMODULE tcti
+#include "tcti-null.h"
+#include "tss2_tctildr.h"       // for Tss2_TctiLdr_Finalize, Tss2_TctiLdr_I...
+#include "util/log.h"           // for LOG_WARNING, LOG_ERROR, LOGBLOB_DEBUG
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the null TCTI context. The only safeguard we have to ensure this
+ * operation is possible is the magic number in the null TCTI context.
+ * If passed a NULL context, or the magic number check fails, this function
+ * will return NULL.
+ */
+TSS2_TCTI_NULL_CONTEXT*
+tcti_null_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_NULL_MAGIC) {
+        return (TSS2_TCTI_NULL_CONTEXT*)tcti_ctx;
+    }
+    return NULL;
+}
+
+/*
+ * This function down-casts the null TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+TSS2_TCTI_COMMON_CONTEXT*
+tcti_null_down_cast (TSS2_TCTI_NULL_CONTEXT *tcti_null)
+{
+    if (tcti_null == NULL) {
+        return NULL;
+    }
+    return &tcti_null->common;
+}
+
+TSS2_RC
+tcti_null_transmit (
+    TSS2_TCTI_CONTEXT *tcti_ctx,
+    size_t size,
+    const uint8_t *cmd_buf)
+{
+    UNUSED(tcti_ctx);
+    UNUSED(size);
+    UNUSED(cmd_buf);
+    LOG_WARNING("transmit can't be executed for tcti null.");
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_null_receive (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    unsigned char *response_buffer,
+    int32_t timeout)
+{
+    UNUSED(tctiContext);
+    UNUSED(response_size);
+    UNUSED(response_buffer);
+    UNUSED(timeout);
+    LOG_WARNING("receive can't be executed for tcti null.");
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_null_cancel (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    UNUSED(tctiContext);
+    LOG_WARNING("cancel can't be executed for tcti null.");
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_null_set_locality (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality)
+{
+    UNUSED(tctiContext);
+    UNUSED(locality);
+    LOG_WARNING("set_locality can't be executed for tcti null.");
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_null_get_poll_handles (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    UNUSED(tctiContext);
+    UNUSED(handles);
+    UNUSED(num_handles);
+    LOG_WARNING("get_poll_handles can't be executed for tcti null.");
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+void
+tcti_null_finalize (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    TSS2_TCTI_NULL_CONTEXT *tcti_null = tcti_null_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_null_down_cast (tcti_null);
+    if (tcti_null == NULL) {
+        return;
+    }
+
+    tcti_common->state = TCTI_STATE_FINAL;
+}
+
+/*
+ * This is an implementation of the standard TCTI initialization function for
+ * this module.
+ */
+TSS2_RC
+Tss2_Tcti_Null_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf)
+{
+    UNUSED(conf);
+    TSS2_TCTI_NULL_CONTEXT *tcti_null = (TSS2_TCTI_NULL_CONTEXT*) tctiContext;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_null_down_cast (tcti_null);
+
+    if (tctiContext == NULL && size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    } else if (tctiContext == NULL) {
+        *size = sizeof (TSS2_TCTI_NULL_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    TSS2_TCTI_MAGIC (tcti_common) = TCTI_NULL_MAGIC;
+    TSS2_TCTI_VERSION (tcti_common) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tcti_common) = tcti_null_transmit;
+    TSS2_TCTI_RECEIVE (tcti_common) = tcti_null_receive;
+    TSS2_TCTI_FINALIZE (tcti_common) = tcti_null_finalize;
+    TSS2_TCTI_CANCEL (tcti_common) = tcti_null_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tcti_common) = tcti_null_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tcti_common) = tcti_null_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tcti_common) = tcti_make_sticky_not_implemented;
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    tcti_common->locality = 3;
+    memset (&tcti_common->header, 0, sizeof (tcti_common->header));
+
+    return TSS2_RC_SUCCESS;
+}
+
+/* public info structure */
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-null",
+    .description = "TCTI module which only provides initialization.",
+    .config_help = "",
+    .init = Tss2_Tcti_Null_Init,
+};
+
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-null.h
+++ b/src/tss2-tcti/tcti-null.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025 Juergen Repp
+ * All rights reserved.
+ */
+
+#ifndef TCTI_NULL_H
+#define TCTI_NULL_H
+
+#include "tcti-common.h"
+#include "tss2_tcti.h"
+
+#define TCTI_NULL_MAGIC 0x9af45c5d7d9d0d3fULL
+
+typedef struct {
+    const char *child_tcti;
+} tcti_null_conf_t;
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+} TSS2_TCTI_NULL_CONTEXT;
+
+#endif /* TCTI_NULL_H */

--- a/test/integration/esys-cp-hash.int.c
+++ b/test/integration/esys-cp-hash.int.c
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2025, Juergen Repp
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include <stdlib.h>           // for free, NULL, EXIT_FAILURE, EXIT_SUCCESS
+
+#include "tss2_common.h"      // for BYTE, TSS2_RC
+#include "tss2_esys.h"        // for ESYS_TR_NONE, Esys_GetRandom, Esys_Star...
+#include "tss2_tpm2_types.h"  // for TPM2B_DIGEST, TPM2_RC_SUCCESS, TPMA_SES...
+
+#define LOGMODULE test
+#include "util/log.h"         // for LOG_ERROR, LOGBLOB_DEBUG, LOG_INFO
+
+
+/** Test the ESYS function Esys_GetRandom.
+ *
+ * Tested ESYS commands:
+ *  - Esys_GetRandom() (M)
+ *  - Esys_StartAuthSession() (M)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SUCCESS
+ */
+int
+test_esyscp_hash(ESYS_CONTEXT * esys_context)
+{
+
+    TSS2_RC r;
+    int i;
+
+    TPM2B_DIGEST *randomBytes;
+
+    uint8_t get_rand_cp_hash[32] =
+        { 0xc0, 0x75, 0xb7, 0xe6, 0x37, 0xa7, 0x13, 0x1b, 0x0c, 0x52,
+          0x3c, 0xf1, 0x96, 0x5e, 0xba, 0xe2, 0xaf, 0xb1, 0x16, 0x0b,
+          0x6e, 0xf7, 0xc7, 0xe9, 0x2d, 0x0d, 0x24, 0xce, 0x0a, 0x5d,
+          0x94, 0x11 };
+
+    ESYS_TR session = ESYS_TR_NONE;
+    const TPMT_SYM_DEF symmetric = {
+        .algorithm = TPM2_ALG_AES,
+        .keyBits = {.aes = 128},
+        .mode = {.aes = TPM2_ALG_CFB}
+    };
+    uint8_t *cp_hash;
+    size_t cp_hash_size;
+    uint8_t *rp_hash;
+    size_t rp_hash_size;
+
+    r = Esys_StartAuthSession(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              NULL,
+                              TPM2_SE_HMAC, &symmetric, TPM2_ALG_SHA256,
+                             &session);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("Esys_StartAuthSession FAILED! Response Code : 0x%x", r);
+        goto error;
+    }
+
+    r = Esys_TRSess_SetAttributes(esys_context, session, TPMA_SESSION_CONTINUESESSION | TPMA_SESSION_AUDIT,
+                                  TPMA_SESSION_CONTINUESESSION | TPMA_SESSION_AUDIT);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("SetAttributes on session FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    r = Esys_GetRandom_Async(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE, 48);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetRandom with session FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    r = Esys_GetCpHash(esys_context, TPM2_ALG_SHA256, &cp_hash, &cp_hash_size);
+
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetCpHash FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    LOGBLOB_DEBUG(cp_hash, cp_hash_size, "cp hash");
+
+    /* Check cp hash for get_random with 48 bytes. */
+    for (i = 0; i < 32; i++) {
+        if (cp_hash[i] != get_rand_cp_hash[i]) {
+            LOG_ERROR("Wrong cp hash value.");
+            free(cp_hash);
+            goto error_cleansession;
+        }
+    }
+    free(cp_hash);
+
+    do {
+        /* Call call finish as long as retry return codes are returned. */
+        r = Esys_GetRandom_Finish(esys_context, &randomBytes);
+        if (r == TSS2_RC_SUCCESS) {
+            break;
+        } else if ((r & ~TSS2_RC_LAYER_MASK) == TSS2_BASE_RC_TRY_AGAIN) {
+            continue;
+        } else{
+            LOG_ERROR("GetRandom with session FAILED! Response Code : 0x%x", r);
+            goto error_cleansession;
+        }
+    } while (1);
+
+    r = Esys_GetRpHash(esys_context, TPM2_ALG_SHA256, &rp_hash, &rp_hash_size);
+
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetRpHash FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+    free(rp_hash);
+
+    LOGBLOB_DEBUG(&randomBytes->buffer[0], randomBytes->size,
+                  "Randoms (count=%i):", randomBytes->size);
+    free(randomBytes);
+
+    r = Esys_GetRandom_Async(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE, 48);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetRandom with session FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    r = Esys_GetCpHash(esys_context, TPM2_ALG_SHA256, &cp_hash, &cp_hash_size);
+
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetCpHash FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    free(cp_hash);
+
+    /* Check whether call of Esys_GetRandom works after abort. */
+
+    r = Esys_Abort(esys_context);
+
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("Abort FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+    r = Esys_GetRandom(esys_context, session, ESYS_TR_NONE, ESYS_TR_NONE, 48,
+                       &randomBytes);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("GetRandom with session FAILED! Response Code : 0x%x", r);
+        goto error_cleansession;
+    }
+
+    free(randomBytes);
+
+    r = Esys_FlushContext(esys_context, session);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", r);
+    }
+
+    return EXIT_SUCCESS;
+
+  error_cleansession:
+    r = Esys_FlushContext(esys_context, session);
+    if (r != TPM2_RC_SUCCESS) {
+        LOG_ERROR("FlushContext FAILED! Response Code : 0x%x", r);
+    }
+ error:
+    return EXIT_FAILURE;
+}
+
+int
+test_invoke_esys(ESYS_CONTEXT * esys_context) {
+    return test_esyscp_hash(esys_context);
+}

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -2123,14 +2123,7 @@ retry:
     rval = Tss2_Sys_SetDecryptParam( sysContext, 10, (uint8_t *)4 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #12 */
 
-    /*
-     * NOTE: Stick test for BAD_SEQUENCE for GetCpBuffer here, just
-     * because it's easier to do this way.
-     */
-    rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)4, &cpBuffer );
-    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #13 */
-
-    /*
+     /*
      * Now finish the write command so that TPM isn't stuck trying
      * to send a response.
      */
@@ -2139,7 +2132,14 @@ retry:
         LOG_INFO ("got TPM2_RC_RETRY, trying again");
         goto retry;
     }
-    CheckPassed( rval ); /* #14 */
+    CheckPassed( rval ); /* #13 */
+
+    /*
+     * NOTE: Stick test for BAD_SEQUENCE for GetCpBuffer here, just
+     * because it's easier to do this way.
+     */
+    rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)4, &cpBuffer );
+    CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); /* #14 */
 
     /* Test GetEncryptParam for no encrypt param case. */
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );

--- a/tss2-dlopen/tss2-dlopen-esys.c
+++ b/tss2-dlopen/tss2-dlopen-esys.c
@@ -2303,3 +2303,12 @@ MAKE_ESYS_1(Esys_GetSysContext,
     TSS2_SYS_CONTEXT **, sys_context);
 MAKE_ESYS_1(Esys_SetCryptoCallbacks,
     ESYS_CRYPTO_CALLBACKS *, callbacks);
+MAKE_ESYS_3(Esys_GetCpHash,
+    TPMI_ALG_HASH, hashAlg,
+    uint8_t **, cpHash,
+    size_t, *cpHash_size);
+MAKE_ESYS_3(Esys_GetRpHash,
+    TPMI_ALG_HASH, hashAlg,
+    uint8_t **, cpHash,
+    size_t, *cpHash_size);
+MAKE_ESYS_0(Esys_Abort);


### PR DESCRIPTION
* The ESYS API is extended with the functions:
   Esys_GetCpHash, Esys_GetRpHash, and Esys_Abort.
   The cp hash can computed after the async call of a function. The rp hash
   after the finish call. If only the async call is executed to to compute the cp hash
   Esys_Abort has to be called to enable the execution of further ESYS commands.
* The function Tss2_Sys_Abort to reset the SYS sate is added.
*  The state handling of Tss2_Sys_GetCpBuffer is changed.
* An integration test is added.
* A tcti module which can only used for tcti initialization is added.

Addresses: #2930.
