### PR TITLE
fapi test: fix tests failing with physical TPMs.

### DIFF
--- a/test/integration/fapi-key-create-policy-authorize-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-sign.int.c
@@ -310,8 +310,7 @@ test_fapi_key_create_policy_authorize_sign(FAPI_CONTEXT *context) {
           "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE "/HN:/policy/pol_name_hash:"
           "/policy/pol_cphash:/policy/pol_authorize_outer:/policy/pol_authorize:/" FAPI_PROFILE
           "/HS/SRK/myPolicySignKey2:/" FAPI_PROFILE "/HS/SRK/myPolicySignKey:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey:/" FAPI_PROFILE "/HS/SRK/myPolicySignKeyOuter"
-          ":/nv/Endorsement_Certificate/1c00002:/nv/Endorsement_Certificate/1c0000a";
+          "/HS/SRK/mySignKey:/" FAPI_PROFILE "/HS/SRK/myPolicySignKeyOuter";
     ASSERT(cmp_strtokens(pathList, check_pathList1, ":"));
 
     SAFE_FREE(pathList);

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -190,17 +190,16 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context) {
     goto_if_error(r, "Error Fapi_Delete", error);
     ASSERT(path_list != NULL);
     LOG_INFO("Path list: %s", path_list);
-    char *check_path_list
-        = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE "/LOCKOUT:/" FAPI_PROFILE
-          "/HE/EK:/" FAPI_PROFILE "/HE:"
-          "/" FAPI_PROFILE "/HN:/" FAPI_PROFILE "/HS/SRK/mySignKey2:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey"
-          ":/nv/Endorsement_Certificate/1c00002:/nv/Endorsement_Certificate/1c0000a";
-    ASSERT(cmp_strtokens(path_list, check_path_list, ":"));
+    char *check_path_list = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE
+                            "/LOCKOUT:/" FAPI_PROFILE "/HE/EK:/" FAPI_PROFILE "/HE:"
+                            "/" FAPI_PROFILE "/HN:/" FAPI_PROFILE
+                            "/HS/SRK/mySignKey2:/" FAPI_PROFILE "/HS/SRK/mySignKey";
 
     /* We need to reset the passwords again, in order to not brick physical TPMs */
     r = Fapi_ChangeAuth(context, "/HS", NULL);
     goto_if_error(r, "Error Fapi_ChangeAuth", error);
+
+    ASSERT(cmp_strtokens(path_list, check_path_list, ":"));
 
     r = Fapi_GetDescription(context, "/HS/SRK", &description);
     goto_if_error(r, "Error GetDescription", error);

--- a/test/integration/fapi-quote.int.c
+++ b/test/integration/fapi-quote.int.c
@@ -334,11 +334,9 @@ test_fapi_quote(FAPI_CONTEXT *context) {
     ASSERT(pathlist != NULL);
     ASSERT(strlen(pathlist) > ASSERT_SIZE);
     LOG_INFO("\nPathlist: %s\n", pathlist);
-    char *check_pathlist
-        = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE "/LOCKOUT:/" FAPI_PROFILE
-          "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE "/HN:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey:/ext/myExtPubKey:/nv/Endorsement_Certificate/1c00002"
-          ":/nv/Endorsement_Certificate/1c0000a";
+    char *check_pathlist = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE
+                           "/LOCKOUT:/" FAPI_PROFILE "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE
+                           "/HN:/" FAPI_PROFILE "/HS/SRK/mySignKey:/ext/myExtPubKey";
     ASSERT(cmp_strtokens(pathlist, check_pathlist, ":"));
     LOG_INFO("\nPathlist: %s\n", check_pathlist);
 

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -172,24 +172,28 @@ cmp_jso(json_object *jso1, json_object *jso2) {
     }
 }
 
-/* Compare two delimiter separated token lists. */
+/*
+ * Compare two delimiter separated token lists.
+ * Every token from check_string must be found in computed string.
+ */
 bool
-cmp_strtokens(char *string1, char *string2, char *delimiter) {
+cmp_strtokens(char *computed_string, char *check_string, char *delimiter) {
     bool  found = false;
     char *token1 = NULL;
     char *token2 = NULL;
     char *end_token1;
     char *end_token2;
-    char *string2_copy;
+    char *computed_string_copy;
 
-    string1 = strdup(string1);
-    ASSERT(string1);
-    token1 = strtok_r(string1, delimiter, &end_token1);
+    check_string = strdup(check_string);
+    ASSERT(check_string);
+    token1 = strtok_r(check_string, delimiter, &end_token1);
     while (token1 != NULL) {
         found = false;
-        string2_copy = strdup(string2);
-        ASSERT(string2_copy);
-        token2 = strtok_r(string2_copy, delimiter, &end_token2);
+        computed_string_copy = strdup(computed_string);
+        ASSERT(computed_string_copy);
+        token2 = strtok_r(computed_string_copy, delimiter, &end_token2);
+
         while (token2 != NULL) {
             if (strcmp(token1, token2) == 0) {
                 found = true;
@@ -197,17 +201,17 @@ cmp_strtokens(char *string1, char *string2, char *delimiter) {
             }
             token2 = strtok_r(NULL, delimiter, &end_token2);
         }
-        free(string2_copy);
+        free(computed_string_copy);
         if (!found) {
             break;
         }
         token1 = strtok_r(NULL, delimiter, &end_token1);
     }
-    free(string1);
+    free(check_string);
     return found;
 
 error:
-    SAFE_FREE(string1);
+    SAFE_FREE(check_string);
     return false;
 }
 

--- a/test/integration/test-fapi.h
+++ b/test/integration/test-fapi.h
@@ -153,7 +153,7 @@ pcr_bank_sha1_exists(FAPI_CONTEXT *context, bool *exists);
 TSS2_RC
 pcr_reset(FAPI_CONTEXT *context, UINT32 pcr);
 
-bool cmp_strtokens(char *string1, char *string2, char *delimiter);
+bool cmp_strtokens(char *computed_string, char *check_string, char *delimiter);
 
 char *normalize_string(const char *string);
 


### PR DESCRIPTION
The check previously assumed that the list of current FAPI paths exactly matched the provided checklist.

However, physical TPMs may contain additional NV objects and therefore additional FAPI paths. These extra paths do not indicate an error.

Change the comparison so that it only verifies that every entry from the checklist is present in the current FAPI path list. Additional paths in the FAPI path list are now ignored.

Also one assertion is moved to ensure that a modified password is reset even when the test fails.

Remove the endorsement certificate paths from the checklist because their presence and exact paths may differ when tests are run with physical TPMs.