### PR TITLE
build: detect externally enabled fortify in debug builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,6 +632,32 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       ADD_LINK_FLAG([-Wl,-z,relro])
       ])
 
+AS_IF([test "x$enable_debug" = "xyes" ], [
+
+    AC_MSG_CHECKING([whether the compiler enables _FORTIFY_SOURCE])
+
+    AC_PREPROC_IFELSE(
+        [AC_LANG_SOURCE([[
+            #include <features.h>
+
+            #ifndef _FORTIFY_SOURCE
+            # error "_FORTIFY_SOURCE is not enabled"
+            #endif
+        ]])],
+        [fortify_enabled=yes],
+        [fortify_enabled=no])
+
+    AC_MSG_RESULT([$fortify_enabled])
+
+    AS_IF([test "x$fortify_enabled" = "xyes"], [
+        CFLAGS=`echo "$CFLAGS" | sed 's/-O0/-Og/g'`
+        CXXFLAGS=`echo "$CXXFLAGS" | sed 's/-O0/-Og/g'`
+
+        AC_MSG_NOTICE(
+            [_FORTIFY_SOURCE is enabled externally; using -Og instead of -O0])
+    ])
+])
+
 AC_ARG_ENABLE([weakcrypto],
     [AS_HELP_STRING([--disable-weakcrypto],
 	           [Disable crypto algorithms considered weak])],,


### PR DESCRIPTION
Use a preprocessor check to determine whether _FORTIFY_SOURCE is enabled externally when configuring a debug build.
Replace -O0 with -Og only when fortify is active, since fortify requires compiler optimization. Keep -O0 on toolchains that do not enable fortify externally to avoid changing debug behavior and unit test results unnecessarily.
This fixes debug builds with compiler wrappers such as the Nix cc-wrapper without applying -Og to all platforms.
