### PR TITLE
Initialize tpm2b before use.

### DIFF
--- a/test/unit/esys-crypto.c
+++ b/test/unit/esys-crypto.c
@@ -33,7 +33,7 @@ check_hash_functions(void **state) {
     TSS2_RC                   rc;
     ESYS_CRYPTO_CONTEXT_BLOB *context;
     uint8_t                   buffer[10] = { 0 };
-    TPM2B                     tpm2b;
+    TPM2B                     tpm2b = { 0 };
     size_t                    size = 0;
 
     ESYS_CRYPTO_CALLBACKS crypto_cb = { 0 };


### PR DESCRIPTION
iesys_crypto_hmac_finish2b uses tpm2b->size but tpm2b is never initialized.

Found with CodeChecker.