### PR TITLE
sys: move from disabling weak crypto to enabling deprecated crypto

### DIFF
--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -682,12 +682,12 @@ test_unit_log_SOURCES = test/unit/log.c \
     test/helper/cmocka_all.h
 
 test_unit_CommonPreparePrologue_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
-test_unit_CommonPreparePrologue_LDADD = $(CMOCKA_LIBS) $(libtss2_sys) $(libtss2_mu)
+test_unit_CommonPreparePrologue_LDADD = $(CMOCKA_LIBS) $(libtss2_sys) $(libtss2_mu) $(libutil)
 test_unit_CommonPreparePrologue_SOURCES = test/unit/CommonPreparePrologue.c \
     src/tss2-sys/sysapi_util.c test/helper/cmocka_all.h
 
 test_unit_CopyCommandHeader_CFLAGS = $(CMOCKA_CFLAGS) $(TESTS_CFLAGS)
-test_unit_CopyCommandHeader_LDADD = $(CMOCKA_LIBS) $(libtss2_sys) $(libtss2_mu)
+test_unit_CopyCommandHeader_LDADD = $(CMOCKA_LIBS) $(libtss2_sys) $(libtss2_mu) $(libutil)
 test_unit_CopyCommandHeader_SOURCES = test/unit/CopyCommandHeader.c \
     src/tss2-sys/sysapi_util.c test/helper/cmocka_all.h
 

--- a/Makefile-test.am
+++ b/Makefile-test.am
@@ -1908,6 +1908,7 @@ test_integration_esys_pcr_basic_int_LDADD   = $(TESTS_LDADD)
 test_integration_esys_pcr_basic_int_LDFLAGS = $(TESTS_LDFLAGS)
 test_integration_esys_pcr_basic_int_SOURCES = \
     test/integration/esys-pcr-basic.int.c \
+    src/tss2-sys/sysapi_util.c \
     test/integration/main-esys.c test/integration/test-esys.h
 
 test_integration_esys_pcr_auth_value_int_CFLAGS  = $(TESTS_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -632,12 +632,12 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       ADD_LINK_FLAG([-Wl,-z,relro])
       ])
 
-AC_ARG_ENABLE([weakcrypto],
-    [AS_HELP_STRING([--disable-weakcrypto],
-	           [Disable crypto algorithms considered weak])],,
-    [enable_weakcrypto=no])
-AS_IF([test "x$enable_weakcrypto" = "xyes"],
-	[AC_DEFINE([DISABLE_WEAK_CRYPTO],[1],[DISABLE WEAK CRYPTO ALGORITHMS])])
+AC_ARG_ENABLE([deprecated_crypto],
+    [AS_HELP_STRING([--enable-deprecated-crypto],
+	           [Enable crypto algorithms considered deprecated])],,
+    [enable_deprecated_crypto=no])
+AS_IF([test "x$enable_deprecated_crypto" != "xno"],
+	[AC_DEFINE([ENABLE_DEPRECATED_CRYPTO],[1],[enable DEPRECATED CRYPTO ALGORITHMS])])
 
 AC_ARG_ENABLE([self-generated-certificate],
             [AS_HELP_STRING([--enable-self-generated-certificate],

--- a/src/tss2-sys/api/Tss2_Sys_HMAC.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC.c
@@ -25,7 +25,7 @@ Tss2_Sys_HMAC_Prepare(TSS2_SYS_CONTEXT       *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC);

--- a/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
+++ b/src/tss2-sys/api/Tss2_Sys_HMAC_Start.c
@@ -25,7 +25,7 @@ Tss2_Sys_HMAC_Start_Prepare(TSS2_SYS_CONTEXT *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC_Start);

--- a/src/tss2-sys/api/Tss2_Sys_Hash.c
+++ b/src/tss2-sys/api/Tss2_Sys_Hash.c
@@ -25,7 +25,7 @@ Tss2_Sys_Hash_Prepare(TSS2_SYS_CONTEXT       *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_Hash);

--- a/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
+++ b/src/tss2-sys/api/Tss2_Sys_HashSequenceStart.c
@@ -24,7 +24,7 @@ Tss2_Sys_HashSequenceStart_Prepare(TSS2_SYS_CONTEXT *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_HashSequenceStart);

--- a/src/tss2-sys/api/Tss2_Sys_MAC.c
+++ b/src/tss2-sys/api/Tss2_Sys_MAC.c
@@ -25,7 +25,7 @@ Tss2_Sys_MAC_Prepare(TSS2_SYS_CONTEXT       *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(inScheme, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_MAC);

--- a/src/tss2-sys/api/Tss2_Sys_MAC_Start.c
+++ b/src/tss2-sys/api/Tss2_Sys_MAC_Start.c
@@ -25,7 +25,7 @@ Tss2_Sys_MAC_Start_Prepare(TSS2_SYS_CONTEXT   *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(inScheme, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_MAC_Start);

--- a/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -26,7 +26,7 @@ Tss2_Sys_PCR_SetAuthPolicy_Prepare(TSS2_SYS_CONTEXT   *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_SetAuthPolicy);

--- a/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -26,7 +26,7 @@ Tss2_Sys_SetCommandCodeAuditStatus_Prepare(TSS2_SYS_CONTEXT *sysContext,
     if (!ctx || !setList || !clearList)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(auditAlg, 0))
+    if (IsAlgorithmDeprecated(auditAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_SetCommandCodeAuditStatus);

--- a/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
+++ b/src/tss2-sys/api/Tss2_Sys_SetPrimaryPolicy.c
@@ -25,7 +25,7 @@ Tss2_Sys_SetPrimaryPolicy_Prepare(TSS2_SYS_CONTEXT      *sysContext,
     if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(hashAlg, 0))
+    if (IsAlgorithmDeprecated(hashAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_SetPrimaryPolicy);

--- a/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
+++ b/src/tss2-sys/api/Tss2_Sys_StartAuthSession.c
@@ -29,7 +29,7 @@ Tss2_Sys_StartAuthSession_Prepare(TSS2_SYS_CONTEXT             *sysContext,
     if (!ctx || !symmetric)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (IsAlgorithmWeak(authHash, 0))
+    if (IsAlgorithmDeprecated(authHash, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_StartAuthSession);

--- a/src/tss2-sys/sysapi_util.c
+++ b/src/tss2-sys/sysapi_util.c
@@ -303,13 +303,13 @@ GetNumResponseHandles(TPM2_CC commandCode) {
     return GetNumHandles(commandCode, 0);
 }
 
-#ifdef DISABLE_WEAK_CRYPTO
+#ifndef ENABLE_DEPRECATED_CRYPTO
 bool
-IsAlgorithmWeak(TPM2_ALG_ID algorithm, TPM2_KEY_SIZE key_size) {
+IsAlgorithmDeprecated(TPM2_ALG_ID algorithm, TPM2_KEY_SIZE key_size) {
     switch (algorithm) {
     case TPM2_ALG_RSA:
         if (key_size < 2048) {
-            LOG_ERROR("Error: weak algorithm");
+            LOG_ERROR("Error: deprecated algorithm");
             return true;
         }
         break;
@@ -318,12 +318,12 @@ IsAlgorithmWeak(TPM2_ALG_ID algorithm, TPM2_KEY_SIZE key_size) {
     case TPM2_ALG_CAMELLIA:
     case TPM2_ALG_SYMCIPHER:
         if (key_size < 128) {
-            LOG_ERROR("Error: weak algorithm");
+            LOG_ERROR("Error: deprecated algorithm");
             return true;
         }
         break;
     case TPM2_ALG_SHA1:
-        LOG_ERROR("Error: weak algorithm");
+        LOG_ERROR("Error: deprecated algorithm");
         return true;
         break;
     }
@@ -337,28 +337,28 @@ ValidatePublicTemplate(const TPM2B_PUBLIC *pub) {
 
     switch (tmpl->type) {
     case TPM2_ALG_RSA:
-        if (IsAlgorithmWeak(tmpl->type, tmpl->parameters.rsaDetail.keyBits)
-            || IsAlgorithmWeak(tmpl->parameters.rsaDetail.symmetric.algorithm,
-                               tmpl->parameters.rsaDetail.symmetric.keyBits.sym))
+        if (IsAlgorithmDeprecated(tmpl->type, tmpl->parameters.rsaDetail.keyBits)
+            || IsAlgorithmDeprecated(tmpl->parameters.rsaDetail.symmetric.algorithm,
+                                     tmpl->parameters.rsaDetail.symmetric.keyBits.sym))
             return TSS2_SYS_RC_BAD_VALUE;
         break;
     case TPM2_ALG_ECC:
-        if (IsAlgorithmWeak(tmpl->parameters.eccDetail.symmetric.algorithm,
-                            tmpl->parameters.eccDetail.symmetric.keyBits.sym))
+        if (IsAlgorithmDeprecated(tmpl->parameters.eccDetail.symmetric.algorithm,
+                                  tmpl->parameters.eccDetail.symmetric.keyBits.sym))
             return TSS2_SYS_RC_BAD_VALUE;
         break;
     case TPM2_ALG_AES:
     case TPM2_ALG_SM4:
     case TPM2_ALG_CAMELLIA:
     case TPM2_ALG_SYMCIPHER:
-        if (IsAlgorithmWeak(tmpl->type, tmpl->parameters.symDetail.sym.keyBits.sym))
+        if (IsAlgorithmDeprecated(tmpl->type, tmpl->parameters.symDetail.sym.keyBits.sym))
             return TSS2_SYS_RC_BAD_VALUE;
         break;
     default:
-        if (IsAlgorithmWeak(tmpl->type, 0))
+        if (IsAlgorithmDeprecated(tmpl->type, 0))
             return TSS2_SYS_RC_BAD_VALUE;
 
-        if (IsAlgorithmWeak(tmpl->nameAlg, 0))
+        if (IsAlgorithmDeprecated(tmpl->nameAlg, 0))
             return TSS2_SYS_RC_BAD_VALUE;
     }
     return TSS2_RC_SUCCESS;
@@ -368,7 +368,7 @@ TSS2_RC
 ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info) {
     const TPMS_NV_PUBLIC *nv_public = &nv_public_info->nvPublic;
 
-    if (IsAlgorithmWeak(nv_public->nameAlg, 0))
+    if (IsAlgorithmDeprecated(nv_public->nameAlg, 0))
         return TSS2_SYS_RC_BAD_VALUE;
 
     return TSS2_RC_SUCCESS;
@@ -382,7 +382,7 @@ ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection) {
     for (i = 0; i < pcr_selection->count; i++) {
         const TPMS_PCR_SELECTION *selection = &pcr_selection->pcrSelections[i];
 
-        if (IsAlgorithmWeak(selection->hash, 0))
+        if (IsAlgorithmDeprecated(selection->hash, 0))
             return TSS2_SYS_RC_BAD_VALUE;
     }
 

--- a/src/tss2-sys/sysapi_util.h
+++ b/src/tss2-sys/sysapi_util.h
@@ -6,7 +6,8 @@
 
 #ifndef TSS2_SYSAPI_UTIL_H
 #define TSS2_SYSAPI_UTIL_H
-#include <stddef.h> // for size_t
+#include <stdbool.h> // for bool
+#include <stddef.h>  // for size_t
 
 #include "tss2_common.h"     // for UINT32, TSS2_RC, UINT8, TSS2_RC_SUCCESS
 #include "tss2_sys.h"        // for TSS2L_SYS_AUTH_COMMAND, TSS2L_SYS_AUTH_...
@@ -100,8 +101,8 @@ TSS2_RC CommonPreparePrologue(TSS2_SYS_CONTEXT_BLOB *ctx, TPM2_CC commandCode);
 
 TSS2_RC CommonPrepareEpilogue(TSS2_SYS_CONTEXT_BLOB *ctx);
 
-#ifdef DISABLE_WEAK_CRYPTO
-bool    IsAlgorithmWeak(TPM2_ALG_ID algorith, TPM2_KEY_SIZE key_size);
+#ifndef ENABLE_DEPRECATED_CRYPTO
+bool    IsAlgorithmDeprecated(TPM2_ALG_ID algorith, TPM2_KEY_SIZE key_size);
 TSS2_RC ValidatePublicTemplate(const TPM2B_PUBLIC *pub);
 TSS2_RC ValidateNV_Public(const TPM2B_NV_PUBLIC *nv_public_info);
 TSS2_RC ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection);
@@ -110,7 +111,7 @@ TSS2_RC ValidateTPML_PCR_SELECTION(const TPML_PCR_SELECTION *pcr_selection);
  * static inline is not portable, so make these empty defines to reduce generating functions
  * and thus binary size for them.
  */
-#define IsAlgorithmWeak(...)            TSS2_RC_SUCCESS
+#define IsAlgorithmDeprecated(...)      TSS2_RC_SUCCESS
 #define ValidatePublicTemplate(...)     TSS2_RC_SUCCESS
 #define ValidateNV_Public(...)          TSS2_RC_SUCCESS
 #define ValidateTPML_PCR_SELECTION(...) TSS2_RC_SUCCESS

--- a/test/integration/esys-pcr-basic.int.c
+++ b/test/integration/esys-pcr-basic.int.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h> // for NULL, EXIT_FAILURE, EXIT_SUCCESS
 
+#include "sysapi_util.h"     // for IsAlgorithmDeprecated
 #include "test-esys.h"       // for EXIT_SKIP, test_invoke_esys
 #include "tss2_common.h"     // for UINT32, TSS2_RC
 #include "tss2_esys.h"       // for Esys_Free, ESYS_TR_NONE, Esys_PCR_Allocate
@@ -106,8 +107,17 @@ test_esys_pcr_basic(ESYS_CONTEXT *esys_context) {
 
     goto_if_error(r, "Error: PCR_Allocate", error);
 
+    TPML_PCR_SELECTION restorePcrSelection = { .count = 0 };
+    for (UINT32 i = 0; i < savedPCRs->data.assignedPCR.count; i++) {
+        if (IsAlgorithmDeprecated(savedPCRs->data.assignedPCR.pcrSelections[i].hash, 0))
+            continue;
+        restorePcrSelection.pcrSelections[restorePcrSelection.count]
+            = savedPCRs->data.assignedPCR.pcrSelections[i];
+        restorePcrSelection.count++;
+    }
+
     r = Esys_PCR_Allocate(esys_context, ESYS_TR_RH_PLATFORM, ESYS_TR_PASSWORD, ESYS_TR_NONE,
-                          ESYS_TR_NONE, &savedPCRs->data.assignedPCR, &allocationSuccess, &maxPCR,
+                          ESYS_TR_NONE, &restorePcrSelection, &allocationSuccess, &maxPCR,
                           &sizeNeeded, &sizeAvailable);
 
     goto_if_error(r, "Error: PCR_Allocate", error);

--- a/test/integration/fapi-quote-destructive-eventlog.int.c
+++ b/test/integration/fapi-quote-destructive-eventlog.int.c
@@ -937,7 +937,7 @@ test_fapi_quote_destructive(FAPI_CONTEXT *context) {
     size_t   signatureSize = 0;
     uint32_t pcrList[13] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 14, 16 };
 
-#ifdef WORDS_BIGENDIAN
+#if defined(WORDS_BIGENDIAN) || !defined(ENABLE_DEPRECATED_CRYPTO)
     return EXIT_SKIP;
 #endif
 

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -911,7 +911,7 @@ nv_write(TSS2_SYS_CONTEXT *sys_context, TPMI_RH_NV_INDEX nvIndex, X509 *cert) {
     TPM2B_AUTH nv_auth = { 0 };
     TPM2B_NV_PUBLIC public_info = {
         .nvPublic = {
-            .nameAlg = TPM2_ALG_SHA1,
+            .nameAlg = TPM2_ALG_SHA256,
             .attributes = TPMA_NV_PPWRITE | TPMA_NV_AUTHREAD | TPMA_NV_OWNERREAD |
                 TPMA_NV_PLATFORMCREATE | TPMA_NV_NO_DA,
             .dataSize = 0,

--- a/test/unit/esys-resubmissions.c
+++ b/test/unit/esys-resubmissions.c
@@ -305,7 +305,7 @@ test_StartAuthSession(void **state) {
     TPM2_SE      sessionType = TPM2_SE_HMAC;
     TPMT_SYM_DEF symmetric
         = { .algorithm = TPM2_ALG_AES, .keyBits = { .aes = 128 }, .mode = { .aes = TPM2_ALG_CFB } };
-    TPMI_ALG_HASH authHash = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH authHash = TPM2_ALG_SHA256;
     ESYS_TR       sessionHandle_handle;
 
     r = Esys_StartAuthSession(esys_context, tpmKey_handle, bind_handle, ESYS_TR_NONE, ESYS_TR_NONE,
@@ -727,7 +727,7 @@ test_Hash(void **state) {
     TSS2_TCTI_CONTEXT_YIELDER *tcti_yielder = tcti_yielder_cast(tcti);
 
     TPM2B_MAX_BUFFER   data = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA256;
     ESYS_TR            hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST      *outHash;
     TPMT_TK_HASHCHECK *validation;
@@ -748,7 +748,7 @@ test_HMAC(void **state) {
 
     ESYS_TR          handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST    *outHMAC;
     r = Esys_HMAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                   &buffer, hashAlg, &outHMAC);
@@ -767,7 +767,7 @@ test_MAC(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER    buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST       *outMAC;
     r = Esys_MAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &buffer,
                  hashAlg, &outMAC);
@@ -818,7 +818,7 @@ test_HMAC_Start(void **state) {
 
     ESYS_TR       handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HMAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                         &auth, hashAlg, &sequenceHandle_handle);
@@ -837,7 +837,7 @@ test_MAC_Start(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH          auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     ESYS_TR             sequenceHandle_handle;
     r = Esys_MAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                        &auth, hashAlg, &sequenceHandle_handle);
@@ -855,7 +855,7 @@ test_HashSequenceStart(void **state) {
     TSS2_TCTI_CONTEXT_YIELDER *tcti_yielder = tcti_yielder_cast(tcti);
 
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HashSequenceStart(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &auth,
                                hashAlg, &sequenceHandle_handle);
@@ -1145,7 +1145,7 @@ test_SetCommandCodeAuditStatus(void **state) {
     TSS2_TCTI_CONTEXT_YIELDER *tcti_yielder = tcti_yielder_cast(tcti);
 
     ESYS_TR       auth_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA256;
     TPML_CC       setList = { 0 };
     TPML_CC       clearList = { 0 };
     r = Esys_SetCommandCodeAuditStatus(esys_context, auth_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
@@ -1241,7 +1241,7 @@ test_PCR_SetAuthPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     TPMI_DH_PCR   pcrNum = 0;
     r = Esys_PCR_SetAuthPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                                ESYS_TR_NONE, &authPolicy, hashAlg, pcrNum);
@@ -1706,7 +1706,7 @@ test_SetPrimaryPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     r = Esys_SetPrimaryPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                               ESYS_TR_NONE, &authPolicy, hashAlg);
 
@@ -2091,7 +2091,7 @@ test_NV_DefineSpace(void **state) {
         .size = 0,
         .nvPublic = {
                      .nvIndex = TPM2_NV_INDEX_FIRST,
-                     .nameAlg = TPM2_ALG_SHA1,
+                     .nameAlg = TPM2_ALG_SHA256,
                      .attributes = (TPMA_NV_PPWRITE |
                                     TPMA_NV_AUTHWRITE |
                                     1 << TPMA_NV_TPM2_NT_SHIFT |

--- a/test/unit/esys-tcti-rcs.c
+++ b/test/unit/esys-tcti-rcs.c
@@ -296,7 +296,7 @@ test_StartAuthSession(void **state) {
     TPM2_SE      sessionType = TPM2_SE_HMAC;
     TPMT_SYM_DEF symmetric
         = { .algorithm = TPM2_ALG_AES, .keyBits = { .aes = 128 }, .mode = { .aes = TPM2_ALG_CFB } };
-    TPMI_ALG_HASH authHash = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH authHash = TPM2_ALG_SHA256;
     ESYS_TR       sessionHandle_handle;
 
     r = Esys_StartAuthSession(esys_context, tpmKey_handle, bind_handle, ESYS_TR_NONE, ESYS_TR_NONE,
@@ -677,7 +677,7 @@ test_Hash(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     TPM2B_MAX_BUFFER   data = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA256;
     ESYS_TR            hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST      *outHash;
     TPMT_TK_HASHCHECK *validation;
@@ -696,7 +696,7 @@ test_HMAC(void **state) {
 
     ESYS_TR          handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST    *outHMAC;
     r = Esys_HMAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                   &buffer, hashAlg, &outHMAC);
@@ -713,7 +713,7 @@ test_MAC(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER    buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST       *outMAC;
     r = Esys_MAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &buffer,
                  hashAlg, &outMAC);
@@ -758,7 +758,7 @@ test_HMAC_Start(void **state) {
 
     ESYS_TR       handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HMAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                         &auth, hashAlg, &sequenceHandle_handle);
@@ -775,7 +775,7 @@ test_MAC_Start(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH          auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     ESYS_TR             sequenceHandle_handle;
     r = Esys_MAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                        &auth, hashAlg, &sequenceHandle_handle);
@@ -791,7 +791,7 @@ test_HashSequenceStart(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HashSequenceStart(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &auth,
                                hashAlg, &sequenceHandle_handle);
@@ -1053,7 +1053,7 @@ test_SetCommandCodeAuditStatus(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     ESYS_TR       auth_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA256;
     TPML_CC       setList = { 0 };
     TPML_CC       clearList = { 0 };
     r = Esys_SetCommandCodeAuditStatus(esys_context, auth_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
@@ -1139,7 +1139,7 @@ test_PCR_SetAuthPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     TPMI_DH_PCR   pcrNum = 0;
     r = Esys_PCR_SetAuthPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                                ESYS_TR_NONE, &authPolicy, hashAlg, pcrNum);
@@ -1555,7 +1555,7 @@ test_SetPrimaryPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     r = Esys_SetPrimaryPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                               ESYS_TR_NONE, &authPolicy, hashAlg);
 
@@ -1896,7 +1896,7 @@ test_NV_DefineSpace(void **state) {
         .size = 0,
         .nvPublic = {
                      .nvIndex = TPM2_NV_INDEX_FIRST,
-                     .nameAlg = TPM2_ALG_SHA1,
+                     .nameAlg = TPM2_ALG_SHA256,
                      .attributes = (TPMA_NV_PPWRITE |
                                     TPMA_NV_AUTHWRITE |
                                     1 << TPMA_NV_TPM2_NT_SHIFT |

--- a/test/unit/esys-tpm-rcs.c
+++ b/test/unit/esys-tpm-rcs.c
@@ -276,7 +276,7 @@ test_StartAuthSession(void **state) {
     TPM2_SE      sessionType = TPM2_SE_HMAC;
     TPMT_SYM_DEF symmetric
         = { .algorithm = TPM2_ALG_AES, .keyBits = { .aes = 128 }, .mode = { .aes = TPM2_ALG_CFB } };
-    TPMI_ALG_HASH authHash = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH authHash = TPM2_ALG_SHA256;
     ESYS_TR       sessionHandle_handle;
 
     r = Esys_StartAuthSession(esys_context, tpmKey_handle, bind_handle, ESYS_TR_NONE, ESYS_TR_NONE,
@@ -657,7 +657,7 @@ test_Hash(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     TPM2B_MAX_BUFFER   data = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH      hashAlg = TPM2_ALG_SHA256;
     ESYS_TR            hierarchy = ESYS_TR_RH_OWNER;
     TPM2B_DIGEST      *outHash;
     TPMT_TK_HASHCHECK *validation;
@@ -676,7 +676,7 @@ test_HMAC(void **state) {
 
     ESYS_TR          handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH    hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST    *outHMAC;
     r = Esys_HMAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                   &buffer, hashAlg, &outHMAC);
@@ -693,7 +693,7 @@ test_MAC(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_MAX_BUFFER    buffer = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     TPM2B_DIGEST       *outMAC;
     r = Esys_MAC(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &buffer,
                  hashAlg, &outMAC);
@@ -738,7 +738,7 @@ test_HMAC_Start(void **state) {
 
     ESYS_TR       handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HMAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                         &auth, hashAlg, &sequenceHandle_handle);
@@ -755,7 +755,7 @@ test_MAC_Start(void **state) {
 
     ESYS_TR             handle_handle = DUMMY_TR_HANDLE_KEY;
     TPM2B_AUTH          auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_MAC_SCHEME hashAlg = TPM2_ALG_SHA256;
     ESYS_TR             sequenceHandle_handle;
     r = Esys_MAC_Start(esys_context, handle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                        &auth, hashAlg, &sequenceHandle_handle);
@@ -771,7 +771,7 @@ test_HashSequenceStart(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     TPM2B_AUTH    auth = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     ESYS_TR       sequenceHandle_handle;
     r = Esys_HashSequenceStart(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &auth,
                                hashAlg, &sequenceHandle_handle);
@@ -1033,7 +1033,7 @@ test_SetCommandCodeAuditStatus(void **state) {
     Esys_GetTcti(esys_context, &tcti);
 
     ESYS_TR       auth_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
-    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH auditAlg = TPM2_ALG_SHA256;
     TPML_CC       setList = { 0 };
     TPML_CC       clearList = { 0 };
     r = Esys_SetCommandCodeAuditStatus(esys_context, auth_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
@@ -1119,7 +1119,7 @@ test_PCR_SetAuthPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     TPMI_DH_PCR   pcrNum = 0;
     r = Esys_PCR_SetAuthPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                                ESYS_TR_NONE, &authPolicy, hashAlg, pcrNum);
@@ -1535,7 +1535,7 @@ test_SetPrimaryPolicy(void **state) {
 
     ESYS_TR       authHandle_handle = DUMMY_TR_HANDLE_HIERARCHY_PLATFORM;
     TPM2B_DIGEST  authPolicy = DUMMY_2B_DATA(.buffer);
-    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA1;
+    TPMI_ALG_HASH hashAlg = TPM2_ALG_SHA256;
     r = Esys_SetPrimaryPolicy(esys_context, authHandle_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
                               ESYS_TR_NONE, &authPolicy, hashAlg);
 
@@ -1876,7 +1876,7 @@ test_NV_DefineSpace(void **state) {
         .size = 0,
         .nvPublic = {
                      .nvIndex = TPM2_NV_INDEX_FIRST,
-                     .nameAlg = TPM2_ALG_SHA1,
+                     .nameAlg = TPM2_ALG_SHA256,
                      .attributes = (TPMA_NV_PPWRITE |
                                     TPMA_NV_AUTHWRITE |
                                     1 << TPMA_NV_TPM2_NT_SHIFT |


### PR DESCRIPTION
Roughly six years ago we introduced a flag that allows disabling weak crypto. Now we see that distros no longer provide certain weak algorithms so it is time to reverse the logic and disable weak crypto by default, require the --enable-deprecated-crypto configure flag to unblock it.

The wording "deprecated" add a slightly better explanation which algorithms are considered in comparison to "weak".

A first step to address #3126.