### PR TITLE
Correctly handle TPM_RH_NULL resources with TPM_RH_PW sessions

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -272,6 +272,7 @@ ESYS_TESTS_INTEGRATION_MANDATORY = \
     test/integration/esys-import.int \
     test/integration/esys-make-credential.int \
     test/integration/esys-make-credential-session.int \
+    test/integration/esys-null-auth-resource.int \
     test/integration/esys-nv-ram-counter.int \
     test/integration/esys-nv-ram-counter-session.int \
     test/integration/esys-nv-ram-counter-session-long-auth.int \
@@ -1715,6 +1716,14 @@ test_integration_esys_make_credential_session_int_LDFLAGS = $(TESTS_LDFLAGS) $(T
 test_integration_esys_make_credential_session_int_SOURCES = \
     $(ESYS_SRC_UTIL_CRYPTO_SRC) \
     test/integration/esys-make-credential.int.c \
+    test/integration/main-esys.c test/integration/test-esys.h
+
+test_integration_esys_null_auth_resource_int_CFLAGS  = $(TESTS_CFLAGS) $(TSS2_ESYS_CFLAGS_CRYPTO)
+test_integration_esys_null_auth_resource_int_LDADD   = $(TESTS_LDADD)
+test_integration_esys_null_auth_resource_int_LDFLAGS = $(TESTS_LDFLAGS) $(TSS2_ESYS_LDFLAGS_CRYPTO)
+test_integration_esys_null_auth_resource_int_SOURCES = \
+    $(ESYS_SRC_UTIL_CRYPTO_SRC) \
+    test/integration/esys-null-auth-resource.int.c \
     test/integration/main-esys.c test/integration/test-esys.h
 
 test_integration_esys_nv_certify_int_CFLAGS  = $(TESTS_CFLAGS)

--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -1259,14 +1259,13 @@ iesys_gen_auths(ESYS_CONTEXT           *esys_context,
         auths->auths[auths->count].nonce.size = 0;
         auths->auths[auths->count].sessionAttributes = 0;
         if (esys_context->session_type[session_idx] == ESYS_TR_PASSWORD) {
+            auths->auths[auths->count].sessionHandle = TPM2_RH_PW;
             if (esys_context->auth_objects[session_idx] == NULL) {
                 auths->auths[auths->count].hmac.size = 0;
-                auths->count += 1;
             } else {
-                auths->auths[auths->count].sessionHandle = TPM2_RH_PW;
                 auths->auths[auths->count].hmac = esys_context->auth_objects[session_idx]->auth;
-                auths->count += 1;
             }
+            auths->count += 1;
             continue;
         }
         RSRC_NODE_T *session = esys_context->session_tab[session_idx];

--- a/test/integration/esys-null-auth-resource.int.c
+++ b/test/integration/esys-null-auth-resource.int.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*******************************************************************************
+ * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include <stdlib.h> // for NULL, EXIT_FAILURE, EXIT_SUCCESS
+
+#include "test-esys.h"       // for EXIT_SKIP, test_invoke_esys
+#include "tss2_common.h"     // for TSS2_RC, TSS2_RC_SUCCESS, TSS2_RESMGR_R...
+#include "tss2_esys.h"       // for Esys_Free, Esys_FlushContext, ESYS_TR_NONE
+#include "tss2_tpm2_types.h" // for TPM2_RC_COMMAND_CODE, TPM2B_ATTEST, TPM2B...
+
+#define LOGMODULE test
+#include "util/log.h" // for goto_if_error, LOG_INFO, LOG_ERROR, LOG...
+
+/** This test ensures that passing TPM_RH_NULL for a command handle
+ *  that accepts TPMI_DH_OBJECT+ works correctly when the corresponding
+ *  authorization session is TPM_RH_PW.
+ *
+ * Tested ESYS commands:
+ *  - Esys_GetTime() (O)
+ *
+ * @param[in,out] esys_context The ESYS_CONTEXT.
+ * @retval EXIT_FAILURE
+ * @retval EXIT_SKIP
+ * @retval EXIT_SUCCESS
+ */
+
+int
+test_esys_get_time(ESYS_CONTEXT *esys_context) {
+    TSS2_RC r;
+    int     failure_return = EXIT_FAILURE;
+
+    TPM2B_ATTEST   *timeInfo = NULL;
+    TPMT_SIGNATURE *signature = NULL;
+
+    ESYS_TR         privacyAdminHandle = ESYS_TR_RH_ENDORSEMENT;
+    TPMT_SIG_SCHEME inScheme = { .scheme = TPM2_ALG_NULL };
+    TPM2B_DATA      qualifyingData = { 0 };
+
+    r = Esys_GetTime(esys_context, privacyAdminHandle, ESYS_TR_NONE, ESYS_TR_PASSWORD,
+                     ESYS_TR_PASSWORD, ESYS_TR_NONE, &qualifyingData, &inScheme, &timeInfo,
+                     &signature);
+    if ((r == TPM2_RC_COMMAND_CODE) || (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER))
+        || (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {
+        LOG_WARNING("Command TPM2_GetTime not supported by TPM.");
+
+        failure_return = EXIT_SKIP;
+        goto error;
+    }
+    goto_if_error(r, "Error: GetTime", error);
+
+    Esys_Free(timeInfo);
+    Esys_Free(signature);
+    return EXIT_SUCCESS;
+
+error:
+
+    Esys_Free(timeInfo);
+    Esys_Free(signature);
+    return failure_return;
+}
+
+int
+test_invoke_esys(ESYS_CONTEXT *esys_context) {
+    return test_esys_get_time(esys_context);
+}


### PR DESCRIPTION
Some TPM commands permit passing `TPM_RH_NULL` in a handle slot that
requires an authorization. An example of these are the various
attestation commands which allow passing `TPM_RH_NULL` for the signing
key. This is done by passing `ESYS_TR_NONE` at the ESAPI layer. In this
case, `esys_GetResourceObject` maps this to a NULL node which then gets
converted to `TPM_RH_NULL`. The NULL node is subsequently passed to
`iesys_gen_auths`. If the corresponding session slot is `ESYS_TR_PASSWORD`,
this function fails to set the session handle, resulting in the TPM
returning `TPM_RC_VALUE` for that session slot.

Regardless of what the handle is set to, the corresponding session slot
still needs to be valid. This change sets the session handle to `TPM_RH_PW`
whenever `ESYS_TR_PASSWORD` is supplied, regardless of what the
corresponding resource handle is.

Signed-off-by: Chris Coulson <chris.coulson@amutable.com>