### PR TITLE
[esys tests] skipped tests are displayed as passed

### DIFF
--- a/test/integration/main-esys.c
+++ b/test/integration/main-esys.c
@@ -57,5 +57,5 @@ main(int argc, char *argv[]) {
 
     test_esys_teardown(test_esys_ctx);
 
-    return EXIT_SUCCESS;
+    return rc;
 }


### PR DESCRIPTION
When running integration tests, skipped tests (responding EXIT_SKIP) are displayed as PASSED. 
In a recent update the main function has been updated but the returned code value is not returned anymore.
main function must return 'rc' instead of 'EXIT_SUCCESS'.