### PR TITLE
mu: Add missing prototypes

### DIFF
--- a/include/tss2/tss2_mu.h
+++ b/include/tss2/tss2_mu.h
@@ -385,6 +385,20 @@ Tss2_MU_TPM2B_PRIVATE_KEY_RSA_Unmarshal(
     TPM2B_PRIVATE_KEY_RSA *dest);
 
 TSS2_RC
+Tss2_MU_TPM2B_PRIVATE_VENDOR_SPECIFIC_Marshal(
+    TPM2B_PRIVATE_VENDOR_SPECIFIC const *src,
+    uint8_t         buffer[],
+    size_t          buffer_size,
+    size_t         *offset);
+
+TSS2_RC
+Tss2_MU_TPM2B_PRIVATE_VENDOR_SPECIFIC_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          buffer_size,
+    size_t         *offset,
+    TPM2B_PRIVATE_VENDOR_SPECIFIC  *dest);
+
+TSS2_RC
 Tss2_MU_TPM2B_PRIVATE_Marshal(
     TPM2B_PRIVATE const *src,
     uint8_t         buffer[],


### PR DESCRIPTION
Add prototypes for `Tss2_MU_TPM2B_PRIVATE_VENDOR_SPECIFIC_Marshal` and `Tss2_MU_TPM2B_PRIVATE_VENDOR_SPECIFIC_Unmarshal`. This fixes compilation with `-Wmissing-prototypes`