### PR TITLE
ci: update cirrus to free bsd 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     libusb_version: v1.0.26
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-2
+      image_family: freebsd-14-3
   install_script:
     - IGNORE_OSVERSION=yes
     - pkg update -f


### PR DESCRIPTION
A version mismatch has to be fixed.