### PR TITLE
io: retry poll calls on EINTR and EAGAIN

### DIFF
--- a/src/tss2-fapi/ifapi_io.c
+++ b/src/tss2-fapi/ifapi_io.c
@@ -27,7 +27,8 @@
 #include "tss2_common.h"  // for TSS2_FAPI_RC_IO_ERROR, TSS2_RC, TSS2_RC_S...
 #include <fcntl.h>        // for open
 #define LOGMODULE fapi
-#include "util/log.h" // for LOG_ERROR, SAFE_FREE, LOG_TRACE, goto_error
+#include "util-io/io.h" // for TEMP_RETRY
+#include "util/log.h"   // for LOG_ERROR, SAFE_FREE, LOG_TRACE, goto_error
 
 /** Determine if a sub file in directory is also a directory
  *
@@ -739,7 +740,7 @@ ifapi_io_poll(IFAPI_IO *io) {
         fds.events = io->pollevents;
         fds.fd = fileno(io->stream);
         LOG_TRACE("Waiting for fd %i with event %i", fds.fd, fds.events);
-        rc = poll(&fds, 1, -1);
+        TEMP_RETRY(rc, poll(&fds, 1, -1));
         if (rc < 0) {
             LOG_ERROR("Poll failed with %d", errno);
             return TSS2_FAPI_RC_IO_ERROR;

--- a/src/tss2-tcti/tcti-device.c
+++ b/src/tss2-tcti/tcti-device.c
@@ -165,7 +165,7 @@ tcti_device_receive(TSS2_TCTI_CONTEXT *tctiContext,
             fds.fd = tcti_dev->fd;
             fds.events = POLLIN;
 
-            rc_poll = poll(&fds, nfds, timeout);
+            TEMP_RETRY(rc_poll, poll(&fds, nfds, timeout));
             if (rc_poll < 0) {
                 LOG_ERROR("Failed to poll for response from fd %d, got errno %d: %s", tcti_dev->fd,
                           errno, strerror(errno));
@@ -225,7 +225,7 @@ tcti_device_receive(TSS2_TCTI_CONTEXT *tctiContext,
     fds.fd = tcti_dev->fd;
     fds.events = POLLIN;
 
-    rc_poll = poll(&fds, nfds, timeout);
+    TEMP_RETRY(rc_poll, poll(&fds, nfds, timeout));
     if (rc_poll < 0) {
         LOG_ERROR("Failed to poll for response from fd %d, got errno %d: %s", tcti_dev->fd, errno,
                   strerror(errno));
@@ -442,7 +442,7 @@ Tss2_Tcti_Device_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *
 
     fds.fd = tcti_dev->fd;
     fds.events = POLLIN;
-    rc_poll = poll(&fds, nfds, 1000); /* Wait 1 sec */
+    TEMP_RETRY(rc_poll, poll(&fds, nfds, 1000)); /* Wait 1 sec */
     if (rc_poll < 0 || rc_poll == 0) {
         LOG_ERROR("Failed to poll for response from fd %d, rc %d, errno %d: %s", tcti_dev->fd,
                   rc_poll, errno, strerror(errno));
@@ -470,7 +470,7 @@ Tss2_Tcti_Device_Init(TSS2_TCTI_CONTEXT *tctiContext, size_t *size, const char *
     fds.fd = tcti_dev->fd;
     fds.events = POLLIN;
     sz = 0;
-    rc_poll = poll(&fds, nfds, 1000); /* Wait 1 sec */
+    TEMP_RETRY(rc_poll, poll(&fds, nfds, 1000)); /* Wait 1 sec */
     if (rc_poll < 0) {
         LOG_DEBUG("Failed to poll for response from fd %d, rc %d, errno %d: %s", tcti_dev->fd,
                   rc_poll, errno, strerror(errno));

--- a/src/util-io/io.c
+++ b/src/util-io/io.c
@@ -338,7 +338,7 @@ socket_poll(SOCKET sock, int wait_flags, int timeout) {
     if (timeout == 0)
         timeout = 10;
 
-    rc_poll = poll(&fds, nfds, timeout);
+    TEMP_RETRY(rc_poll, poll(&fds, nfds, timeout));
     if (rc_poll < 0) {
         LOG_ERROR("Failed to poll for response from fd %d, got errno %d: %s", sock, errno,
                   strerror(errno));


### PR DESCRIPTION
Wrap poll calls in TEMP_RETRY to avoid failures due to signal interrupts.

Addresses #3086.