### PR TITLE
ESYS: use the default OpenSSL context for internal EC operations

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -836,7 +836,8 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC        *key,
     const EC_POINT *eph_pub_key = NULL; /* Public part of ephemeral key */
     const BIGNUM   *eph_priv_key = NULL;
 #else
-    BIGNUM *eph_priv_key = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
+    BIGNUM       *eph_priv_key = NULL;
 #endif
     EC_POINT *tpm_pub_key = NULL; /* Public part of TPM key */
     EC_POINT *mul_eph_tpm = NULL;
@@ -883,7 +884,14 @@ iesys_cryptossl_get_ecdh_point(TPM2B_PUBLIC        *key,
     }
 
     /* Create ephemeral key */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     if ((ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) == NULL || EVP_PKEY_keygen_init(ctx) <= 0) {
+#else
+    if (!(libctx = OSSL_LIB_CTX_new()))
+        goto_error(r, TSS2_ESYS_RC_MEMORY, "Create libctx for ec key generation", cleanup);
+    if ((ctx = EVP_PKEY_CTX_new_from_name(libctx, "EC", NULL)) == NULL
+        || EVP_PKEY_keygen_init(ctx) <= 0) {
+#endif
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE, "Initialize ec key generation", cleanup);
     }
 
@@ -974,6 +982,7 @@ cleanup:
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
     /* Note: free of eph_pub_key already done by free of eph_ec_key */
 #else
+    OSSL_FREE(libctx, OSSL_LIB_CTX);
     OSSL_FREE(eph_priv_key, BN);
 #endif
     OSSL_FREE(bn_x, BN);


### PR DESCRIPTION
Initialize a new default library context to avoid calling the TPM in case it is loaded in the global library context, like in commit ec58f0a43.

---

Fixes #3083.

To validate, I do this:

in `/etc/ssl/openssl.cnf`:

```ini
#...
[provider_sect]
default = default_sect
tpm2provider = tpm2provider_sect

[default_sect]
activate = 1

[tpm2provider_sect]
activate = 1
module = /usr/lib/aarch64-linux-gnu/ossl-modules/tpm2.so
#...
```

Then, I run these commands:

```console
$ dd if=/dev/zero of=virtual-disk.img bs=1M count=50
50+0 records in
50+0 records out
52428800 bytes (52 MB, 50 MiB) copied, 0.0169446 s, 3.1 GB/s
$ sudo losetup /dev/loop1 virtual-disk.img
$ sudo cryptsetup -y luksFormat /dev/loop1

WARNING!
========
This will overwrite data on /dev/loop1 irrevocably.

Are you sure? (Type 'yes' in capital letters): YES
Enter passphrase for /home/pi/virtual-disk.img:
Verify passphrase:
$ sudo cryptsetup open /dev/loop1 virtual-disk
Enter passphrase for /home/pi/virtual-disk.img:
$ sudo mkfs.ext4 /dev/mapper/virtual-disk
mke2fs 1.47.2 (1-Jan-2025)
Creating filesystem with 34816 1k blocks and 8720 inodes
Filesystem UUID: dcacd9b0-7839-4367-a752-3935ebaaf866
Superblock backups stored on blocks:
        8193, 24577

Allocating group tables: done
Writing inode tables: done
Creating journal (4096 blocks): done
Writing superblocks and filesystem accounting information: done

$ sudo mkdir -p /virtual-disk
$ sudo mount /dev/mapper/virtual-disk /virtual-disk/
$ echo "This is a testfile" | sudo tee /virtual-disk/testfile
This is a testfile
$ sudo umount /virtual-disk
$ sudo cryptsetup close virtual-disk
```

Now, without this commit, the following fails:

```console
# LD_LIBRARY_PATH=/usr/local/lib systemd-cryptenroll --tpm2-device=auto --tpm2-with-pin=true /dev/loop1
🔐 Please enter current passphrase for disk /dev/loop1: ••••
🔐 Please enter TPM2 PIN: ••••
🔐 Please enter TPM2 PIN (repeat): ••••
TPM2 device supports SHA256 PCR bank but none of the selected PCRs are valid! Firmware apparently did not initialize any of the selected PCRs. Proceeding anyway with SHA256 bank. PCR policy effectively unenforced!
ERROR:esys_crypto:src/tss2-esys/esys_crypto_ossl.c:923:iesys_cryptossl_get_ecdh_point() ErrorCode (0x00070001) Get ephemeral key
ERROR:esys:src/tss2-esys/esys_iutil.c:414:iesys_compute_encrypted_salt() During computation of ECC public key. ErrorCode (0x00070001)
ERROR:esys:src/tss2-esys/api/Esys_StartAuthSession.c:225:Esys_StartAuthSession_Async() Error in parameter encryption. ErrorCode (0x00070001)
ERROR:esys:src/tss2-esys/api/Esys_StartAuthSession.c:117:Esys_StartAuthSession() Error in async function ErrorCode (0x00070001)
Failed to seal to TPM2: State not recoverable
```

With my diff:

```console
# LD_LIBRARY_PATH=/usr/local/lib systemd-cryptenroll --tpm2-device=auto --tpm2-with-pin=true /dev/loop1
🔐 Please enter current passphrase for disk /dev/loop1: (press TAB for no echo)
root@piwithtmp:/home/pi# LD_LIBRARY_PATH=/usr/local/lib systemd-cryptenroll --tpm2-device=auto --tpm2-with-pin=true /dev
/loop1
🔐 Please enter current passphrase for disk /dev/loop1: ••••
🔐 Please enter TPM2 PIN: ••••
🔐 Please enter TPM2 PIN (repeat): ••••
TPM2 device supports SHA256 PCR bank but none of the selected PCRs are valid! Firmware apparently did not initialize any of the selected PCRs. Proceeding anyway with SHA256 bank. PCR policy effectively unenforced!
New TPM2 token enrolled as key slot 1.
```