### PR TITLE
ci: Cirrus ci update freebsd-14-1 to freebsd-14-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     libusb_version: v1.0.26
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-1
+      image_family: freebsd-14-2
   install_script:
     - IGNORE_OSVERSION=yes
     - pkg update -f


### PR DESCRIPTION
The resource projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-1 was not found.