### PR TITLE
ci: fix git fetch depth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-            fetch-depth: 01
+            fetch-depth: 0
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action


### PR DESCRIPTION
The fetch depth for test-coverage was accidentally set to 01.