### PR TITLE
ci appveyor: switch to ossl3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,55 +11,9 @@ configuration:
 
 platform:
   - x64
-
-environment:
-  OPENSSL_ROOT_DIR: "C:/Program Files/OpenSSL-Win64"
-  OPENSSL_INCLUDE_DIR: "C:/Program Files/OpenSSL-Win64/include"
-  OPENSSL_LIB_DIR: "C:/Program Files/OpenSSL-Win64/lib/VC"
-
-install:
-  # Install 64-bit OpenSSL 1.1.x
-  - choco install openssl --version=1.1.1.1400 -y
-  - ps: |
-      Write-Host "Checking OpenSSL installation..."
-      dir "$env:OPENSSL_INCLUDE_DIR\openssl" | select Name
-      dir "$env:OPENSSL_LIB_DIR"
-
-      Write-Host "Configuring environment for x64"
-      # Runtime DLLs
-      $env:PATH = "$env:OPENSSL_ROOT_DIR/bin;" + $env:PATH
-      # Compiler: add OpenSSL headers
-      $env:CL   = "/I`"$env:OPENSSL_INCLUDE_DIR`" " + $env:CL
-      # Linker: point to actual libs
-      $env:LINK = "/LIBPATH:`"$env:OPENSSL_LIB_DIR`" libcrypto64MD.lib libssl64MD.lib " + $env:LINK
-
-      # --- Symlink fix for legacy paths in .vcxproj ---
-      $legacyPath = "C:\OpenSSL-v11-Win64\lib"
-      New-Item -ItemType Directory -Force -Path $legacyPath | Out-Null
-
-      $cryptoTarget = "`"$env:OPENSSL_LIB_DIR\libcrypto64MD.lib`""
-      $sslTarget    = "`"$env:OPENSSL_LIB_DIR\libssl64MD.lib`""
-
-      cmd.exe /c "mklink `"$legacyPath\libcrypto.lib`" $cryptoTarget"
-      cmd.exe /c "mklink `"$legacyPath\libssl.lib`"    $sslTarget"
-
-      Write-Host "Created symlinks in $legacyPath"
-      dir $legacyPath
+  - x86
 
 build:
   project: tpm2-tss.sln
   parallel: false
   verbosity: normal
-
-test_script:
-  - ps: |
-      Write-Host "Skipping DLL check (Chocolatey package does not ship libcrypto-1_1.dll/libssl-1_1.dll)."
-      $outputDir = "C:\projects\tpm2-tss\bin\$env:configuration"
-      if (Test-Path $outputDir) {
-        Get-ChildItem $outputDir -Filter *.exe | ForEach-Object {
-          Write-Host "Running $($_.FullName)..."
-          try { & $_.FullName --version 2>$null } catch { Write-Host "Failed to run $_" }
-        }
-      } else {
-        Write-Host "No output directory $outputDir found."
-      }

--- a/src/tss2-esys/openssl.props
+++ b/src/tss2-esys/openssl.props
@@ -2,10 +2,30 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenSslDir>C:\OpenSSL-v11-Win64</OpenSslDir>
-    <OpenSslDir32Bit>C:\OpenSSL-v11-Win32</OpenSslDir32Bit>
+    <!-- 64-Bit Installation -->
+    <OpenSslDir>C:\OpenSSL-v35-Win64</OpenSslDir>
+    <!-- Falls du auch 32-Bit brauchst -->
+    <OpenSslDir32Bit>C:\OpenSSL-v35-Win32</OpenSslDir32Bit>
   </PropertyGroup>
-  <PropertyGroup />
-  <ItemDefinitionGroup />
+  <!-- x64 Build -->
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
+    <IncludePath>$(OpenSslDir)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(OpenSslDir)\lib\VC\x64\MD;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <!-- Win32 Build -->
+  <PropertyGroup Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x86'">
+    <IncludePath>$(OpenSslDir32Bit)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(OpenSslDir32Bit)\lib\VC\x86\MD;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x86'">
+    <Link>
+      <AdditionalDependencies>libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup />
 </Project>

--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -131,7 +131,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -148,7 +148,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -164,7 +164,7 @@
       <TargetMachine>MachineARM</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -181,7 +181,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir32Bit)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -191,7 +191,7 @@
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;OSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -201,7 +201,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;strtok_r=strtok_s;OSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -212,7 +212,7 @@
     </ClCompile>
     <Link>
       <TargetMachine>MachineARM64</TargetMachine>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -223,7 +223,7 @@
     </ClCompile>
     <Link>
       <TargetMachine>MachineARM64</TargetMachine>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;$(OpenSslDir)\lib\libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tctildr.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
 * Visual Studio 2019 changed to Visual Studio 2022
 * Paths related to ossl3 where added to the props file.
 