### PR TITLE
Fixed possible “Resource temporarily unavailable” (EAGAIN) errors in TCTI implementation

### DIFF
--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -117,7 +117,8 @@ tcti_device_transmit (
                    command_size);
     size = write_all (tcti_dev->fd,
                       command_buffer,
-                      command_size);
+                      command_size,
+                      -1);
     if (size != command_size) {
         LOG_ERROR ("wrong number of bytes written. Expected %zu, wrote %zd.",
                    command_size,
@@ -465,7 +466,7 @@ Tss2_Tcti_Device_Init (
     struct pollfd fds;
     int rc_poll, nfds = 1;
 
-    ssize_t sz = (ssize_t) write_all (tcti_dev->fd, cmd, sizeof(cmd));
+    ssize_t sz = (ssize_t) write_all (tcti_dev->fd, cmd, sizeof(cmd), -1);
     if (sz != sizeof(cmd)) {
         LOG_ERROR ("Could not probe device for partial response read support");
         close_tpm (&tcti_dev->fd);

--- a/src/tss2-tcti/tcti-pcap-builder.c
+++ b/src/tss2-tcti/tcti-pcap-builder.c
@@ -242,7 +242,7 @@ pcap_init (pcap_buider_ctx *ctx)
     offset += ret;
 
     /* write file header: SHB and IDB (can be written multiple times to same file) */
-    uret = write_all (ctx->fd, buf, offset);
+    uret = write_all (ctx->fd, buf, offset, -1);
     if (uret != offset) {
         LOG_ERROR ("Failed to write to file %s: %s", filename, strerror (errno));
         goto error;
@@ -291,7 +291,7 @@ pcap_print (
     }
     pdu_len = ret;
 
-    uret = write_all (ctx->fd, buf, pdu_len);
+    uret = write_all (ctx->fd, buf, pdu_len, -1);
     if (uret != pdu_len) {
         LOG_ERROR ("Failed to write to file: %s", strerror (errno));
         ret = -1;

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -173,7 +173,7 @@ TSS2_RC tcti_control_command (
     /* transmit */
     LOGBLOB_DEBUG(req_buf, req_buf_len, "Sending %zu bytes to socket %" PRIu32
                   ":", req_buf_len, tcti_swtpm->ctrl_sock);
-    ret = write_all (tcti_swtpm->ctrl_sock, req_buf, req_buf_len);
+    ret = write_all (tcti_swtpm->ctrl_sock, req_buf, req_buf_len, -1);
     if (ret < req_buf_len) {
         LOG_ERROR("Failed to send control command %d with error: %zd",
                   cmd_code, ret);
@@ -298,7 +298,7 @@ tcti_swtpm_transmit (
         return rc;
     }
 
-    rc = socket_xmit_buf (tcti_swtpm->tpm_sock, cmd_buf, size);
+    rc = socket_xmit_buf (tcti_swtpm->tpm_sock, cmd_buf, size, -1);
     if (rc != TSS2_RC_SUCCESS) {
         return rc;
     }
@@ -417,7 +417,7 @@ tcti_swtpm_receive (
     if (tcti_common->header.size == 0) {
         LOG_DEBUG("Receiving header to determine the size of the response.");
         uint8_t res_header[10];
-        ret = socket_recv_buf (tcti_swtpm->tpm_sock, &res_header[0], 10);
+        ret = socket_recv_buf (tcti_swtpm->tpm_sock, &res_header[0], 10, timeout);
         if (ret != 10) {
             rc = TSS2_TCTI_RC_IO_ERROR;
             goto out;
@@ -447,7 +447,8 @@ tcti_swtpm_receive (
         LOG_DEBUG ("Reading response of size %" PRIu32, tcti_common->header.size);
         ret = socket_recv_buf (tcti_swtpm->tpm_sock,
                                (unsigned char *)&response_buffer[10],
-                               tcti_common->header.size - 10);
+                               tcti_common->header.size - 10,
+                               timeout);
         if (ret < tcti_common->header.size - 10) {
             rc = TSS2_TCTI_RC_IO_ERROR;
             goto out;

--- a/src/util-io/io.h
+++ b/src/util-io/io.h
@@ -28,6 +28,9 @@ typedef SSIZE_T ssize_t;
 #define SOCKET_ERROR ((-1))
 #endif
 
+#define SOCKET_POLL_RD 1
+#define SOCKET_POLL_WR 2
+
 #ifdef _WIN32
 #define TEMP_RETRY(dest, exp) \
 {   int __ret; \
@@ -65,7 +68,8 @@ size_t
 read_all (
     SOCKET fd,
     uint8_t *data,
-    size_t size);
+    size_t size,
+    int timeout);
 /*
  * Write 'size' bytes from 'buf' to file descriptor 'fd'. Additionally this
  * function will retry calls to the 'write' function when recoverable errors
@@ -76,7 +80,8 @@ size_t
 write_all (
     SOCKET fd,
     const uint8_t *buf,
-    size_t size);
+    size_t size,
+    int timeout);
 /*
  * Connect to the given target using TCP. 'control' is to distinguish the data
  * socket from the control socket. For TCP, the data socket and control socket
@@ -108,15 +113,18 @@ size_t
 socket_recv_buf (
     SOCKET sock,
     uint8_t *data,
-    size_t size);
+    size_t size,
+    int timeout);
 TSS2_RC
 socket_xmit_buf (
     SOCKET sock,
     const void *buf,
-    size_t size);
+    size_t size,
+    int timeout);
 TSS2_RC
 socket_poll (
     SOCKET sock,
+    int wait_flags,
     int timeout);
 
 #ifdef __cplusplus

--- a/test/unit/io.c
+++ b/test/unit/io.c
@@ -78,7 +78,7 @@ write_all_simple_success_test (void **state)
     uint8_t buf [10];
 
     will_return (__wrap_write, sizeof (buf));
-    ret = write_all (99, buf, sizeof (buf));
+    ret = write_all (99, buf, sizeof (buf), -1);
     assert_int_equal(ret, sizeof (buf));
 }
 /*
@@ -92,7 +92,7 @@ read_all_eof_test (void **state)
     uint8_t buf [10];
 
     will_return (__wrap_read, 0);
-    ret = read_all (10, buf, sizeof (buf));
+    ret = read_all (10, buf, sizeof (buf), -1);
     assert_int_equal (ret, 0);
 }
 /*
@@ -108,7 +108,7 @@ read_all_twice_eof (void **state)
 
     will_return (__wrap_read, 5);
     will_return (__wrap_read, 0);
-    ret = read_all (10, buf, 10);
+    ret = read_all (10, buf, 10, -1);
     assert_int_equal (ret, 5);
 }
 /* When passed all NULL values ensure that we get back the expected RC. */


### PR DESCRIPTION
We have observed the following problem:

When using the `mssim` TCTI, _“Resource temporarily unavailable”_ errors occur regularly. Often 2 out of 3 runs will fail!

For example, it looks like this:

```
tpm2_load -T 'mssim:host=192.168.178.47,port=2323' -C 0x81000006 -P 12345 -u ecc.pub -r ecc.priv -c ecc.ctx
Error message: WARNING:tcti:src/util-io/io.c:66:read_all() read on fd 3 failed with errno 11: Resource temporarily unavailable
ERROR:esys:src/tss2-esys/api/Esys_ContextSave.c:251:Esys_ContextSave_Finish() Received a non-TPM Error
ERROR:esys:src/tss2-esys/api/Esys_ContextSave.c:92:Esys_ContextSave() Esys Finish ErrorCode (0x000a000a)
ERROR: Esys_ContextSave(0xA000A) - tcti:IO failure
```

Note that “Resource temporarily unavailable” comes down to an **`EAGAIN`** error (i.e. errno 11).

---

I think the reason why this can happen is the way how `tcti_mssim_receive()` is currently implemented: It will first `poll()` the network socket until it becomes "ready for reading", and once this has happened, it will attempt to `recv()` the **_full_** response message. This is actually wrapped in the `socket_recv_buf()` function, which just calls the `read_all()` function.

There are, to my understanding, at least two ways how this can go wrong:

- If `poll()` signals that the network socket is "ready for reading", it means that **_some_** bytes can be read now, but it does **not** guarantee that the _full_ message is available yet. Nonetheless, the subsequent `read_all()` always attempts to read the *full* message, by repeatedly calling `recv()`. This will fail, if the _full_ message cannot be read right now. Specifically, the `read_all()` function will fail with an **`EAGAIN`** error (instead of blocking and waiting), if insufficient data is available at the moment – because the socket was opened in `O_NONBLOCK` mode. And that is, I suppose, precisely what we are seeing.
 
- At least on the Linux platform, the `poll()` and `select()` functions may cause a so-called **_"spurious readiness notification"_**. This means that a socket may be reported as "ready for reading" but then the subsequent `read()` may still block because the socket is **not** actually ready. In `O_NONBLOCK` mode, `recv()` or `read()` will fail with **`EAGAIN`** in this situation.

  For reference, please see the "BUGS" sections at:
  * https://man7.org/linux/man-pages/man2/poll.2.html
  * https://man7.org/linux/man-pages/man2/select.2.html

---

At the core of the problem is that the `TEMP_RETRY` macro does **not** currently handle the `EAGAIN` (and `EWOULDBLOCK`) errors.

At least on the Linux platform. It appears there is some handling on FreeBSD already 🤔 

This patch aims to fix the problem by invoking `poll()` when an `EAGAIN` error was encountered.

Regards.