### PR TITLE
fix(esys): update nonce for pure policy session responses

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -816,13 +816,15 @@ iesys_check_rp_hmacs(ESYS_CONTEXT *esys_context, TSS2L_SYS_AUTH_RESPONSE *rspAut
             continue;
 
         IESYS_SESSION *rsrc_session = &session->rsrc.misc.rsrc_session;
+        rsrc_session->nonceTPM = rspAuths->auths[i].nonce;
+        rsrc_session->sessionAttributes = rspAuths->auths[i].sessionAttributes;
         if (rsrc_session->type_policy_session == POLICY_PASSWORD
             || (rsrc_session->sessionType == TPM2_SE_POLICY
                 && rsrc_session->type_policy_session != POLICY_AUTH
                 && rsrc_session->sizeHmacValue == 0)) {
-            /* A policy password session has no auth value */
+            /* These policy sessions have no response HMAC. */
             if (rspAuths->auths[i].hmac.size != 0) {
-                LOG_ERROR("PolicyPassword session's HMAC must be 0-length.");
+                LOG_ERROR("Policy session's HMAC must be 0-length.");
                 return TSS2_ESYS_RC_RSP_AUTH_FAILED;
             }
             continue;
@@ -835,8 +837,6 @@ iesys_check_rp_hmacs(ESYS_CONTEXT *esys_context, TSS2L_SYS_AUTH_RESPONSE *rspAut
 
         TPM2B_AUTH rp_hmac;
         rp_hmac.size = sizeof(TPMU_HA);
-        rsrc_session->nonceTPM = rspAuths->auths[i].nonce;
-        rsrc_session->sessionAttributes = rspAuths->auths[i].sessionAttributes;
         r = iesys_crypto_authHmac(
             &esys_context->crypto_backend, rsrc_session->authHash, &rsrc_session->sessionValue[0],
             rsrc_session->sizeHmacValue, &rp_digest[0], rp_digest_size, &rsrc_session->nonceTPM,

--- a/test/integration/esys-create-policy-auth.int.c
+++ b/test/integration/esys-create-policy-auth.int.c
@@ -30,6 +30,8 @@
  *  - Esys_FlushContext() (M)
  *  - Esys_CreatePrimary() (M)
  *  - Esys_Create() (M)
+ *  - Esys_Load() (M)
+ *  - Esys_TRSess_SetAttributes() (M)
  *
  * Used compiler defines: TEST_ECC
  *
@@ -42,6 +44,7 @@ int
 test_esys_create_policy_auth(ESYS_CONTEXT *esys_context) {
     TSS2_RC r;
     ESYS_TR primaryHandle = ESYS_TR_NONE;
+    ESYS_TR loadedHandle = ESYS_TR_NONE;
     ESYS_TR trialHandle = ESYS_TR_NONE;
     ESYS_TR policyHandle = ESYS_TR_NONE;
 
@@ -70,6 +73,7 @@ test_esys_create_policy_auth(ESYS_CONTEXT *esys_context) {
     goto_if_error(r, "Error esys policy get digest", error);
 
     r = Esys_FlushContext(esys_context, trialHandle);
+    trialHandle = ESYS_TR_NONE;
     goto_if_error(r, "Error esys flush context", error);
 
     TPM2B_AUTH authValuePrimary = { .size = 5, .buffer = { 1, 2, 3, 4, 5 } };
@@ -187,6 +191,10 @@ test_esys_create_policy_auth(ESYS_CONTEXT *esys_context) {
                                TPM2_CC_Create);
     goto_if_error(r, "Error esys policy command code", error);
 
+    r = Esys_TRSess_SetAttributes(esys_context, policyHandle,
+                                  TPMA_SESSION_CONTINUESESSION | TPMA_SESSION_ENCRYPT, 0xff);
+    goto_if_error(r, "Error setting policy session attributes", error);
+
     TPM2B_SENSITIVE_CREATE inSensitive2
         = { .size = 0,
             .sensitive = { .userAuth = { .size = 0, .buffer = { 0 } },
@@ -244,6 +252,14 @@ test_esys_create_policy_auth(ESYS_CONTEXT *esys_context) {
 
     LOG_INFO("\nSecond key created.");
 
+    r = Esys_Load(esys_context, primaryHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  outPrivate2, outPublic2, &loadedHandle);
+    goto_if_error(r, "Error loading second key", error);
+
+    r = Esys_FlushContext(esys_context, loadedHandle);
+    loadedHandle = ESYS_TR_NONE;
+    goto_if_error(r, "Error flushing second key", error);
+
     r = Esys_FlushContext(esys_context, policyHandle);
     policyHandle = ESYS_TR_NONE;
     goto_if_error(r, "Error during FlushContext", error);
@@ -259,6 +275,12 @@ test_esys_create_policy_auth(ESYS_CONTEXT *esys_context) {
     return EXIT_SUCCESS;
 
 error:
+
+    if (loadedHandle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_context, loadedHandle) != TSS2_RC_SUCCESS) {
+            LOG_ERROR("Cleanup loadedHandle failed.");
+        }
+    }
 
     if (trialHandle != ESYS_TR_NONE) {
         if (Esys_FlushContext(esys_context, trialHandle) != TSS2_RC_SUCCESS) {


### PR DESCRIPTION
Update the ESYS session nonce and response session attributes before skipping response HMAC computation for pure policy sessions.

Extend the Create policy authorization integration test to exercise response parameter encryption and verify that the resulting private blob can subsequently be loaded.

### Root cause

Commit `9f1f6120` added a fast path that skips response HMAC computation when a pure policy session returns a zero-length HMAC.

The new path executes `continue` before copying the response nonce and session attributes into the ESYS session state. When the policy session also has `TPMA_SESSION_ENCRYPT`, the subsequent response parameter decryption therefore derives its AES-CFB key and IV using the previous TPM nonce.

For `TPM2_Create`, this corrupts the decrypted `outPrivate` value. Passing that value to `TPM2_Load` fails with `TPM_RC_SIZE` for parameter `1` (`0x000001d5`).

### Fix

Move the updates of `nonceTPM` and `sessionAttributes` before the branch that skips response HMAC computation.

This preserves the intended handling of zero-length HMACs while ensuring that the session state used for response parameter decryption is current.

### Regression test

The first commit adds a regression test without changing the ESAPI implementation:

- `465457432d0a59a5137aadc3e9778fe7f5d8c658`

The test:

1. creates a parent authorized by a pure `PolicyCommandCode` session;
2. enables `TPMA_SESSION_ENCRYPT` on that session;
3. calls `Esys_Create`, whose first response parameter is `outPrivate`;
4. passes the ESYS-decrypted private blob to `Esys_Load`.

Checking out this commit and running the test reproduces the regression:

```console
$ git checkout 465457432d0a59a5137aadc3e9778fe7f5d8c658
$ make check TESTS=test/integration/esys-create-policy-auth.int

FAIL: test/integration/esys-create-policy-auth
Esys_Load() Esys Finish ErrorCode (0x000001d5)
Error loading second key ErrorCode (0x000001d5)
```

The second commit contains the fix:

- `f4996df8ca137698c26a434ce762427c9c479272`

Running the same test at that commit succeeds:

```console
$ git checkout f4996df8ca137698c26a434ce762427c9c479272
$ make check TESTS=test/integration/esys-create-policy-auth.int

PASS: test/integration/esys-create-policy-auth.int

# TOTAL: 1
# PASS:  1
# FAIL:  0
```

The test was run in an Ubuntu 24.04 container using `swtpm` 0.10.1 and `libtpms` 0.10.2.

