### PR TITLE
esys: fix stale nonceTPM for pure policy sessions with parameter encryption

### DIFF
--- a/src/tss2-esys/esys_iutil.c
+++ b/src/tss2-esys/esys_iutil.c
@@ -825,6 +825,14 @@ iesys_check_rp_hmacs(ESYS_CONTEXT *esys_context, TSS2L_SYS_AUTH_RESPONSE *rspAut
                 LOG_ERROR("PolicyPassword session's HMAC must be 0-length.");
                 return TSS2_ESYS_RC_RSP_AUTH_FAILED;
             }
+            /* Even though the HMAC check is skipped, nonceTPM and the
+               session attributes must still be updated from the response.
+               iesys_decrypt_param() derives the parameter decryption key
+               from rsrc_session->nonceTPM via KDFa; leaving it stale here
+               corrupts decrypted response parameters for any session with
+               parameter encryption enabled. */
+            rsrc_session->nonceTPM = rspAuths->auths[i].nonce;
+            rsrc_session->sessionAttributes = rspAuths->auths[i].sessionAttributes;
             continue;
         }
 


### PR DESCRIPTION
## Summary

Fixes #3145. `iesys_check_rp_hmacs()` skips HMAC verification for pure
policy sessions (`sizeHmacValue == 0`), a branch added in 9f1f612
("iesys: Skip computing HMAC authorizations for pure policy
sessions"). That skip branch `continue`s without ever updating
`rsrc_session->nonceTPM` or `rsrc_session->sessionAttributes` from the
response auth — unlike the normal (non-skipped) path a few lines
below it, which does:

```c
rsrc_session->nonceTPM = rspAuths->auths[i].nonce;
rsrc_session->sessionAttributes = rspAuths->auths[i].sessionAttributes;
```

`iesys_decrypt_param()` derives the response parameter decryption key
via KDFa from `rsrc_session->nonceTPM` and `nonceCaller`
(`src/tss2-esys/esys_iutil.c`, `iesys_decrypt_param`). When
`nonceTPM` is left stale, the derived key is wrong and the decrypted
response parameter comes out corrupted.

This breaks `Esys_Create` and `Esys_Load` (and any other command that
returns an encrypted parameter) whenever they are called with an
**unsalted, unbound policy session** (`tpmKey=TPM_RH_NULL`,
`bind=TPM_RH_NULL`) that has `TPMA_SESSION_ENCRYPT`/`DECRYPT` set —
exactly the session pattern the `tss-esapi` Rust crate uses in
`ak::load_ak()`/`ak::create_ak_2()` to create and load Attestation
Keys under an Endorsement Key, as described in #3145.

## Fix

Update `nonceTPM` and `sessionAttributes` from the response before the
early `continue`, matching what the non-skipped path already does.

## Verification

Built tpm2-tss from source, ran the 2x2 reproducer from #3145 against
swtpm:

**Before the fix** (reproduces the issue exactly):
```
                    Load: PLAIN    Load: ENCRYPTED
Create: PLAIN       PASS             FAIL (0x00070011)
Create: ENCRYPTED   FAIL (0x000001d5) FAIL (0x000001d5)
```

**After the fix**:
```
                    Load: PLAIN    Load: ENCRYPTED
Create: PLAIN       PASS             PASS
Create: ENCRYPTED   PASS             PASS
```

All four combinations pass with the fix applied, and I reverted it
locally to confirm the exact same failure pattern reported in #3145
reproduces without it — same error codes (`0x00070011` on Load-plain
after encrypted Create/Load, `0x000001d5` TPM_RC_SIZE for the
corrupted private blob).

---
> This fix and its verification were developed with assistance from Claude Code (claude.ai/code).
