### PR TITLE
CI: update ubuntu and arch , fix scanbuild warnings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,14 +2,64 @@ version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
-image: Visual Studio 2019
+
+image: Visual Studio 2022
+
 configuration:
   - Debug
   - Release
+
 platform:
-  - x86
   - x64
+
+environment:
+  OPENSSL_ROOT_DIR: "C:/Program Files/OpenSSL-Win64"
+  OPENSSL_INCLUDE_DIR: "C:/Program Files/OpenSSL-Win64/include"
+  OPENSSL_LIB_DIR: "C:/Program Files/OpenSSL-Win64/lib/VC"
+
+install:
+  # Install 64-bit OpenSSL 1.1.x
+  - choco install openssl --version=1.1.1.1400 -y
+  - ps: |
+      Write-Host "Checking OpenSSL installation..."
+      dir "$env:OPENSSL_INCLUDE_DIR\openssl" | select Name
+      dir "$env:OPENSSL_LIB_DIR"
+
+      Write-Host "Configuring environment for x64"
+      # Runtime DLLs
+      $env:PATH = "$env:OPENSSL_ROOT_DIR/bin;" + $env:PATH
+      # Compiler: add OpenSSL headers
+      $env:CL   = "/I`"$env:OPENSSL_INCLUDE_DIR`" " + $env:CL
+      # Linker: point to actual libs
+      $env:LINK = "/LIBPATH:`"$env:OPENSSL_LIB_DIR`" libcrypto64MD.lib libssl64MD.lib " + $env:LINK
+
+      # --- Symlink fix for legacy paths in .vcxproj ---
+      $legacyPath = "C:\OpenSSL-v11-Win64\lib"
+      New-Item -ItemType Directory -Force -Path $legacyPath | Out-Null
+
+      $cryptoTarget = "`"$env:OPENSSL_LIB_DIR\libcrypto64MD.lib`""
+      $sslTarget    = "`"$env:OPENSSL_LIB_DIR\libssl64MD.lib`""
+
+      cmd.exe /c "mklink `"$legacyPath\libcrypto.lib`" $cryptoTarget"
+      cmd.exe /c "mklink `"$legacyPath\libssl.lib`"    $sslTarget"
+
+      Write-Host "Created symlinks in $legacyPath"
+      dir $legacyPath
+
 build:
   project: tpm2-tss.sln
   parallel: false
   verbosity: normal
+
+test_script:
+  - ps: |
+      Write-Host "Skipping DLL check (Chocolatey package does not ship libcrypto-1_1.dll/libssl-1_1.dll)."
+      $outputDir = "C:\projects\tpm2-tss\bin\$env:configuration"
+      if (Test-Path $outputDir) {
+        Get-ChildItem $outputDir -Filter *.exe | ForEach-Object {
+          Write-Host "Running $($_.FullName)..."
+          try { & $_.FullName --version 2>$null } catch { Write-Host "Failed to run $_" }
+        }
+      } else {
+        Write-Host "No output directory $outputDir found."
+      }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-20.04, fedora-32, opensuse-leap, ubuntu-22.04, alpine-3.15]
+        docker_image: [fedora-32, opensuse-leap, ubuntu-22.04, ubuntu-24.04, alpine-3.15, arch-linux ]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository

--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -43,23 +43,15 @@ is_directory(const char* dir_name, struct dirent *entry, bool *isdir) {
     TSS2_RC r;
     char *path;
 
-#ifdef _DIRENT_HAVE_D_TYPE
-    if (entry->d_type == DT_DIR) {
-        *isdir = true;
-        return TSS2_RC_SUCCESS;
-    } else if (entry->d_type != DT_UNKNOWN) {
-        *isdir = false;
-        return TSS2_RC_SUCCESS;
-    }
-#endif
     /* stat is used if d_type is not supported or unknown. */
     struct stat file_stat;
     r = ifapi_asprintf(&path, "%s/%s", dir_name, entry->d_name);
     return_if_error(r, "Out of memory");
 
     if (stat(path, &file_stat) == -1) {
+        LOG_ERROR("stat failed for %s.", path);
         free(path);
-        return_error(TSS2_FAPI_RC_IO_ERROR, "stat failed.");
+        return TSS2_FAPI_RC_IO_ERROR;
     }
     if (S_ISDIR(file_stat.st_mode)) {
         *isdir = true;
@@ -84,15 +76,6 @@ is_regular_file(const char* dir_name, struct dirent *entry, bool *isreg) {
     TSS2_RC r;
     char *path;
 
-#ifdef _DIRENT_HAVE_D_TYPE
-    if (entry->d_type == DT_REG) {
-        *isreg = true;
-        return TSS2_RC_SUCCESS;
-    } else if (entry->d_type != DT_UNKNOWN){
-        *isreg = false;
-        return TSS2_RC_SUCCESS;
-    }
-#endif
     /* stat is used if d_type is not supported or unknown. */
     struct stat file_stat;
     r = ifapi_asprintf(&path, "%s/%s", dir_name, entry->d_name);

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -874,6 +874,7 @@ keystore_list_all_abs(
     goto_if_error(r, "Out of memory.", cleanup);
 
     r = ifapi_io_dirfiles_all(full_search_path, &file_ary_user, &num_paths_user);
+    goto_if_error(r, "List directory files", cleanup);
 
     *numresults = num_paths_system + num_paths_user;
     SAFE_FREE(full_search_path);

--- a/test/integration/esys-check-auth-with-trailing-zero.int.c
+++ b/test/integration/esys-check-auth-with-trailing-zero.int.c
@@ -320,6 +320,7 @@ test_esys_trailing_zeros_in_auth(ESYS_CONTEXT * esys_context)
                                  ESYS_TR_NONE,
                                  ESYS_TR_NONE,
                                  &newAuth);
+    goto_if_error(r, "Error Esys_HierarchyChangeAuth", error);
 
     r = Esys_StartAuthSession(esys_context, primaryHandle, ESYS_TR_RH_OWNER, ESYS_TR_NONE,
                               ESYS_TR_NONE, ESYS_TR_NONE, NULL, TPM2_SE_HMAC,

--- a/test/integration/fapi-key-create-policy-pcr-sign.int.c
+++ b/test/integration/fapi-key-create-policy-pcr-sign.int.c
@@ -67,8 +67,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     char *policy = NULL;
     char *path_list = NULL;
 
-    const char *policy_sha256_check =
-        "{" \
+#define POLICY_SHA256_CHECK "{" \
         "  \"description\":\"Description pol_16_0\"," \
         "  \"policyDigests\":[" \
         "    {" \
@@ -96,8 +95,8 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "  ]" \
         "}";
 
-    const char *policy_sha384_check =
-        "{" \
+
+#define POLICY_SHA384_CHECK "{" \
         "  \"description\":\"Description pol_16_0\"," \
         "  \"policyDigests\":[" \
         "    {" \
@@ -125,8 +124,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "  ]" \
         "}" ;
 
-    const char *policy_sha256_export_check =
-        "{" \
+    #define POLICY_SHA256_EXPORT_CHECK "{" \
         "  \"description\":\"Description pol_16_0\"," \
         "  \"policyDigests\":[" \
         "    {" \
@@ -170,8 +168,7 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "  ]" \
         "}";
 
-       const char *policy_sha384_export_check =
-        "{" \
+#define POLICY_SHA384_EXPORT_CHECK "{" \
         "  \"description\":\"Description pol_16_0\"," \
         "  \"policyDigests\":[" \
         "    { " \
@@ -214,7 +211,6 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
         "    }" \
         "  ]" \
         "}";
-
 
     r = Fapi_Provision(context, NULL, NULL, NULL);
     goto_if_error(r, "Error Fapi_Provision", error);
@@ -280,8 +276,10 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     LOG_INFO("\nTEST_JSON\nPolicy_sha256:\n%s\nEND_JSON", policy);
 
     if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
+        const char *policy_sha384_check = POLICY_SHA384_CHECK;
         CHECK_JSON(policy, policy_sha384_check, error);
     } else {
+        const char *policy_sha256_check = POLICY_SHA256_CHECK;
         CHECK_JSON(policy, policy_sha256_check, error);
     }
 
@@ -295,8 +293,10 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     ASSERT(policy != NULL);
     LOG_INFO("\nTEST_JSON\nPolicy export1:\n%s\nEND_JSON", policy);
     if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
+        const char *policy_sha384_export_check =  POLICY_SHA384_EXPORT_CHECK;
         CHECK_JSON(policy, policy_sha384_export_check, error)
     } else {
+        const char *policy_sha256_export_check = POLICY_SHA256_EXPORT_CHECK;
         CHECK_JSON(policy, policy_sha256_export_check, error)
     }
 
@@ -425,9 +425,11 @@ test_fapi_key_create_policy_pcr_sign(FAPI_CONTEXT *context)
     goto_if_error(r, "Error Fapi_ExportPolicy", error);
     ASSERT(policy != NULL);
 
-        if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0){
+    if (strcmp(FAPI_PROFILE, "P_ECC384") == 0 || strcmp(FAPI_PROFILE, "P_RSA3072") == 0) {
+        const char *policy_sha384_check = POLICY_SHA384_CHECK;
         CHECK_JSON(policy, policy_sha384_check, error);
     } else {
+        const char *policy_sha256_check = POLICY_SHA256_CHECK;
         CHECK_JSON(policy, policy_sha256_check, error);
     }
     fprintf(stderr, "\nPolicy from key:\n%s\n", policy);

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -1411,7 +1411,6 @@ int
 test_fapi_setup(TSS2_TEST_FAPI_CONTEXT **test_ctx)
 {
     char template[] = "/tmp/fapi_tmpdir.XXXXXX";
-    char *tmpdir = NULL;
     size_t size;
     int ret;
 
@@ -1422,12 +1421,7 @@ test_fapi_setup(TSS2_TEST_FAPI_CONTEXT **test_ctx)
         goto error;
     }
 
-    tmpdir = strdup(template);
-    if (!tmpdir) {
-        LOG_ERROR("Failed to allocate name of temp dir.");
-        goto error;
-    }
-    (*test_ctx)->tmpdir = mkdtemp(tmpdir);
+    (*test_ctx)->tmpdir = strdup(mkdtemp(template));
     if (!(*test_ctx)->tmpdir) {
         LOG_ERROR("No temp dir created");
         goto error;
@@ -1449,7 +1443,6 @@ test_fapi_setup(TSS2_TEST_FAPI_CONTEXT **test_ctx)
     return ret;
 
  error:
-    SAFE_FREE(tmpdir);
     SAFE_FREE(*test_ctx);
     return EXIT_ERROR;
 }


### PR DESCRIPTION
* CI: Remove ubuntu 20.04, add arch-linux and ubuntu-24.04
* FAPI: Enable usage of links in fapi-io.c
* FAPI Test: fix scanbuild error produced by mkdtemp.
* ESYS Test: Fix return code check in check auth with trailing zeros.
* FAPI Test: Fix scanbuild warning fapi-key-create-policy-pcr-sign.