### PR TITLE
FAPI: Fix outdated fapi profiles.

### DIFF
--- a/dist/fapi-profiles/P_ECCP256SHA256.json
+++ b/dist/fapi-profiles/P_ECCP256SHA256.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/dist/fapi-profiles/P_ECCP384SHA384.json
+++ b/dist/fapi-profiles/P_ECCP384SHA384.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA384",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt,user",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/dist/fapi-profiles/P_RSA2048SHA256.json
+++ b/dist/fapi-profiles/P_RSA2048SHA256.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {

--- a/dist/fapi-profiles/P_RSA3072SHA384.json
+++ b/dist/fapi-profiles/P_RSA3072SHA384.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA384",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt,user",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {

--- a/test/data/fapi/P_ECC.json
+++ b/test/data/fapi/P_ECC.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_ECC384.json
+++ b/test/data/fapi/P_ECC384.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA384",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt,user",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_ECC_error.json
+++ b/test/data/fapi/P_ECC_error.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt,0x81000001",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_ECC_sh_eh_policy.json
+++ b/test/data/fapi/P_ECC_sh_eh_policy.json
@@ -2,7 +2,6 @@
     "type": "TPM2_ALG_ECC",
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000002",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
     "ecc_signing_scheme": {
         "scheme":"TPM2_ALG_ECDSA",

--- a/test/data/fapi/P_ECC_sh_eh_policy_sha384.json
+++ b/test/data/fapi/P_ECC_sh_eh_policy_sha384.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA384",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt,user",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_ECC_system.json
+++ b/test/data/fapi/P_ECC_system.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_RSA.json
+++ b/test/data/fapi/P_RSA.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {

--- a/test/data/fapi/P_RSA2.json
+++ b/test/data/fapi/P_RSA2.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000002",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {

--- a/test/data/fapi/P_RSA3072.json
+++ b/test/data/fapi/P_RSA3072.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA384",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt,user",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {

--- a/test/data/fapi/P_RSA_EK_persistent.json
+++ b/test/data/fapi/P_RSA_EK_persistent.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt",
      "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template": "system,restricted,decrypt,0x81000000",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_RSA_nameAlg_sha1.json
+++ b/test/data/fapi/P_RSA_nameAlg_sha1.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA1",
     "srk_template": "system,restricted,decrypt",
      "srk_description": "Storage root key SRK",
-    "srk_persistent": 0,
     "ek_template": "system,restricted,decrypt,0x81000000",
     "ek_description": "Endorsement key EK",
     "ecc_signing_scheme": {

--- a/test/data/fapi/P_RSA_sh_policy.json
+++ b/test/data/fapi/P_RSA_sh_policy.json
@@ -3,7 +3,6 @@
     "nameAlg":"TPM2_ALG_SHA256",
     "srk_template": "system,restricted,decrypt,0x81000001",
     "srk_description": "Storage root key SRK",
-    "srk_persistent": 1,
     "ek_template":  "system,restricted,decrypt",
     "ek_description": "Endorsement key EK",
     "rsa_signing_scheme": {


### PR DESCRIPTION
The variable srk_persistent in the profile is no longer used. A persistent SRK will be created if the TPM handle is added to the variable srk_template.
E.g.:  "srk_template": "system,restricted,decrypt,0x81000001"