### PR TITLE
feat(tss2-mu): add TPM2_ST_ATTEST_NV_DIGEST attestation type support

### DIFF
--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -629,11 +629,12 @@ typedef UINT16 TPM2_ST;
 #define TPM2_ST_RESERVED3                                                                          \
     ((TPM2_ST)0x801B) /* do not use . NOTE This was previously assigned to TPM2_ST_ATTEST_NV. The  \
                          tag is changed because the structure has changed */
-#define TPM2_ST_CREATION    ((TPM2_ST)0x8021) /* tag for a ticket type */
-#define TPM2_ST_VERIFIED    ((TPM2_ST)0x8022) /* tag for a ticket type */
-#define TPM2_ST_AUTH_SECRET ((TPM2_ST)0x8023) /* tag for a ticket type */
-#define TPM2_ST_HASHCHECK   ((TPM2_ST)0x8024) /* tag for a ticket type */
-#define TPM2_ST_AUTH_SIGNED ((TPM2_ST)0x8025) /* tag for a ticket type */
+#define TPM2_ST_ATTEST_NV_DIGEST ((TPM2_ST)0x801C) /* tag for an attestation structure */
+#define TPM2_ST_CREATION         ((TPM2_ST)0x8021) /* tag for a ticket type */
+#define TPM2_ST_VERIFIED         ((TPM2_ST)0x8022) /* tag for a ticket type */
+#define TPM2_ST_AUTH_SECRET      ((TPM2_ST)0x8023) /* tag for a ticket type */
+#define TPM2_ST_HASHCHECK        ((TPM2_ST)0x8024) /* tag for a ticket type */
+#define TPM2_ST_AUTH_SIGNED      ((TPM2_ST)0x8025) /* tag for a ticket type */
 #define TPM2_ST_FU_MANIFEST                                                                        \
     ((TPM2_ST)0x8029) /* tag for a structure describing a Field Upgrade Policy */
 
@@ -2073,13 +2074,14 @@ typedef TPM2_ST TPMI_ST_ATTEST;
 /* Definition of TPMU_ATTEST Union <OUT> */
 typedef union TPMU_ATTEST TPMU_ATTEST;
 union TPMU_ATTEST {
-    TPMS_CERTIFY_INFO       certify;
-    TPMS_CREATION_INFO      creation;
-    TPMS_QUOTE_INFO         quote;
-    TPMS_COMMAND_AUDIT_INFO commandAudit;
-    TPMS_SESSION_AUDIT_INFO sessionAudit;
-    TPMS_TIME_ATTEST_INFO   time;
-    TPMS_NV_CERTIFY_INFO    nv;
+    TPMS_CERTIFY_INFO           certify;
+    TPMS_CREATION_INFO          creation;
+    TPMS_QUOTE_INFO             quote;
+    TPMS_COMMAND_AUDIT_INFO     commandAudit;
+    TPMS_SESSION_AUDIT_INFO     sessionAudit;
+    TPMS_TIME_ATTEST_INFO       time;
+    TPMS_NV_CERTIFY_INFO        nv;
+    TPMS_NV_DIGEST_CERTIFY_INFO nvDigest;
 };
 
 /* Definition of TPMS_ATTEST Structure <OUT> */

--- a/src/tss2-mu/tpmu-types.c
+++ b/src/tss2-mu/tpmu-types.c
@@ -579,7 +579,11 @@ TPMU_MARSHAL2(TPMU_ATTEST,
               TPM2_ST_ATTEST_NV,
               ADDR,
               nv,
-              Tss2_MU_TPMS_NV_CERTIFY_INFO_Marshal)
+              Tss2_MU_TPMS_NV_CERTIFY_INFO_Marshal,
+              TPM2_ST_ATTEST_NV_DIGEST,
+              ADDR,
+              nvDigest,
+              Tss2_MU_TPMS_NV_DIGEST_CERTIFY_INFO_Marshal)
 TPMU_UNMARSHAL2(TPMU_ATTEST,
                 TPM2_ST_ATTEST_CERTIFY,
                 certify,
@@ -601,7 +605,10 @@ TPMU_UNMARSHAL2(TPMU_ATTEST,
                 Tss2_MU_TPMS_TIME_ATTEST_INFO_Unmarshal,
                 TPM2_ST_ATTEST_NV,
                 nv,
-                Tss2_MU_TPMS_NV_CERTIFY_INFO_Unmarshal)
+                Tss2_MU_TPMS_NV_CERTIFY_INFO_Unmarshal,
+                TPM2_ST_ATTEST_NV_DIGEST,
+                nvDigest,
+                Tss2_MU_TPMS_NV_DIGEST_CERTIFY_INFO_Unmarshal)
 
 TPMU_MARSHAL2(TPMU_SYM_KEY_BITS,
               TPM2_ALG_AES,


### PR DESCRIPTION
This pull request adds support for the missing `TPM2_ST_ATTEST_NV_DIGEST` attestation structure to the TSS. This constant is defined in Page 74 of [TCG TPM 2.0 Library Specification, Part 2: Structures v184](https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf)
