### PR TITLE
Check length of Eh and Sh before memcopy.

### DIFF
--- a/src/tss2-fapi/api/Fapi_Provision.c
+++ b/src/tss2-fapi/api/Fapi_Provision.c
@@ -1328,17 +1328,19 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context) {
         } else {
             command->hierarchy_policy = NULL;
         }
-        if (command->authValueEh) {
-            context->state = PROVISION_CHANGE_EH_AUTH;
-            /* Save auth value of endorsement hierarchy in context. */
-            memcpy(&command->hierarchy_auth.buffer[0], command->authValueEh,
-                   strlen(command->authValueEh));
-            command->hierarchy_auth.size = strlen(command->authValueEh);
-        } else {
+        if (!command->authValueEh) {
             /* Auth value of lockout hierarchy will not be changed. */
             context->state = PROVISION_EH_CHANGE_POLICY;
             return TSS2_FAPI_RC_TRY_AGAIN;
         }
+        if (strlen(command->authValueEh) > sizeof(TPMU_HA)) {
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Endorsement hierarchy too long.", error_cleanup);
+        }
+
+        /* Save auth value of endorsement hierarchy in context. */
+        memcpy(&command->hierarchy_auth.buffer[0], command->authValueEh,
+               strlen(command->authValueEh));
+        command->hierarchy_auth.size = strlen(command->authValueEh);
         context->state = PROVISION_CHANGE_EH_AUTH;
         fallthrough;
 
@@ -1394,18 +1396,20 @@ Fapi_Provision_Finish(FAPI_CONTEXT *context) {
         } else {
             command->hierarchy_policy = NULL;
         }
-        if (command->authValueSh) {
-            context->state = PROVISION_CHANGE_SH_AUTH;
-            /* Save auth value of owner hierarchy in context. */
-            memcpy(&command->hierarchy_auth.buffer[0], command->authValueSh,
-                   strlen(command->authValueSh));
-            command->hierarchy_auth.size = strlen(command->authValueSh);
-            context->state = PROVISION_CHANGE_SH_AUTH;
-        } else {
+        if (!command->authValueSh) {
             /* Auth value of owner hierarchy will not be changed. */
             context->state = PROVISION_SH_CHANGE_POLICY;
             return TSS2_FAPI_RC_TRY_AGAIN;
         }
+        if (strlen(command->authValueSh) > sizeof(TPMU_HA)) {
+            goto_error(r, TSS2_FAPI_RC_BAD_VALUE, "Storage hierarchy too long.", error_cleanup);
+        }
+
+        /* Save auth value of owner hierarchy in context. */
+        memcpy(&command->hierarchy_auth.buffer[0], command->authValueSh,
+               strlen(command->authValueSh));
+        command->hierarchy_auth.size = strlen(command->authValueSh);
+
         context->state = PROVISION_CHANGE_SH_AUTH;
         fallthrough;
 


### PR DESCRIPTION
To my understanding the `command->authValueSh` check is purely defensive.

---

With the patch:

```console
$ ../poc
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:1387:Fapi_Provision_Finish() ErrorCode (0x0006000b) Endorsement hierarchy too long.
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/LOCKOUT/object.json
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HE/EK/object.json
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HS/SRK/object.json
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:180:Fapi_Provision() ErrorCode (0x0006000b) Provision
Fapi_Provision returned 0x0006000b
$ cat ../poc.c
/* poc.c
 * gcc poc.c -ltss2-fapi -fsanitize=address -o poc
 */
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <tss2/tss2_fapi.h>

int main(void) {
    FAPI_CONTEXT *ctx = NULL;
    if (Fapi_Initialize(&ctx, NULL) != TSS2_RC_SUCCESS) return 1;

    char eh[2026];
    memset(eh, 'A', sizeof(eh) - 1);
    eh[sizeof(eh) - 1] = '\0';

    TSS2_RC rc = Fapi_Provision(ctx, eh, NULL, NULL);
    fprintf(stderr, "Fapi_Provision returned 0x%08x\n", rc);

    Fapi_Finalize(&ctx);
    return 0;
}
```

Then, without the diff:

```console
$ git restore -p src
...
$ make && sudo make install 

add "ek_cert_less":  "yes", to  fapi-config.json again
...

$ ../poc
...

trace:fapi:src/tss2-fapi/api/Fapi_Provision.c:1395:Fapi_Provision_Finish() State context->state reached PROVISION_CHANGE_EH_AUTH
trace:fapi:src/tss2-fapi/fapi_util.c:3761:ifapi_change_auth_hierarchy() State context->hierarchy_state reached HIERARCHY_CHANGE_AUTH_INIT
trace:esys:src/tss2-esys/api/Esys_HierarchyChangeAuth.c:157:Esys_HierarchyChangeAuth_Async() context=0x522000000100, authHandle=10b, newAuth=0x52f000005a00
trace:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() Marshalling TPM2_ST from 0x7fff3af11460 to buffer 0x521000003d50 at index 0x0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset parameter non-NULL, updated to 2
trace:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset non-NULL, initial value: 10
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() Marshalling UINT32 from 0x7fff3af114a0 to buffer 0x521000003d50 at index 0xa
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset parameter non-NULL, updated to 14
debug:marshal:src/tss2-mu/tpm2b-types.c:298:Tss2_MU_TPM2B_AUTH_Marshal() offset non-NULL, initial value: 14
WARNING:marshal:src/tss2-mu/tpm2b-types.c:298:Tss2_MU_TPM2B_AUTH_Marshal() size: 103 for buffer of TPM2B_AUTH is larger than max length of buffer: 64
ERROR:esys:src/tss2-esys/api/Esys_HierarchyChangeAuth.c:186:Esys_HierarchyChangeAuth_Async() SAPI Prepare returned error. ErrorCode (0x00090010)
ERROR:fapi:src/tss2-fapi/fapi_util.c:3774:ifapi_change_auth_hierarchy() HierarchyChangeAuth ErrorCode (0x00090010)
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:1402:Fapi_Provision_Finish() Change auth hierarchy. ErrorCode (0x00090010)
trace:esys:src/tss2-esys/api/Esys_FlushContext.c:115:Esys_FlushContext_Async() context=0x522000000100, flushHandle=4046836c
trace:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() Marshalling TPM2_ST from 0x7fff3af11560 to buffer 0x521000003d50 at index 0x0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset parameter non-NULL, updated to 2
trace:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset non-NULL, initial value: 10
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() Marshalling UINT32 from 0x7fff3af115a0 to buffer 0x521000003d50 at index 0xa
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset parameter non-NULL, updated to 14
trace:esys:src/tss2-esys/api/Esys_FlushContext.c:177:Esys_FlushContext_Finish() context=0x522000000100
trace:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() Unmarshaling TPM2_ST from 0x521000003d50 to buffer 0x521000003d1e at index 0x0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset parameter non-NULL, updated to 2
trace:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset non-NULL, initial value: 2
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() Unmarshaling UINT32 from 0x521000003d50 to buffer 0x521000003d20 at index 0x2
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset parameter non-NULL, updated to 6
trace:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset non-NULL, initial value: 6
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() Unmarshaling UINT32 from 0x521000003d50 to buffer 0x521000003d24 at index 0x6
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset parameter non-NULL, updated to 10
trace:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() Unmarshaling TPM2_ST from 0x521000003d50 to buffer 0x7fff3b014630 at index 0x0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset parameter non-NULL, updated to 2
trace:esys:src/tss2-esys/api/Esys_EvictControl.c:165:Esys_EvictControl_Async() context=0x522000000100, auth=101, objectHandle=41414141,persistentHandle=41414141
ERROR:esys:src/tss2-esys/esys_iutil.c:1005:esys_GetResourceObject() Error: Esys handle does not exist (0x00070018).
ERROR:esys:src/tss2-esys/api/Esys_EvictControl.c:191:Esys_EvictControl_Async() objectHandle unknown. ErrorCode (0x00070018)
ERROR:esys:src/tss2-esys/api/Esys_EvictControl.c:92:Esys_EvictControl() Error in async function ErrorCode (0x00070018)
trace:esys:src/tss2-esys/api/Esys_EvictControl.c:165:Esys_EvictControl_Async() context=0x522000000100, auth=101, objectHandle=41414141,persistentHandle=41414141
ERROR:esys:src/tss2-esys/esys_iutil.c:1005:esys_GetResourceObject() Error: Esys handle does not exist (0x00070018).
ERROR:esys:src/tss2-esys/api/Esys_EvictControl.c:191:Esys_EvictControl_Async() objectHandle unknown. ErrorCode (0x00070018)
ERROR:esys:src/tss2-esys/api/Esys_EvictControl.c:92:Esys_EvictControl() Error in async function ErrorCode (0x00070018)
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry LOCKOUT
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/LOCKOUT
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry object.json
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/LOCKOUT/object.json
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry HE
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HE
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry EK
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HE/EK
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry object.json
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HE/EK/object.json
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry HS
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HS
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry SRK
trace:fapi:src/tss2-fapi/ifapi_io.c:424:ifapi_io_remove_directories() Removing directory: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HS/SRK
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry object.json
WARNING:fapi:src/tss2-fapi/ifapi_io.c:457:ifapi_io_remove_directories() Removing: /usr/local/var/lib/tpm2-tss/system/keystore/P_ECCP256SHA256/HS/SRK/object.json
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry .
trace:fapi:src/tss2-fapi/ifapi_io.c:432:ifapi_io_remove_directories() Deleting directory entry ..
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:fapi:src/tss2-fapi/ifapi_io.c:485:ifapi_io_remove_directories() SUCCESS
trace:esys:src/tss2-esys/api/Esys_FlushContext.c:115:Esys_FlushContext_Async() context=0x522000000100, flushHandle=40468367
trace:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() Marshalling TPM2_ST from 0x7fff3af11720 to buffer 0x521000003d50 at index 0x0
debug:marshal:src/tss2-mu/base-types.c:162:Tss2_MU_TPM2_ST_Marshal() offset parameter non-NULL, updated to 2
trace:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset non-NULL, initial value: 10
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() Marshalling UINT32 from 0x7fff3af11760 to buffer 0x521000003d50 at index 0xa
debug:marshal:src/tss2-mu/base-types.c:156:Tss2_MU_UINT32_Marshal() offset parameter non-NULL, updated to 14
trace:esys:src/tss2-esys/api/Esys_FlushContext.c:177:Esys_FlushContext_Finish() context=0x522000000100
trace:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() Unmarshaling TPM2_ST from 0x521000003d50 to buffer 0x521000003d1e at index 0x0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset parameter non-NULL, updated to 2
trace:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset non-NULL, initial value: 2
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() Unmarshaling UINT32 from 0x521000003d50 to buffer 0x521000003d20 at index 0x2
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset parameter non-NULL, updated to 6
trace:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset non-NULL, initial value: 6
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() Unmarshaling UINT32 from 0x521000003d50 to buffer 0x521000003d24 at index 0x6
debug:marshal:src/tss2-mu/base-types.c:157:Tss2_MU_UINT32_Unmarshal() offset parameter non-NULL, updated to 10
trace:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset non-NULL, initial value: 0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() Unmarshaling TPM2_ST from 0x521000003d50 to buffer 0x7fff3b015630 at index 0x0
debug:marshal:src/tss2-mu/base-types.c:163:Tss2_MU_TPM2_ST_Unmarshal() offset parameter non-NULL, updated to 2
AddressSanitizer:DEADLYSIGNAL
=================================================================
==75949==ERROR: AddressSanitizer: SEGV on unknown address 0x41414141414131 (pc 0x7fff3f07cf0c bp 0x7fffdb6e0150 sp 0x7fffdb6e0110 T0)
==75949==The signal is caused by a READ memory access.
    #0 0x7fff3f07cf0c in __aarch64_cas1_acq_rel ../../../src/libgcc/config/aarch64/lse.S:205
    #1 0x7fff3ef9332c in bool __sanitizer::atomic_compare_exchange_strong<__sanitizer::atomic_uint8_t>(__sanitizer::atomic_uint8_t volatile*, __sanitizer::atomic_uint8_t::Type*, __sanitizer::atomic_uint8_t::Type, __sanitizer::memory_order) ../../../../src/libsanitizer/sanitizer_common/sanitizer_atomic_clang.h:81
    #2 0x7fff3ef9332c in __asan::Allocator::AtomicallySetQuarantineFlagIfAllocated(__asan::AsanChunk*, void*, __sanitizer::BufferedStackTrace*) ../../../../src/libsanitizer/asan/asan_allocator.cpp:668
    #3 0x7fff3ef9332c in __asan::Allocator::Deallocate(void*, unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) ../../../../src/libsanitizer/asan/asan_allocator.cpp:724
    #4 0x7fff3f029298 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:53
    #5 0x7fff3ed535e8 in Fapi_Provision_Finish (/usr/lib/libtss2-fapi.so.1+0xc35e8) (BuildId: 9e2a3b6779b4fbc942e82910918e0c4c384287ca)
    #6 0x7fff3ed5bd04 in Fapi_Provision (/usr/lib/libtss2-fapi.so.1+0xcbd04) (BuildId: 9e2a3b6779b4fbc942e82910918e0c4c384287ca)
    #7 0x5555952c0f94 in main (/home/pi/poc+0xf94) (BuildId: 756d854d3ae69feb0163ea000a20bdf45face792)
    #8 0x7fff3eae2258  (/lib/aarch64-linux-gnu/libc.so.6+0x22258) (BuildId: 364ae7d0d333deedc69b1abb8cd7724816acba78)
    #9 0x7fff3eae2338 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x22338) (BuildId: 364ae7d0d333deedc69b1abb8cd7724816acba78)
    #10 0x5555952c0cec in _start (/home/pi/poc+0xcec) (BuildId: 756d854d3ae69feb0163ea000a20bdf45face792)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ../../../src/libgcc/config/aarch64/lse.S:205 in __aarch64_cas1_acq_rel
==75949==ABORTING

```

The warning (`WARNING:marshal:src/tss2-mu/tpm2b-types.c:298:Tss2_MU_TPM2B_AUTH_Marshal() size: 103 for buffer of TPM2B_AUTH is larger than max length of buffer: 64`) should maybe be a hard error.