### PR TITLE
FAPI: guard get_number against NULL token

### DIFF
--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -215,6 +215,9 @@ static bool
 get_number(const char *token, int64_t *num) {
     int itoken = 0;
     int pos = 0;
+    if (!token) {
+        return false;
+    }
     if (strncmp(token, "0x", 2) == 0) {
         itoken = 2;
         sscanf(&token[itoken], "%" PRIx64 "%n", num, &pos);


### PR DESCRIPTION
json_object_get_string returns NULL when the underlying JSON value is the literal null. ifapi_json_BYTE_deserialize forwards that NULL into get_number, where strncmp dereferences it and crashes.

Add an early NULL check at the top of get_number so callers passing a JSON null receive a clean false instead of a segfault.