### PR TITLE
ci: switch to freebsd 14.4

### DIFF
--- a/.github/workflows/ci-freebsd.yaml
+++ b/.github/workflows/ci-freebsd.yaml
@@ -17,10 +17,13 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
-          release: "14.3"
+          release: "14.4"
           prepare: |
+            export ASSUME_ALWAYS_YES=yes
             export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
             export PATH="/usr/local/bin:/usr/local/sbin:$PATH"
+            rm -rf /var/db/pkg/repo-* /var/db/pkg/FreeBSD.meta /var/cache/pkg/*
+            pkg bootstrap -f
             pkg update -f
             pkg install -y bash
             pkg install -y gmake


### PR DESCRIPTION
With freebsd 14.3 the error:
pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:14:amd64 did occur.