### PR TITLE
FAPI: Fix leak in Fapi_Sign

### DIFF
--- a/src/tss2-fapi/api/Fapi_Sign.c
+++ b/src/tss2-fapi/api/Fapi_Sign.c
@@ -300,7 +300,7 @@ Fapi_Sign_Finish(
             /* Perform the signing operation using a helper. */
             r = ifapi_key_sign(context, command->key_object,
                     command->padding, &command->digest, &command->tpm_signature,
-                    &command->publicKey,
+                    publicKey ? &command->publicKey : NULL,
                     (certificate) ? &command->certificate : NULL);
             return_try_again(r);
             goto_if_error(r, "Fapi sign.", cleanup);


### PR DESCRIPTION
Fapi_Sign causes a memory leak when the optional public key output parameter is not provided. Fixes: #2962