### PR TITLE
FAPI: validate EventSize before reading Event[] in check_event_string

### DIFF
--- a/src/tss2-fapi/ifapi_json_eventlog_serialize.c
+++ b/src/tss2-fapi/ifapi_json_eventlog_serialize.c
@@ -272,14 +272,19 @@ ifapi_json_TCG_DIGEST2_cb(const TCG_DIGEST2 *in, size_t size, void *data) {
  */
 static TSS2_RC
 check_event_string(const TCG_EVENT2 *in, const char *string) {
-    if (strncmp((const char *)&in->Event[0], string, strlen(string)) != 0) {
+    size_t expected = strlen(string);
+    if (in->EventSize < expected) {
+        return_error2(TSS2_FAPI_RC_BAD_VALUE, "EventSize %u too small for %s", in->EventSize,
+                      string);
+    }
+    if (memcmp(in->Event, string, expected) != 0) {
         return_error2(TSS2_FAPI_RC_BAD_VALUE, "Invalid event string. %s expected", string);
     }
-    if (in->EventSize == strlen(string)) {
+    if (in->EventSize == expected) {
         /* String without NULL terminator */
         return TSS2_RC_SUCCESS;
     }
-    if (in->EventSize == strlen(string) + 1 && in->Event[strlen(string)] == '\0') {
+    if (in->EventSize == expected + 1 && in->Event[expected] == '\0') {
         /* String with NULL terminator */
         return TSS2_RC_SUCCESS;
     }


### PR DESCRIPTION
Fix https://github.com/tpm2-software/tpm2-tss/issues/3075:
check_event_string compares in->Event[] against a fixed string with strncmp(in->Event, string, strlen(string)) before validating that in->EventSize >= strlen(string). When EventSize is smaller than the expected fixed string, the comparison reads past the event payload. Two callers pass fixed strings: EV_EFI_HCRTM_EVENT ("HCRTM", 5 bytes) and EV_OMIT_BOOT_DEVICE_EVENTS ("BOOT ATTEMPTS OMITTED", 21 bytes).

Public Fapi_GetEventLog has two layered caller-side mitigations on this path: parse_event2 enforces buf_size >= event_size + EventSize, and file_to_buffer over-allocates the file buffer to calloc(1, UINT16_MAX). Together they mask the OOB on stock builds for the HCRTM case. The BOOT ATTEMPTS OMITTED case (21-byte string) needs up to 17 bytes of trailing slack and can OOB on file sizes near UINT16_MAX*n boundaries, so the bug is reachable through public API on narrow preconditions and is straightforwardly latent on direct callers.

Validate EventSize first, and switch to memcmp now that the comparison is bounded. Same shape as the EV_EFI_HCRTM_EVENT check at ifapi_eventlog_system.c:208 (parse_event2body), which already validates EventSize == len before strncmp via short-circuit evaluation.
