### PR TITLE
TCTI: Disable Tss2_Tcti_Info() functions when NO_DL is defined.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -256,6 +256,48 @@ for cortex-m4:
 make
 ```
 
+# Static linking
+
+Building TSS as *static* libraries can be done as follows:
+```
+./bootstrap
+./configure \
+        --enable-static \
+        --enable-nodl \
+        --disable-shared \
+        --disable-fapi \
+        --disable-tcti-cmd \
+        --disable-tcti-i2c-ftdi
+        --disable-tcti-i2c-helper \
+        --disable-tcti-libtpms \
+        --disable-tcti-pcap \
+        --disable-tcti-spi-ftdi \
+        --disable-tcti-spi-helper  \
+        --disable-tcti-spi-lt2go \
+        --disable-tcti-spi-ltt2go \
+        --disable-tcti-spidev
+make
+```
+
+**Hint:** To enable fully static linking of TSS, including the TCTI modules, configure the build with `--enable-static` and `--enable-nodl`.
+
+It is strongly recommended to *disable* any unnecessary TCTI modules, since every enabled module becomes a required dependency of the application and must be linked explicitly. Also, use `--disable-fapi` whenever possible to reduce the number of required dependencies!
+
+The application needs to be linked with the static TSS libraries, *all* enabled TCTI modules as well as the OpenSSL (libcrypto) library:
+```
+gcc \
+        main.c \
+        -static \
+        -o my_program \
+        -ltss2-esys \
+        -ltss2-sys \
+        -ltss2-mu \
+        -ltss2-tcti-device \
+        -ltss2-tcti-mssim \
+        -ltss2-tcti-swtpm \
+        -lcrypto
+```
+
 ## Test operating systems in the CI
 
 * ubuntu-20.04

--- a/src/tss2-tcti/tcti-cmd.c
+++ b/src/tss2-tcti/tcti-cmd.c
@@ -598,6 +598,7 @@ Tss2_Tcti_Cmd_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *con
 }
 
 /* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_cmd_info = {
     .version = TCTI_VERSION,
     .name = TCTI_CMD_NAME,
@@ -610,3 +611,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_cmd_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -503,6 +503,8 @@ Tss2_Tcti_Device_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *
     return TSS2_RC_SUCCESS;
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_device_info = {
     .version = TCTI_VERSION,
     .name = "tcti-device",
@@ -516,3 +518,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_device_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-i2c-ftdi.c
+++ b/src/tss2-tcti/tcti-i2c-ftdi.c
@@ -256,6 +256,8 @@ Tss2_Tcti_I2c_Ftdi_Init(TSS2_TCTI_CONTEXT *tcti_context, size_t *size, const cha
     return Tss2_Tcti_I2c_Helper_Init(tcti_context, size, &tcti_platform);
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_i2c_ftdi_info
     = { .version = TCTI_VERSION,
         .name = "tcti-i2c-ftdi",
@@ -267,3 +269,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_i2c_ftdi_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-i2c-helper.c
+++ b/src/tss2-tcti/tcti-i2c-helper.c
@@ -884,6 +884,8 @@ Tss2_Tcti_I2c_Helper_Init(TSS2_TCTI_CONTEXT             *tcti_context,
     return TSS2_RC_SUCCESS;
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_i2c_helper_info = {
     .version = TCTI_VERSION,
     .name = "tcti-i2c-helper",
@@ -903,3 +905,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_i2c_helper_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-libtpms.c
+++ b/src/tss2-tcti/tcti-libtpms.c
@@ -944,6 +944,7 @@ cleanup_dl:
 }
 
 /* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_libtpms_info = {
     .version = TCTI_VERSION,
     .name = "tcti-libtpms",
@@ -956,3 +957,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_libtpms_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-mssim.c
+++ b/src/tss2-tcti/tcti-mssim.c
@@ -603,6 +603,7 @@ fail_out:
 }
 
 /* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_mssim_info = {
     .version = TCTI_VERSION,
     .name = "tcti-socket",
@@ -615,3 +616,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_mssim_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-null.c
+++ b/src/tss2-tcti/tcti-null.c
@@ -142,6 +142,7 @@ Tss2_Tcti_Null_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *co
 }
 
 /* public info structure */
+#ifndef NO_DL
 const TSS2_TCTI_INFO tss2_tcti_info = {
     .version = TCTI_VERSION,
     .name = "tcti-null",
@@ -154,3 +155,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-pcap.c
+++ b/src/tss2-tcti/tcti-pcap.c
@@ -259,6 +259,7 @@ Tss2_Tcti_Pcap_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *co
 }
 
 /* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_pcap_info = {
     .version = TCTI_VERSION,
     .name = "tcti-pcap",
@@ -271,3 +272,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_pcap_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-spi-ftdi.c
+++ b/src/tss2-tcti/tcti-spi-ftdi.c
@@ -201,6 +201,8 @@ Tss2_Tcti_Spi_Ftdi_Init(TSS2_TCTI_CONTEXT *tcti_context, size_t *size, const cha
     return Tss2_Tcti_Spi_Helper_Init(tcti_context, size, &tcti_platform);
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_spi_ftdi_info
     = { .version = TCTI_VERSION,
         .name = "tcti-spi-ftdi",
@@ -212,3 +214,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_spi_ftdi_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-spi-helper.c
+++ b/src/tss2-tcti/tcti-spi-helper.c
@@ -830,6 +830,8 @@ Tss2_Tcti_Spi_Helper_Init(TSS2_TCTI_CONTEXT             *tcti_context,
     return TSS2_RC_SUCCESS;
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_spi_helper_info = {
     .version = TCTI_VERSION,
     .name = "tcti-spi-helper",
@@ -849,3 +851,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_spi_helper_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-spi-ltt2go.c
+++ b/src/tss2-tcti/tcti-spi-ltt2go.c
@@ -369,6 +369,8 @@ Tss2_Tcti_Spi_Ltt2go_Init(TSS2_TCTI_CONTEXT *tcti_context, size_t *size, const c
     return Tss2_Tcti_Spi_Helper_Init(tcti_context, size, &tcti_platform);
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_ltt2go_info
     = { .version = TCTI_VERSION,
         .name = "tcti-spi-ltt2go",
@@ -380,3 +382,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_ltt2go_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-spidev.c
+++ b/src/tss2-tcti/tcti-spidev.c
@@ -189,6 +189,8 @@ Tss2_Tcti_Spidev_Init(TSS2_TCTI_CONTEXT *tcti_context, size_t *size, const char 
     return Tss2_Tcti_Spi_Helper_Init(tcti_context, size, &platform);
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_spidev_info
     = { .version = TCTI_VERSION,
         .name = "tcti-spidev",
@@ -200,3 +202,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_spidev_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-swtpm.c
+++ b/src/tss2-tcti/tcti-swtpm.c
@@ -589,6 +589,7 @@ fail_out:
 }
 
 /* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_swtpm_info = {
     .version = TCTI_VERSION,
     .name = "tcti-swtpm",
@@ -601,3 +602,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_swtpm_info;
 }
+#endif /* NO_DL */

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -290,6 +290,8 @@ Tss2_Tcti_Tbs_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *con
     return TSS2_RC_SUCCESS;
 }
 
+/* public info structure */
+#ifndef NO_DL
 static const TSS2_TCTI_INFO tss2_tcti_tbs_info = {
     .version = TCTI_VERSION,
     .name = "tcti-tbs",
@@ -302,3 +304,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_tbs_info;
 }
+#endif /* NO_DL */

--- a/test/fuzz/tcti/tcti-fuzzing.c
+++ b/test/fuzz/tcti/tcti-fuzzing.c
@@ -235,6 +235,7 @@ Tss2_Tcti_Fuzzing_Init(TSS2_TCTI_CONTEXT *tcti_ctx, size_t *size, const char *co
 }
 
 /* public info structure */
+#ifndef NO_DL
 const TSS2_TCTI_INFO tss2_tcti_fuzzing_info = {
     .version = TCTI_VERSION,
     .name = "tcti-fuzzing",
@@ -247,3 +248,4 @@ const TSS2_TCTI_INFO *
 Tss2_Tcti_Info(void) {
     return &tss2_tcti_fuzzing_info;
 }
+#endif /* NO_DL */


### PR DESCRIPTION
Disable **`Tss2_Tcti_Info()`** in all TCTI modules, if  `NO_DL` is defined.

These function are **not** even used when building with the `--enable-nodl` option, because `tctildr-nodl.c` will call `Tss2_Tcti_XYZ_Init()` directly. However, the **multiple** `Tss2_Tcti_Info` global symbols will cause conflicts (linker error) when ***statically*** linking more than one TCTI library! This is resolved by simply disabling these functions when `NO_DL` is defined.

We also disable all the `tss2_tcti_xyz_info` structs, because they would be *unused*, if `Tss2_Tcti_Info()` is disabled.