### PR TITLE
iesys: Skip computing HMAC authorizations for pure policy sessions

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -816,7 +816,10 @@ iesys_check_rp_hmacs(ESYS_CONTEXT *esys_context, TSS2L_SYS_AUTH_RESPONSE *rspAut
             continue;
 
         IESYS_SESSION *rsrc_session = &session->rsrc.misc.rsrc_session;
-        if (rsrc_session->type_policy_session == POLICY_PASSWORD) {
+        if (rsrc_session->type_policy_session == POLICY_PASSWORD
+            || (rsrc_session->sessionType == TPM2_SE_POLICY
+                && rsrc_session->type_policy_session != POLICY_AUTH
+                && rsrc_session->sizeHmacValue == 0)) {
             /* A policy password session has no auth value */
             if (rspAuths->auths[i].hmac.size != 0) {
                 LOG_ERROR("PolicyPassword session's HMAC must be 0-length.");
@@ -1165,6 +1168,19 @@ iesys_compute_hmac(ESYS_CONTEXT      *esys_context,
 
     if (session != NULL) {
         IESYS_SESSION *rsrc_session = &session->rsrc.misc.rsrc_session;
+
+        /* For pure policy sessions, return an empty authorization HMAC
+           instead of computing a HMAC with a zero length key. */
+        if (rsrc_session->sessionType == TPM2_SE_POLICY
+            && rsrc_session->type_policy_session != POLICY_AUTH
+            && rsrc_session->sizeHmacValue == 0) {
+            auth->hmac.size = 0;
+            auth->sessionHandle = session->rsrc.handle;
+            auth->nonce = rsrc_session->nonceCaller;
+            auth->sessionAttributes = rsrc_session->sessionAttributes;
+            return TSS2_RC_SUCCESS;
+        }
+
         r = iesys_crypto_hash_get_digest_size(rsrc_session->authHash, &authHash_size);
         return_if_error(r, "Initializing auth session");
 


### PR DESCRIPTION
This PR addresses an issue in using tpm2_unseal on systems running in FIPS mode, that implement FIPS 140-3 and also SP 800-131A [1] .

[1] https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf

FIPS SP800-131A [1], Section 10, Table 9, which can be found on named page 20, but really page 26 in your pdf reader, mentions that for HMAC generations, key lengths < 112 bits are "Disallowed", and key lengths >= 112 bits are "Acceptable".

When a pure policy session is used, on both the command and response side, HMACs are computed with 0 length keys, which causes issues with openssl in FIPS mode.

This PR  changes the command side, by modifying iesys_compute_hmac() to return an empty authorization HMAC instead of computing a new HMAC with a 0 length key.

The response side is also changed, by modifying iesys_check_rp_hmacs() to extend the special case for POLICY_PASSWORD to also include pure policy sessions, instead of computing a new HMAC with a 0 length key.

Addresses: #2889

I'm not sure if you are interested in these changes, I just wanted to open the PR to see if you have any feedback on it, and it might end up useful as a vendor patch for other distros that also need to make FIPS SP800-131A work with their packages.