### PR TITLE
doc: Fix license header in md files.

### DIFF
--- a/doc/fapi-config.md
+++ b/doc/fapi-config.md
@@ -55,7 +55,8 @@ in the config file:
     "hashAlg" : "sha256",
     "digest" : "9e56...214d"
     }
- ```# License
+ ```
+ # License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tcti-i2c-ftdi.md
+++ b/doc/tcti-i2c-ftdi.md
@@ -58,7 +58,8 @@ tpm2-abrmd --allow-root --session --tcti=i2c-ftdi &
 export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
 tpm2_startup -c
 tpm2_getrandom 8 --hex
-```# License
+```
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tcti-i2c-helper.md
+++ b/doc/tcti-i2c-helper.md
@@ -8,7 +8,9 @@ These methods are supplied to `Tss2_Tcti_I2c_Helper_Init` via the `TSS2_TCTI_I2C
 
 Documentation detailing the implementation of platform methods can be found in `tss2_tcti_i2c_helper.h`.
 For an example implementation that uses the I2C TCTI helper to communicate with an I2C-based TPM over the
-FTDI MPSSE USB to I2C bridge, refer to the `tcti-i2c-ftdi` module.# License
+FTDI MPSSE USB to I2C bridge, refer to the `tcti-i2c-ftdi` module.
+
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tcti-spi-ftdi.md
+++ b/doc/tcti-spi-ftdi.md
@@ -57,7 +57,8 @@ tpm2-abrmd --allow-root --session --tcti=spi-ftdi &
 export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd,bus_type=session"
 tpm2_startup -c
 tpm2_getrandom 8 --hex
-```# License
+```
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tcti-spi-helper.md
+++ b/doc/tcti-spi-helper.md
@@ -243,7 +243,8 @@ TSS2_TCTI_CONTEXT* create_tcti_ctx()
 
     return tcti_ctx;
 }
-```# License
+```
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tcti-spi-ltt2go.md
+++ b/doc/tcti-spi-ltt2go.md
@@ -165,7 +165,8 @@ Now, plug in the LetsTrust-TPM2Go and access it by:
 export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
 sudo -u tss tpm2_startup -c
 sudo -u tss tpm2_getrandom 8 --hex
-```# License
+```
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/tss-for-zephyr.md
+++ b/doc/tss-for-zephyr.md
@@ -318,7 +318,8 @@ Esys_GetRandom
 Random: 03e61dfcf7d1a8d8af18a93d
 Tss2_TctiLdr_Finalize
 Esys_Finalize
-```# License
+```
+# License
 
 This work is licensed under the
 [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
In some case the license header did not start at the beginning of line.