### PR TITLE
FAPI: clear command state in async functions.

### DIFF
--- a/src/tss2-fapi/api/Fapi_AuthorizePolicy.c
+++ b/src/tss2-fapi/api/Fapi_AuthorizePolicy.c
@@ -184,6 +184,9 @@ Fapi_AuthorizePolicy_Async(FAPI_CONTEXT  *context,
         check_not_null(policyRef);
     }
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     if (policyRefSize > sizeof(policy->policyRef.buffer)) {
         return_error(TSS2_FAPI_RC_BAD_VALUE, "PolicyRef too large.");
     }

--- a/src/tss2-fapi/api/Fapi_ChangeAuth.c
+++ b/src/tss2-fapi/api/Fapi_ChangeAuth.c
@@ -163,6 +163,9 @@ Fapi_ChangeAuth_Async(FAPI_CONTEXT *context, char const *entityPath, char const 
     check_not_null(context);
     check_not_null(entityPath);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful pointer aliases */
     IFAPI_Entity_ChangeAuth *command = &(context->cmd.Entity_ChangeAuth);
 

--- a/src/tss2-fapi/api/Fapi_CreateNv.c
+++ b/src/tss2-fapi/api/Fapi_CreateNv.c
@@ -184,6 +184,9 @@ Fapi_CreateNv_Async(FAPI_CONTEXT *context,
     check_not_null(context);
     check_not_null(path);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful alias pointers */
     IFAPI_NV_Cmds *nvCmd = &(context->nv_cmd);
     TPM2B_AUTH    *auth = &nvCmd->auth;

--- a/src/tss2-fapi/api/Fapi_CreateSeal.c
+++ b/src/tss2-fapi/api/Fapi_CreateSeal.c
@@ -187,6 +187,9 @@ Fapi_CreateSeal_Async(FAPI_CONTEXT  *context,
     check_not_null(context);
     check_not_null(path);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Reset all context-internal session state information. */
     r = ifapi_session_init(context);
     return_if_error(r, "Initialize CreateSeal");

--- a/src/tss2-fapi/api/Fapi_GetAppData.c
+++ b/src/tss2-fapi/api/Fapi_GetAppData.c
@@ -124,6 +124,9 @@ Fapi_GetAppData_Async(FAPI_CONTEXT *context, char const *path) {
     check_not_null(context);
     check_not_null(path);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Reset all context-internal session state information. */
     r = ifapi_session_init(context);
     return_if_error(r, "Initialize GetAppData");

--- a/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
+++ b/src/tss2-fapi/api/Fapi_GetPlatformCertificates.c
@@ -149,6 +149,9 @@ Fapi_GetPlatformCertificates_Async(FAPI_CONTEXT *context) {
     /* Check for NULL parameters */
     check_not_null(context);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Reset all context-internal session state information. */
     r = ifapi_session_init(context);
     return_if_error(r, "Initialize Fapi_GetPlatformCertificates");

--- a/src/tss2-fapi/api/Fapi_GetTpmBlobs.c
+++ b/src/tss2-fapi/api/Fapi_GetTpmBlobs.c
@@ -135,6 +135,9 @@ Fapi_GetTpmBlobs_Async(FAPI_CONTEXT *context, char const *path) {
     check_not_null(context);
     check_not_null(path);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     if (context->state != FAPI_STATE_INIT) {
         return_error(TSS2_FAPI_RC_BAD_SEQUENCE, "Invalid State");
     }

--- a/src/tss2-fapi/api/Fapi_NvIncrement.c
+++ b/src/tss2-fapi/api/Fapi_NvIncrement.c
@@ -155,6 +155,9 @@ Fapi_NvIncrement_Async(FAPI_CONTEXT *context, char const *nvPath) {
     check_not_null(context);
     check_not_null(nvPath);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful alias pointers */
     IFAPI_NV_Cmds *command = &context->nv_cmd;
 

--- a/src/tss2-fapi/api/Fapi_NvSetBits.c
+++ b/src/tss2-fapi/api/Fapi_NvSetBits.c
@@ -161,6 +161,9 @@ Fapi_NvSetBits_Async(FAPI_CONTEXT *context, char const *nvPath, uint64_t bitmap)
     check_not_null(context);
     check_not_null(nvPath);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful alias pointers */
     IFAPI_NV_Cmds *command = &context->nv_cmd;
 

--- a/src/tss2-fapi/api/Fapi_NvWrite.c
+++ b/src/tss2-fapi/api/Fapi_NvWrite.c
@@ -159,6 +159,9 @@ Fapi_NvWrite_Async(FAPI_CONTEXT *context, char const *nvPath, uint8_t const *dat
     check_not_null(nvPath);
     check_not_null(data);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful alias pointers */
     IFAPI_NV_Cmds *command = &context->nv_cmd;
 

--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -233,6 +233,9 @@ Fapi_Provision_Async(FAPI_CONTEXT *context,
     /* Check for NULL parameters */
     check_not_null(context);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Helpful alias pointers */
     IFAPI_Provision *command = &context->cmd.Provision;
 

--- a/src/tss2-fapi/api/Fapi_Quote.c
+++ b/src/tss2-fapi/api/Fapi_Quote.c
@@ -206,6 +206,9 @@ Fapi_Quote_Async(FAPI_CONTEXT  *context,
     check_not_null(pcrList);
     check_not_null(keyPath);
 
+    /* Cleanup command context. */
+    memset(&context->cmd, 0, sizeof(IFAPI_CMD_STATE));
+
     /* Check for invalid parameters */
     if (pcrListSize == 0) {
         LOG_ERROR("pcrListSize must not be NULL");

--- a/src/tss2-fapi/ifapi_policy.c
+++ b/src/tss2-fapi/ifapi_policy.c
@@ -38,7 +38,7 @@
  *
  * @param[in,out] context The FAPI_CONTEXT.
  * @param[in]     policyPath The policy path for policy store.
- * @param[in]     policy The result of policy deserialization.
+ * @param[in,out] policy The result of policy deserialization.
  * @param[in]     hash_alg The used hash alg for policy digest computations.
  * @param[out]    digest_idx The index of the current digest. The policy digest can be
  *                computed for several hash algorithms the digets index is a reverence
@@ -89,13 +89,21 @@ ifapi_calculate_tree_ex(IFAPI_POLICY_CTX   *context,
 
     statecase(context->state, POLICY_READ);
         r = ifapi_policy_store_load_async(pstore, io, policyPath);
-        goto_if_error2(r, "Can't open: %s", cleanup, policyPath);
+        if (r) {
+            LOG_ERROR("Can't open: %s", policyPath);
+            memset(policy, 0, sizeof(TPMS_POLICY));
+            goto cleanup;
+        }
         fallthrough;
 
     statecase(context->state, POLICY_READ_FINISH);
         r = ifapi_policy_store_load_finish(pstore, io, policy);
         return_try_again(r);
-        goto_if_error(r, "read_finish failed", cleanup);
+        if (r) {
+            LOG_ERROR("read_finish failed");
+            memset(policy, 0, sizeof(TPMS_POLICY));
+            goto cleanup;
+        }
         fallthrough;
 
     statecase(context->state, POLICY_INSTANTIATE_PREPARE);
@@ -201,13 +209,21 @@ ifapi_execute_tree_ex(enum IFAPI_STATE_POLICY    *state,
 
     statecase(*state, POLICY_READ);
         r = ifapi_policy_store_load_async(pstore, io, policyPath);
-        goto_if_error2(r, "Can't open: %s", cleanup, policyPath);
+        if (r) {
+            LOG_ERROR("Can't open: %s", policyPath);
+            memset(policy, 0, sizeof(TPMS_POLICY));
+            goto cleanup;
+        }
         fallthrough;
 
     statecase(*state, POLICY_READ_FINISH);
         r = ifapi_policy_store_load_finish(pstore, io, policy);
         return_try_again(r);
-        goto_if_error(r, "read_finish failed", cleanup);
+        if (r) {
+            LOG_ERROR("read_finish failed");
+            memset(policy, 0, sizeof(TPMS_POLICY));
+            goto cleanup;
+        }
         fallthrough;
 
     statecase(*state, POLICY_EXECUTE_PREPARE);


### PR DESCRIPTION
memset zero is called in the async functions for the command state to ensure the correct cleanup in error cases.
Also if a policy is not available in policy store memset zero will be called for the policy.
Fixes: #3081