### PR TITLE
Update OpenSSL API compatibility

### DIFF
--- a/src/tss2-fapi/ifapi_curl.c
+++ b/src/tss2-fapi/ifapi_curl.c
@@ -97,7 +97,7 @@ ifapi_get_crl_from_cert(X509 *cert, X509_CRL **crl) {
                 GENERAL_NAME   *gen_name = sk_GENERAL_NAME_value(distpoint->name.fullname, j);
                 ASN1_IA5STRING *asn1_str = gen_name->d.uniformResourceIdentifier;
                 SAFE_FREE(url);
-                url = (unsigned char *)strdup((char *)asn1_str->data);
+                url = (unsigned char *)strdup((char *)ASN1_STRING_get0_data(asn1_str));
                 goto_if_null2(url, "Out of memory", r, TSS2_FAPI_RC_MEMORY, cleanup);
             }
         }
@@ -139,8 +139,8 @@ cleanup:
 
 static bool
 is_self_signed(X509 *cert) {
-    X509_NAME *issuer = X509_get_issuer_name(cert);
-    X509_NAME *subject = X509_get_subject_name(cert);
+    const X509_NAME *issuer = X509_get_issuer_name(cert);
+    const X509_NAME *subject = X509_get_subject_name(cert);
 
     /* Compare the issuer and subject names */
     if (X509_NAME_cmp(issuer, subject) == 0) {
@@ -212,7 +212,7 @@ ifapi_curl_verify_ek_cert(char *root_cert_pem, char *intermed_cert_pem, char *ek
                 continue;
             }
             uri = ad->location->d.uniformResourceIdentifier;
-            url = uri->data;
+            url = (unsigned char *)ASN1_STRING_get0_data(uri);
             curl_rc = ifapi_get_curl_buffer(url, &cert_buffer, &cert_buffer_size);
             if (curl_rc != 0) {
                 goto_error(r, TSS2_FAPI_RC_NO_CERT, "Get certificate.", cleanup);

--- a/src/tss2-fapi/ifapi_verify_cert_chain.c
+++ b/src/tss2-fapi/ifapi_verify_cert_chain.c
@@ -47,8 +47,8 @@ free_cert_list(NODE_OBJECT_T *node) {
 /* Check whether certificate is self signed. */
 static bool
 is_self_signed_cert(X509 *cert) {
-    X509_NAME *issuer = X509_get_issuer_name(cert);
-    X509_NAME *subject = X509_get_subject_name(cert);
+    const X509_NAME *issuer = X509_get_issuer_name(cert);
+    const X509_NAME *subject = X509_get_subject_name(cert);
 
     /* Compare the issuer and subject names */
     if (X509_NAME_cmp(issuer, subject) == 0) {
@@ -69,7 +69,7 @@ get_issuer_url(X509 *cert) {
         ACCESS_DESCRIPTION *ad = sk_ACCESS_DESCRIPTION_value(info, i);
         if (OBJ_obj2nid(ad->method) == NID_ad_ca_issuers && ad->location->type == GEN_URI) {
             ASN1_IA5STRING *uri = ad->location->d.uniformResourceIdentifier;
-            char           *url = strndup((char *)uri->data, uri->length);
+            char *url = strndup((char *)ASN1_STRING_get0_data(uri), ASN1_STRING_length(uri));
             AUTHORITY_INFO_ACCESS_free(info);
             return url;
         }
@@ -102,7 +102,7 @@ download_cert(char *url) {
 }
 
 void
-log_x509_name(X509_NAME *name) {
+log_x509_name(const X509_NAME *name) {
     char *str = X509_NAME_oneline(name, NULL, 0);
     LOG_DEBUG("X509_name: %s", str);
     free(str);
@@ -146,7 +146,7 @@ error:
 
 /* Function to find a certificate node by subject from issuer. */
 bool
-find_cert_by_issuer(NODE_OBJECT_T *head, X509_NAME *issuer_name) {
+find_cert_by_issuer(NODE_OBJECT_T *head, const X509_NAME *issuer_name) {
     NODE_OBJECT_T *current = head;
 
     while (current) {


### PR DESCRIPTION
This change allows the code to be compiled against OpenSSL 4.

Replace direct access to ASN1_STRING data members with the ASN1_STRING_get0_data() accessor function, as modern OpenSSL versions use opaque structures. Additionally, add const qualifiers to X509_NAME pointers to ensure const-correctness with newer OpenSSL APIs.