### PR TITLE
Fixed computation of Attached Component (AC) handles

### DIFF
--- a/include/tss2/tss2_tpm2_types.h
+++ b/include/tss2/tss2_tpm2_types.h
@@ -1080,6 +1080,7 @@ typedef UINT8 TPM2_HT;
 #define TPM2_HT_PERSISTENT                                                                         \
     ((TPM2_HT)0x81) /* Persistent Objects  assigned by the TPM when a loaded transient object is   \
                        made persistent */
+#define TPM2_HT_AC ((TPM2_HT)0x90) /* handle for an Attached Component */
 
 /* Definition of TPM2_HANDLE TPM2_RH Constants <S> */
 typedef TPM2_HANDLE TPM2_RH;
@@ -1167,6 +1168,9 @@ typedef TPM2_HANDLE TPM2_HC;
                                                    */
 #define TPM2_PERMANENT_FIRST ((TPM2_HC)TPM2_RH_FIRST)
 #define TPM2_PERMANENT_LAST  ((TPM2_HC)TPM2_RH_LAST)
+#define TPM2_HR_AC           ((TPM2_HC)(TPM2_HT_AC << TPM2_HR_SHIFT))
+#define TPM2_AC_FIRST        ((TPM2_HC)(TPM2_HR_AC + 0))
+#define TPM2_AC_LAST         ((TPM2_HC)(TPM2_HR_AC + 0x0000FFFF))
 #define TPM2_HR_NV_AC        ((TPM2_HC)((TPM2_HT_NV_INDEX << TPM2_HR_SHIFT) + 0xD00000))
 #define TPM2_NV_AC_FIRST     ((TPM2_HC)(TPM2_HR_NV_AC + 0))
 #define TPM2_NV_AC_LAST      ((TPM2_HC)(TPM2_HR_NV_AC + 0x0000FFFF))

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -279,7 +279,7 @@ iesys_handle_to_tpm_handle(ESYS_TR esys_handle, TPM2_HANDLE *tpm_handle) {
         return TPM2_RC_SUCCESS;
     }
     if (esys_handle >= ESYS_TR_RH_AC_FIRST && esys_handle <= ESYS_TR_RH_AC_LAST) {
-        *tpm_handle = TPM2_NV_AC_FIRST + (esys_handle - ESYS_TR_RH_AC_FIRST);
+        *tpm_handle = TPM2_AC_FIRST + (esys_handle - ESYS_TR_RH_AC_FIRST);
         return TPM2_RC_SUCCESS;
     }
     LOG_ERROR("Error: Esys invalid ESAPI handle (%" PRIx32 ").", esys_handle);

--- a/test/integration/esys-tr-getName.int.c
+++ b/test/integration/esys-tr-getName.int.c
@@ -38,7 +38,7 @@ test_esys_tr_getName(ESYS_CONTEXT *ectx) {
     r = Esys_TR_GetTpmHandle(ectx, ac, &tpmHandle);
     goto_if_error(r, "Error getting TPM Handle from Esys_TR_GetTpmHandle", error);
 
-    if (tpmHandle != TPM2_NV_AC_FIRST) {
+    if (tpmHandle != TPM2_AC_FIRST) {
         LOG_ERROR("Handles mismatch");
         goto error;
     }
@@ -46,7 +46,7 @@ test_esys_tr_getName(ESYS_CONTEXT *ectx) {
     TPM2B_NAME name1, *name2, act_name1, *act_name2;
     size_t     offset = 0;
 
-    r = Tss2_MU_TPM2_HANDLE_Marshal(TPM2_NV_AC_FIRST, &name1.name[0], sizeof(name1.name), &offset);
+    r = Tss2_MU_TPM2_HANDLE_Marshal(TPM2_AC_FIRST, &name1.name[0], sizeof(name1.name), &offset);
     goto_if_error(r, "Error Marshaling AC name", error);
     name1.size = offset;
 


### PR DESCRIPTION
Fixed computation of **Attached Component (AC)** handles in the `iesys_handle_to_tpm_handle()` function.

Also added missing definitions of `TPM2_HR_AC`, `TPM2_AC_FIRST` and `TPM2_AC_LAST`.

**Note:** The computation of an "AC" TPM handle should to be based on `TPM2_AC_FIRST`, instead of `TPM2_NV_AC_FIRST`.