### PR TITLE
build: Removed deprecated ACLOCAL_AMFLAGS to support slibtool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,6 @@
 
 ### Initialize global variables used throughout the file ###
 INCLUDE_DIRS    = -I$(srcdir)/src -I$(srcdir)/include/tss2
-ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
 				  $(SANITIZER_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(SANITIZER_LDFLAGS)


### PR DESCRIPTION
The --install option in ACLOCAL_AMFLAGS creates problems for Gentoo users using slibtool. ACLOCAL_AMFLAGS has been deprecated since Automake 1.13 in favor of AC_CONFIG_MACROS_DIR([m4]). This allows slibtool to work. 