### PR TITLE
Update Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,43 +2,48 @@
 
 ## Supported Versions
 
-Currently supported versions:
-
-| Version  | Supported          |
-| -------- | ------------------ |
-| >= 2.4.0 | :white_check_mark: |
-|  < 2.4.0 | :x:                |
+We provide patch updates for each minor release for at least one year
+from its initial release.
+Check the initial release date for your minor version at:
+   - <https://github.com/tpm2-software/tpm2-tss/releases>
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+The preferred method is to report security vulnerabilities by opening a
+GitHub Security Advisory (GHSA) to coordinate disclosure.
+Alternatively, write an encrypted email to all maintainers using the keys
+listed in [MAINTAINERS](MAINTAINERS.md).
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Please do not create temporary private forks when coordinating a GHSA.
+They complicate mitigation and release coordination and clutter the
+organization's repository list.
 
 ## Security Reporting Guidelines
 
-### Reporting
-
-Security vulnerabilities *should be emailed* to **all** members of the [MAINTAINERS](MAINTAINERS) file to coordinate the
-disclosure of the vulnerability.
-
 ### Tracking
 
-When a maintainer is notified of a security vulnerability, they *must* create a GitHub security advisory
-per the instructions at:
-
+When a maintainer is notified of a security vulnerability, they *must*
+create a GitHub Security Advisory (GHSA) per the instructions at:
   - <https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories>
 
-Maintainers *should* use the optional feature through GitHub to request a CVE be issued, alternatively RedHat has provided CVE's
-in the past and *may* be used, but preference is on GitHub as the issuing CNA.
+Maintainers *should* use GitHub's optional feature to request that a CVE be
+issued.
+Alternatively, Red Hat has acted as a CNA for us in the past, but GitHub is
+the preferred issuing CNA.
 
 ### Publishing
 
-Once ready, maintainers should publish the security vulnerability as outlined in:
+Before publication, maintainers *must* ensure the GHSA summary contains no
+proof-of-concept (PoC) exploit code and *must* move any such code to a
+private comment on the advisory.
 
+Once ready, maintainers *should* publish the security advisory as outlined
+at:
   - <https://docs.github.com/en/code-security/repository-security-advisories/publishing-a-repository-security-advisory>
 
-As well as ensuring the publishing of the CVE, maintainers *shal*l have new release versions ready to publish at the same time as
-the CVE. Maintainers *should* should strive to adhere to a sub 60 say turn around from report to release.
+Maintainers *must* ensure the CVE is published and have new release
+versions ready to publish at the same time as the advisory/CVE.
+Maintainers *should* strive to keep the turnaround from report to release
+under 60 days.
+
+Reporters are credited unless they request otherwise.


### PR DESCRIPTION
* remove outdated information
* remove duplicate reporting statements
* remove outdated supported versions, link to releases instead
* fix broken MAINTAINERS link
* fix wording and typos
* wrap lines arount 80 characters like some paragraphs already did
* add reporting via GHSA
* address temporary private forks
* address PoCs in GHSA description
* mention reporter credit
* mention email encryption and keys in MAINTAINERS.md
* start sentences on new lines