### PR TITLE
TCTI/ESYS/FAPI Fixes for static code checker complains

### DIFF
--- a/src/tss2-esys/api/Esys_AC_Send.c
+++ b/src/tss2-esys/api/Esys_AC_Send.c
@@ -169,14 +169,23 @@ Esys_AC_Send_Async(ESYS_CONTEXT     *esysContext,
     r = esys_GetResourceObject(esysContext, ac, &handleNode);
     if (r != TSS2_RC_SUCCESS)
         return r;
+    if (!handleNode) {
+        return_error(TSS2_ESYS_RC_BAD_VALUE, "Could not get ac object.");
+    }
     tpmi_ac = handleNode->rsrc.handle;
     r = esys_GetResourceObject(esysContext, sendObject, &handleNode);
     if (r != TSS2_RC_SUCCESS)
         return r;
+    if (!handleNode) {
+        return_error(TSS2_ESYS_RC_BAD_VALUE, "Could not get send object.");
+    }
     tpmi_sendObject = handleNode->rsrc.handle;
     r = esys_GetResourceObject(esysContext, nvAuthHandle, &handleNode);
     if (r != TSS2_RC_SUCCESS)
         return r;
+    if (!handleNode) {
+        return_error(TSS2_ESYS_RC_BAD_VALUE, "Could not get nvAuthHandle object.");
+    }
     tpmi_nvAuthHandle = handleNode->rsrc.handle;
     /* Initial invocation of SAPI to prepare the command buffer with parameters */
     r = Tss2_Sys_AC_Send_Prepare(esysContext->sys, tpmi_sendObject, tpmi_nvAuthHandle, tpmi_ac,

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -308,7 +308,9 @@ Esys_TR_FromTPMPublic_Finish(ESYS_CONTEXT *esys_context, ESYS_TR *object) {
         iesys_compute_session_value(esys_context->session_tab[1], NULL, NULL);
         iesys_compute_session_value(esys_context->session_tab[2], NULL, NULL);
         r = Esys_TR_FromTPMPublic_Async(
-            esys_context, objectHandleNode->rsrc.handle, esys_context->session_tab[0]->esys_handle,
+            esys_context, objectHandleNode->rsrc.handle,
+            esys_context->session_tab[0] ? esys_context->session_tab[0]->esys_handle
+                                         : ESYS_TR_PASSWORD,
             esys_context->session_tab[1] ? esys_context->session_tab[1]->esys_handle : ESYS_TR_NONE,
             esys_context->session_tab[2] ? esys_context->session_tab[2]->esys_handle
                                          : ESYS_TR_NONE);

--- a/src/tss2-esys/esys_tr.c
+++ b/src/tss2-esys/esys_tr.c
@@ -55,6 +55,7 @@ Esys_TR_Serialize(ESYS_CONTEXT *esys_context,
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Get resource object");
+    return_if_null(esys_object, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     r = iesys_MU_IESYS_RESOURCE_Marshal(&esys_object->rsrc, NULL, SIZE_MAX, buffer_size);
     return_if_error(r, "Marshal resource object");
@@ -228,6 +229,7 @@ Esys_TR_FromTPMPublic_Finish(ESYS_CONTEXT *esys_context, ESYS_TR *object) {
 
     r = esys_GetResourceObject(esys_context, objectHandle, &objectHandleNode);
     goto_if_error(r, "get resource", error_cleanup);
+    return_if_null(objectHandleNode, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     /* Check whether the object was already initialized. */
     first_call = !objectHandleNode->rsrc.rsrcType;
@@ -466,6 +468,7 @@ Esys_TR_SetAuth(ESYS_CONTEXT *esys_context, ESYS_TR esys_handle, TPM2B_AUTH cons
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     if (r != TPM2_RC_SUCCESS)
         return r;
+    return_if_null(esys_object, "Could not get esys object.", TSS2_ESYS_RC_BAD_VALUE);
 
     if (authValue == NULL) {
         esys_object->auth.size = 0;
@@ -520,6 +523,7 @@ Esys_TR_GetName(ESYS_CONTEXT *esys_context, ESYS_TR esys_handle, TPM2B_NAME **na
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
+    return_if_null(esys_object, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     *name = malloc(sizeof(TPM2B_NAME));
     if (*name == NULL) {
@@ -571,6 +575,7 @@ Esys_TRSess_GetAttributes(ESYS_CONTEXT *esys_context, ESYS_TR esys_handle, TPMA_
     ESYS_ASSERT_NON_NULL(esys_context);
     TSS2_RC r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
+    return_if_null(esys_object, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     if (esys_object->rsrc.rsrcType != IESYSC_SESSION_RSRC)
         return_error(TSS2_ESYS_RC_BAD_TR, "Object is not a session object");
@@ -637,6 +642,7 @@ Esys_TRSess_GetNonceTPM(ESYS_CONTEXT *esys_context, ESYS_TR esys_handle, TPM2B_N
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
+    return_if_null(esys_object, "Object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     *nonceTPM = calloc(1, sizeof(**nonceTPM));
     if (*nonceTPM == NULL) {
@@ -686,6 +692,7 @@ Esys_TR_GetTpmHandle(ESYS_CONTEXT *esys_context, ESYS_TR esys_handle, TPM2_HANDL
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Get resource object");
+    return_if_null(esys_object, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     *tpm_handle = esys_object->rsrc.handle;
 
@@ -715,6 +722,7 @@ Esys_TRSess_GetAuthRequired(ESYS_CONTEXT *esys_context,
 
     r = esys_GetResourceObject(esys_context, esys_handle, &esys_object);
     return_if_error(r, "Object not found");
+    return_if_null(esys_object, "Esys object not found", TSS2_ESYS_RC_BAD_VALUE);
 
     if (esys_object->rsrc.rsrcType != IESYSC_SESSION_RSRC) {
         return_if_error(TSS2_ESYS_RC_BAD_TR, "Auth value needed for non-session object requested.");

--- a/src/tss2-fapi/fapi_crypto.c
+++ b/src/tss2-fapi/fapi_crypto.c
@@ -372,9 +372,9 @@ ifapi_tpm_ecc_sig_to_der(const TPMT_SIGNATURE *tpmSignature,
 
     /* Initialize the byte buffer for the DER representation */
     *signature = malloc(osslRC);
-    signatureWalking = *signature;
     goto_if_null(*signature, "Out of memory", TSS2_FAPI_RC_MEMORY, cleanup);
 
+    signatureWalking = *signature;
     if (signatureSize != NULL) {
         *signatureSize = osslRC;
     }
@@ -383,6 +383,7 @@ ifapi_tpm_ecc_sig_to_der(const TPMT_SIGNATURE *tpmSignature,
     osslRC = i2d_ECDSA_SIG(ecdsaSignature, &signatureWalking);
     if (!osslRC) {
         free(*signature);
+        *signature = NULL;
         if (signatureSize != NULL) {
             *signatureSize = 0;
         }

--- a/src/tss2-fapi/ifapi_helpers.c
+++ b/src/tss2-fapi/ifapi_helpers.c
@@ -388,11 +388,11 @@ ifapi_hierarchy_path_p(const char *path) {
     if (strncmp("P_", &path[pos1], 2) == 0) {
         start = strchr(&path[pos1], IFAPI_FILE_DELIM_CHAR);
         if (start) {
-            pos2 = (int)(start - &path[pos1]);
-            if (strncmp("/", &path[pos1 + pos2], 1) == 0)
-                pos2 += 1;
-            if (strncmp("/", &path[pos1 + pos2], 1) == 0)
-                pos2 += 1;
+            pos2 = (size_t)(start - &path[pos1]);
+            if (path[pos1 + pos2] == IFAPI_FILE_DELIM_CHAR)
+                pos2++;
+            if (path[pos1 + pos2] == IFAPI_FILE_DELIM_CHAR)
+                pos2++;
         }
     }
     /* Check whether only hierarchy is specified in path */

--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -190,6 +190,10 @@ ifapi_io_read_finish(struct IFAPI_IO *io, uint8_t **buffer, size_t *length) {
     else
         ifapi_io_retry = IFAPI_IO_RETRIES;
 
+    if (!io || !io->stream) {
+        return_error(TSS2_FAPI_RC_BAD_REFERENCE, "Bad referenced passed.");
+    }
+
     ssize_t ret = read(fileno(io->stream), &io->char_rbuffer[io->buffer_idx],
                        io->buffer_length - io->buffer_idx);
     if (ret < 0 && (errno == EINTR || errno == EAGAIN))

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -693,6 +693,8 @@ ifapi_json_IFAPI_OBJECT_deserialize(json_object *jso, IFAPI_OBJECT *out) {
     LOG_TRACE("call");
     return_if_null(out, "Bad reference.", TSS2_FAPI_RC_BAD_REFERENCE);
 
+    out->policy = NULL;
+
     if (!ifapi_get_sub_object(jso, "objectType", &jso2)) {
         LOG_ERROR("Field \"objectType\" not found.");
         return TSS2_FAPI_RC_BAD_VALUE;

--- a/src/tss2-fapi/ifapi_json_deserialize.c
+++ b/src/tss2-fapi/ifapi_json_deserialize.c
@@ -335,9 +335,8 @@ ifapi_json_import_IFAPI_KEY_deserialize(json_object *jso, IFAPI_KEY *out) {
 
     /* Get structure with public data from binary blob. */
     r = Tss2_MU_TPM2B_PUBLIC_Unmarshal(public_blob.buffer, public_blob.size, &offset, &out->public);
-    goto_if_error(r, "Invalid public data.", error_cleanup);
-
     SAFE_FREE(public_blob.buffer);
+    goto_if_error(r, "Invalid public data.", error_cleanup);
 
     if (!ifapi_get_sub_object(jso, "private", &jso2)) {
         memset(&out->private, 0, sizeof(UINT8_ARY));

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -36,6 +36,10 @@
  */
 TSS2_RC
 ifapi_check_valid_path(const char *path) {
+    if (!path) {
+        return_error(TSS2_FAPI_RC_BAD_REFERENCE, "No reference to path");
+    }
+
     for (size_t i = 0; i < strlen(path); i++) {
         if (!(isalnum(path[i]) || path[i] == '_' || path[i] == '-' || path[i] == '/')) {
             LOG_ERROR("Invalid character %c in path %s", path[i], path);
@@ -881,6 +885,9 @@ ifapi_keystore_list_all(IFAPI_KEYSTORE *keystore,
     if (*numresults > 0) {
         /* Convert absolute path to relative path */
         for (i = 0; i < *numresults; i++) {
+            if (!(*results)[i]) {
+                return_if_error(TSS2_ESYS_RC_BAD_REFERENCE, "Invalid reference.");
+            }
             full_path_to_fapi_path(keystore, (*results)[i]);
         }
     }

--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -327,6 +327,7 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name) {
         goto_if_error(r, "Out of memory", error);
 
         free_string_list(node_list);
+        node_list = NULL;
     }
 
     /* Normalize the pathname. '/' at the beginning no '/' at the end. */
@@ -347,7 +348,8 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name) {
 
 error:
     SAFE_FREE(*file_name);
-    free_string_list(node_list);
+    if (node_list)
+        free_string_list(node_list);
     return r;
 }
 /** Expand FAPI path to object path.

--- a/src/tss2-fapi/ifapi_policy_instantiate.c
+++ b/src/tss2-fapi/ifapi_policy_instantiate.c
@@ -53,7 +53,9 @@ get_policy_elements(TPML_POLICYELEMENTS *policy, NODE_OBJECT_T **policy_element_
     return r;
 
 error_cleanup:
-    ifapi_free_node_list(*policy_element_list);
+    if (*policy_element_list)
+        ifapi_free_node_list(*policy_element_list);
+    *policy_element_list = NULL;
     return r;
 }
 

--- a/src/tss2-fapi/ifapi_policy_store.c
+++ b/src/tss2-fapi/ifapi_policy_store.c
@@ -138,6 +138,10 @@ ifapi_policy_store_load_async(IFAPI_POLICY_STORE *pstore, IFAPI_IO *io, const ch
 
     LOG_TRACE("Load policy: %s", path);
 
+    if (!path) {
+        return_error(TSS2_FAPI_RC_BAD_REFERENCE, "No reference to path.");
+    }
+
     /* First it will be checked whether the only valid characters occur in the path. */
     if (pstore) {
         r = ifapi_check_valid_path(path);

--- a/src/tss2-fapi/ifapi_policyutil_execute.c
+++ b/src/tss2-fapi/ifapi_policyutil_execute.c
@@ -259,6 +259,9 @@ ifapi_policyutil_execute(FAPI_CONTEXT *context, ESYS_TR *session) {
     switch (pol_util_ctx->state) {
     statecase(pol_util_ctx->state, POLICY_UTIL_INIT);
         LOG_DEBUG("Util session: %x", pol_util_ctx->policy_session);
+        if (!pol_util_ctx->pol_exec_ctx) {
+            goto_error(r, TSS2_FAPI_RC_GENERAL_FAILURE, "Invalid policy stack", error);
+        }
         if (*session == ESYS_TR_NONE || *session == 0) {
             /* Create a new  policy session for the current policy execution */
             hash_alg = pol_util_ctx->pol_exec_ctx->hash_alg;
@@ -285,7 +288,7 @@ ifapi_policyutil_execute(FAPI_CONTEXT *context, ESYS_TR *session) {
         if (r) {
             /* Cleanup stack */
             IFAPI_POLICYUTIL_STACK *utl_ctx = pol_util_ctx->prev;
-            while (utl_ctx) {
+            while (utl_ctx && pol_util_ctx->pol_exec_ctx) {
                 if (utl_ctx->pol_exec_ctx->session == pol_util_ctx->pol_exec_ctx->session) {
                     utl_ctx->pol_exec_ctx->session = ESYS_TR_NONE;
                 }

--- a/src/tss2-tcti/mpsse/mpsse.c
+++ b/src/tss2-tcti/mpsse/mpsse.c
@@ -853,7 +853,7 @@ ReadBits(struct mpsse_context *mpsse, int size) {
     rdata = InternalRead(mpsse, size);
     EnableBitmode(mpsse, 0);
 
-    if (rdata) {
+    if (rdata && size > 0) {
         /* The last byte in rdata will have all the read bits set or unset as needed. */
         bits = rdata[size - 1];
 
@@ -870,9 +870,8 @@ ReadBits(struct mpsse_context *mpsse, int size) {
              */
             bits = (char)((bits >> (8 - size)) & 0xff);
         }
-
-        free(rdata);
     }
+    free(rdata);
 
     return bits;
 }

--- a/src/util-io/io.c
+++ b/src/util-io/io.c
@@ -80,6 +80,10 @@ read_all(SOCKET fd, uint8_t *data, size_t size, int timeout) {
             return recvd_total;
         }
         LOGBLOB_DEBUG(&data[recvd_total], recvd, "read %zd bytes from fd %d:", recvd, fd);
+        if ((size_t)recvd > (SIZE_MAX - recvd_total)) {
+            LOG_ERROR("Overflow for written_total");
+            return recvd_total;
+        }
         recvd_total += recvd;
         size -= recvd;
     } while (size > 0);
@@ -102,6 +106,10 @@ write_all(SOCKET fd, const uint8_t *buf, size_t size, int timeout) {
 #endif
         if (written >= 0) {
             LOG_DEBUG("wrote %zd bytes to fd %d", written, fd);
+            if ((size_t)written > (SIZE_MAX - written_total)) {
+                LOG_ERROR("Overflow for written_total");
+                return written_total;
+            }
             written_total += (size_t)written;
         } else {
 #ifdef _WIN32


### PR DESCRIPTION
Several fixes related to double free, null pointer de-referencing, and usage of garbage data were made.