### PR TITLE
TCTI: Add Tss2_Tcti_Null_Context struct

### DIFF
--- a/src/tss2-tcti/tcti-null.h
+++ b/src/tss2-tcti/tcti-null.h
@@ -12,6 +12,11 @@
 
 #define TCTI_NULL_MAGIC 0x9af45c5d7d9d0d3fULL
 
+static const TSS2_TCTI_CONTEXT_COMMON_V2 Tss2_Tcti_Null_Context = {
+    .v1.magic = TCTI_NULL_MAGIC,
+    .v1.version = 2,
+};
+
 typedef struct {
     const char *child_tcti;
 } tcti_null_conf_t;


### PR DESCRIPTION
This struct can be used for quick access without requiring to call Tss2_Tcti_Null_Init() first.
Fixes: #2950