### PR TITLE
FAPI: Fix always-true condition in get_boolean_from_json.

### DIFF
--- a/src/tss2-fapi/tpm_json_deserialize.c
+++ b/src/tss2-fapi/tpm_json_deserialize.c
@@ -309,9 +309,9 @@ get_boolean_from_json(json_object *jso, TPMI_YES_NO *value) {
     TSS2_RC r = ifapi_json_TPMI_YES_NO_deserialize(jso, value);
     if (r != TSS2_RC_SUCCESS) {
         const char *token = json_object_get_string(jso);
-        if (strcasecmp(token, "set") != 0 || strcasecmp(token, "on") != 0) {
+        if (strcasecmp(token, "set") == 0 || strcasecmp(token, "on") == 0) {
             *value = 1;
-        } else if (strcasecmp(token, "off") != 0) {
+        } else if (strcasecmp(token, "off") == 0) {
             *value = 0;
         } else {
             return_error(TSS2_FAPI_RC_BAD_VALUE, "No boolean value");


### PR DESCRIPTION
The string fallback in get_boolean_from_json() uses

    if (strcasecmp(token, "set") != 0 || strcasecmp(token, "on") != 0)

This is always true, because a token cannot equal both "set" and "on".
So *value is always set to 1, and the "off" and error branches are never
reached. Even "off" is read as true.

Use == instead, so "set" and "on" give 1, "off" gives 0, and any other
token is rejected. Serialized data is not affected, because booleans are
written as 0/1 and handled before this fallback.
