### PR TITLE
TCTI: Fix clock source on illumos in pcap builder

### DIFF
--- a/src/tss2-tcti/tcti-pcap-builder.c
+++ b/src/tss2-tcti/tcti-pcap-builder.c
@@ -24,7 +24,7 @@
 #define LOGMODULE tcti
 #include "util/log.h"       // for LOG_ERROR, LOG_WARNING, LOG_TRACE
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__illumos__)
 #define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
 #endif
 


### PR DESCRIPTION
illumos needs a similar fix to FreeBSD for defining the clock source to use with pcap builder.