### PR TITLE
CI: Update container images and versions

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -8,6 +8,9 @@ set -eo pipefail
 source $DOCKER_BUILD_DIR/.ci/docker-prelude.sh
 
 export CONFIGURE_OPTIONS=
+# OpenSSL 3.5 disables SHA-1 signatures by default but the FAPI integration
+# suite contains a legacy SHA-1 signing check.
+export OPENSSL_ENABLE_SHA1_SIGNATURES=1
 
 if [ -d build ]; then
   rm -rf build
@@ -102,7 +105,7 @@ fi
 
 if [ "$SCANBUILD" == "yes" ]; then
   scan-build --status-bugs make -j
-elif [ "$CC" == "clang" -a "$DOCKER_IMAGE" == "ubuntu-24.04" ]; then
+elif [ "$CC" == "clang" -a "$DOCKER_IMAGE" == "ubuntu-24.04-dev" ]; then
   make -j compile_commands.json
   run-clang-tidy -header-filter $PWD $(find src include -name '*.c' -o -name '*.h') 2>&1 | tee clang-tidy.log
   make -j clean

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,7 +9,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/tpm2-software/ubuntu-24.04
+      image: ghcr.io/tpm2-software/ubuntu-24.04-dev
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -25,4 +25,4 @@ jobs:
         if: ${{ failure() }}
         run: |
           echo "Clang format check failed. Please run clang-format on your code or see the diff in the step above."
-          echo "docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04 clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)"
+          echo "docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04-dev clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,7 +9,7 @@ jobs:
   clang-tidy-check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/tpm2-software/ubuntu-24.04
+      image: ghcr.io/tpm2-software/ubuntu-26.04-dev
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [fedora-32, opensuse-leap, ubuntu-22.04, ubuntu-24.04, alpine-3.15, arch-linux ]
+        docker_image: [fedora-44-dev, centos-stream10-dev, opensuse-leap-dev, ubuntu-26.04-dev, alpine-3.24-dev, arch-linux-dev ]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
@@ -50,7 +50,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: clang
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           SCANBUILD: yes
           WITH_TCTI: swtpm
           PROJECT_NAME: ${{ github.event.repository.name }}
@@ -74,7 +74,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           TEST_TCTI_CONFIG: true
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure
@@ -87,7 +87,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-20.04, ubuntu-22.04-mbedtls-3.1]
+        docker_image: [ubuntu-26.04-dev, ubuntu-22.04-mbedtls-3.6]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           WITH_CRYPTO: none
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure
@@ -147,7 +147,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           ENABLE_COVERAGE: true
           WITH_TCTI: swtpm
           PROJECT_NAME: ${{ github.event.repository.name }}
@@ -175,7 +175,7 @@ jobs:
         uses:
           tpm2-software/ci/runCI@main
         with:
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           GEN_FUZZ: 1
           CXX: clang++
           CC: clang
@@ -203,7 +203,7 @@ jobs:
           REPO_BRANCH: ${{ github.ref }}
           REPO_NAME: ${{ github.repository }}
           ENABLE_COVERITY: true
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           CC: gcc
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SUBMISSION_EMAIL: tadeusz.struk@intel.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ submitters acceptance of the DCO.
 Please note that we now require REUSE and clang-format to also pass on PRs.
 You may run
 ```sh
-docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04 clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)
+docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04-dev clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)
 ```
 before submitting in order to align with our format requirements.
 

--- a/doc/coding_standard_c.md
+++ b/doc/coding_standard_c.md
@@ -9,7 +9,7 @@ check the surrounding code and imitate its style [1].
 For simplicity, we use clang-format for all files (also as part of the CI).
 Thus before commiting any code, we recommend you run
 ```sh
-docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04 clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)
+docker run -u $UID -v $PWD:$PWD ghcr.io/tpm2-software/ubuntu-24.04-dev clang-format -i $(find -name '*.h' -or -name '*.c' | xargs realpath)
 ```
 This ensures that the code will not break during your pull request.
 


### PR DESCRIPTION
* use size optimized dev images
* move from Ubuntu 22.04 to 26.04
* move from Fedora 32 to 44
* move from Alpine 3.15 to 3.24
* add CentOS Stream 10
* update mbedtls from 3.1 to 3.6