### PR TITLE
Size bound sub-types when unmarshalling TPM2B types

### DIFF
--- a/src/tss2-mu/tpm2b-types.c
+++ b/src/tss2-mu/tpm2b-types.c
@@ -193,7 +193,7 @@
 #define TPM2B_UNMARSHAL_SUBTYPE(type, subtype, member)                                             \
     TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, size_t *offset, \
                                        type *dest) {                                               \
-        size_t  local_offset = 0;                                                                  \
+        size_t  local_offset = 0, local_buffer_size = 0;                                           \
         UINT16  size = 0;                                                                          \
         TSS2_RC rc;                                                                                \
                                                                                                    \
@@ -233,11 +233,16 @@
                                                                                                    \
         if (dest != NULL) {                                                                        \
             dest->size = size;                                                                     \
-            rc = Tss2_MU_##subtype##_Unmarshal(buffer, buffer_size, &local_offset, &dest->member); \
-            if (rc)                                                                                \
-                return rc;                                                                         \
-        } else {                                                                                   \
-            local_offset += size;                                                                  \
+        }                                                                                          \
+        local_buffer_size = local_offset + size;                                                   \
+        rc = Tss2_MU_##subtype##_Unmarshal(buffer, local_buffer_size, &local_offset,               \
+                                           dest ? &dest->member : NULL);                           \
+        if (rc)                                                                                    \
+            return rc;                                                                             \
+        if (local_offset != local_buffer_size) {                                                   \
+            LOG_DEBUG("Unmarshaled object size %zu does not match TPM2B size field %u",            \
+                      local_offset - (local_buffer_size - size), size);                            \
+            return TSS2_MU_RC_INSUFFICIENT_BUFFER;                                                 \
         }                                                                                          \
                                                                                                    \
         if (offset != NULL) {                                                                      \

--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -290,6 +290,40 @@ tpm2b_unmarshal_success_offset(void **state) {
 }
 
 /*
+ * Test ensures the unmarshaling of a TPM2B subtype is bound by the size prefix.
+ */
+static void
+tpm2b_unmarshal_subtype_exceeds_size(void **state) {
+    TPM2B_ECC_POINT point = { 0 };
+    size_t          offset = 0;
+    uint8_t         buffer[] = { 0x00, 0x08, /* size = 8, real content is 12 */
+                                 0x00, 0x04, 0xef, 0xbe, 0xad, 0xde,   /* x: 2 + 4 = 6 bytes */
+                                 0x00, 0x04, 0x44, 0x33, 0x22, 0x11 }; /* y: 2 + 4 = 6 bytes */
+    TSS2_RC         rc;
+
+    rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, sizeof(buffer), &offset, &point);
+    assert_int_equal(rc, TSS2_MU_RC_INSUFFICIENT_BUFFER);
+}
+
+/*
+ * Test ensures that unmarshaling of a TPM2B type produces an error if the
+ * subtype doesn't consume all of the supplied bytes.
+ */
+static void
+tpm2b_unmarshal_subtype_smaller_than_size(void **state) {
+    TPM2B_ECC_POINT point = { 0 };
+    size_t          offset = 0;
+    uint8_t         buffer[] = { 0x00, 0x10, /* size = 16, real content is 12 */
+                                 0x00, 0x04, 0xef, 0xbe, 0xad, 0xde, /* x: 2 + 4 = 6 bytes */
+                                 0x00, 0x04, 0x44, 0x33, 0x22, 0x11, /* y: 2 + 4 = 6 bytes */
+                                 0x00, 0x00, 0x00, 0x00 };           /* 4 trailing padding bytes */
+    TSS2_RC         rc;
+
+    rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, sizeof(buffer), &offset, &point);
+    assert_int_equal(rc, TSS2_MU_RC_INSUFFICIENT_BUFFER);
+}
+
+/*
  * Test case ensures a NULL buffer parameter produces a BAD_REFERENCE RC.
  */
 void
@@ -354,6 +388,22 @@ tpm2b_unmarshal_dest_null_offset_valid(void **state) {
     rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, sizeof(buffer), &offset, NULL);
     assert_int_equal(rc, TSS2_RC_SUCCESS);
     assert_int_equal(offset, 24);
+}
+
+/*
+ * Test ensures the unmarshaling of a TPM2B subtype is bound by the size prefix
+ * even when dest is NULL and with a valid offset
+ */
+static void
+tpm2b_unmarshal_subtype_exceeds_size_dest_null_offset_valid(void **state) {
+    size_t  offset = 0;
+    uint8_t buffer[] = { 0x00, 0x08,                           /* size = 8, real content is 12 */
+                         0x00, 0x04, 0xef, 0xbe, 0xad, 0xde,   /* x: 2 + 4 = 6 bytes */
+                         0x00, 0x04, 0x44, 0x33, 0x22, 0x11 }; /* y: 2 + 4 = 6 bytes */
+    TSS2_RC rc;
+
+    rc = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(buffer, sizeof(buffer), &offset, NULL);
+    assert_int_equal(rc, TSS2_MU_RC_INSUFFICIENT_BUFFER);
 }
 
 /*
@@ -460,9 +510,12 @@ main(void) {
             cmocka_unit_test(tpm2b_marshal_buffer_size_lt_data_nad_lt_offset),
             cmocka_unit_test(tpm2b_unmarshal_success),
             cmocka_unit_test(tpm2b_unmarshal_success_offset),
+            cmocka_unit_test(tpm2b_unmarshal_subtype_exceeds_size),
+            cmocka_unit_test(tpm2b_unmarshal_subtype_smaller_than_size),
             cmocka_unit_test(tpm2b_unmarshal_buffer_null),
             cmocka_unit_test(tpm2b_unmarshal_dest_null),
             cmocka_unit_test(tpm2b_unmarshal_dest_null_offset_valid),
+            cmocka_unit_test(tpm2b_unmarshal_subtype_exceeds_size_dest_null_offset_valid),
             cmocka_unit_test(tpm2b_unmarshal_buffer_size_lt_data_nad_lt_offset),
             cmocka_unit_test(tpm2b_public_rsa_marshal_success),
             cmocka_unit_test(tpm2b_public_rsa_unique_size_marshal_success),


### PR DESCRIPTION
When unmarshalling the subtype for a `TPM2B` sized structure type, the
unmarshalling is not bound by the `TPM2B` size field. If a TPM returns an
incorrectly formed payload, it's possible that the subtype may consume
more bytes than is indicated in the size field. In this case, it's
likely that unmarshalling will fail at some undefined point in the future,
but there is no explicit handling of this case.

This adds an explicit size bound for the subtype in the
`TPM2B_UNMARSHAL_SUBTYPE` macro, so that unmarshaling fails immediately if
the subtype tries to consume more bytes than what is indicated in the
size field. It also ensures that unmarshaling fails if the subtype
doesn't consume all bytes provided to it, as indicated by the size field,
which catches trailing bytes.

Signed-off-by: Chris Coulson <chris.coulson@amutable.com>