### PR TITLE
Fix session functionality with loaded tpm2 openssl provider

### DIFF
--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -111,6 +111,56 @@ iesys_cryptossl_context_free(IESYS_CRYPTOSSL_CONTEXT *ctx) {
 }
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
+static const EVP_CIPHER *
+get_ossl_cipher(TPM2_ALG_ID tpm_sym_alg, UINT16 key_bits, TPM2_ALG_ID tpm_mode) {
+    if (tpm_mode != TPM2_ALG_CFB)
+        return NULL;
+
+    switch (tpm_sym_alg) {
+    case TPM2_ALG_AES:
+        switch (key_bits) {
+        case 128:
+            return EVP_aes_128_cfb();
+        case 192:
+            return EVP_aes_192_cfb();
+        case 256:
+            return EVP_aes_256_cfb();
+        default:
+            return NULL;
+        }
+    case TPM2_ALG_SM4:
+        return key_bits == 128 ? EVP_sm4_cfb128() : NULL;
+    default:
+        return NULL;
+    }
+}
+#else
+static const char *
+get_ossl_cipher(TPM2_ALG_ID tpm_sym_alg, UINT16 key_bits, TPM2_ALG_ID tpm_mode) {
+    if (tpm_mode != TPM2_ALG_CFB)
+        return NULL;
+
+    switch (tpm_sym_alg) {
+    case TPM2_ALG_AES:
+        switch (key_bits) {
+        case 128:
+            return "AES-128-CFB";
+        case 192:
+            return "AES-192-CFB";
+        case 256:
+            return "AES-256-CFB";
+        default:
+            return NULL;
+        }
+    case TPM2_ALG_SM4:
+        return key_bits == 128 ? "SM4-CFB" : NULL;
+    default:
+        return NULL;
+    }
+}
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 static const EVP_MD *
 get_ossl_hash_md(TPM2_ALG_ID hashAlg) {
     switch (hashAlg) {
@@ -1034,6 +1084,9 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t          *key,
     const EVP_CIPHER *cipher_alg = NULL;
     EVP_CIPHER_CTX   *ctx = NULL;
     int               cipher_len;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_LIB_CTX *libctx = NULL;
+#endif
 
     if (key == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Bad reference");
@@ -1041,13 +1094,16 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t          *key,
 
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS AES input");
 
-    if (key_bits == 128 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_128_cfb();
-    else if (key_bits == 192 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_192_cfb();
-    else if (key_bits == 256 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_256_cfb();
-    else {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    if (!(cipher_alg = get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode))) {
+#else
+    if (!(libctx = OSSL_LIB_CTX_new())) {
+        goto_error(r, TSS2_ESYS_RC_MEMORY, "Create OpenSSL library context", cleanup);
+    }
+
+    if (!(cipher_alg
+          = EVP_CIPHER_fetch(libctx, get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode), NULL))) {
+#endif
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE,
                    "AES algorithm not implemented or illegal mode (CFB expected).", cleanup);
     }
@@ -1076,9 +1132,11 @@ iesys_cryptossl_sym_aes_encrypt(uint8_t          *key,
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS AES output");
 
 cleanup:
-
     OSSL_FREE(ctx, EVP_CIPHER_CTX);
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_FREE(cipher_alg, EVP_CIPHER);
+    OSSL_FREE(libctx, OSSL_LIB_CTX);
+#endif
     return r;
 }
 
@@ -1112,6 +1170,9 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t          *key,
     const EVP_CIPHER *cipher_alg = NULL;
     EVP_CIPHER_CTX   *ctx = NULL;
     int               cipher_len = 0;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_LIB_CTX *libctx = NULL;
+#endif
 
     if (key == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Bad reference");
@@ -1121,14 +1182,16 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t          *key,
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE, "AES encrypt called with wrong algorithm.", cleanup);
     }
 
-    if (key_bits == 128 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_128_cfb();
-    else if (key_bits == 192 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_192_cfb();
-    else if (key_bits == 256 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_aes_256_cfb();
-    else {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    if (!(cipher_alg = get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode))) {
+#else
+    if (!(libctx = OSSL_LIB_CTX_new())) {
+        goto_error(r, TSS2_ESYS_RC_MEMORY, "Create OpenSSL library context", cleanup);
+    }
 
+    if (!(cipher_alg
+          = EVP_CIPHER_fetch(libctx, get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode), NULL))) {
+#endif
         goto_error(r, TSS2_ESYS_RC_NOT_IMPLEMENTED, "AES algorithm not implemented.", cleanup);
     }
 
@@ -1154,8 +1217,11 @@ iesys_cryptossl_sym_aes_decrypt(uint8_t          *key,
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS AES output");
 
 cleanup:
-
     OSSL_FREE(ctx, EVP_CIPHER_CTX);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_FREE(cipher_alg, EVP_CIPHER);
+    OSSL_FREE(libctx, OSSL_LIB_CTX);
+#endif
     return r;
 }
 
@@ -1190,6 +1256,9 @@ iesys_cryptossl_sym_sm4_encrypt(uint8_t          *key,
     const EVP_CIPHER *cipher_alg = NULL;
     EVP_CIPHER_CTX   *ctx = NULL;
     int               cipher_len;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_LIB_CTX *libctx = NULL;
+#endif
 
     if (key == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Bad reference");
@@ -1197,15 +1266,22 @@ iesys_cryptossl_sym_sm4_encrypt(uint8_t          *key,
 
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS SM4 input");
 
-    if (key_bits == 128 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_sm4_cfb128();
-    else {
-        goto_error(r, TSS2_ESYS_RC_BAD_VALUE,
-                   "SM4 algorithm not implemented or illegal mode (CFB expected).", cleanup);
-    }
-
     if (tpm_sym_alg != TPM2_ALG_SM4) {
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE, "SM4 encrypt called with wrong algorithm.", cleanup);
+    }
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    if (!(cipher_alg = get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode))) {
+#else
+    if (!(libctx = OSSL_LIB_CTX_new())) {
+        goto_error(r, TSS2_ESYS_RC_MEMORY, "Create OpenSSL library context", cleanup);
+    }
+
+    if (!(cipher_alg
+          = EVP_CIPHER_fetch(libctx, get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode), NULL))) {
+#endif
+        goto_error(r, TSS2_ESYS_RC_BAD_VALUE,
+                   "SM4 algorithm not implemented or illegal mode (CFB expected).", cleanup);
     }
 
     /* Create and initialize the context */
@@ -1228,9 +1304,11 @@ iesys_cryptossl_sym_sm4_encrypt(uint8_t          *key,
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS SM4 output");
 
 cleanup:
-
     OSSL_FREE(ctx, EVP_CIPHER_CTX);
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_FREE(cipher_alg, EVP_CIPHER);
+    OSSL_FREE(libctx, OSSL_LIB_CTX);
+#endif
     return r;
 }
 
@@ -1264,6 +1342,9 @@ iesys_cryptossl_sym_sm4_decrypt(uint8_t          *key,
     const EVP_CIPHER *cipher_alg = NULL;
     EVP_CIPHER_CTX   *ctx = NULL;
     int               cipher_len = 0;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_LIB_CTX *libctx = NULL;
+#endif
 
     if (key == NULL || buffer == NULL) {
         return_error(TSS2_ESYS_RC_BAD_REFERENCE, "Bad reference");
@@ -1273,9 +1354,16 @@ iesys_cryptossl_sym_sm4_decrypt(uint8_t          *key,
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE, "SM4 decrypt called with wrong algorithm.", cleanup);
     }
 
-    if (key_bits == 128 && tpm_mode == TPM2_ALG_CFB)
-        cipher_alg = EVP_sm4_cfb128();
-    else {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    if (!(cipher_alg = get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode))) {
+#else
+    if (!(libctx = OSSL_LIB_CTX_new())) {
+        goto_error(r, TSS2_ESYS_RC_MEMORY, "Create OpenSSL library context", cleanup);
+    }
+
+    if (!(cipher_alg
+          = EVP_CIPHER_fetch(libctx, get_ossl_cipher(tpm_sym_alg, key_bits, tpm_mode), NULL))) {
+#endif
         goto_error(r, TSS2_ESYS_RC_BAD_VALUE,
                    "SM4 algorithm not implemented or illegal mode (CFB expected).", cleanup);
     }
@@ -1302,8 +1390,11 @@ iesys_cryptossl_sym_sm4_decrypt(uint8_t          *key,
     LOGBLOB_TRACE(buffer, buffer_size, "IESYS SM4 output");
 
 cleanup:
-
     OSSL_FREE(ctx, EVP_CIPHER_CTX);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_FREE(cipher_alg, EVP_CIPHER);
+    OSSL_FREE(libctx, OSSL_LIB_CTX);
+#endif
     return r;
 }
 #endif

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -694,7 +694,13 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC *pub_tpm_key,
     }
 #endif /* OPENSSL_VERSION_NUMBER < 0x30000000L */
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     if (!(ctx = EVP_PKEY_CTX_new(evp_rsa_key, NULL))) {
+#else
+    /* this is nessecary from OpenSSL 3.0.0 to avoid using the TPM2 provider using
+     * OpenSSL in a circular dependency */
+    if (!(ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_rsa_key, NULL))) {
+#endif
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE, "Could not create evp context.", cleanup);
     }
 

--- a/src/tss2-esys/esys_crypto_ossl.c
+++ b/src/tss2-esys/esys_crypto_ossl.c
@@ -394,9 +394,17 @@ iesys_cryptossl_hmac_start(ESYS_CRYPTO_CONTEXT_BLOB **context,
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE, "Failed to create HMAC key", cleanup);
     }
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     if (1
         != EVP_DigestSignInit(mycontext->hash.ossl_context, NULL, mycontext->hash.ossl_hash_alg,
                               NULL, hkey)) {
+#else
+    /* this is nessecary from OpenSSL 3.0.0 to avoid using the TPM2 provider using
+     * OpenSSL in a circular dependency */
+    if (1
+        != EVP_DigestSignInit_ex(mycontext->hash.ossl_context, NULL, get_ossl_hash_md(hashAlg),
+                                 mycontext->hash.ossl_libctx, NULL, hkey, NULL)) {
+#endif
         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE, "DigestSignInit", cleanup);
     }
 


### PR DESCRIPTION
The following operations in in esys_crypto_ossl need to be done in software. Otherwise it leads to circular dependencies when the tpm2-openssl provider is loaded and an auth session is being started:
- asymmetric encryption (used when the session is started)
- hmac calculation
- symmetric encryption and decryption (used during the session)

This completes the work started in ec58f0a43931b18de9c3c5e0cd884892c218041a

FIX: https://github.com/tpm2-software/tpm2-tss/issues/3130