### PR TITLE
build: Fix tests with --nodl and swtpm.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,7 +303,7 @@ src_tss2_tcti_libtss2_tctildr_la_SOURCES = \
     src/tss2-tcti/tctildr.c src/tss2-tcti/tctildr.h \
     src/tss2-tcti/tctildr-interface.h
 if NO_DL
-src_tss2_tcti_libtss2_tctildr_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim)
+src_tss2_tcti_libtss2_tctildr_la_LIBADD += $(libtss2_tcti_device) $(libtss2_tcti_mssim) $(libtss2_tcti_swtpm)
 src_tss2_tcti_libtss2_tctildr_la_SOURCES += src/tss2-tcti/tctildr-nodl.c src/tss2-tcti/tctildr-nodl.h
 else
 src_tss2_tcti_libtss2_tctildr_la_LIBADD += $(LIBADD_DL)


### PR DESCRIPTION
The  compile error Tss2_Tcti_Swtpm_Init undefined was produced with the configure option --nodl.