### PR TITLE
tcti: initialize variables in handle_from_name

### DIFF
--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -12,6 +12,7 @@
 #include <dlfcn.h>              // for dlclose, dlerror, dlsym, dlopen, RTLD...
 #include <limits.h>             // for PATH_MAX
 #include <stdio.h>              // for NULL, size_t, snprintf
+#include <string.h>             // for memset
 
 #include "tctildr-interface.h"  // for tctildr_finalize_data, tctildr_get_info
 #include "tctildr.h"            // for tcti_from_info, FMT_LIB_SUFFIX, FMT_L...
@@ -82,7 +83,7 @@ TSS2_RC
 handle_from_name(const char *file,
                  void **handle)
 {
-    size_t size;
+    size_t size = 0;
     char file_xfrm[PATH_MAX];
     const char *formats[] = {
         /* <name> */
@@ -102,6 +103,7 @@ handle_from_name(const char *file,
     }
 
     for (size_t i = 0; i < ARRAY_SIZE(formats); i++) {
+        memset(file_xfrm, 0, sizeof(file_xfrm));
         size = snprintf(file_xfrm, sizeof(file_xfrm), formats[i], file);
         if (size >= sizeof(file_xfrm)) {
             LOG_ERROR("TCTI name truncated in transform.");


### PR DESCRIPTION
This change may seem somewhat redundant, but without it valgrind reports many issues like the following:

==1355== Conditional jump or move depends on uninitialised value(s)
==1355==    at 0x401C024: index (strchr.S:85)
==1355==    by 0x4007BF7: _dl_map_object (dl-load.c:2017)
==1355==    by 0x400B383: dl_open_worker_begin (dl-open.c:553)
==1355==    by 0x4001457: _dl_catch_exception (dl-catch.c:237)
==1355==    by 0x400AB07: dl_open_worker (dl-open.c:778)
==1355==    by 0x4001457: _dl_catch_exception (dl-catch.c:237)
==1355==    by 0x400AF1F: _dl_open (dl-open.c:880)
==1355==    by 0x4F5D207: dlopen_doit (dlopen.c:56)
==1355==    by 0x4001457: _dl_catch_exception (dl-catch.c:237)
==1355==    by 0x400157F: _dl_catch_error (dl-catch.c:256)
==1355==    by 0x4F5CCFF: _dlerror_run (dlerror.c:138)
==1355==    by 0x4F5D2CB: dlopen_implementation (dlopen.c:71)
==1355==    by 0x4F5D2CB: dlopen@@GLIBC_2.34 (dlopen.c:81)
==1355==  Uninitialised value was created by a stack allocation
==1355==    at 0x5592DF4: handle_from_name (tctildr-dl.c:85)

With this extra clean initialization the valgrind report becomes several 100 lines shorter, at least in my case.