### PR TITLE
libtpms: mock mremap to support FreeBSD with -Werror=implicit-function-declaration

### DIFF
--- a/src/tss2-tcti/tcti-libtpms.c
+++ b/src/tss2-tcti/tcti-libtpms.c
@@ -30,6 +30,10 @@
 #define LOGMODULE tcti
 #include "util/log.h"           // for LOG_ERROR, LOG_TRACE, LOG_DEBUG, LOGB...
 
+#if defined(__FreeBSD__)
+#define mremap(a,b,c,d) ((void*)(-1))
+#endif
+
 /*
  * libtpms API calls need to be wrapped. We set the current active TCTI module
  * for this thread. This is needed because libtpms may call callbacks and these


### PR DESCRIPTION
mremap is merely unreachable when building for FreeBSD, which makes the compiler mad about the implicit function declaration.