### PR TITLE
CI: Restrict clang-tidy to PRs

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 name: clang-tidy-check
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   clang-tidy-check:


### PR DESCRIPTION
Apparently the clang-tidy action from marketplace only works on PRs not master. Thus restricting it to PRs.