### PR TITLE
fapi test: fix tests failing with physical TPMs (4.2.x)

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -14,7 +14,7 @@ source $DOCKER_BUILD_DIR/.ci/download-deps.sh
 
 get_deps "$WORKSPACE"
 
-export LD_LIBRARY_PATH=/usr/local/lib/
+export LD_LIBRARY_PATH="/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Change to the build dir
 echo "echo changing to $DOCKER_BUILD_DIR"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,7 +9,7 @@ jobs:
   clang-tidy-check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/tpm2-software/ubuntu-24.04
+      image: ghcr.io/tpm2-software/ubuntu-26.04-dev
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [fedora-32, opensuse-leap, ubuntu-22.04, ubuntu-24.04, alpine-3.15, arch-linux ]
+        docker_image: [fedora-44-dev, centos-stream10-dev, opensuse-leap-dev, ubuntu-26.04-dev, alpine-3.24-dev, arch-linux-dev, nixos-26.05-dev ]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
@@ -50,7 +50,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: clang
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           SCANBUILD: yes
           WITH_TCTI: swtpm
           PROJECT_NAME: ${{ github.event.repository.name }}
@@ -74,7 +74,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           TEST_TCTI_CONFIG: true
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure
@@ -87,7 +87,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-20.04, ubuntu-22.04-mbedtls-3.1]
+        docker_image: [ubuntu-26.04-dev, ubuntu-22.04-mbedtls-3.6]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           WITH_CRYPTO: none
           PROJECT_NAME: ${{ github.event.repository.name }}
       - name: failure
@@ -147,7 +147,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           CC: gcc
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           ENABLE_COVERAGE: true
           WITH_TCTI: swtpm
           PROJECT_NAME: ${{ github.event.repository.name }}
@@ -175,7 +175,7 @@ jobs:
         uses:
           tpm2-software/ci/runCI@main
         with:
-          DOCKER_IMAGE: fedora-32
+          DOCKER_IMAGE: fedora-44-dev
           GEN_FUZZ: 1
           CXX: clang++
           CC: clang
@@ -203,7 +203,7 @@ jobs:
           REPO_BRANCH: ${{ github.ref }}
           REPO_NAME: ${{ github.repository }}
           ENABLE_COVERITY: true
-          DOCKER_IMAGE: ubuntu-20.04
+          DOCKER_IMAGE: ubuntu-26.04-dev
           CC: gcc
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SUBMISSION_EMAIL: tadeusz.struk@intel.com

--- a/test/integration/fapi-ext-public-key.int.c
+++ b/test/integration/fapi-ext-public-key.int.c
@@ -183,8 +183,9 @@ test_fapi_ext_public_key(FAPI_CONTEXT *context) {
         goto error;
     }
 
-    uint8_t digest[20] = { 0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a, 0xba, 0x3e,
-                           0x25, 0x71, 0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d };
+    uint8_t digest[32] = { 0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a, 0xba, 0x3e, 0x25,
+                           0x71, 0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d, 0x25, 0x71,
+                           0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d, 0xd8, 0x9d };
     uint8_t signature[256];
     size_t  signatureLength = 256;
 
@@ -193,16 +194,16 @@ test_fapi_ext_public_key(FAPI_CONTEXT *context) {
         goto error;
     }
     if (EVP_PKEY_sign_init(ctx) <= 0 || EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) <= 0
-        || EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha1()) <= 0) {
+        || EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha256()) <= 0) {
         LOG_ERROR("Test EVP_PKEY_sign_init failed.");
         goto error;
     }
-    if (EVP_PKEY_sign(ctx, signature, &signatureLength, digest, 20) <= 0) {
+    if (EVP_PKEY_sign(ctx, signature, &signatureLength, digest, 32) <= 0) {
         LOG_ERROR("Test EVP_PKEY_sign failed.");
         goto error;
     }
 
-    r = Fapi_VerifySignature(context, "/ext/myExtPubKey", digest, 20, signature, 256);
+    r = Fapi_VerifySignature(context, "/ext/myExtPubKey", digest, 32, signature, 256);
     goto_if_error(r, "Error Fapi_VerifySignature", error);
 
     r = Fapi_SetCertificate(context, "/ext/myExtPubKey", cert);

--- a/test/integration/fapi-key-create-policy-authorize-sign.int.c
+++ b/test/integration/fapi-key-create-policy-authorize-sign.int.c
@@ -310,8 +310,7 @@ test_fapi_key_create_policy_authorize_sign(FAPI_CONTEXT *context) {
           "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE "/HN:/policy/pol_name_hash:"
           "/policy/pol_cphash:/policy/pol_authorize_outer:/policy/pol_authorize:/" FAPI_PROFILE
           "/HS/SRK/myPolicySignKey2:/" FAPI_PROFILE "/HS/SRK/myPolicySignKey:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey:/" FAPI_PROFILE "/HS/SRK/myPolicySignKeyOuter"
-          ":/nv/Endorsement_Certificate/1c00002:/nv/Endorsement_Certificate/1c0000a";
+          "/HS/SRK/mySignKey:/" FAPI_PROFILE "/HS/SRK/myPolicySignKeyOuter";
     ASSERT(cmp_strtokens(pathList, check_pathList1, ":"));
 
     SAFE_FREE(pathList);

--- a/test/integration/fapi-key-create-sign.int.c
+++ b/test/integration/fapi-key-create-sign.int.c
@@ -190,17 +190,16 @@ test_fapi_key_create_sign(FAPI_CONTEXT *context) {
     goto_if_error(r, "Error Fapi_Delete", error);
     ASSERT(path_list != NULL);
     LOG_INFO("Path list: %s", path_list);
-    char *check_path_list
-        = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE "/LOCKOUT:/" FAPI_PROFILE
-          "/HE/EK:/" FAPI_PROFILE "/HE:"
-          "/" FAPI_PROFILE "/HN:/" FAPI_PROFILE "/HS/SRK/mySignKey2:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey"
-          ":/nv/Endorsement_Certificate/1c00002:/nv/Endorsement_Certificate/1c0000a";
-    ASSERT(cmp_strtokens(path_list, check_path_list, ":"));
+    char *check_path_list = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE
+                            "/LOCKOUT:/" FAPI_PROFILE "/HE/EK:/" FAPI_PROFILE "/HE:"
+                            "/" FAPI_PROFILE "/HN:/" FAPI_PROFILE
+                            "/HS/SRK/mySignKey2:/" FAPI_PROFILE "/HS/SRK/mySignKey";
 
     /* We need to reset the passwords again, in order to not brick physical TPMs */
     r = Fapi_ChangeAuth(context, "/HS", NULL);
     goto_if_error(r, "Error Fapi_ChangeAuth", error);
+
+    ASSERT(cmp_strtokens(path_list, check_path_list, ":"));
 
     r = Fapi_GetDescription(context, "/HS/SRK", &description);
     goto_if_error(r, "Error GetDescription", error);

--- a/test/integration/fapi-quote.int.c
+++ b/test/integration/fapi-quote.int.c
@@ -334,11 +334,9 @@ test_fapi_quote(FAPI_CONTEXT *context) {
     ASSERT(pathlist != NULL);
     ASSERT(strlen(pathlist) > ASSERT_SIZE);
     LOG_INFO("\nPathlist: %s\n", pathlist);
-    char *check_pathlist
-        = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE "/LOCKOUT:/" FAPI_PROFILE
-          "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE "/HN:/" FAPI_PROFILE
-          "/HS/SRK/mySignKey:/ext/myExtPubKey:/nv/Endorsement_Certificate/1c00002"
-          ":/nv/Endorsement_Certificate/1c0000a";
+    char *check_pathlist = "/" FAPI_PROFILE "/HS/SRK:/" FAPI_PROFILE "/HS:/" FAPI_PROFILE
+                           "/LOCKOUT:/" FAPI_PROFILE "/HE/EK:/" FAPI_PROFILE "/HE:/" FAPI_PROFILE
+                           "/HN:/" FAPI_PROFILE "/HS/SRK/mySignKey:/ext/myExtPubKey";
     ASSERT(cmp_strtokens(pathlist, check_pathlist, ":"));
     LOG_INFO("\nPathlist: %s\n", check_pathlist);
 

--- a/test/integration/main-fapi.c
+++ b/test/integration/main-fapi.c
@@ -172,24 +172,28 @@ cmp_jso(json_object *jso1, json_object *jso2) {
     }
 }
 
-/* Compare two delimiter separated token lists. */
+/*
+ * Compare two delimiter separated token lists.
+ * Every token from check_string must be found in computed string.
+ */
 bool
-cmp_strtokens(char *string1, char *string2, char *delimiter) {
+cmp_strtokens(char *computed_string, char *check_string, char *delimiter) {
     bool  found = false;
     char *token1 = NULL;
     char *token2 = NULL;
     char *end_token1;
     char *end_token2;
-    char *string2_copy;
+    char *computed_string_copy;
 
-    string1 = strdup(string1);
-    ASSERT(string1);
-    token1 = strtok_r(string1, delimiter, &end_token1);
+    check_string = strdup(check_string);
+    ASSERT(check_string);
+    token1 = strtok_r(check_string, delimiter, &end_token1);
     while (token1 != NULL) {
         found = false;
-        string2_copy = strdup(string2);
-        ASSERT(string2_copy);
-        token2 = strtok_r(string2_copy, delimiter, &end_token2);
+        computed_string_copy = strdup(computed_string);
+        ASSERT(computed_string_copy);
+        token2 = strtok_r(computed_string_copy, delimiter, &end_token2);
+
         while (token2 != NULL) {
             if (strcmp(token1, token2) == 0) {
                 found = true;
@@ -197,17 +201,17 @@ cmp_strtokens(char *string1, char *string2, char *delimiter) {
             }
             token2 = strtok_r(NULL, delimiter, &end_token2);
         }
-        free(string2_copy);
+        free(computed_string_copy);
         if (!found) {
             break;
         }
         token1 = strtok_r(NULL, delimiter, &end_token1);
     }
-    free(string1);
+    free(check_string);
     return found;
 
 error:
-    SAFE_FREE(string1);
+    SAFE_FREE(check_string);
     return false;
 }
 

--- a/test/integration/test-fapi.h
+++ b/test/integration/test-fapi.h
@@ -153,7 +153,7 @@ pcr_bank_sha1_exists(FAPI_CONTEXT *context, bool *exists);
 TSS2_RC
 pcr_reset(FAPI_CONTEXT *context, UINT32 pcr);
 
-bool cmp_strtokens(char *string1, char *string2, char *delimiter);
+bool cmp_strtokens(char *computed_string, char *check_string, char *delimiter);
 
 char *normalize_string(const char *string);
 


### PR DESCRIPTION
The check previously assumed that the list of current FAPI paths exactly matched the provided checklist.

However, physical TPMs may contain additional NV objects and therefore additional FAPI paths. These extra paths do not indicate an error.

Change the comparison so that it only verifies that every entry from the checklist is present in the current FAPI path list. Additional paths in the FAPI path list are now ignored.

Also one assertion is moved to ensure that a modified password is reset even when the test fails.

Remove the endorsement certificate paths from the checklist because their presence and exact paths may differ when tests are run with physical TPMs.