### PR TITLE
build: Fix file tss2-rc.vcxproj not in release (4.1.x)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,5 +22,5 @@ task:
     # Due to a race condition that only occurs in the cirrus ci, "make distcheck" has been replaced by "make check".
     #
     ./bootstrap &&
-    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --enable-nodl --disable-dependency-tracking &&
+    ./configure --enable-self-generated-certificate --enable-unit=yes --enable-integration=yes --with-crypto=ossl --disable-doxygen-doc --enable-tcti-swtpm=yes --enable-tcti-libtpms=no --enable-tcti-mssim=no --disable-dependency-tracking &&
     gmake -j check || { cat /tmp/cirrus-ci-build/tpm2-tss-*/_build/sub/test-suite.log; exit 1; }

--- a/Makefile.am
+++ b/Makefile.am
@@ -618,7 +618,8 @@ libtss2_rc = src/tss2-rc/libtss2-rc.la
 tss2_HEADERS += $(srcdir)/include/tss2/tss2_rc.h
 lib_LTLIBRARIES += $(libtss2_rc)
 pkgconfig_DATA += lib/tss2-rc.pc
-EXTRA_DIST += lib/tss2-rc.map lib/tss2-rc.def
+EXTRA_DIST += lib/tss2-rc.map lib/tss2-rc.def \
+              src/tss2-rc/tss2-rc.vcxproj
 
 if HAVE_LD_VERSION_SCRIPT
 src_tss2_rc_libtss2_rc_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/tss2-rc.map


### PR DESCRIPTION
* src/tss2-rc/tss2-rc.vcxproj is added to EXTRA_DIST files. Addresses: #2969
* --nodl removed for cirrus CI.