### PR TITLE
FAPI: Fix instantiation of policyduplication select.

### DIFF
--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -331,9 +331,18 @@ ifapi_policyeval_instantiate_finish(
             break;
 
         case POLICYDUPLICATIONSELECT:
+            if  (pol_element->element.PolicyDuplicationSelect.newParentName.size) {
+                break;
+            }
             if (pol_element->element.PolicyDuplicationSelect.newParentPublic.type) {
                 /* public data is already set in policy. Path will not be needed. */
                 SAFE_FREE(pol_element->element.PolicyDuplicationSelect.newParentPath);
+                r = ifapi_get_name(
+                     &pol_element->element.PolicyDuplicationSelect.newParentPublic,
+                     &pol_element->element.PolicyDuplicationSelect.newParentName);
+                return_if_error(r, "Compute object name");
+
+                pol_element->element.PolicyDuplicationSelect.newParentPublic.type = 0;
                 break;
             }
 


### PR DESCRIPTION
The instantiation of the policy did only work when a object path was used in the policy definition. Now also the object name or the public data of the object can be used.