### PR TITLE
FAPI: validate eventlog size before first dereference in parse_eventlog

### DIFF
--- a/src/tss2-fapi/ifapi_eventlog_system.c
+++ b/src/tss2-fapi/ifapi_eventlog_system.c
@@ -695,6 +695,14 @@ parse_eventlog(tpm2_eventlog_context *ctx, BYTE const *eventlog, size_t size) {
     TCG_EVENT         *event = (TCG_EVENT *)eventlog;
     bool               ret;
 
+    if (size == 0) {
+        return true;
+    }
+    if (size < sizeof(*event)) {
+        LOG_ERROR("eventlog too small for first TCG_EVENT (%zu < %zu)", size, sizeof(*event));
+        return false;
+    }
+
     if (event->eventType == EV_NO_ACTION) {
         ret = specid_event(event, size, &next);
         if (!ret) {


### PR DESCRIPTION
Fix https://github.com/tpm2-software/tpm2-tss/issues/3076:
parse_eventlog dereferences event->eventType (offset 4 of TCG_EVENT) before validating that the input buffer is at least sizeof(TCG_EVENT) bytes. Any caller that passes a buffer shorter than 8 bytes triggers a heap OOB read on the first field access, including the empty-buffer case.

Public Fapi_GetEventLog is currently safe because file_to_buffer always calloc(1, UINT16_MAX) and the offset-4 read lands on zero padding, but the function-level invariant is wrong: parse_eventlog accepts a (buffer, size) pair and uses size correctly later (for foreach_event2, specid_event), only the first dereference skips the precondition check.

Add the up-front size check, matching the bound-check convention already used throughout this file (lines 117, 124, 232, 250, 256, 269, 280, ...).