### PR TITLE
[4.1.x] backport: fix double free in FAPI keystore path expansion error case

### DIFF
--- a/src/tss2-fapi/ifapi_keystore.c
+++ b/src/tss2-fapi/ifapi_keystore.c
@@ -340,6 +340,7 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
         goto_if_error(r, "Out of memory", error);
 
         free_string_list(node_list);
+        node_list = NULL;
     }
 
     /* Normalize the pathname. '/' at the beginning no '/' at the end. */
@@ -360,7 +361,8 @@ expand_path(IFAPI_KEYSTORE *keystore, const char *path, char **file_name)
 
 error:
     SAFE_FREE(*file_name);
-    free_string_list(node_list);
+    if (node_list)
+        free_string_list(node_list);
     return r;
 }
 /** Expand FAPI path to object path.


### PR DESCRIPTION
4.1.x is missing the FAPI double-free fix that's on master. In ifapi_keystore.c's path expansion, an error/allocation-failure branch frees the node_list but doesn't null it, so a subsequent cleanup re-walks and frees the same nodes again.

verified the double-free path is reachable on 4.1.x: modeled the expand_path control flow with -fsanitize=address (ubuntu:22.04), forcing the normalization realloc to fail. pre-fix ASan reports a heap-use-after-free in free_string_list (the second free re-walks the freed list) and aborts; with the fix applied expand_path returns cleanly. trigger is OOM in the normalization block, so it's an error-path bug.

clean cherry-pick (-x), original author (Juergen Repp) preserved. glad to rebase.

upstream: https://github.com/tpm2-software/tpm2-tss/commit/714b0473b4018e08b1ddc9840fbcaa5d91d105de