### PR TITLE
FAPI: fix TOCTOU race in ifapi_io_read_async

### DIFF
--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -141,24 +141,8 @@ ifapi_io_read_async(struct IFAPI_IO *io, const char *filename) {
         return TSS2_FAPI_RC_IO_ERROR;
     }
 
-    if (fseek(io->stream, 0L, SEEK_END) == -1) {
-        LOG_ERROR("fseek failed for \"%s\".", filename);
-        fclose(io->stream);
-        return TSS2_FAPI_RC_IO_ERROR;
-    };
-    long length = ftell(io->stream);
-    if (length == -1 || length == LONG_MAX) {
-        LOG_ERROR("ftell failed for \"%s\".", filename);
-        fclose(io->stream);
-        return TSS2_FAPI_RC_IO_ERROR;
-    };
-    fclose(io->stream);
+    long length = statbuf.st_size;
 
-    io->stream = fopen(filename, "rt");
-    if (io->stream == NULL) {
-        LOG_ERROR("Open file \"%s\": %s", filename, strerror(errno));
-        return TSS2_FAPI_RC_IO_ERROR;
-    }
     io->char_rbuffer = malloc(length + 1);
     if (io->char_rbuffer == NULL) {
         fclose(io->stream);

--- a/test/unit/fapi-io.c
+++ b/test/unit/fapi-io.c
@@ -189,10 +189,7 @@ check_io_read_async(void **state) {
     assert_int_equal(r, TSS2_FAPI_RC_IO_ERROR);
 
     will_return(__wrap_fopen, MOCK_STREAM);
-    will_return(__wrap_fopen, MOCK_STREAM);
     will_return(__wrap_fcntl, 0);
-    will_return(__wrap_fseek, 0);
-    will_return(__wrap_ftell, 1);
     will_return(__wrap_malloc, NULL);
     errno = 0;
     io.char_buffer = NULL;
@@ -204,10 +201,7 @@ check_io_read_async(void **state) {
     wrap_malloc_test = false;
 
     will_return(__wrap_fopen, MOCK_STREAM);
-    will_return(__wrap_fopen, MOCK_STREAM);
     will_return(__wrap_fcntl, 0);
-    will_return(__wrap_fseek, 0);
-    will_return(__wrap_ftell, 1);
     will_return(__wrap_fcntl, 0);
     will_return(__wrap_fcntl, -1);
 


### PR DESCRIPTION
This PR removes `fclose` + `fopen` in `ifapi_io_read_async` to avoid the TOCTOU risk. It also replaces `fseek` + `ftell` logic with a single `statbuf.st_size`.