### PR TITLE
tcti: dynamically load Windows TCTI libraries

### DIFF
--- a/src/tss2-tcti/tctildr-dl.c
+++ b/src/tss2-tcti/tctildr-dl.c
@@ -9,10 +9,17 @@
 #include "config.h" // IWYU pragma: keep
 #endif
 
-#include <dlfcn.h>  // for dlclose, dlerror, dlsym, dlopen, RTLD...
 #include <limits.h> // for PATH_MAX
 #include <stdio.h>  // for NULL, size_t, snprintf
 #include <string.h> // for memset
+#ifdef _WIN32
+#include <windows.h> // for FreeLibrary, GetProcAddress, LoadLibraryA
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
+#else
+#include <dlfcn.h> // for dlclose, dlerror, dlsym, dlopen, RTLD...
+#endif
 
 #include "tctildr-interface.h" // for tctildr_finalize_data, tctildr_get_info
 #include "tctildr.h"           // for tcti_from_info, FMT_LIB_SUFFIX, FMT_L...
@@ -29,6 +36,16 @@ struct {
     char *conf;
     char *description;
 } tctis[] = {
+#ifdef _WIN32
+    {
+        .file = "tss2-tcti-tbs.dll",
+        .description = "Access to Windows TPM Base Services",
+    },
+    {
+        .file = "tss2-tcti-mssim.dll",
+        .description = "Access to TPM simulator using MS protocol",
+    },
+#else
     {
         .file = "libtss2-tcti-default.so",
         .description = "Access libtss2-tcti-default.so",
@@ -60,6 +77,7 @@ struct {
         .file = "libtss2-tcti-mssim.so.0",
         .description = "Access to libtss2-tcti-mssim.so",
     },
+#endif
 };
 
 const TSS2_TCTI_INFO *
@@ -69,11 +87,19 @@ info_from_handle(void *dlhandle) {
     if (dlhandle == NULL)
         return NULL;
 
+#ifdef _WIN32
+    info_func = (TSS2_TCTI_INFO_FUNC)GetProcAddress((HMODULE)dlhandle, TSS2_TCTI_INFO_SYMBOL);
+    if (info_func == NULL) {
+        LOG_ERROR("Failed to get reference to TSS2_TCTI_INFO_SYMBOL: 0x%lx", GetLastError());
+        return NULL;
+    }
+#else
     info_func = dlsym(dlhandle, TSS2_TCTI_INFO_SYMBOL);
     if (info_func == NULL) {
         LOG_ERROR("Failed to get reference to TSS2_TCTI_INFO_SYMBOL: %s", dlerror());
         return NULL;
     }
+#endif
 
     return info_func();
 }
@@ -82,6 +108,14 @@ handle_from_name(const char *file, void **handle) {
     size_t      size = 0;
     char        file_xfrm[PATH_MAX];
     const char *formats[] = {
+#ifdef _WIN32
+        /* tss2-tcti-<name>.dll */
+        "tss2-tcti-%s.dll",
+        /* tss2-<name>.dll */
+        "tss2-%s.dll",
+        /* <name> */
+        "%s",
+#else
         /* <name> */
         "%s",
         /* libtss2-tcti-<name>.so.0 */
@@ -92,6 +126,7 @@ handle_from_name(const char *file, void **handle) {
         FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX_0,
         /* libtss2-<name>.so */
         FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX,
+#endif
     };
 
     if (handle == NULL) {
@@ -105,11 +140,19 @@ handle_from_name(const char *file, void **handle) {
             LOG_ERROR("TCTI name truncated in transform.");
             return TSS2_TCTI_RC_BAD_VALUE;
         }
+#ifdef _WIN32
+        *handle = LoadLibraryA(file_xfrm);
+#else
         *handle = dlopen(file_xfrm, RTLD_NOW);
+#endif
         if (*handle != NULL) {
             return TSS2_RC_SUCCESS;
         } else {
+#ifdef _WIN32
+            LOG_DEBUG("Could not load TCTI file \"%s\": 0x%lx", file_xfrm, GetLastError());
+#else
             LOG_DEBUG("Could not load TCTI file \"%s\": %s", file, dlerror());
+#endif
         }
     }
 
@@ -130,17 +173,29 @@ tcti_from_file(const char *file, const char *conf, TSS2_TCTI_CONTEXT **tcti, voi
         return r;
     }
 
+#ifdef _WIN32
+    infof = (TSS2_TCTI_INFO_FUNC)GetProcAddress((HMODULE)handle, TSS2_TCTI_INFO_SYMBOL);
+#else
     infof = (TSS2_TCTI_INFO_FUNC)dlsym(handle, TSS2_TCTI_INFO_SYMBOL);
+#endif
     if (infof == NULL) {
         LOG_ERROR("Info not found in TCTI file: %s", file);
+#ifdef _WIN32
+        FreeLibrary((HMODULE)handle);
+#else
         dlclose(handle);
+#endif
         return TSS2_ESYS_RC_BAD_REFERENCE;
     }
 
     r = tcti_from_info(infof, conf, tcti);
     if (r != TSS2_RC_SUCCESS) {
         LOG_ERROR("Could not initialize TCTI file: %s", file);
+#ifdef _WIN32
+        FreeLibrary((HMODULE)handle);
+#else
         dlclose(handle);
+#endif
         return r;
     }
 
@@ -298,7 +353,11 @@ tctildr_get_tcti(const char *name, const char *conf, TSS2_TCTI_CONTEXT **tcti, v
 void
 tctildr_finalize_data(void **data) {
     if (data != NULL && *data != NULL) {
+#ifdef _WIN32
+        FreeLibrary((HMODULE)*data);
+#else
         dlclose(*data);
+#endif
         *data = NULL;
     }
 }

--- a/src/tss2-tcti/tss2-tctildr.vcxproj
+++ b/src/tss2-tcti/tss2-tctildr.vcxproj
@@ -127,7 +127,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -144,7 +144,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -154,7 +154,7 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -165,7 +165,7 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -181,7 +181,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -198,7 +198,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -209,7 +209,7 @@
     <Link>
       <TargetMachine>MachineARM64</TargetMachine>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -221,13 +221,13 @@
     <Link>
       <TargetMachine>MachineARM64</TargetMachine>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tctildr.def</ModuleDefinitionFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\util\log.c" />
     <ClCompile Include="tctildr.c" />
-    <ClCompile Include="tctildr-nodl.c" />
+    <ClCompile Include="tctildr-dl.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\util\log.h" />

--- a/tpm2-tss.sln
+++ b/tpm2-tss.sln
@@ -28,10 +28,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tcti-tbs", "src\tss2-t
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tctildr", "src\tss2-tcti\tss2-tctildr.vcxproj", "{40EC0A14-E90F-450F-B250-2071B05ED099}"
-	ProjectSection(ProjectDependencies) = postProject
-		{6BA6146F-8B38-49A2-A156-769E0F2CC302} = {6BA6146F-8B38-49A2-A156-769E0F2CC302}
-		{89B6B774-2886-48CF-B1D0-534AC449E0FD} = {89B6B774-2886-48CF-B1D0-534AC449E0FD}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-rc", "src\tss2-rc\tss2-rc.vcxproj", "{0674A684-8945-4EDB-858F-1A2ECDEFFDC1}"
 EndProject


### PR DESCRIPTION
## Summary

- use the dynamic TCTI loader implementation on Windows
- load TCTI DLLs with LoadLibrary/GetProcAddress
- remove static MSSIM and TBS dependencies from tss2-tctildr

## Testing

- Built tss2-tctildr for Windows x64 Release
- Verified tss2-tctildr.dll has no MSSIM or TBS import dependency
- TPM2-TSS integration tests: 263 passed, 11 skipped